### PR TITLE
Fix: Cron Trigger Schedule and Middleware Bypass

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,5 +34,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico).*)"],
 };

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/snapshot",
-      "schedule": "0 0 * * *"
+      "schedule": "0 16 * * *"
     }
   ]
 }


### PR DESCRIPTION
This PR:
- Adjusts the cron schedule to midnight UTC+8 (16:00 UTC).
- Excludes /api/cron routes from the global authentication middleware to allow Vercel's triggers to reach the endpoint.
- Securely retains the CRON_SECRET check within the route itself.