### PR TITLE
feat: add Net Worth History page

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -7,6 +7,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "accounts": "Accounts",
+    "history": "History",
     "settings": "Settings"
   },
   "common": {
@@ -67,6 +68,16 @@
   },
   "accounts": {
     "title": "Accounts"
+  },
+  "history": {
+    "title": "Net Worth History",
+    "colDate": "Date",
+    "colNetWorth": "Net Worth",
+    "colAssets": "Assets",
+    "colLiabilities": "Liabilities",
+    "colChange": "Change",
+    "noData": "No snapshots yet. Take a snapshot from the dashboard to start tracking.",
+    "noDataForRange": "No data for this range."
   },
   "netWorthCard": {
     "netWorth": "Net Worth",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -7,6 +7,7 @@
   "nav": {
     "dashboard": "儀表板",
     "accounts": "帳戶",
+    "history": "歷史紀錄",
     "settings": "設定"
   },
   "common": {
@@ -67,6 +68,16 @@
   },
   "accounts": {
     "title": "帳戶"
+  },
+  "history": {
+    "title": "淨資產歷史",
+    "colDate": "日期",
+    "colNetWorth": "淨資產",
+    "colAssets": "總資產",
+    "colLiabilities": "總負債",
+    "colChange": "變化",
+    "noData": "尚無快照。請從儀表板建立快照以開始追蹤歷史。",
+    "noDataForRange": "此範圍內無資料。"
   },
   "netWorthCard": {
     "netWorth": "淨資產",

--- a/src/app/(main)/history/loading.tsx
+++ b/src/app/(main)/history/loading.tsx
@@ -1,0 +1,33 @@
+export default function HistoryLoading() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <div className="h-9 w-56 rounded-lg bg-muted" />
+
+      <div className="rounded-xl border border-border/50 bg-card p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-4 w-32 rounded bg-muted" />
+          <div className="flex gap-1">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-6 w-8 rounded-md bg-muted/60" />
+            ))}
+          </div>
+        </div>
+        <div className="h-[250px] rounded-lg bg-muted/40" />
+      </div>
+
+      <div className="rounded-xl border border-border/50 bg-card p-6 space-y-3">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-4 w-40 rounded bg-muted" />
+          <div className="flex gap-1">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-6 w-8 rounded-md bg-muted/60" />
+            ))}
+          </div>
+        </div>
+        {[...Array(7)].map((_, i) => (
+          <div key={i} className="h-10 rounded bg-muted/40" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -1,0 +1,53 @@
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-session";
+import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { getTranslations, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
+import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
+import { HistoryTable } from "@/components/history/history-table";
+
+const CLIENT_NAMESPACES = ["trendChart", "history"];
+
+export default async function HistoryPage() {
+  const session = await getSession();
+  if (!session?.user?.id) return null;
+  const userId = session.user.id;
+
+  const [t, allMessages, settings] = await Promise.all([
+    getTranslations("history"),
+    getMessages(),
+    getOrCreateSettings(userId),
+  ]);
+
+  const snapshotsRaw = await prisma.netWorthSnapshot.findMany({
+    where: { userId, baseCurrency: settings.baseCurrency },
+    orderBy: { date: "asc" },
+  });
+
+  const snapshots = snapshotsRaw.map((s) => ({
+    id: s.id,
+    date: s.date.toISOString().split("T")[0],
+    netWorth: Number(s.netWorth),
+    totalAssets: Number(s.totalAssets),
+    totalLiabilities: Number(s.totalLiabilities),
+  }));
+
+  return (
+    <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
+      <div className="space-y-8">
+        <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+          {t("title")}
+        </h2>
+
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+          <LazyTrendChart baseCurrency={settings.baseCurrency} snapshots={snapshots} hideRangeFilter />
+        </div>
+
+        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+          <HistoryTable snapshots={snapshots} baseCurrency={settings.baseCurrency} />
+        </div>
+      </div>
+    </NextIntlClientProvider>
+  );
+}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -28,7 +28,7 @@ const ranges = [
   { label: "All", days: Infinity },
 ];
 
-export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: SnapshotData[]; baseCurrency?: string }) {
+export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = false }: { snapshots: SnapshotData[]; baseCurrency?: string; hideRangeFilter?: boolean }) {
   const [range, setRange] = useState("All");
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("trendChart");
@@ -39,7 +39,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: Sna
   cutoff.setDate(cutoff.getDate() - selectedRange.days);
 
   const filtered =
-    selectedRange.days === Infinity
+    hideRangeFilter || selectedRange.days === Infinity
       ? snapshots
       : snapshots.filter((s) => new Date(s.date) >= cutoff);
 
@@ -47,21 +47,23 @@ export function TrendChart({ snapshots, baseCurrency = "USD" }: { snapshots: Sna
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-base font-medium">{t("title")}</CardTitle>
-        <div className="flex gap-1">
-          {ranges.map((r) => (
-            <button
-              key={r.label}
-              onClick={() => setRange(r.label)}
-              className={`px-2 py-1 text-xs rounded-md transition-colors ${
-                range === r.label
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-muted"
-              }`}
-            >
-              {r.label}
-            </button>
-          ))}
-        </div>
+        {!hideRangeFilter && (
+          <div className="flex gap-1">
+            {ranges.map((r) => (
+              <button
+                key={r.label}
+                onClick={() => setRange(r.label)}
+                className={`px-2 py-1 text-xs rounded-md transition-colors ${
+                  range === r.label
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        )}
       </CardHeader>
       <CardContent>
         {filtered.length === 0 ? (

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/currencies";
+
+type SnapshotRow = {
+  id: string;
+  date: string;
+  netWorth: number;
+  totalAssets: number;
+  totalLiabilities: number;
+};
+
+type Props = {
+  snapshots: SnapshotRow[];
+  baseCurrency: string;
+};
+
+export function HistoryTable({ snapshots, baseCurrency }: Props) {
+  const t = useTranslations("history");
+
+  const rows = useMemo(() => {
+    return [...snapshots].reverse().map((snap, idx, arr) => ({
+      ...snap,
+      change: arr[idx + 1] ? snap.netWorth - arr[idx + 1].netWorth : null,
+    }));
+  }, [snapshots]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-medium">{t("title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <div className="py-12 text-center text-muted-foreground text-sm">
+            {t("noData")}
+          </div>
+        ) : (
+          <div className="max-h-[480px] overflow-y-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("colDate")}</TableHead>
+                  <TableHead className="text-right">{t("colNetWorth")}</TableHead>
+                  <TableHead className="text-right">{t("colAssets")}</TableHead>
+                  <TableHead className="text-right">{t("colLiabilities")}</TableHead>
+                  <TableHead className="text-right">{t("colChange")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="text-sm">
+                      {new Date(row.date + "T00:00:00").toLocaleDateString(undefined, {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCurrency(row.netWorth, baseCurrency)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCurrency(row.totalAssets, baseCurrency)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCurrency(row.totalLiabilities, baseCurrency)}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        "text-right tabular-nums font-medium",
+                        row.change === null || row.change === 0
+                          ? "text-muted-foreground"
+                          : row.change > 0
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-red-500 dark:text-red-400"
+                      )}
+                    >
+                      {row.change === null
+                        ? "—"
+                        : (row.change >= 0 ? "+" : "") +
+                          formatCurrency(row.change, baseCurrency)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { Copy, LayoutDashboard, Settings } from "lucide-react";
+import { Copy, History, LayoutDashboard, Settings } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -17,6 +17,7 @@ export function Sidebar() {
   const navItems = [
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
     { label: t("nav.accounts"), href: "/accounts", icon: Copy },
+    { label: t("nav.history"), href: "/history", icon: History },
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
@@ -82,6 +83,7 @@ export function MobileNav() {
   const navItems = [
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
     { label: t("nav.accounts"), href: "/accounts", icon: Copy },
+    { label: t("nav.history"), href: "/history", icon: History },
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 


### PR DESCRIPTION
## Summary

- Adds a dedicated `/history` route with the full snapshot chart (no range picker) and a scrollable table showing all past net worth snapshots
- Table columns: Date, Net Worth, Assets, Liabilities, Change (color-coded green/red delta vs. previous day)
- Adds History nav link (between Accounts and Settings) in both desktop sidebar and mobile bottom nav
- Adds `hideRangeFilter` prop to `TrendChart` so the dashboard chart is unchanged
- Full i18n support for `en-US` and `zh-TW`

## Test plan

- [ ] Navigate to `/history` — chart and table render correctly
- [ ] Table shows all snapshots in reverse-chronological order; first row shows `—` in Change column
- [ ] History link appears in sidebar (desktop) and bottom nav (mobile), highlights as active on `/history`
- [ ] Switch language to 繁體中文 — all labels translate
- [ ] Dashboard trend chart still shows range filter buttons (unchanged)
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)