### PR TITLE
Optimize dashboard critical-path: add lightweight totals, suspense-loaded details, and performance suggestions

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -61,9 +61,26 @@
 | 55 | Replace console logs with structured logging | Observability | 🟡 Medium | 2-4 hrs | ❌ Not Done |
 | 56 | Add baseline automated tests (unit/API/E2E smoke) | Testing | 🔴 High | 1-2 days | ❌ Not Done |
 | 57 | Improve accessibility semantics on controls/tables | Accessibility | 🟡 Medium | 2-3 hrs | ❌ Not Done |
+| 58 | Optimize dashboard critical-path data loading for FCP/LCP | Performance | 🔴 High | 3-5 hrs | ❌ Not Done |
+| 59 | Replace eager multi-route prefetch with selective/idle prefetch | Performance | 🟡 Medium | 30-60 min | ❌ Not Done |
+| 60 | Reduce over-fetching in net-worth aggregation queries | Performance | 🔴 High | 2-4 hrs | ❌ Not Done |
+| 61 | Add route-level server timing instrumentation for Core Web Vitals triage | Observability | 🟡 Medium | 1-2 hrs | ❌ Not Done |
+| 62 | Defer non-critical dashboard widgets below the fold | Performance | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 ---
 
 
+
+## 2026-04-10 Performance Suggestions (FCP/LCP)
+
+> Captures actionable items from the latest performance review focused on low FCP and LCP in Speed Insights.
+
+58. **Optimize dashboard critical-path data loading** (`src/components/dashboard/dashboard-content.tsx`): split above-the-fold summary rendering from heavier history/table/chart data so first meaningful paint is not blocked by full dashboard aggregation.
+59. **Replace eager route prefetch-on-mount** in sidebar (`src/components/layout/sidebar.tsx`) with selective/idle prefetch to avoid competing with initial render bandwidth and main-thread work.
+60. **Reduce over-fetching in net-worth aggregation** (`src/lib/services/net-worth-service.ts`) by limiting price/rate lookups to symbols/currencies actually present for the current user.
+61. **Add server timing instrumentation** around dashboard data calls (`getNetWorthSummary`, `getNormalizedHistory`, auth/session) to identify whether low LCP is DB/API latency vs client rendering.
+62. **Defer non-critical dashboard widgets** (charts/tables) behind nested Suspense boundaries or below-the-fold loading so the LCP element can render earlier.
+
+---
 ## 2026-04-10 Targeted Suggestions (Latest Review)
 
 > Added from the latest code review so active items are tracked in this canonical file (`SUGGESTIONS.md`).

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,45 +1,42 @@
 import { prisma } from "@/lib/prisma";
+import { Suspense } from "react";
 import { NetWorthCard } from "@/components/dashboard/net-worth-card";
 import { LazyTrendChart, LazyAllocationChart } from "@/components/dashboard/lazy-charts";
 import { AccountsSummary } from "@/components/dashboard/accounts-summary";
 import { DashboardActions } from "@/components/dashboard/dashboard-actions";
-import { getNetWorthSummary } from "@/lib/services/net-worth-service";
+import { getNetWorthSummary, getNetWorthTotals } from "@/lib/services/net-worth-service";
 import { redirect } from "next/navigation";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { getNormalizedHistory } from "@/lib/services/history-service";
 import { LazyCurrencyExposureChart } from "@/components/dashboard/lazy-charts";
 
