### PR TITLE
Fix Vercel preview auth redirects to stay on PR deployment

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { signIn } from "@/auth"
 import { Button } from "@/components/ui/button"
 import { TrendingUp } from "lucide-react"
+import { headers } from "next/headers"
 import { getTranslations } from "next-intl/server"
 
 export default async function LoginPage() {
@@ -31,7 +32,12 @@ export default async function LoginPage() {
         <form
           action={async () => {
             "use server"
-            await signIn("google", { redirectTo: "/" })
+            const headerStore = await headers()
+            const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host")
+            const protocol = headerStore.get("x-forwarded-proto") ?? "https"
+            const redirectTo = host ? `${protocol}://${host}/` : "/"
+
+            await signIn("google", { redirectTo })
           }}
           className="pt-4"
         >

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,6 +12,32 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.id = token.sub
       }
       return session
-    }
+    },
+    redirect({ url, baseUrl }) {
+      if (url.startsWith("/")) {
+        return `${baseUrl}${url}`
+      }
+
+      try {
+        const targetUrl = new URL(url)
+        const currentBaseUrl = new URL(baseUrl)
+
+        if (targetUrl.origin === currentBaseUrl.origin) {
+          return url
+        }
+
+        const isVercelPreviewRedirect =
+          targetUrl.hostname.endsWith(".vercel.app") &&
+          currentBaseUrl.hostname.endsWith(".vercel.app")
+
+        if (isVercelPreviewRedirect) {
+          return url
+        }
+      } catch {
+        return baseUrl
+      }
+
+      return baseUrl
+    },
   }
 })


### PR DESCRIPTION
### Motivation
- Preview deployments on Vercel were being redirected to the production host after OAuth, causing users to land on the production site instead of the PR preview.
- The OAuth return flow needs an absolute `redirectTo` that targets the active preview host rather than a hardcoded or baseUrl-derived production host.
- The NextAuth `redirect` callback must allow valid redirects between Vercel deployment domains so the provider can return to the preview origin.

### Description
- Added a `redirect` callback to NextAuth in `src/auth.ts` that returns `baseUrl + url` for path redirects, allows same-origin full URLs, and permits cross-origin redirects when both origin hosts end with `.vercel.app`.
- Updated the login server action in `src/app/login/page.tsx` to import `headers` from `next/headers`, derive `host` from `x-forwarded-host`/`host` and `protocol` from `x-forwarded-proto`, build an absolute `redirectTo` (`protocol://host/`), and pass it to `signIn` so the OAuth flow returns to the active deployment.
- Modified files: `src/auth.ts` and `src/app/login/page.tsx`.

### Testing
- Ran `npm install` which completed but emitted dependency resolution warnings related to `@swc`/`@swc/helpers` and some EventEmitter warnings, indicating potential peer dependency mismatches.
- Running `npm ci` failed in this environment due to a lockfile mismatch (`package.json` and `package-lock.json` out of sync), so a clean CI install could not be performed.
- Running `npm run lint` failed in this environment with a missing ESLint config module (`Cannot find module '/workspace/asset_tracker/node_modules/eslint/config'`), so lint checks did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b53b6b9483218c95d18098cfbcb2)