### PR TITLE
feat: add Monthly/Yearly Performance Reports page (#15)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -8,6 +8,7 @@
     "dashboard": "Dashboard",
     "accounts": "Accounts",
     "history": "History",
+    "performance": "Performance",
     "settings": "Settings"
   },
   "common": {
@@ -249,6 +250,23 @@
     "subtitle": "Securely access your financial portfolio",
     "googleButton": "Continue with Google",
     "footer": "By continuing, you agree to secure your data privately."
+  },
+  "performance": {
+    "title": "Performance",
+    "monthly": "Monthly",
+    "yearly": "Yearly",
+    "chartTitle": "Period-over-Period Change",
+    "summaryTitle": "Summary",
+    "bestPeriod": "Best Period",
+    "worstPeriod": "Worst Period",
+    "averageGrowth": "Avg Growth / Period",
+    "periodsAnalyzed": "Periods Analyzed",
+    "changePercent": "Change %",
+    "netWorth": "Net Worth",
+    "change": "Change",
+    "start": "Start",
+    "end": "End",
+    "noData": "No snapshot data yet. Snapshots are created daily — check back after the first snapshot."
   },
   "transactionHistory": {
     "title": "Transaction History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -8,6 +8,7 @@
     "dashboard": "儀表板",
     "accounts": "帳戶",
     "history": "歷史紀錄",
+    "performance": "績效報告",
     "settings": "設定"
   },
   "common": {
@@ -249,6 +250,23 @@
     "subtitle": "安全地訪問您的財務投資組合",
     "googleButton": "使用 Google 帳號繼續",
     "footer": "繼續操作即表示您同意私密地保護您的數據。"
+  },
+  "performance": {
+    "title": "績效報告",
+    "monthly": "月度",
+    "yearly": "年度",
+    "chartTitle": "期間漲跌幅",
+    "summaryTitle": "摘要",
+    "bestPeriod": "最佳期間",
+    "worstPeriod": "最差期間",
+    "averageGrowth": "平均成長率",
+    "periodsAnalyzed": "分析期數",
+    "changePercent": "漲跌幅",
+    "netWorth": "淨資產",
+    "change": "變化",
+    "start": "期初",
+    "end": "期末",
+    "noData": "尚無快照資料。每日自動建立快照，請在第一次快照後回來查看。"
   },
   "transactionHistory": {
     "title": "交易紀錄",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9585,6 +9585,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",

--- a/src/app/(main)/performance/page.tsx
+++ b/src/app/(main)/performance/page.tsx
@@ -1,0 +1,43 @@
+import { getSession } from "@/lib/auth-session";
+import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { getNormalizedHistory } from "@/lib/services/history-service";
+import { computePerformancePeriods } from "@/lib/performance-utils";
+import { getTranslations, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { pickMessages } from "@/lib/i18n-utils";
+import { PerformanceContent } from "@/components/performance/performance-content";
+
+const CLIENT_NAMESPACES = ["performance", "common"];
+
+export default async function PerformancePage() {
+  const session = await getSession();
+  if (!session?.user?.id) return null;
+  const userId = session.user.id;
+
+  const [t, allMessages, settings] = await Promise.all([
+    getTranslations("performance"),
+    getMessages(),
+    getOrCreateSettings(userId),
+  ]);
+
+  const snapshots = await getNormalizedHistory(userId, settings.baseCurrency);
+
+  const monthlyData = computePerformancePeriods(snapshots, "monthly");
+  const yearlyData = computePerformancePeriods(snapshots, "yearly");
+
+  return (
+    <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
+      <div className="space-y-8">
+        <h2 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+          {t("title")}
+        </h2>
+
+        <PerformanceContent
+          monthlyData={monthlyData}
+          yearlyData={yearlyData}
+          baseCurrency={settings.baseCurrency}
+        />
+      </div>
+    </NextIntlClientProvider>
+  );
+}

--- a/src/app/api/reports/performance/route.ts
+++ b/src/app/api/reports/performance/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getNormalizedHistory } from "@/lib/services/history-service";
+import { computePerformancePeriods } from "@/lib/performance-utils";
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const period = (searchParams.get("period") ?? "monthly") as
+    | "monthly"
+    | "yearly";
+  const currency = searchParams.get("currency") ?? "USD";
+
+  const snapshots = await getNormalizedHistory(session.user.id, currency);
+  const data = computePerformancePeriods(snapshots, period);
+
+  return NextResponse.json(data);
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { Copy, History, LayoutDashboard, Settings } from "lucide-react";
+import { Copy, History, LayoutDashboard, Settings, TrendingUp } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -18,6 +18,7 @@ export function Sidebar() {
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
     { label: t("nav.accounts"), href: "/accounts", icon: Copy },
     { label: t("nav.history"), href: "/history", icon: History },
+    { label: t("nav.performance"), href: "/performance", icon: TrendingUp },
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
@@ -84,6 +85,7 @@ export function MobileNav() {
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
     { label: t("nav.accounts"), href: "/accounts", icon: Copy },
     { label: t("nav.history"), href: "/history", icon: History },
+    { label: t("nav.performance"), href: "/performance", icon: TrendingUp },
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 

--- a/src/components/performance/performance-chart.tsx
+++ b/src/components/performance/performance-chart.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  ReferenceLine,
+} from "recharts";
+import { useTranslations } from "next-intl";
+import type { PerformancePeriod } from "@/lib/performance-utils";
+
+function formatPeriodLabel(period: string): string {
+  if (period.length === 7) {
+    // "YYYY-MM" → "Jan 2024"
+    const [year, month] = period.split("-");
+    const date = new Date(Number(year), Number(month) - 1, 1);
+    return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  }
+  // "YYYY"
+  return period;
+}
+
+interface TooltipPayload {
+  payload: PerformancePeriod;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  baseCurrency,
+  t,
+}: {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  baseCurrency: string;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  const fmt = (v: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: baseCurrency,
+      maximumFractionDigits: 0,
+    }).format(v);
+  const sign = d.changePercent >= 0 ? "+" : "";
+  return (
+    <div className="rounded-lg border bg-card p-3 text-xs shadow-md space-y-1">
+      <p className="font-semibold text-sm">{formatPeriodLabel(d.period)}</p>
+      <p className="text-muted-foreground">
+        {t("start")}: <span className="text-foreground">{fmt(d.startValue)}</span>
+      </p>
+      <p className="text-muted-foreground">
+        {t("end")}: <span className="text-foreground">{fmt(d.endValue)}</span>
+      </p>
+      <p className="text-muted-foreground">
+        {t("change")}:{" "}
+        <span className={d.change >= 0 ? "text-green-500" : "text-red-500"}>
+          {sign}{fmt(d.change)}
+        </span>
+      </p>
+      <p className="text-muted-foreground">
+        {t("changePercent")}:{" "}
+        <span className={d.changePercent >= 0 ? "text-green-500" : "text-red-500"}>
+          {sign}{d.changePercent.toFixed(2)}%
+        </span>
+      </p>
+    </div>
+  );
+}
+
+export function PerformanceChart({
+  periods,
+  baseCurrency = "USD",
+}: {
+  periods: PerformancePeriod[];
+  baseCurrency?: string;
+}) {
+  const t = useTranslations("performance");
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-medium">{t("chartTitle")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {periods.length === 0 ? (
+          <div className="h-[300px] flex items-center justify-center text-muted-foreground text-sm text-center px-4">
+            {t("noData")}
+          </div>
+        ) : !mounted ? (
+          <div className="h-[300px]" />
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={periods} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" vertical={false} />
+              <XAxis
+                dataKey="period"
+                tick={{ fontSize: 11 }}
+                tickFormatter={formatPeriodLabel}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => `${v.toFixed(0)}%`}
+              />
+              <ReferenceLine y={0} className="stroke-border" strokeWidth={1} />
+              <Tooltip
+                content={
+                  <CustomTooltip baseCurrency={baseCurrency} t={t} />
+                }
+              />
+              <Bar dataKey="changePercent" name={t("changePercent")} radius={[3, 3, 0, 0]}>
+                {periods.map((p, i) => (
+                  <Cell
+                    key={i}
+                    fill={p.changePercent >= 0 ? "#22c55e" : "#ef4444"}
+                    fillOpacity={0.85}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/performance/performance-content.tsx
+++ b/src/components/performance/performance-content.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { PerformanceSummaryCards } from "./performance-summary";
+import { useTranslations } from "next-intl";
+import type { PerformanceData } from "@/lib/performance-utils";
+
+function ChartSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="h-5 w-48 bg-muted animate-pulse rounded" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-[300px] bg-muted animate-pulse rounded" />
+      </CardContent>
+    </Card>
+  );
+}
+
+const LazyPerformanceChart = dynamic(
+  () =>
+    import("./performance-chart").then((m) => m.PerformanceChart),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+type PeriodMode = "monthly" | "yearly";
+
+export function PerformanceContent({
+  monthlyData,
+  yearlyData,
+  baseCurrency,
+}: {
+  monthlyData: PerformanceData;
+  yearlyData: PerformanceData;
+  baseCurrency: string;
+}) {
+  const t = useTranslations("performance");
+  const [mode, setMode] = useState<PeriodMode>("monthly");
+
+  const activeData = mode === "monthly" ? monthlyData : yearlyData;
+
+  return (
+    <div className="space-y-6">
+      {/* Period toggle */}
+      <div className="flex gap-1">
+        {(["monthly", "yearly"] as PeriodMode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            className={`px-3 py-1.5 text-sm rounded-md transition-colors font-medium ${
+              mode === m
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            {t(m)}
+          </button>
+        ))}
+      </div>
+
+      {/* Summary stats */}
+      <PerformanceSummaryCards summary={activeData.summary} />
+
+      {/* Bar chart */}
+      <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+        <LazyPerformanceChart
+          periods={activeData.periods}
+          baseCurrency={baseCurrency}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/performance/performance-summary.tsx
+++ b/src/components/performance/performance-summary.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
+import type { PerformanceSummary as PerformanceSummaryType } from "@/lib/performance-utils";
+
+function formatPeriodLabel(period: string): string {
+  if (period.length === 7) {
+    const [year, month] = period.split("-");
+    const date = new Date(Number(year), Number(month) - 1, 1);
+    return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  }
+  return period;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: "green" | "red" | "neutral";
+}) {
+  const colorClass =
+    color === "green"
+      ? "text-green-500"
+      : color === "red"
+        ? "text-red-500"
+        : "text-foreground";
+  return (
+    <Card>
+      <CardContent className="pt-5 pb-4">
+        <p className="text-xs text-muted-foreground mb-1">{label}</p>
+        <p className={`text-2xl font-bold ${colorClass}`}>{value}</p>
+        {sub && <p className="text-xs text-muted-foreground mt-0.5">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PerformanceSummaryCards({
+  summary,
+}: {
+  summary: PerformanceSummaryType;
+}) {
+  const t = useTranslations("performance");
+
+  const fmtPct = (v: number) => {
+    const sign = v >= 0 ? "+" : "";
+    return `${sign}${v.toFixed(2)}%`;
+  };
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+        {t("summaryTitle")}
+      </h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard
+          label={t("bestPeriod")}
+          value={
+            summary.bestPeriod ? fmtPct(summary.bestPeriod.changePercent) : "—"
+          }
+          sub={
+            summary.bestPeriod
+              ? formatPeriodLabel(summary.bestPeriod.period)
+              : undefined
+          }
+          color="green"
+        />
+        <StatCard
+          label={t("worstPeriod")}
+          value={
+            summary.worstPeriod
+              ? fmtPct(summary.worstPeriod.changePercent)
+              : "—"
+          }
+          sub={
+            summary.worstPeriod
+              ? formatPeriodLabel(summary.worstPeriod.period)
+              : undefined
+          }
+          color="red"
+        />
+        <StatCard
+          label={t("averageGrowth")}
+          value={fmtPct(summary.averageChangePercent)}
+          color={
+            summary.averageChangePercent >= 0
+              ? "green"
+              : summary.averageChangePercent < 0
+                ? "red"
+                : "neutral"
+          }
+        />
+        <StatCard
+          label={t("periodsAnalyzed")}
+          value={String(summary.totalPeriods)}
+          color="neutral"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/performance-utils.ts
+++ b/src/lib/performance-utils.ts
@@ -1,0 +1,99 @@
+import type { NormalizedSnapshot } from "@/lib/services/history-service";
+
+export interface PerformancePeriod {
+  period: string; // "2024-01" for monthly, "2024" for yearly
+  startValue: number;
+  endValue: number;
+  change: number;
+  changePercent: number;
+}
+
+export interface PerformanceSummary {
+  bestPeriod: PerformancePeriod | null;
+  worstPeriod: PerformancePeriod | null;
+  averageChangePercent: number;
+  totalPeriods: number;
+}
+
+export interface PerformanceData {
+  periods: PerformancePeriod[];
+  summary: PerformanceSummary;
+}
+
+function getPeriodKey(date: string, mode: "monthly" | "yearly"): string {
+  return mode === "monthly" ? date.substring(0, 7) : date.substring(0, 4);
+}
+
+export function computePerformancePeriods(
+  snapshots: NormalizedSnapshot[],
+  mode: "monthly" | "yearly"
+): PerformanceData {
+  if (snapshots.length === 0) {
+    return {
+      periods: [],
+      summary: {
+        bestPeriod: null,
+        worstPeriod: null,
+        averageChangePercent: 0,
+        totalPeriods: 0,
+      },
+    };
+  }
+
+  // Group snapshots by period key (already sorted asc by date from history-service)
+  const grouped = new Map<string, NormalizedSnapshot[]>();
+  for (const s of snapshots) {
+    const key = getPeriodKey(s.date, mode);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(s);
+  }
+
+  const periods: PerformancePeriod[] = [];
+  let prevEndValue: number | null = null;
+
+  for (const [key, periodSnapshots] of grouped) {
+    // Snapshots already sorted asc; last one is the end-of-period value
+    const endSnapshot = periodSnapshots[periodSnapshots.length - 1];
+    const endValue = endSnapshot.netWorth;
+
+    // Start value is the previous period's end (continuity chain).
+    // For the very first period, fall back to the first snapshot of that period.
+    const startValue =
+      prevEndValue !== null ? prevEndValue : periodSnapshots[0].netWorth;
+
+    const change = endValue - startValue;
+    const changePercent =
+      startValue !== 0 ? (change / Math.abs(startValue)) * 100 : 0;
+
+    periods.push({ period: key, startValue, endValue, change, changePercent });
+    prevEndValue = endValue;
+  }
+
+  // Compute summary
+  let bestPeriod: PerformancePeriod | null = null;
+  let worstPeriod: PerformancePeriod | null = null;
+  let totalChangePercent = 0;
+
+  for (const p of periods) {
+    totalChangePercent += p.changePercent;
+    if (!bestPeriod || p.changePercent > bestPeriod.changePercent) {
+      bestPeriod = p;
+    }
+    if (!worstPeriod || p.changePercent < worstPeriod.changePercent) {
+      worstPeriod = p;
+    }
+  }
+
+  const averageChangePercent =
+    periods.length > 0 ? totalChangePercent / periods.length : 0;
+
+  return {
+    periods,
+    summary: {
+      bestPeriod,
+      worstPeriod,
+      averageChangePercent,
+      totalPeriods: periods.length,
+    },
+  };
+}


### PR DESCRIPTION
- New `/performance` page with period-over-period bar chart (green/red bars)
- Summary stats: best period, worst period, average growth rate, total periods
- Monthly/Yearly toggle; all data computed server-side from existing snapshots
- New `computePerformancePeriods()` utility in `src/lib/performance-utils.ts`
- New `GET /api/reports/performance` endpoint
- Navigation item added to sidebar (both desktop and mobile)
- Full i18n support: en-US and zh-TW translations

https://claude.ai/code/session_01UJJXyHBUVguAWeAbc1BAmc