### PR TITLE
Refactor: Extract i18n configuration to dedicated config module

### DIFF
--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -14,7 +14,7 @@ import {
 import { CURRENCIES } from "@/lib/currencies";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
-import { SUPPORTED_LOCALES, type Locale } from "@/i18n/request";
+import { SUPPORTED_LOCALES, type Locale } from "@/i18n/config";
 
 export function SettingsForm({
   currentCurrency,

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,3 @@
+export const SUPPORTED_LOCALES = ["en-US", "zh-TW"] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = "en-US";

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,9 +1,8 @@
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
+import { SUPPORTED_LOCALES, DEFAULT_LOCALE, type Locale } from "./config";
 
-export const SUPPORTED_LOCALES = ["en-US", "zh-TW"] as const;
-export type Locale = (typeof SUPPORTED_LOCALES)[number];
-export const DEFAULT_LOCALE: Locale = "en-US";
+export { SUPPORTED_LOCALES, DEFAULT_LOCALE, type Locale };
 
 function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
   const lower = acceptLanguage.toLowerCase();


### PR DESCRIPTION
## Summary
Extracted i18n locale configuration into a dedicated `config.ts` module to improve code organization and reduce circular dependencies.

## Key Changes
- Created new `src/i18n/config.ts` module containing:
  - `SUPPORTED_LOCALES` constant
  - `Locale` type definition
  - `DEFAULT_LOCALE` constant
- Updated `src/i18n/request.ts` to import and re-export from the new config module instead of defining these locally
- Updated `src/components/settings/settings-form.tsx` to import locale types from `@/i18n/config` instead of `@/i18n/request`

## Benefits
- **Better separation of concerns**: Configuration is now isolated from request handling logic
- **Reduced coupling**: Components can import locale types without depending on request utilities
- **Improved maintainability**: Single source of truth for i18n configuration

https://claude.ai/code/session_01EuY4uSxYT7DvKTwbUxvZcA