### PR TITLE
perf: split i18n messages per route to reduce HTML payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ npm run start        # Start production server
 npm run lint         # Run ESLint
 
 # Database
-npx prisma generate  # Regenerate Prisma client
+npx prisma generate  # Regenerate Prisma client after schema changes
 npx prisma db push   # Push schema to database (dev)
 npx prisma studio    # Open Prisma Studio GUI
 ```
@@ -54,12 +54,16 @@ src/app/
 ├── login/page.tsx          # Public login page
 ├── (main)/                 # Auth-gated route group
 │   ├── layout.tsx          # Sidebar + mobile header shell
-│   ├── page.tsx            # Dashboard (revalidate: 60s)
+│   ├── page.tsx            # Dashboard
+│   ├── accounts/page.tsx   # Accounts list
 │   ├── accounts/[id]/      # Account detail page
 │   └── settings/           # User settings
 └── api/
     ├── auth/[...nextauth]/ # NextAuth handlers
-    ├── accounts/           # CRUD for accounts + holdings + transactions
+    ├── accounts/           # CRUD for accounts
+    ├── accounts/[id]/holdings/          # Holdings CRUD
+    ├── accounts/[id]/transactions/      # HoldingTransaction CRUD
+    ├── accounts/[id]/cash-transactions/ # CashTransaction CRUD
     ├── exchange-rates/     # Fetch + refresh exchange rates
     ├── prices/refresh/     # Manual price refresh trigger
     ├── snapshots/          # Net worth snapshot history
@@ -67,6 +71,11 @@ src/app/
     ├── settings/           # User settings API
     └── cron/snapshot/      # Daily cron job (requires CRON_SECRET bearer token)
 ```
+
+### Next.js 16 Breaking Changes
+
+- **`params` is a `Promise`** — page components receive `params: Promise<{ id: string }>` and must `await params` before accessing fields.
+- Read `node_modules/next/dist/docs/` for any Next.js APIs before using them — many APIs changed from earlier versions.
 
 ### Auth Architecture (Split Config Pattern)
 
@@ -77,6 +86,8 @@ NextAuth v5 requires two files to avoid loading Node.js-only modules in Edge mid
 - `src/middleware.ts` — Uses `auth.config.ts` to protect all routes except `/login` and `/api/auth/*`
 
 The `session.user.id` is populated from `token.sub` in the JWT callback.
+
+In RSC/pages, always get the session via `getSession()` from `src/lib/auth-session.ts` — it wraps `auth()` in React `cache()` to deduplicate the JWT decode per render.
 
 ### RSC → Client Component Serialization
 
@@ -89,6 +100,27 @@ Prisma models contain `Decimal` and `Date` objects which cannot be passed direct
 **Do not spread Prisma model instances** — Decimal/Date fields won't strip properly. Use the explicit serializers which reconstruct plain objects field-by-field.
 
 In-app calculation types build on these: `HoldingWithPrice`, `AccountWithValue`, `NetWorthSummary`.
+
+### Database (Neon Serverless)
+
+`src/lib/prisma.ts` uses `PrismaNeon` adapter (`@prisma/adapter-neon`) with WebSocket support via the `ws` package. The `DATABASE_URL` must be a Neon PostgreSQL connection string. The client is singleton-cached in `globalThis` for dev hot-reload safety.
+
+### i18n (next-intl)
+
+Supported locales: `en-US` (default), `zh-TW`. Message files live in `messages/`. Locale is resolved from:
+1. `NEXT_LOCALE` cookie (set by settings UI)
+2. `Accept-Language` request header
+
+In RSC/pages: `const t = await getTranslations("namespace")` from `next-intl/server`.  
+Config entry point: `src/i18n/request.ts` (loaded by `next.config.ts` via `createNextIntlPlugin`).
+
+### Currency Utilities (`src/lib/currencies.ts`)
+
+- `CURRENCIES` — static list of supported currencies with code/name/symbol
+- `formatCurrency(amount, currencyCode, compact?)` — Intl-formatted currency string
+- `formatNumber(amount, decimals?)` — Intl-formatted number
+- `getCurrencySymbol(code)` — symbol lookup
+- `getLocaleDefaultCurrency(locale)` — returns `"TWD"` for `zh-TW`, otherwise `"USD"`
 
 ### Price & Exchange Rate Pipeline
 
