### PR TITLE
Dark mode refinement, performance, mobile nav auto-hide, and chart fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,40 +89,40 @@
 }
 
 .dark {
-  --background: oklch(0.12 0.015 260); /* Very dark sleek violet/slate */
-  --foreground: oklch(0.96 0.005 260);
-  --card: oklch(0.15 0.015 260);
-  --card-foreground: oklch(0.96 0.005 260);
-  --popover: oklch(0.15 0.015 260);
-  --popover-foreground: oklch(0.96 0.005 260);
-  --primary: oklch(0.65 0.18 150); /* Glowing Emerald */
-  --primary-foreground: oklch(0.1 0.02 150);
-  --secondary: oklch(0.2 0.02 260);
-  --secondary-foreground: oklch(0.96 0.005 260);
-  --muted: oklch(0.2 0.02 260);
-  --muted-foreground: oklch(0.7 0.02 260);
-  --accent: oklch(0.2 0.02 260);
-  --accent-foreground: oklch(0.96 0.005 260);
-  --destructive: oklch(0.55 0.18 20);
+  --background: oklch(0.10 0.020 265); /* Deep cool slate-indigo */
+  --foreground: oklch(0.95 0.008 255);
+  --card: oklch(0.155 0.022 262); /* Visibly elevated above background */
+  --card-foreground: oklch(0.95 0.008 255);
+  --popover: oklch(0.17 0.022 262);
+  --popover-foreground: oklch(0.95 0.008 255);
+  --primary: oklch(0.68 0.21 150); /* Vivid glowing emerald */
+  --primary-foreground: oklch(0.08 0.025 150);
+  --secondary: oklch(0.20 0.028 262);
+  --secondary-foreground: oklch(0.92 0.008 255);
+  --muted: oklch(0.19 0.026 262);
+  --muted-foreground: oklch(0.62 0.028 258); /* More readable mid-tone */
+  --accent: oklch(0.22 0.030 262);
+  --accent-foreground: oklch(0.95 0.008 255);
+  --destructive: oklch(0.58 0.20 22);
   --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.22 0.02 260);
