### PR TITLE
Enable trustHost in NextAuth configuration

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -2,6 +2,7 @@ import GoogleProvider from "next-auth/providers/google"
 import type { NextAuthConfig } from "next-auth"
 
 export default {
+  trustHost: true,
   providers: [
     GoogleProvider({
       clientId: process.env.AUTH_GOOGLE_ID!,


### PR DESCRIPTION
## Description
Enable the `trustHost` option in the NextAuth configuration. This setting allows NextAuth to trust the `X-Forwarded-Host` and `X-Forwarded-Proto` headers, which is important for proper authentication flow when the application is behind a proxy or load balancer.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests
- [x] No testing needed - configuration change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have commented complex code
- [ ] I have updated documentation
- [x] No new warnings generated

## Related Issues
Closes #

https://claude.ai/code/session_01Te9FytMyi4rfgBmHnm4eLJ