@@ -111,6 +143,17 @@ In-app calculation types build on these: `HoldingWithPrice`, `AccountWithValue`,
 
 `GET /api/cron/snapshot` — requires `Authorization: Bearer <CRON_SECRET>` header. Refreshes all prices, then creates `NetWorthSnapshot` records for every user. Intended to be called by a scheduler (e.g., Vercel Cron).
 
+### Component Organization
+
+```
+src/components/
+├── ui/           # shadcn/ui primitives (button, dialog, table, etc.)
+├── accounts/     # Account detail, holding form, transaction history, inline editors
+├── dashboard/    # Net worth card, allocation chart, trend chart, accounts summary
+├── layout/       # Sidebar, mobile header, theme provider/toggle
+└── settings/     # Settings form
+```
+
 ### Key Conventions
 
 - Use `@/*` path alias for all imports from `src/`
@@ -120,6 +163,7 @@ In-app calculation types build on these: `HoldingWithPrice`, `AccountWithValue`,
 - Add shadcn/ui components via `npx shadcn@latest add <component>`
 - Zod 4 schemas live in `@/lib/validators.ts`
 - Prisma schema: `prisma/schema.prisma`; generated client: `src/generated/prisma/` (gitignored)
+- i18n strings go in `messages/en-US.json` and `messages/zh-TW.json`
 
 ### Required Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,53 @@
 # 💰 Asset Tracker
 