-  --input: oklch(0.22 0.02 260);
-  --ring: oklch(0.65 0.18 150);
-  
-  --chart-1: oklch(0.65 0.18 150);
-  --chart-2: oklch(0.7 0.14 210);
-  --chart-3: oklch(0.65 0.17 260);
-  --chart-4: oklch(0.75 0.17 300);
-  --chart-5: oklch(0.85 0.12 330);
-  
-  --sidebar: oklch(0.12 0.015 260);
-  --sidebar-foreground: oklch(0.96 0.005 260);
-  --sidebar-primary: oklch(0.65 0.18 150);
-  --sidebar-primary-foreground: oklch(0.1 0.02 150);
-  --sidebar-accent: oklch(0.18 0.02 260);
-  --sidebar-accent-foreground: oklch(0.96 0.005 260);
-  --sidebar-border: oklch(0.22 0.02 260);
-  --sidebar-ring: oklch(0.65 0.18 150);
+  --border: oklch(0.26 0.028 262); /* More visible, still subtle */
+  --input: oklch(0.21 0.025 262);
+  --ring: oklch(0.68 0.21 150);
+
+  --chart-1: oklch(0.70 0.21 150); /* Vivid emerald */
+  --chart-2: oklch(0.72 0.17 210); /* Electric cyan */
+  --chart-3: oklch(0.67 0.20 262); /* Rich indigo */
+  --chart-4: oklch(0.76 0.20 300); /* Vivid violet */
+  --chart-5: oklch(0.82 0.15 330); /* Soft pink */
+
+  --sidebar: oklch(0.10 0.020 265);
+  --sidebar-foreground: oklch(0.95 0.008 255);
+  --sidebar-primary: oklch(0.68 0.21 150);
+  --sidebar-primary-foreground: oklch(0.08 0.025 150);
+  --sidebar-accent: oklch(0.19 0.026 262);
+  --sidebar-accent-foreground: oklch(0.92 0.008 255);
+  --sidebar-border: oklch(0.24 0.025 262);
+  --sidebar-ring: oklch(0.68 0.21 150);
 }
 
 @layer base {
@@ -130,8 +130,19 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-background via-background to-muted/20 min-h-screen text-base;
+    @apply bg-background text-foreground min-h-screen text-base;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  }
+  /* Static ambient gradients — no runtime color computation */
+  :root body {
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% -10%, oklch(0.6 0.16 150 / 0.06), transparent),
+      radial-gradient(ellipse 60% 40% at 100% 80%, oklch(0.6 0.15 260 / 0.04), transparent);
+  }
+  .dark body {
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% -10%, oklch(0.68 0.21 150 / 0.08), transparent),
+      radial-gradient(ellipse 60% 40% at 100% 80%, oklch(0.67 0.20 262 / 0.06), transparent);
   }
   html {
     @apply font-sans scroll-smooth;
@@ -140,14 +151,18 @@
 
 /* Premium utilities */
 @layer utilities {
+  /* .glass is intentionally blur-free for static layout elements.
+     Fixed/sticky overlays (sidebar, mobile header, mobile nav) apply backdrop-blur inline. */
   .glass {
-    @apply bg-background/60 backdrop-blur-xl border border-border/50 shadow-sm dark:bg-background/40;
+    @apply bg-background/80 border border-border/50 shadow-sm
+           dark:bg-card/80 dark:border-border/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)];
   }
   .card-gradient {
     @apply relative overflow-hidden;
   }
   .card-gradient::after {
     content: "";
-    @apply absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-transparent pointer-events-none;
+    @apply absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-transparent pointer-events-none
+           dark:from-primary/8 dark:to-chart-3/5;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default async function DashboardPage() {
       </div>
       
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-slide-in-bottom delay-200 duration-500">
-        <div className="glass rounded-xl p-1 card-gradient transition-all hover:shadow-lg">
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
           <TrendChart
             baseCurrency={baseCurrency}
             snapshots={snapshots.map((s) => ({
@@ -58,12 +58,12 @@ export default async function DashboardPage() {
             }))}
           />
         </div>
-        <div className="glass rounded-xl p-1 card-gradient transition-all hover:shadow-lg">
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
           <AllocationChart summary={summary} />
         </div>
       </div>
-      
-      <div className="animate-slide-in-bottom delay-300 duration-500 glass rounded-xl p-1 card-gradient transition-all hover:shadow-lg">
+
+      <div className="animate-slide-in-bottom delay-300 duration-500 bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
         <AccountsSummary summary={summary} />
       </div>
     </div>

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import type { NetWorthSummary } from "@/lib/types";
@@ -22,6 +23,9 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const assetAccounts = summary.accounts.filter((a) => a.type === "ASSET");
 
   const categoryMap = new Map<string, number>();
@@ -51,6 +55,8 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
             No assets to display.
           </div>
+        ) : !mounted ? (
+          <div className="h-[250px]" />
         ) : (
           <ResponsiveContainer width="100%" height={250}>
             <PieChart>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   LineChart,
@@ -31,6 +31,8 @@ const ranges = [
 
 export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: SnapshotData[]; baseCurrency?: string }) {
   const [range, setRange] = useState("All");
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
   const cutoff = new Date();
@@ -66,6 +68,8 @@ export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: Sna
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
             No snapshot data yet. Add accounts and take a snapshot.
           </div>
+        ) : !mounted ? (
+          <div className="h-[250px]" />
         ) : (
           <ResponsiveContainer width="100%" height={250}>
             <AreaChart data={filtered}>
@@ -99,8 +103,8 @@ export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: Sna
               <Area
                 type="monotone"
                 dataKey="netWorth"
-                stroke="hsl(var(--primary))"
-                fill="hsl(var(--primary))"
+                stroke="var(--primary)"
+                fill="var(--primary)"
                 fillOpacity={0.1}
                 strokeWidth={2}
                 name="Net Worth"

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -4,7 +4,7 @@ import { ThemeToggle } from "./theme-toggle";
 
 export function MobileHeader() {
   return (
-    <header className="md:hidden sticky top-0 left-0 right-0 z-50 glass border-b border-border/50 bg-background/60 backdrop-blur-xl px-4 py-3 flex items-center justify-between">
+    <header className="md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between">
       <div className="flex flex-col">
         <h1 className="text-lg font-bold tracking-tight bg-gradient-to-br from-primary to-chart-3 bg-clip-text text-transparent">
           Asset Tracker

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Copy, LayoutDashboard, Settings } from "lucide-react";
 import { motion } from "framer-motion";
@@ -29,7 +30,7 @@ export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="hidden md:flex w-64 flex-col border-r bg-sidebar/50 backdrop-blur-xl text-sidebar-foreground glass z-10 shrink-0">
+    <aside className="hidden md:flex w-64 flex-col border-r bg-sidebar/80 backdrop-blur-md text-sidebar-foreground glass z-10 shrink-0">
       <div className="p-6">
         <h1 className="text-xl font-bold tracking-tight bg-gradient-to-br from-primary to-chart-3 bg-clip-text text-transparent">Asset Tracker</h1>
         <p className="text-sm text-muted-foreground mt-1 font-medium">Net Worth Dashboard</p>
@@ -81,9 +82,51 @@ export function Sidebar() {
 
 export function MobileNav() {
   const pathname = usePathname();
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const main = document.querySelector("main");
+    let lastY = 0;
+    let touchStartY = 0;
+
+    // Read scroll position from whichever container is actually scrolling.
+    // On most browsers main scrolls; on iOS Safari the viewport may scroll instead.
+    const getScrollY = () => Math.max(main?.scrollTop ?? 0, window.scrollY);
+
+    const onScroll = () => {
+      const y = getScrollY();
+      if (y > lastY && y > 64) setHidden(true);
+      else if (y < lastY) setHidden(false);
+      lastY = y;
+    };
+
+    // Touch direction — fallback for browsers that throttle scroll events
+    const onTouchStart = (e: TouchEvent) => {
+      touchStartY = e.touches[0].clientY;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const delta = touchStartY - e.touches[0].clientY;
+      if (delta > 10) setHidden(true);
+      else if (delta < -10) setHidden(false);
+    };
+
+    main?.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    return () => {
+      main?.removeEventListener("scroll", onScroll);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+    };
+  }, []);
 
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 glass border-t border-border/50 flex justify-around py-3 pb-safe">
+    <nav className={cn(
+      "md:hidden fixed bottom-0 left-0 right-0 z-50 glass backdrop-blur-md border-t border-border/50 flex justify-around py-3 pb-safe transition-transform duration-300 ease-in-out",
+      hidden && "translate-y-full"
+    )}>
       {navItems.map((item) => {
         const isActive =
           item.href === "/"


### PR DESCRIPTION
## Summary

- **Dark mode redesign**: deeper background (`oklch(0.10)`), more chromatic card surfaces, vivid emerald primary and chart colors, better border visibility and muted foreground contrast
- **Render performance**: removed `backdrop-blur` from static layout cards (was firing on 3 cards with nothing to blur behind them); fixed double-blur on sidebar and mobile header; replaced `transition-all` with `transition-shadow` on dashboard cards; static body gradient values instead of runtime CSS relative color syntax
- **Mobile nav auto-hide**: bottom tab slides off on scroll down, reappears on scroll up; uses `Math.max(main.scrollTop, window.scrollY)` to handle iOS Safari's viewport scroll fallback; fixes previous bug where `window` scroll event fired with `scrollY=0` and immediately reverted the hide
- **Chart rendering on intranet**: `ResponsiveContainer` was measuring 0-width during SSR hydration — fixed with a mount guard so charts render only after the DOM has layout; also fixed `hsl(var(--primary))` → `var(--primary)` in TrendChart (oklch CSS vars cannot be nested inside `hsl()`)

## Test plan

- [ ] Dark mode looks richer with better depth and contrast vs light mode
- [ ] No visible blur on dashboard cards; sidebar/mobile header still have blur
- [ ] Mobile bottom nav hides when scrolling down, reappears on scroll up — on both localhost and intranet URL
- [ ] Charts render correctly on first load from intranet (no HMR needed)
- [ ] TrendChart line uses the correct emerald color in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)