### PR TITLE
perf: optimize dashboard loading for better FCP/LCP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    optimizePackageImports: ["recharts", "lucide-react", "date-fns"],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
-        "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.2",
         "next-auth": "^5.0.0-beta.30",
@@ -6574,33 +6573,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -8545,21 +8517,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.36.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",
     "next-auth": "^5.0.0-beta.30",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -11,10 +11,7 @@ export default function MainLayout({
       <Sidebar />
       <main className="flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full">
         <MobileHeader />
-        {/* Subtle background decoration */}
-        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-primary/5 blur-3xl pointer-events-none -z-10" />
-        <div className="absolute top-[20%] right-[-5%] w-[30%] h-[30%] rounded-full bg-chart-4/5 blur-3xl pointer-events-none -z-10" />
-        <div className="mx-auto w-full max-w-6xl p-4 md:p-6 relative z-0">{children}</div>
+        <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
       </main>
       <MobileNav />
     </>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,20 +1,16 @@
+import { Suspense } from "react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { NetWorthCard } from "@/components/dashboard/net-worth-card";
-import { TrendChart } from "@/components/dashboard/trend-chart";
-import { AllocationChart } from "@/components/dashboard/allocation-chart";
-import { AccountsSummary } from "@/components/dashboard/accounts-summary";
-import { DashboardActions } from "@/components/dashboard/dashboard-actions";
-import { getNetWorthSummary } from "@/lib/services/net-worth-service";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
 
-export const revalidate = 60; // Cache page for 60s instead of force-dynamic
+export const revalidate = 60;
 
 export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
 
-  // Parallel: check user exists + load settings at the same time
   const [dbUser, settings] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     prisma.setting.findUnique({ where: { userId } }),
@@ -27,68 +23,21 @@ export default async function DashboardPage() {
 
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
-  // If settings doesn't exist yet, create it (non-blocking for the main flow)
   if (!settings) {
-    // Fire and forget — don't block the render
     prisma.setting.create({ data: { userId, baseCurrency: "USD" } }).catch(() => {});
   }
 
-  // Parallel: fetch all heavy data at once
-  const [summary, snapshots, latestPrice] = await Promise.all([
-    getNetWorthSummary(userId, baseCurrency),
-    prisma.netWorthSnapshot.findMany({
-      where: { userId, baseCurrency },
-      orderBy: { date: "asc" },
-    }),
-    prisma.priceCache.findFirst({
-      orderBy: { updatedAt: "desc" },
-      select: { updatedAt: true },
-    }),
-  ]);
-
-  // Get latest snapshot date
-  const latestSnapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
-
   return (
-    <div className="space-y-8 animate-fade-in">
+    <div className="space-y-8">
       <div className="flex items-center justify-between mb-2">
-        <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent animate-slide-in-bottom">
+        <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
           Dashboard
         </h2>
       </div>
 
-      <div className="animate-slide-in-bottom delay-50">
-        <DashboardActions
-          baseCurrency={baseCurrency}
-          lastPriceUpdate={latestPrice?.updatedAt?.toISOString() ?? null}
-          lastSnapshotDate={latestSnapshot?.date?.toISOString() ?? null}
-        />
-      </div>
-      
-      <div className="animate-slide-in-bottom delay-100">
-        <NetWorthCard summary={summary} />
-      </div>
-      
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-slide-in-bottom delay-200 duration-500">
-        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
-          <TrendChart
-            baseCurrency={baseCurrency}
-            snapshots={snapshots.map((s) => ({
-              date: s.date.toISOString().split("T")[0],
-              netWorth: Number(s.netWorth),
-              totalAssets: Number(s.totalAssets),
-              totalLiabilities: Number(s.totalLiabilities),
-            }))}
-          />
-        </div>
-        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
-          <AllocationChart summary={summary} />
-        </div>
-      </div>
-
-      <div className="animate-slide-in-bottom delay-300 duration-500 bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
-        <AccountsSummary summary={summary} />
-      </div>
+      <Suspense fallback={<DashboardSkeleton />}>
+        <DashboardContent userId={userId} baseCurrency={baseCurrency} />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,61 @@
+import { prisma } from "@/lib/prisma";
+import { NetWorthCard } from "@/components/dashboard/net-worth-card";
+import { LazyTrendChart, LazyAllocationChart } from "@/components/dashboard/lazy-charts";
+import { AccountsSummary } from "@/components/dashboard/accounts-summary";
+import { DashboardActions } from "@/components/dashboard/dashboard-actions";
+import { getNetWorthSummary } from "@/lib/services/net-worth-service";
+
+export async function DashboardContent({
+  userId,
+  baseCurrency,
+}: {
+  userId: string;
+  baseCurrency: string;
+}) {
+  const [summary, snapshots, latestPrice] = await Promise.all([
+    getNetWorthSummary(userId, baseCurrency),
+    prisma.netWorthSnapshot.findMany({
+      where: { userId, baseCurrency },
+      orderBy: { date: "asc" },
+    }),
+    prisma.priceCache.findFirst({
+      orderBy: { updatedAt: "desc" },
+      select: { updatedAt: true },
+    }),
+  ]);
+
+  const latestSnapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
+
+  return (
+    <>
+      <DashboardActions
+        baseCurrency={baseCurrency}
+        lastPriceUpdate={latestPrice?.updatedAt?.toISOString() ?? null}
+        lastSnapshotDate={latestSnapshot?.date?.toISOString() ?? null}
+      />
+
+      <NetWorthCard summary={summary} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+          <LazyTrendChart
+            baseCurrency={baseCurrency}
+            snapshots={snapshots.map((s) => ({
+              date: s.date.toISOString().split("T")[0],
+              netWorth: Number(s.netWorth),
+              totalAssets: Number(s.totalAssets),
+              totalLiabilities: Number(s.totalLiabilities),
+            }))}
+          />
+        </div>
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+          <LazyAllocationChart summary={summary} />
+        </div>
+      </div>
+
+      <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+        <AccountsSummary summary={summary} />
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export function DashboardSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between mb-2">
+        <div className="h-9 w-48 bg-muted animate-pulse rounded-lg" />
+      </div>
+
+      {/* Actions skeleton */}
+      <div className="h-10 w-full bg-muted animate-pulse rounded-lg" />
+
+      {/* Net Worth Cards skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i}>
+            <CardContent className="pt-6">
+              <div className="h-4 w-24 bg-muted animate-pulse rounded mb-2" />
+              <div className="h-8 w-36 bg-muted animate-pulse rounded" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Charts skeleton */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {[...Array(2)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <div className="h-5 w-32 bg-muted animate-pulse rounded" />
+            </CardHeader>
+            <CardContent>
+              <div className="h-[250px] bg-muted animate-pulse rounded" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Accounts summary skeleton */}
+      <Card>
+        <CardHeader>
+          <div className="h-5 w-40 bg-muted animate-pulse rounded" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+function ChartSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="h-5 w-32 bg-muted animate-pulse rounded" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-[250px] bg-muted animate-pulse rounded" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export const LazyTrendChart = dynamic(
+  () => import("./trend-chart").then((m) => m.TrendChart),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+export const LazyAllocationChart = dynamic(
+  () => import("./allocation-chart").then((m) => m.AllocationChart),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -66,7 +66,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: Sna
       <CardContent>
         {filtered.length === 0 ? (
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
-            No snapshot data yet. Add accounts and take a snapshot.
+            No data to display yet. Add accounts and your net worth will be tracked automatically at midnight (UTC+8).
           </div>
         ) : !mounted ? (
           <div className="h-[250px]" />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Copy, LayoutDashboard, Settings } from "lucide-react";
-import { motion } from "framer-motion";
 import { ThemeToggle } from "./theme-toggle";
 
 const navItems = [
@@ -47,24 +46,19 @@ export function Sidebar() {
               key={item.href}
               href={item.href}
               className={cn(
-                "group relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-300",
+                "group relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200",
                 isActive
                   ? "text-primary shadow-sm"
                   : "text-sidebar-foreground/70 hover:text-foreground"
               )}
             >
               {isActive && (
-                <motion.div
-                  layoutId="sidebar-active"
-                  className="absolute inset-0 rounded-lg bg-primary/10 border border-primary/20"
-                  transition={{ type: "spring", stiffness: 350, damping: 30 }}
-                />
+                <div className="absolute inset-0 rounded-lg bg-primary/10 border border-primary/20 transition-all duration-200" />
               )}
-              {/* Subtle hover effect for non-active items */}
               {!isActive && (
-                <div className="absolute inset-0 rounded-lg bg-sidebar-accent/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 -z-10" />
+                <div className="absolute inset-0 rounded-lg bg-sidebar-accent/50 opacity-0 group-hover:opacity-100 transition-opacity duration-200 -z-10" />
               )}
-              <Icon className={cn("z-10 h-5 w-5 transition-transform duration-300", isActive ? "scale-110" : "group-hover:scale-110")} />
+              <Icon className={cn("z-10 h-5 w-5 transition-transform duration-200", isActive ? "scale-110" : "group-hover:scale-110")} />
               <span className="z-10">{item.label}</span>
             </Link>
           );
@@ -89,8 +83,6 @@ export function MobileNav() {
     let lastY = 0;
     let touchStartY = 0;
 
-    // Read scroll position from whichever container is actually scrolling.
-    // On most browsers main scrolls; on iOS Safari the viewport may scroll instead.
     const getScrollY = () => Math.max(main?.scrollTop ?? 0, window.scrollY);
 
     const onScroll = () => {
@@ -100,7 +92,6 @@ export function MobileNav() {
       lastY = y;
     };
 
-    // Touch direction — fallback for browsers that throttle scroll events
     const onTouchStart = (e: TouchEvent) => {
       touchStartY = e.touches[0].clientY;
     };
@@ -145,12 +136,9 @@ export function MobileNav() {
             )}
           >
             {isActive && (
-              <motion.div
-                layoutId="mobile-active"
-                className="absolute inset-x-2 -top-3 h-0.5 bg-primary rounded-b-full shadow-[0_2px_8px_rgba(0,0,0,0.5)] shadow-primary/50"
-              />
+              <div className="absolute inset-x-2 -top-3 h-0.5 bg-primary rounded-b-full shadow-[0_2px_8px_rgba(0,0,0,0.5)] shadow-primary/50 transition-all duration-200" />
             )}
-            <Icon className={cn("h-5 w-5 transition-transform duration-300", isActive ? "scale-110" : "group-hover:scale-110")} />
+            <Icon className={cn("h-5 w-5 transition-transform duration-200", isActive ? "scale-110" : "group-hover:scale-110")} />
             <span>{item.label}</span>
           </Link>
         );


### PR DESCRIPTION
## Summary
- Add `<Suspense>` boundaries with skeleton fallbacks so the dashboard shell streams immediately while data loads
- Lazy-load Recharts via `next/dynamic` with `ssr: false` to defer heavy chart JS from the initial bundle
- Remove `framer-motion` (~5MB) — replaced sidebar/nav animations with CSS transitions
- Remove expensive `blur-3xl` decorative elements and staggered entry animations that block LCP
- Add `optimizePackageImports` in `next.config.ts` for recharts, lucide-react, date-fns
- Update trend chart empty state text to reflect automatic midnight snapshots

## Test plan
- [ ] Verify dashboard loads with skeleton → content streaming transition
- [ ] Verify charts render correctly after lazy load
- [ ] Verify sidebar active indicator and mobile nav still animate smoothly (CSS-only)
- [ ] Verify no visual regressions on login, accounts, and settings pages
- [ ] Check Speed Insights score after deploy (target: FCP <1.5s, LCP <3s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)