### PR TITLE
Fix: allow dev server network access

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"


### PR DESCRIPTION
Binds the Next.js dev server to 0.0.0.0 to enable access from other devices in the local network and via Tailscale.