-A modern, high-performance, and visually stunning net worth and investment tracker. Built with **Next.js 16**, **Prisma**, and **Tailwind CSS**.
+A modern, high-performance net worth and investment tracker. Built with **Next.js 16**, **Prisma**, and **Tailwind CSS**.
 
 ![Dashboard Mockup](https://images.unsplash.com/photo-1611974714013-3c8c0d088bd3?auto=format&fit=crop&q=80&w=1200&h=400)
 
 ## ✨ Features
 
-- **🚀 Real-time Tracking**: Automatically fetch latest prices for Stocks, ETFs, and Cryptocurrencies (via Yahoo Finance).
+- **🔐 Google OAuth**: Secure multi-user authentication via NextAuth.js v5.
+- **🚀 Real-time Tracking**: Automatically fetch latest prices for Stocks, ETFs, and Cryptocurrencies (via Yahoo Finance + CoinGecko fallback).
 - **🌍 Multi-Currency Support**: Track assets in USD, TWD, EUR, and more. All values are automatically converted to your selected **Base Currency**.
 - **📈 Trend Visualization**: Interactive charts showing your net worth, assets, and liabilities over time.
 - **🤖 Automated Snapshots**: Built-in Vercel Cron integration to automatically record your net worth daily.
-- **🌗 Cyber-Glassmorphism UI**: Beautiful, premium design with full support for Light, Dark, and System modes.
-- **💼 Unified Portfolio**: Combine bank accounts, brokerages, and crypto wallets into one single dashboard.
+- **🌗 Light / Dark / System Theme**: Full theme support with smooth toggle.
+- **💼 Unified Portfolio**: Combine bank accounts, brokerages, and crypto wallets into one dashboard.
+- **🌐 Internationalization**: English (en-US) and Traditional Chinese (zh-TW), auto-detected from browser.
 
 ## 🛠️ Tech Stack
 
-- **Framework**: Next.js 16 (App Router)
-- **Database**: PostgreSQL (via Prisma ORM)
-- **Styling**: Tailwind CSS 4
-- **Animations**: Framer Motion
+- **Framework**: Next.js 16 (App Router, React Server Components)
+- **Database**: PostgreSQL via Prisma 7 (Neon serverless adapter)
+- **Auth**: NextAuth.js v5 (Google OAuth, JWT sessions)
+- **Styling**: Tailwind CSS 4 + shadcn/ui v4
+- **i18n**: next-intl
 - **Icons**: Lucide React
 - **Charts**: Recharts
+- **Validation**: Zod 4
 
 ## 🚀 Getting Started
 
 ### 1. Prerequisites
 
 - Node.js 18+
-- A PostgreSQL database (e.g., Neon, Supabase, or Prisma Postgres)
+- A [Neon](https://neon.tech) PostgreSQL database (or any PostgreSQL with a Neon-compatible connection string)
+- A Google OAuth app (for authentication)
 
 ### 2. Environment Variables
 
 Create a `.env` file in the root directory:
 
 ```env
-DATABASE_URL="your_postgresql_connection_string"
+DATABASE_URL="your_neon_postgresql_connection_string"
+AUTH_SECRET="your_secure_random_string"
+AUTH_GOOGLE_ID="your_google_oauth_client_id"
+AUTH_GOOGLE_SECRET="your_google_oauth_client_secret"
 CRON_SECRET="your_secure_random_string"
 ```
 
 > [!TIP]
-> You can generate a random `CRON_SECRET` using `openssl rand -base64 32`.
+> Generate `AUTH_SECRET` and `CRON_SECRET` with `openssl rand -base64 32`.
 
 ### 3. Installation
 
@@ -55,7 +63,7 @@ npx prisma db push
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your dashboard!
+Open [http://localhost:3000](http://localhost:3000) to see your dashboard.
 
 ## 🤖 Automated Snapshots (Cron Jobs)
 
@@ -65,11 +73,11 @@ This project is optimized for **Vercel** and includes native Cron Job support vi
 - **Schedule**: Every day at 00:00 UTC.
 - **Security**: Protected via `CRON_SECRET` header verification.
 
-To enable automation, deploy to Vercel and ensure the `CRON_SECRET` environment variable is set in your project settings.
+To enable automation, deploy to Vercel and set all environment variables in your project settings.
 
 ## 📝 Roadmap
 
-Check the [SUGGESTIONS.md](./SUGGESTIONS.md) file for our prioritized feature roadmap, including cost basis tracking, performance reports, and data migration.
+Check the [SUGGESTIONS.md](./SUGGESTIONS.md) file for the prioritized feature roadmap.
 
 ## 📄 License
 

--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -7,16 +7,19 @@
 | 1 | Fix hardcoded USD in trend chart tooltip | Bug Fix | 🔴 High | 10 min | ✅ Done |
 | 2 | Deduplicate balance editor into `<InlineBalanceEditor>` | Code Quality | 🟡 Medium | 30 min | ✅ Done |
 | 3 | Remove test-rate API route | Cleanup | 🟢 Low | 5 min | ✅ Done |
-| 4 | Dashboard "Refresh Prices" button (Snapshot moved to Settings) | Feature | 🔴 High | 1-2 hrs | ✅ Done |
+| 4 | Dashboard "Refresh Prices" button | Feature | 🔴 High | 1-2 hrs | ✅ Done |
 | 5 | "Last Updated" timestamp for prices on dashboard | Feature | 🔴 High | 1-2 hrs | ✅ Done |
 | 6 | Dark/Light/System theme toggle | Feature | 🟡 Medium | 1-2 hrs | ✅ Done |
+| 8 | Authentication & multi-user support | Feature | 🔴 High | 6-10 hrs | ✅ Done |
+| 10 | Error handling & loading states | Architecture | 🟡 Medium | 3-4 hrs | ✅ Done |
+| 11 | Fix N+1 query patterns | Architecture | 🟡 Medium | 3-5 hrs | ✅ Done |
+| 12 | Input validation on API routes | Architecture | 🟡 Medium | 2-3 hrs | ✅ Done |
 | 18 | Automated Daily Snapshots (Cron) | Feature | 🔴 High | 1-2 hrs | ✅ Done |
+| 19 | Internationalization (en-US / zh-TW) | Feature | 🟡 Medium | 3-4 hrs | ✅ Done |
+| 20 | Inline account name editing | UX | 🟡 Medium | 1-2 hrs | ✅ Done |
+| 21 | Holding & cash transaction history | Feature | 🔴 High | 3-4 hrs | ✅ Done |
 | 7 | Cost basis & gain/loss tracking | Feature | 🔴 High | 4-6 hrs | ❌ Not Done |
-| 8 | Authentication & multi-user support | Feature | 🔴 High | 6-10 hrs | ❌ Not Done |
 | 9 | Data import/export | Feature | 🔴 High | 4-6 hrs | ❌ Not Done |
-| 10 | Error handling & loading states | Architecture | 🟡 Medium | 3-4 hrs | ❌ Not Done |
-| 11 | Fix N+1 query patterns | Architecture | 🟡 Medium | 3-5 hrs | ❌ Not Done |
-| 12 | Input validation on API routes | Architecture | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 | 13 | Account reordering & archiving | UX | 🟡 Medium | 3-4 hrs | ❌ Not Done |
 | 14 | Mobile-responsive holdings table | UX | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 | 15 | Monthly/yearly performance reports | Analytics | 🟡 Medium | 4-5 hrs | ❌ Not Done |
@@ -28,77 +31,49 @@
 ## Details (Pending Tasks)
 
 ### 7. Cost Basis & Gain/Loss Tracking
-BUY/SELL transactions exist but have no `price` field. Without cost basis, users can't see profit/loss per holding.
+BUY/SELL transactions exist and are recorded, but have no `price` field — so cost basis can't be computed.
 
 - Add a `price` (Decimal) column to `HoldingTransaction` to record purchase/sale price
 - Compute **average cost basis**, **unrealized P&L**, and **total return %** per holding
 - Display gain/loss with green/red coloring on the account detail page
 
-### 8. Authentication & Multi-User Support
-No auth — anyone who can reach the URL owns all the data. Fine for local use, risky if deployed.
-
-- Add NextAuth.js (or Clerk) for authentication
-- Add a `userId` foreign key to `Account` and `Setting`
-- Protect all API routes and server components
-
 ### 9. Data Import/Export
-No way to back up data or migrate. One database wipe and everything is gone.
+No way to back up data or migrate between environments.
 
 - **Export:** "Download as CSV/JSON" button on accounts and holdings pages
 - **Import:** CSV import for bulk-adding holdings (e.g. from brokerage statements)
 - Full database backup/restore via JSON dump
 
-### 10. Error Handling & Loading States
-Many client-side fetches have minimal error handling. Server Components use `force-dynamic` everywhere.
-
-- Add Suspense boundaries and loading skeletons for server components
-- Add retry logic or exponential backoff for price/exchange-rate fetches
-- Add an error boundary component
-
-### 11. Fix N+1 Query Patterns
-`fetchStockPrices` loops through symbols one-by-one. `getNetWorthSummary` calls `getExchangeRate()` in a loop, each triggering DB + HTTP requests.
-
-- Batch stock price fetches (Yahoo Finance supports arrays)
-- Pre-load all needed exchange rates in a single query at the start of `getNetWorthSummary()`
-- Add in-memory cache for exchange rates within a single request lifecycle
-
-### 12. Input Validation on API Routes
-Validators file exists (`validators.ts`) but not all API routes consistently validate inputs with Zod.
-
-- Audit all `route.ts` files to ensure they validate request bodies
-- Return proper 400 status codes with descriptive error messages
-- Consider a shared middleware pattern
-
 ### 13. Account Reordering & Archiving
-`isActive` exists on accounts but no UI to archive/unarchive. No way to reorder.
+`isActive` exists on the `Account` model but there is no UI to archive/unarchive. No way to reorder accounts.
 
-- Add an "Archive" option (instead of only hard delete)
+- Add an "Archive" option in the account actions menu (instead of only hard delete)
 - Show archived accounts in a collapsed section
-- Add `sortOrder` field for manual reordering
+- Add `sortOrder` field for manual drag-to-reorder
 
 ### 14. Mobile-Responsive Holdings Table
-The holdings table has 9 columns — cramped on mobile.
+The holdings table has many columns — cramped on mobile.
 
 - Switch to card-based layout on mobile
-- Or make the table horizontally scrollable with sticky first column
-- Consider collapsible rows
+- Or make the table horizontally scrollable with a sticky first column
+- Consider collapsible rows for transaction history
 
 ### 15. Monthly/Yearly Performance Reports
-Trend chart shows raw net worth but doesn't compute period-over-period growth.
+The trend chart shows raw net worth values but doesn't compute period-over-period growth.
 
 - "Performance" view with monthly/yearly % change
 - Bar chart showing month-over-month changes
 - Summary stats: best month, worst month, average growth
 
 ### 16. Currency Exposure Chart
-Multi-currency holdings supported but allocation chart only groups by category, not currency.
+Multi-currency holdings are supported, but the allocation chart only groups by asset category, not currency.
 
-- Add a "Currency Exposure" pie/donut chart on the dashboard
-- Shows what % of net worth is in each currency
+- Add a "Currency Exposure" pie/donut chart to the dashboard
+- Shows what % of net worth is held in each currency
 
 ### 17. Dividend / Income Tracking
 Many stock/ETF holders care about dividend income, not just price appreciation.
 
-- Add a `DIVIDEND` transaction type
+- Add a `DIVIDEND` transaction type to `HoldingTransaction`
 - Track dividend income per holding and aggregate monthly/yearly
-- Display on dashboard as a separate income chart
+- Display as a separate income chart on the dashboard

--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -3,6 +3,11 @@ import { notFound } from "next/navigation";
 import { AccountDetail } from "@/components/accounts/account-detail";
 import { serializeAccountWithHoldings } from "@/lib/types";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "@/lib/services/exchange-rate-service";
+import { getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
+
+const CLIENT_NAMESPACES = ["accountDetail", "common", "categories"];
 
 export default async function AccountDetailPage({
   params,
@@ -11,14 +16,15 @@ export default async function AccountDetailPage({
 }) {
   const { id } = await params;
 
-  // Parallel: load account, cached prices, and exchange rates at once
-  const [account, allRatesMap, cachedPrices] = await Promise.all([
+  // Parallel: load account, cached prices, exchange rates, and messages at once
+  const [account, allRatesMap, cachedPrices, messages] = await Promise.all([
     prisma.account.findUnique({
       where: { id },
       include: { holdings: { where: { quantity: { gt: 0 } } } },
     }),
     getAllExchangeRates(),
     prisma.priceCache.findMany(),
+    getMessages(),
   ]);
 
   if (!account) notFound();
@@ -52,8 +58,10 @@ export default async function AccountDetailPage({
   await resolveMissingRates(missingPairs, ratesMap);
 
   return (
-    <div className="space-y-6">
-      <AccountDetail account={serialized} priceMap={priceMap} ratesMap={ratesMap} />
-    </div>
+    <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
+      <div className="space-y-6">
+        <AccountDetail account={serialized} priceMap={priceMap} ratesMap={ratesMap} />
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -1,16 +1,28 @@
 import { getSession } from "@/lib/auth-session";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
 import { prisma } from "@/lib/prisma";
 import { AccountsList } from "@/components/accounts/accounts-list";
 import { serializeAccountWithHoldings } from "@/lib/types";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "@/lib/services/exchange-rate-service";
 
+const CLIENT_NAMESPACES = [
+  "accountsList",
+  "accountForm",
+  "quickAddHolding",
+  "categories",
+];
+
 export default async function AccountsPage() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
-  const t = await getTranslations("accounts");
+  const [t, messages] = await Promise.all([
+    getTranslations("accounts"),
+    getMessages(),
+  ]);
 
   // Parallel: fetch accounts + settings + all exchange rates at once
   const [accountsRaw, settings, allRatesMap] = await Promise.all([
@@ -107,9 +119,11 @@ export default async function AccountsPage() {
   await resolveMissingRates(missingPairs, ratesMap);
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
-      <AccountsList accounts={serialized} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
-    </div>
+    <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
+        <AccountsList accounts={serialized} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -2,25 +2,42 @@ import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
+
+const CLIENT_NAMESPACES = [
+  "netWorthCard",
+  "dashboardActions",
+  "trendChart",
+  "allocationChart",
+  "accountsSummary",
+  "categories",
+  "common",
+];
 
 export default async function DashboardPage() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
-  const t = await getTranslations("dashboard");
+  const [t, messages] = await Promise.all([
+    getTranslations("dashboard"),
+    getMessages(),
+  ]);
 
   return (
-    <div className="space-y-8">
-      <div className="flex items-center justify-between mb-2">
-        <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
-          {t("title")}
-        </h2>
-      </div>
+    <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
+      <div className="space-y-8">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+            {t("title")}
+          </h2>
+        </div>
 
-      <Suspense fallback={<DashboardSkeleton />}>
-        <DashboardContent userId={userId} />
-      </Suspense>
-    </div>
+        <Suspense fallback={<DashboardSkeleton />}>
+          <DashboardContent userId={userId} />
+        </Suspense>
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -3,13 +3,20 @@ import { SettingsForm } from "@/components/settings/settings-form";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";
 import { Button } from "@/components/ui/button";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
+
+const CLIENT_NAMESPACES = ["settings", "toast", "languages"];
 
 export default async function SettingsPage() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
-  const t = await getTranslations("settings");
+  const [t, allMessages] = await Promise.all([
+    getTranslations("settings"),
+    getMessages(),
+  ]);
 
   let settings = await prisma.setting.findUnique({ where: { userId } });
   if (!settings) {
@@ -17,23 +24,25 @@ export default async function SettingsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
-      <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
+    <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
+        <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
 
-      <div className="mt-8 border-t pt-8">
-        <h3 className="text-lg font-medium text-red-500 mb-4">{t("dangerZone")}</h3>
-        <form
-          action={async () => {
-            "use server";
-            await signOut({ redirectTo: "/login" });
-          }}
-        >
-          <Button variant="destructive" type="submit">
-            {t("signOut")}
-          </Button>
-        </form>
+        <div className="mt-8 border-t pt-8">
+          <h3 className="text-lg font-medium text-red-500 mb-4">{t("dangerZone")}</h3>
+          <form
+            action={async () => {
+              "use server";
+              await signOut({ redirectTo: "/login" });
+            }}
+          >
+            <Button variant="destructive" type="submit">
+              {t("signOut")}
+            </Button>
+          </form>
+        </div>
       </div>
-    </div>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
+import { pickMessages } from "@/lib/i18n-utils";
 import "./globals.css";
 
 const outfit = Outfit({
@@ -46,7 +47,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="h-full flex flex-col md:flex-row overflow-hidden bg-background text-foreground">
-        <NextIntlClientProvider messages={messages}>
+        <NextIntlClientProvider messages={pickMessages(messages, ["app", "nav"])}>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"

--- a/src/lib/i18n-utils.ts
+++ b/src/lib/i18n-utils.ts
@@ -1,0 +1,18 @@
+import type { Messages } from "next-intl";
+
+/**
+ * Pick a subset of top-level namespaces from the full messages object.
+ * Used to limit what gets serialized into the HTML for NextIntlClientProvider.
+ */
+export function pickMessages(
+  messages: Messages,
+  namespaces: string[]
+): Messages {
+  const picked: Record<string, unknown> = {};
+  for (const ns of namespaces) {
+    if (ns in messages) {
+      picked[ns] = messages[ns];
+    }
+  }
+  return picked as Messages;
+}


### PR DESCRIPTION
## Summary

- Root `NextIntlClientProvider` now ships only `app` and `nav` namespaces (sidebar/header), down from the entire messages JSON on every page
- Each page wraps its content with a nested `NextIntlClientProvider` providing only the namespaces its client components use
- New `src/lib/i18n-utils.ts` — `pickMessages(messages, namespaces)` helper to filter top-level namespaces
- Also updates `CLAUDE.md`, `README.md`, and `SUGGESTIONS.md` to reflect completed features (auth, i18n, error handling, N+1 fixes)

## Per-page namespace breakdown

| Page | Client namespaces |
|---|---|
| Root layout | `app`, `nav` |
| Dashboard | + `netWorthCard`, `dashboardActions`, `trendChart`, `allocationChart`, `accountsSummary`, `categories`, `common` |
| Accounts list | + `accountsList`, `accountForm`, `quickAddHolding`, `categories` |
| Account detail | + `accountDetail`, `common`, `categories` |
| Settings | + `settings`, `toast`, `languages` |
| Login | nothing (server-only) |

## Test plan

- [ ] Dashboard loads and all text renders correctly in both `en-US` and `zh-TW`
- [ ] Accounts list page — add/delete accounts, category labels render
- [ ] Account detail page — edit name, add/remove holdings, common labels render
- [ ] Settings page — currency/language change, price refresh, snapshot all work
- [ ] No `MISSING_MESSAGE` warnings in browser console on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)