### PR TITLE
Support 7-decimal crypto qty, fix crypto price fetching, and add edit holding UI

### DIFF
--- a/src/app/accounts/[id]/page.tsx
+++ b/src/app/accounts/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { AccountDetail } from "@/components/accounts/account-detail";
 import { serializeAccountWithHoldings } from "@/lib/types";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
+import { getExchangeRate } from "@/lib/services/exchange-rate-service";
 
 export const dynamic = "force-dynamic";
 
@@ -60,9 +61,20 @@ export default async function AccountDetailPage({
 
   const serialized = serializeAccountWithHoldings(account);
 
+  const ratesMap: Record<string, number> = {};
+  for (const holding of serialized.holdings) {
+    const hc = holding.currency || "USD";
+    if (hc !== serialized.currency) {
+      const key = `${hc}_${serialized.currency}`;
+      if (ratesMap[key] === undefined) {
+        ratesMap[key] = await getExchangeRate(hc, serialized.currency);
+      }
+    }
+  }
+
   return (
     <div className="space-y-6">
-      <AccountDetail account={serialized} priceMap={priceMap} />
+      <AccountDetail account={serialized} priceMap={priceMap} ratesMap={ratesMap} />
     </div>
   );
 }

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { AccountsList } from "@/components/accounts/accounts-list";
 import { serializeAccountWithHoldings } from "@/lib/types";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
+import { getExchangeRate } from "@/lib/services/exchange-rate-service";
 
 export const dynamic = "force-dynamic";
 
@@ -54,10 +55,23 @@ export default async function AccountsPage() {
 
   const serialized = accounts.map(serializeAccountWithHoldings);
 
+  const ratesMap: Record<string, number> = {};
+  for (const account of serialized) {
+    for (const holding of account.holdings) {
+      const hc = holding.currency || "USD";
+      if (hc !== account.currency) {
+        const key = `${hc}_${account.currency}`;
+        if (ratesMap[key] === undefined) {
+          ratesMap[key] = await getExchangeRate(hc, account.currency);
+        }
+      }
+    }
+  }
+
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold tracking-tight">Accounts</h2>
-      <AccountsList accounts={serialized} priceMap={priceMap} />
+      <AccountsList accounts={serialized} priceMap={priceMap} ratesMap={ratesMap} />
     </div>
   );
 }

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -41,9 +41,11 @@ const CATEGORY_LABELS: Record<string, string> = {
 export function AccountDetail({
   account,
   priceMap,
+  ratesMap = {},
 }: {
   account: SerializedAccountWithHoldings;
   priceMap: Record<string, number>;
+  ratesMap?: Record<string, number>;
 }) {
   const router = useRouter();
   const [editingBalance, setEditingBalance] = useState(false);
@@ -53,7 +55,9 @@ export function AccountDetail({
 
   const holdingsWithValue = account.holdings.map((h) => {
     const price = priceMap[h.symbol] ?? null;
-    const marketValue = price !== null ? price * h.quantity : null;
+    const hc = h.currency || "USD";
+    const rate = hc === account.currency ? 1 : ratesMap[`${hc}_${account.currency}`] ?? 1;
+    const marketValue = price !== null ? price * h.quantity * rate : null;
     return { ...h, currentPrice: price, marketValue };
   });
 
@@ -262,7 +266,7 @@ export function AccountDetail({
                     </TableCell>
                     <TableCell className="text-right font-medium">
                       {h.marketValue !== null
-                        ? formatCurrency(h.marketValue, h.currency || "USD")
+                        ? formatCurrency(h.marketValue, account.currency)
                         : "—"}
                     </TableCell>
                     <TableCell className="text-right text-muted-foreground">

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -23,8 +23,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { formatCurrency, formatNumber } from "@/lib/currencies";
 import { HoldingForm } from "./holding-form";
+import { EditHoldingDialog } from "./edit-holding-dialog";
 import { toast } from "sonner";
-import type { SerializedAccountWithHoldings } from "@/lib/types";
+import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/types";
 
 const CATEGORY_LABELS: Record<string, string> = {
   BANK: "Bank",
@@ -51,6 +52,7 @@ export function AccountDetail({
   const [editingBalance, setEditingBalance] = useState(false);
   const [balance, setBalance] = useState(String(account.cashBalance));
   const [showHoldingForm, setShowHoldingForm] = useState(false);
+  const [editingHolding, setEditingHolding] = useState<SerializedHolding | null>(null);
   const [deleting, setDeleting] = useState(false);
 
   const holdingsWithValue = account.holdings.map((h) => {
@@ -257,7 +259,7 @@ export function AccountDetail({
                       <Badge variant="outline">{h.currency || "USD"}</Badge>
                     </TableCell>
                     <TableCell className="text-right">
-                      {formatNumber(h.quantity, h.assetType === "CRYPTO" ? 6 : 2)}
+                      {formatNumber(h.quantity, h.assetType === "CRYPTO" ? 7 : 2)}
                     </TableCell>
                     <TableCell className="text-right">
                       {h.currentPrice !== null
@@ -281,6 +283,11 @@ export function AccountDetail({
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem
+                            onClick={() => setEditingHolding(h)}
+                          >
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
                             className="text-destructive"
                             onClick={() => deleteHolding(h.id)}
                           >
@@ -302,6 +309,15 @@ export function AccountDetail({
         onClose={() => setShowHoldingForm(false)}
         accountId={account.id}
       />
+
+      {editingHolding && (
+        <EditHoldingDialog
+          open={!!editingHolding}
+          onClose={() => setEditingHolding(null)}
+          holding={editingHolding}
+          accountId={account.id}
+        />
+      )}
     </>
   );
 }

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -27,9 +27,11 @@ const CATEGORY_LABELS: Record<string, string> = {
 export function AccountsList({
   accounts,
   priceMap,
+  ratesMap = {},
 }: {
   accounts: SerializedAccountWithHoldings[];
   priceMap: Record<string, number>;
+  ratesMap?: Record<string, number>;
 }) {
   const router = useRouter();
   const [showForm, setShowForm] = useState(false);
@@ -137,6 +139,7 @@ export function AccountsList({
                 key={account.id}
                 account={account}
                 priceMap={priceMap}
+                ratesMap={ratesMap}
                 isSelected={selected.has(account.id)}
                 onToggle={() => toggleSelect(account.id)}
                 isSelecting={isSelecting}
@@ -155,6 +158,7 @@ export function AccountsList({
                 key={account.id}
                 account={account}
                 priceMap={priceMap}
+                ratesMap={ratesMap}
                 isSelected={selected.has(account.id)}
                 onToggle={() => toggleSelect(account.id)}
                 isSelecting={isSelecting}
@@ -172,12 +176,14 @@ export function AccountsList({
 function AccountCard({
   account,
   priceMap,
+  ratesMap,
   isSelected,
   onToggle,
   isSelecting,
 }: {
   account: SerializedAccountWithHoldings;
   priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
   isSelected: boolean;
   onToggle: () => void;
   isSelecting: boolean;
@@ -185,7 +191,9 @@ function AccountCard({
   const isBrokerage = account.category === "BROKERAGE" || account.category === "CRYPTO_WALLET";
   const holdingsValue = account.holdings.reduce((sum, h) => {
     const price = (priceMap || {})[h.symbol] ?? 0;
-    return sum + price * h.quantity;
+    const hc = h.currency || "USD";
+    const rate = hc === account.currency ? 1 : ratesMap[`${hc}_${account.currency}`] ?? 1;
+    return sum + price * h.quantity * rate;
   }, 0);
   const displayValue = isBrokerage ? holdingsValue : account.cashBalance;
   const displayCurrency = account.currency;

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import type { SerializedHolding } from "@/lib/types";
+
+const ASSET_TYPES = [
+  { value: "STOCK", label: "Stock" },
+  { value: "ETF", label: "ETF" },
+  { value: "CRYPTO", label: "Crypto" },
+  { value: "MUTUAL_FUND", label: "Mutual Fund" },
+  { value: "BOND", label: "Bond" },
+  { value: "OTHER", label: "Other" },
+];
+
+export function EditHoldingDialog({
+  open,
+  onClose,
+  holding,
+  accountId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  holding: SerializedHolding;
+  accountId: string;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [quantity, setQuantity] = useState(String(holding.quantity));
+  const [name, setName] = useState(holding.name);
+  const [assetType, setAssetType] = useState<"STOCK" | "ETF" | "CRYPTO" | "MUTUAL_FUND" | "BOND" | "OTHER">(holding.assetType);
+
+  function handleOpen(isOpen: boolean) {
+    if (!isOpen) {
+      onClose();
+    }
+  }
+
+  // Reset form when holding changes
+  function resetToHolding() {
+    setQuantity(String(holding.quantity));
+    setName(holding.name);
+    setAssetType(holding.assetType);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+
+    const parsedQty = parseFloat(quantity);
+    if (isNaN(parsedQty) || parsedQty <= 0) {
+      toast.error("Quantity must be a positive number");
+      setLoading(false);
+      return;
+    }
+
+    // Build update payload — only send changed fields
+    const updates: Record<string, unknown> = { id: holding.id };
+    if (parsedQty !== holding.quantity) updates.quantity = parsedQty;
+    if (name !== holding.name) updates.name = name;
+    if (assetType !== holding.assetType) updates.assetType = assetType;
+
+    // Nothing changed
+    if (Object.keys(updates).length === 1) {
+      onClose();
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/accounts/${accountId}/holdings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(JSON.stringify(err.error) || "Failed");
+      }
+
+      toast.success("Holding updated");
+      onClose();
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update holding"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Holding</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Symbol display (read-only) */}
+          <div className="flex items-center gap-3 rounded-lg border bg-muted/50 p-3">
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-mono font-bold">{holding.symbol}</span>
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  {holding.currency || "USD"}
+                </Badge>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={resetToHolding}
+              className="text-xs text-muted-foreground"
+            >
+              Reset
+            </Button>
+          </div>
+
+          {/* Name */}
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Apple Inc."
+              required
+            />
+          </div>
+
+          {/* Asset Type */}
+          <div className="space-y-2">
+            <Label>Asset Type</Label>
+            <select
+              value={assetType}
+              onChange={(e) => setAssetType(e.target.value as typeof assetType)}
+              className="flex h-9 w-full rounded-lg border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {ASSET_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Quantity */}
+          <div className="space-y-2">
+            <Label className="text-base font-medium">Quantity</Label>
+            <Input
+              type="number"
+              step="any"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              placeholder="e.g. 100"
+              required
+              className="text-lg h-12"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Saving..." : "Save Changes"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -41,28 +41,29 @@ export async function getNetWorthSummary(
     });
 
     // Convert each holding's market value from its native currency to base currency
+    // AND to the account's local currency
     let holdingsInBase = 0;
+    let holdingsInAccountCurrency = 0;
     for (const h of holdingsWithPrice) {
       if (h.marketValue !== null) {
         // Use the holding's currency, fall back to PriceCache currency, then USD
         const holdingCurrency = h.currency || priceMap[h.symbol]?.currency || "USD";
-        const holdingRate = await getExchangeRate(holdingCurrency, baseCurrency);
-        holdingsInBase += h.marketValue * holdingRate;
+        
+        const holdingRateToBase = await getExchangeRate(holdingCurrency, baseCurrency);
+        holdingsInBase += h.marketValue * holdingRateToBase;
+        
+        const holdingRateToAccount = await getExchangeRate(holdingCurrency, account.currency);
+        holdingsInAccountCurrency += h.marketValue * holdingRateToAccount;
       }
     }
 
     const cashInBase = cashBalance * rate;
     const totalValue = cashInBase + holdingsInBase;
 
-    const holdingsValue = holdingsWithPrice.reduce(
-      (sum, h) => sum + (h.marketValue ?? 0),
-      0
-    );
-
     accountsWithValue.push({
       ...serializeAccount(account),
       holdings: holdingsWithPrice,
-      totalValue: cashBalance + holdingsValue,
+      totalValue: cashBalance + holdingsInAccountCurrency,
       totalValueInBaseCurrency: totalValue,
     });
 

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -54,33 +54,68 @@ export async function fetchStockPrices(
   return results;
 }
 
+// Strip currency suffix from crypto symbol (e.g. "BTC-USD" -> "BTC")
+function stripCurrencySuffix(symbol: string): string {
+  return symbol.replace(/-[A-Z]{3,4}$/, "");
+}
+
 export async function fetchCryptoPrices(
   symbols: string[]
 ): Promise<Map<string, { price: number; currency: string }>> {
   const results = new Map<string, { price: number; currency: string }>();
   if (symbols.length === 0) return results;
 
-  const ids = symbols
-    .map((s) => COINGECKO_IDS[s] || s.toLowerCase())
-    .filter(Boolean);
-
-  if (ids.length === 0) return results;
-
+  // Primary: Use Yahoo Finance (crypto symbols like BTC-USD are valid Yahoo symbols)
   try {
-    const res = await fetch(
-      `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=usd`,
-      { next: { revalidate: 0 } }
-    );
-    const data = await res.json();
-
+    const YahooFinance = (await import("yahoo-finance2")).default;
+    const yahooFinance = new YahooFinance();
     for (const symbol of symbols) {
-      const geckoId = COINGECKO_IDS[symbol] || symbol.toLowerCase();
-      if (data[geckoId]?.usd) {
-        results.set(symbol, { price: data[geckoId].usd, currency: "USD" });
+      try {
+        const quote = await yahooFinance.quote(symbol);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const q = quote as any;
+        if (q.regularMarketPrice) {
+          results.set(symbol, {
+            price: q.regularMarketPrice,
+            currency: q.currency || "USD",
+          });
+        }
+      } catch {
+        console.error(`Yahoo Finance: failed to fetch crypto price for ${symbol}`);
       }
     }
   } catch (error) {
-    console.error("Failed to fetch crypto prices:", error);
+    console.error("Yahoo Finance crypto fetch failed:", error);
+  }
+
+  // Fallback: Use CoinGecko for any symbols not found via Yahoo Finance
+  const missing = symbols.filter((s) => !results.has(s));
+  if (missing.length > 0) {
+    const symbolMap = missing.map((s) => {
+      const base = stripCurrencySuffix(s);
+      const geckoId = COINGECKO_IDS[base] || base.toLowerCase();
+      return { original: s, base, geckoId };
+    });
+
+    const ids = symbolMap.map((s) => s.geckoId).filter(Boolean);
+    if (ids.length > 0) {
+      try {
+        const res = await fetch(
+          `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=usd`,
+          { cache: "no-store" }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          for (const { original, geckoId } of symbolMap) {
+            if (data[geckoId]?.usd) {
+              results.set(original, { price: data[geckoId].usd, currency: "USD" });
+            }
+          }
+        }
+      } catch (error) {
+        console.error("CoinGecko fallback failed:", error);
+      }
+    }
   }
 
   return results;


### PR DESCRIPTION
## Changes
- Crypto quantity now supports up to 7 decimal places for better precision.
- Fixed crypto price fetching:
  - Yahoo Finance is now the primary source for crypto prices (handling symbols like BTC-USD).
  - CoinGecko is used as a fallback if Yahoo Finance fails.
- Added Holding Edit functionality:
  - New EditHoldingDialog component to modify quantity, name, and asset type.
  - Interactive Edit button in the holdings dropdown menu.