-export async function DashboardContent({ userId }: { userId: string }) {
-  const [dbUser, settings] = await Promise.all([
-    prisma.user.findUnique({ where: { id: userId } }),
-    getOrCreateSettings(userId),
-  ]);
+function DashboardDetailsSkeleton() {
+  return (
+    <>
+      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+        <div className="h-[340px] rounded-xl bg-muted animate-pulse lg:col-span-2 xl:col-span-1" />
+        <div className="h-[340px] rounded-xl bg-muted animate-pulse" />
+        <div className="h-[340px] rounded-xl bg-muted animate-pulse" />
+      </div>
+      <div className="h-[420px] rounded-xl bg-muted animate-pulse" />
+    </>
+  );
+}
 
-  if (!dbUser) redirect("/api/auth/signout");
-
-  const baseCurrency = settings.baseCurrency;
-
-  const [summary, snapshots, latestPrice] = await Promise.all([
+async function DashboardDetailsSection({
+  userId,
+  baseCurrency,
+}: {
+  userId: string;
+  baseCurrency: string;
+}) {
+  const [summary, snapshots] = await Promise.all([
     getNetWorthSummary(userId, baseCurrency),
     getNormalizedHistory(userId, baseCurrency),
-    prisma.priceCache.findFirst({
-      orderBy: { updatedAt: "desc" },
-      select: { updatedAt: true },
-    }),
   ]);
-
-  const latestSnapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
 
   return (
     <>
-      <DashboardActions
-        baseCurrency={baseCurrency}
-        lastPriceUpdate={latestPrice?.updatedAt?.toISOString() ?? null}
-        lastSnapshotDate={latestSnapshot?.date ?? null}
-      />
-
-      <NetWorthCard summary={summary} />
-
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
         <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg lg:col-span-2 xl:col-span-1">
           <LazyTrendChart
@@ -58,6 +55,46 @@ export async function DashboardContent({ userId }: { userId: string }) {
       <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
         <AccountsSummary summary={summary} />
       </div>
+    </>
+  );
+}
+
+export async function DashboardContent({ userId }: { userId: string }) {
+  const [dbUser, settings] = await Promise.all([
+    prisma.user.findUnique({ where: { id: userId } }),
+    getOrCreateSettings(userId),
+  ]);
+
+  if (!dbUser) redirect("/api/auth/signout");
+
+  const baseCurrency = settings.baseCurrency;
+
+  const [totals, latestPrice, latestSnapshot] = await Promise.all([
+    getNetWorthTotals(userId, baseCurrency),
+    prisma.priceCache.findFirst({
+      orderBy: { updatedAt: "desc" },
+      select: { updatedAt: true },
+    }),
+    prisma.netWorthSnapshot.findFirst({
+      where: { userId },
+      orderBy: { date: "desc" },
+      select: { date: true },
+    }),
+  ]);
+
+  return (
+    <>
+      <DashboardActions
+        baseCurrency={baseCurrency}
+        lastPriceUpdate={latestPrice?.updatedAt?.toISOString() ?? null}
+        lastSnapshotDate={latestSnapshot?.date?.toISOString() ?? null}
+      />
+
+      <NetWorthCard summary={totals} />
+
+      <Suspense fallback={<DashboardDetailsSkeleton />}>
+        <DashboardDetailsSection userId={userId} baseCurrency={baseCurrency} />
+      </Suspense>
     </>
   );
 }

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -3,9 +3,9 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
-import type { NetWorthSummary } from "@/lib/types";
+import type { NetWorthTotals } from "@/lib/services/net-worth-service";
 
-export function NetWorthCard({ summary }: { summary: NetWorthSummary }) {
+export function NetWorthCard({ summary }: { summary: NetWorthTotals }) {
   const { totalAssets, totalLiabilities, netWorth, baseCurrency } = summary;
   const t = useTranslations("netWorthCard");
 

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -6,6 +6,104 @@ import {
 } from "@/lib/types";
 import type { AccountWithValue, NetWorthSummary, HoldingWithPrice } from "@/lib/types";
 
+export interface NetWorthTotals {
+  totalAssets: number;
+  totalLiabilities: number;
+  netWorth: number;
+  baseCurrency: string;
+}
+
+/**
+ * Lightweight totals query for above-the-fold dashboard rendering.
+ * Avoids building account-level breakdown payloads used by charts/tables.
+ */
+export async function getNetWorthTotals(
+  userId: string,
+  baseCurrency: string
+): Promise<NetWorthTotals> {
+  const accounts = await prisma.account.findMany({
+    where: { userId, isActive: true },
+    select: {
+      id: true,
+      type: true,
+      currency: true,
+      cashBalance: true,
+      holdings: {
+        where: { quantity: { gt: 0 } },
+        select: { symbol: true, quantity: true, currency: true },
+      },
+    },
+  });
+
+  const symbols = [...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol)))];
+  const accountCurrencies = accounts.map((a) => a.currency);
+  const holdingCurrencies = accounts.flatMap((a) =>
+    a.holdings.map((h) => h.currency).filter(Boolean) as string[]
+  );
+  const currencies = [...new Set([baseCurrency, ...accountCurrencies, ...holdingCurrencies])];
+
+  const [prices, allRatesMap] = await Promise.all([
+    symbols.length > 0
+      ? prisma.priceCache.findMany({
+          where: { symbol: { in: symbols } },
+          select: { symbol: true, price: true, currency: true },
+        })
+      : Promise.resolve([]),
+    getAllExchangeRates(),
+  ]);
+
+  const priceMap = Object.fromEntries(
+    prices.map((p) => [p.symbol, { price: Number(p.price), currency: p.currency }])
+  );
+
+  const missingPairs = new Set<string>();
+  for (const from of currencies) {
+    if (resolveRate(allRatesMap, from, baseCurrency) === undefined) {
+      missingPairs.add(`${from}_${baseCurrency}`);
+    }
+  }
+
+  if (missingPairs.size > 0) {
+    const pairs: Array<[string, string]> = [...missingPairs].map((key) => {
+      const [from, to] = key.split("_");
+      return [from, to];
+    });
+    const resolvedMap: Record<string, number> = {};
+    await resolveMissingRates(pairs, resolvedMap);
+    for (const [key, rate] of Object.entries(resolvedMap)) {
+      allRatesMap.set(key, rate);
+    }
+  }
+
+  const getRate = (from: string, to: string) => resolveRate(allRatesMap, from, to) ?? 1;
+
+  let totalAssets = 0;
+  let totalLiabilities = 0;
+
+  for (const account of accounts) {
+    const accountRate = getRate(account.currency, baseCurrency);
+    let totalValueInBase = Number(account.cashBalance) * accountRate;
+
+    for (const h of account.holdings) {
+      const priceEntry = priceMap[h.symbol];
+      if (!priceEntry) continue;
+      const holdingCurrency = h.currency || priceEntry.currency || "USD";
+      const valueInHoldingCurrency = Number(priceEntry.price) * Number(h.quantity);
+      totalValueInBase += valueInHoldingCurrency * getRate(holdingCurrency, baseCurrency);
+    }
+
+    if (account.type === "ASSET") totalAssets += totalValueInBase;
+    else totalLiabilities += totalValueInBase;
+  }
+
+  return {
+    totalAssets,
+    totalLiabilities,
+    netWorth: totalAssets - totalLiabilities,
+    baseCurrency,
+  };
+}
+
 export async function getNetWorthSummary(
   userId: string,
   baseCurrency: string


### PR DESCRIPTION
### Motivation

- Reduce First Contentful Paint (FCP) and Largest Contentful Paint (LCP) by moving heavy dashboard aggregation off the critical render path. 
- Provide a lightweight above-the-fold payload so the main summary can render immediately while detailed charts/tables load asynchronously. 
- Capture targeted performance remediation items in `SUGGESTIONS.md` to track follow-ups for dashboard FCP/LCP improvements. 

### Description

- Added targeted performance suggestions (items 58–62) to `SUGGESTIONS.md` documenting actionable fixes for dashboard critical-path loading and instrumentation. 
- Introduced `getNetWorthTotals` in `src/lib/services/net-worth-service.ts` to compute lightweight totals by limiting price lookups to symbols present for the user and resolving only required exchange rates. 
- Refactored `src/components/dashboard/dashboard-content.tsx` to render `DashboardActions` and `NetWorthCard` immediately and moved heavier chart/table breakdown into a `DashboardDetailsSection` that is wrapped with React `Suspense` and a `DashboardDetailsSkeleton`. 
- Updated `src/components/dashboard/net-worth-card.tsx` to consume the new `NetWorthTotals` shape returned by `getNetWorthTotals` and adjusted types accordingly. 

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8791f157c8321896ef2667f2c760e)