### PR TITLE
Enhance Accounts page UX with portfolio summaries, search & filters

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -131,7 +131,18 @@
     "deleteButton": "Delete ({count})",
     "deleteConfirm": "{count, plural, one {Delete # account?} other {Delete # accounts?}} This cannot be undone.",
     "deleteSuccess": "{count, plural, one {Deleted # account} other {Deleted # accounts}}",
-    "deleteFailed": "Failed to delete accounts"
+    "deleteFailed": "Failed to delete accounts",
+    "netPosition": "Net Position",
+    "searchPlaceholder": "Search accounts, categories, holdings, or symbols",
+    "resultsCount": "{count, plural, one {# account shown} other {# accounts shown}}",
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all",
+    "noMatches": "No matching accounts found. Try another search or filter.",
+    "filters": {
+      "all": "All",
+      "asset": "Assets",
+      "liability": "Liabilities"
+    }
   },
   "accountForm": {
     "title": "Add Account",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -131,7 +131,18 @@
     "deleteButton": "刪除（{count}）",
     "deleteConfirm": "確定要刪除 {count} 個帳戶？此操作無法復原。",
     "deleteSuccess": "已刪除 {count} 個帳戶",
-    "deleteFailed": "刪除帳戶失敗"
+    "deleteFailed": "刪除帳戶失敗",
+    "netPosition": "淨部位",
+    "searchPlaceholder": "搜尋帳戶、分類、持倉或代號",
+    "resultsCount": "{count, plural, one {顯示 # 個帳戶} other {顯示 # 個帳戶}}",
+    "expandAll": "全部展開",
+    "collapseAll": "全部收合",
+    "noMatches": "找不到符合條件的帳戶，請嘗試其他搜尋或篩選。",
+    "filters": {
+      "all": "全部",
+      "asset": "資產",
+      "liability": "負債"
+    }
   },
   "accountForm": {
     "title": "新增帳戶",

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -7,11 +7,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { formatCurrency } from "@/lib/currencies";
 import { AccountForm } from "./account-form";
 import { QuickAddHolding } from "./quick-add-holding";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
+import { Search, Wallet2, Landmark, ChevronDown, ChevronUp } from "lucide-react";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 
 const CATEGORY_ICONS: Record<string, string> = {
@@ -74,14 +76,54 @@ export function AccountsList({
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<"ALL" | "ASSET" | "LIABILITY">("ALL");
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(() => {
     const all = new Set<string>();
     for (const a of accounts) all.add(`${a.type}_${a.category}`);
     return all;
   });
 
-  const assets = accounts.filter((a) => a.type === "ASSET");
-  const liabilities = accounts.filter((a) => a.type === "LIABILITY");
+  const filteredAccounts = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return accounts.filter((account) => {
+      if (typeFilter !== "ALL" && account.type !== typeFilter) return false;
+      if (!normalizedQuery) return true;
+
+      const matchesAccount =
+        account.name.toLowerCase().includes(normalizedQuery) ||
+        account.category.toLowerCase().includes(normalizedQuery) ||
+        account.currency.toLowerCase().includes(normalizedQuery);
+      if (matchesAccount) return true;
+
+      return account.holdings.some((holding) =>
+        `${holding.symbol} ${holding.name}`.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [accounts, query, typeFilter]);
+
+  const assets = filteredAccounts.filter((a) => a.type === "ASSET");
+  const liabilities = filteredAccounts.filter((a) => a.type === "LIABILITY");
+
+  const totalAssets = useMemo(
+    () =>
+      assets.reduce((sum, account) => {
+        const value = getAccountValue(account, priceMap, ratesMap);
+        const rate = account.currency === baseCurrency ? 1 : ratesMap[`${account.currency}_${baseCurrency}`] ?? 1;
+        return sum + value * rate;
+      }, 0),
+    [assets, priceMap, ratesMap, baseCurrency]
+  );
+
+  const totalLiabilities = useMemo(
+    () =>
+      liabilities.reduce((sum, account) => {
+        const value = getAccountValue(account, priceMap, ratesMap);
+        const rate = account.currency === baseCurrency ? 1 : ratesMap[`${account.currency}_${baseCurrency}`] ?? 1;
+        return sum + value * rate;
+      }, 0),
+    [liabilities, priceMap, ratesMap, baseCurrency]
+  );
 
   const assetsByCategory = useMemo(() => {
     const grouped: Record<string, SerializedAccountWithHoldings[]> = {};
@@ -123,10 +165,12 @@ export function AccountsList({
   }
 
   function toggleAll() {
-    if (selected.size === accounts.length) {
+    const visibleIds = filteredAccounts.map((a) => a.id);
+    const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selected.has(id));
+    if (allVisibleSelected) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(accounts.map((a) => a.id)));
+      setSelected(new Set(visibleIds));
     }
   }
 
@@ -153,15 +197,103 @@ export function AccountsList({
   }
 
   const isSelecting = selected.size > 0;
+  const allCategoriesExpanded =
+    [...assetsByCategory.map(({ category }) => `ASSET_${category}`), ...liabilitiesByCategory.map(({ category }) => `LIABILITY_${category}`)]
+      .every((key) => expandedCategories.has(key));
+
+  function expandOrCollapseAll(expand: boolean) {
+    if (!expand) {
+      setExpandedCategories(new Set());
+      return;
+    }
+    setExpandedCategories(
+      new Set([
+        ...assetsByCategory.map(({ category }) => `ASSET_${category}`),
+        ...liabilitiesByCategory.map(({ category }) => `LIABILITY_${category}`),
+      ])
+    );
+  }
 
   return (
     <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <Card className="card-gradient border-border/60">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">{t("accountsList.assets")}</span>
+              <Wallet2 className="h-4 w-4 text-emerald-500" />
+            </div>
+            <p className="mt-2 text-2xl font-semibold tabular-nums">{formatCurrency(totalAssets, baseCurrency)}</p>
+          </CardContent>
+        </Card>
+        <Card className="card-gradient border-border/60">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">{t("accountsList.liabilities")}</span>
+              <Landmark className="h-4 w-4 text-rose-500" />
+            </div>
+            <p className="mt-2 text-2xl font-semibold tabular-nums">{formatCurrency(totalLiabilities, baseCurrency)}</p>
+          </CardContent>
+        </Card>
+        <Card className="card-gradient border-border/60">
+          <CardContent className="pt-5 pb-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">{t("accountsList.netPosition")}</span>
+              <span className="text-xs font-medium text-muted-foreground">{baseCurrency}</span>
+            </div>
+            <p className="mt-2 text-2xl font-semibold tabular-nums">{formatCurrency(totalAssets - totalLiabilities, baseCurrency)}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/60">
+        <CardContent className="pt-5 pb-5 space-y-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("accountsList.searchPlaceholder")}
+                className="pl-10"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              {(["ALL", "ASSET", "LIABILITY"] as const).map((filter) => (
+                <Button
+                  key={filter}
+                  variant={typeFilter === filter ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setTypeFilter(filter)}
+                >
+                  {t(`accountsList.filters.${filter.toLowerCase()}`)}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm text-muted-foreground">
+              {t("accountsList.resultsCount", { count: filteredAccounts.length })}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8"
+              onClick={() => expandOrCollapseAll(!allCategoriesExpanded)}
+            >
+              {allCategoriesExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              {allCategoriesExpanded ? t("accountsList.collapseAll") : t("accountsList.expandAll")}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          {accounts.length > 0 && (
+          {filteredAccounts.length > 0 && (
             <>
               <Checkbox
-                checked={selected.size === accounts.length && accounts.length > 0}
+                checked={filteredAccounts.length > 0 && filteredAccounts.every((account) => selected.has(account.id))}
                 onCheckedChange={toggleAll}
               />
               <span className="text-sm text-muted-foreground">
@@ -188,6 +320,12 @@ export function AccountsList({
       {accounts.length === 0 && (
         <p className="text-center text-muted-foreground py-12">
           {t("accountsList.noAccounts")}
+        </p>
+      )}
+
+      {accounts.length > 0 && filteredAccounts.length === 0 && (
+        <p className="text-center text-muted-foreground py-12">
+          {t("accountsList.noMatches")}
         </p>
       )}
 


### PR DESCRIPTION
### Motivation
- Improve discoverability and navigation for users with many accounts and holdings by adding quick summary metrics and search/filter controls.
- Make bulk actions safer by ensuring selection applies to the visible (filtered) set rather than the entire dataset.

### Description
- Added a top-level portfolio overview strip showing `Assets`, `Liabilities`, and `Net Position` cards that compute totals in the base currency using `useMemo` for efficiency (changes in `src/components/accounts/accounts-list.tsx`).
- Introduced a search input, type filters (`All` / `Assets` / `Liabilities`), a visible-results counter, and expand/collapse-all controls to help users find and navigate accounts quickly (UI + icons from `lucide-react`).
- Updated bulk-select behavior so `select all` toggles only the currently filtered/visible accounts and added a friendly empty-state when filters return no matches.
- Added i18n keys for all new UI labels and messages in both `messages/en-US.json` and `messages/zh-TW.json`.

### Testing
- Ran `npm run lint`, which failed due to ESLint module resolution issues in this environment (local `eslint/config` import error).
- Ran `npx tsc --noEmit`, which failed due to missing ambient type definition packages in the current environment.
- Verified the TypeScript and JSON changes were applied and files updated: `src/components/accounts/accounts-list.tsx`, `messages/en-US.json`, and `messages/zh-TW.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8adfaea00832199790b5fb6581645)