### PR TITLE
feat: improve empty states with clear CTAs

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -76,8 +76,9 @@
     "colAssets": "Assets",
     "colLiabilities": "Liabilities",
     "colChange": "Change",
-    "noData": "No snapshots yet. Take a snapshot from the dashboard to start tracking.",
-    "noDataForRange": "No data for this range."
+    "noData": "No snapshots yet. Your net worth history appears after your first daily snapshot.",
+    "noDataForRange": "No data for this range.",
+    "goDashboard": "Go to Dashboard"
   },
   "netWorthCard": {
     "netWorth": "Net Worth",
@@ -122,7 +123,8 @@
     "selected": "{count} selected",
     "addItem": "Add Item",
     "addAccount": "Add Account",
-    "noAccounts": "No accounts yet. Add your first account to get started.",
+    "emptyTitle": "No accounts yet",
+    "noAccounts": "Track your assets and liabilities by adding your first account.",
     "assets": "Assets",
     "liabilities": "Liabilities",
     "nAccounts": "{count, plural, one {# account} other {# accounts}}",
@@ -253,7 +255,12 @@
   "transactionHistory": {
     "title": "Transaction History",
     "loading": "Loading...",
-    "empty": "No transactions yet.",
+    "empty": "No transactions yet",
+    "emptyDescription": "Your activity will show up here once you add your first transaction.",
+    "emptyDescriptionInvestments": "Add a holding to begin recording buy and sell activity for this account.",
+    "emptyDescriptionBank": "Update your cash balance to create your first deposit or withdrawal transaction.",
+    "ctaAddHolding": "Add Holding",
+    "ctaUpdateCash": "Update Cash Balance",
     "loadMore": "Load More",
     "colDate": "Date",
     "colSymbol": "Symbol",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -76,8 +76,9 @@
     "colAssets": "總資產",
     "colLiabilities": "總負債",
     "colChange": "變化",
-    "noData": "尚無快照。請從儀表板建立快照以開始追蹤歷史。",
-    "noDataForRange": "此範圍內無資料。"
+    "noData": "尚無快照。首次每日快照建立後，這裡就會顯示淨資產歷史。",
+    "noDataForRange": "此範圍內無資料。",
+    "goDashboard": "前往儀表板"
   },
   "netWorthCard": {
     "netWorth": "淨資產",
@@ -122,7 +123,8 @@
     "selected": "已選 {count} 項",
     "addItem": "新增項目",
     "addAccount": "新增帳戶",
-    "noAccounts": "尚無帳戶。新增您的第一個帳戶以開始使用。",
+    "emptyTitle": "尚無帳戶",
+    "noAccounts": "新增第一個帳戶，開始追蹤您的資產與負債。",
     "assets": "資產",
     "liabilities": "負債",
     "nAccounts": "{count} 個帳戶",
@@ -253,7 +255,12 @@
   "transactionHistory": {
     "title": "交易紀錄",
     "loading": "載入中...",
-    "empty": "尚無交易紀錄。",
+    "empty": "尚無交易紀錄",
+    "emptyDescription": "新增第一筆交易後，這裡會顯示您的活動紀錄。",
+    "emptyDescriptionInvestments": "先新增持倉，即可開始記錄此帳戶的買賣交易。",
+    "emptyDescriptionBank": "更新現金餘額即可建立第一筆存提款交易。",
+    "ctaAddHolding": "新增持倉",
+    "ctaUpdateCash": "更新現金餘額",
     "loadMore": "載入更多",
     "colDate": "日期",
     "colSymbol": "代號",

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -189,6 +189,9 @@ export function AccountDetail({
   }
 
   const isBank = account.category === "BANK";
+  const transactionEmptyActionLabel = isBank
+    ? t("transactionHistory.ctaUpdateCash")
+    : t("transactionHistory.ctaAddHolding");
 
   return (
     <>
@@ -440,7 +443,24 @@ export function AccountDetail({
         </Card>
       )}
 
-      <TransactionHistory accountId={account.id} isBank={isBank} refreshTrigger={refreshTrigger} />
+      <TransactionHistory
+        accountId={account.id}
+        isBank={isBank}
+        refreshTrigger={refreshTrigger}
+        emptyDescription={
+          isBank
+            ? t("transactionHistory.emptyDescriptionBank")
+            : t("transactionHistory.emptyDescriptionInvestments")
+        }
+        emptyActionLabel={transactionEmptyActionLabel}
+        onEmptyAction={() => {
+          if (isBank) {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+            return;
+          }
+          setShowHoldingForm(true);
+        }}
+      />
 
       <HoldingForm
         open={showHoldingForm}

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -13,6 +13,7 @@ import { QuickAddHolding } from "./quick-add-holding";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+import { FolderPlus } from "lucide-react";
 
 const CATEGORY_ICONS: Record<string, string> = {
   BANK: "🏦",
@@ -186,9 +187,20 @@ export function AccountsList({
       </div>
 
       {accounts.length === 0 && (
-        <p className="text-center text-muted-foreground py-12">
-          {t("accountsList.noAccounts")}
-        </p>
+        <Card className="border-dashed">
+          <CardContent className="py-12 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <FolderPlus className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h3 className="text-lg font-semibold">{t("accountsList.emptyTitle")}</h3>
+            <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+              {t("accountsList.noAccounts")}
+            </p>
+            <Button className="mt-6" onClick={() => setShowForm(true)}>
+              {t("accountsList.addAccount")}
+            </Button>
+          </CardContent>
+        </Card>
       )}
 
       {assetsByCategory.length > 0 && (

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/table";
 import { formatNumber } from "@/lib/currencies";
 import type { SerializedTransaction } from "@/lib/types";
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, ReceiptText, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -50,7 +50,21 @@ const TYPE_VARIANTS: Record<string, "default" | "secondary" | "destructive"> = {
   EDIT: "secondary",
 };
 
-export function TransactionHistory({ accountId, isBank, refreshTrigger }: { accountId: string; isBank?: boolean; refreshTrigger?: number }) {
+export function TransactionHistory({
+  accountId,
+  isBank,
+  refreshTrigger,
+  onEmptyAction,
+  emptyActionLabel,
+  emptyDescription,
+}: {
+  accountId: string;
+  isBank?: boolean;
+  refreshTrigger?: number;
+  onEmptyAction?: () => void;
+  emptyActionLabel?: string;
+  emptyDescription?: string;
+}) {
   const router = useRouter();
   const t = useTranslations("transactionHistory");
   const tCommon = useTranslations("common");
@@ -177,9 +191,20 @@ export function TransactionHistory({ accountId, isBank, refreshTrigger }: { acco
       </CardHeader>
       <CardContent>
         {transactions.length === 0 ? (
-          <p className="text-muted-foreground text-center py-8">
-            {t("empty")}
-          </p>
+          <div className="py-10 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <ReceiptText className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <p className="text-sm font-medium">{t("empty")}</p>
+            <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+              {emptyDescription ?? t("emptyDescription")}
+            </p>
+            {onEmptyAction && emptyActionLabel && (
+              <Button className="mt-5" onClick={onEmptyAction}>
+                {emptyActionLabel}
+              </Button>
+            )}
+          </div>
         ) : (
           <Table>
             <TableHeader>

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -13,6 +15,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/currencies";
+import { CalendarClock } from "lucide-react";
 
 type SnapshotRow = {
   id: string;
@@ -44,8 +47,14 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
       </CardHeader>
       <CardContent>
         {rows.length === 0 ? (
-          <div className="py-12 text-center text-muted-foreground text-sm">
-            {t("noData")}
+          <div className="py-12 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <CalendarClock className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <p className="text-sm text-muted-foreground">{t("noData")}</p>
+            <Button asChild variant="outline" className="mt-4">
+              <Link href="/">{t("goDashboard")}</Link>
+            </Button>
           </div>
         ) : (
           <div className="max-h-[480px] overflow-y-auto">

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -52,9 +52,9 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
               <CalendarClock className="h-6 w-6 text-muted-foreground" />
             </div>
             <p className="text-sm text-muted-foreground">{t("noData")}</p>
-            <Button asChild variant="outline" className="mt-4">
-              <Link href="/">{t("goDashboard")}</Link>
-            </Button>
+            <Link href="/" className={cn(buttonVariants({ variant: "outline" }), "mt-4")}>
+              {t("goDashboard")}
+            </Link>
           </div>
         ) : (
           <div className="max-h-[480px] overflow-y-auto">


### PR DESCRIPTION
### Motivation
- Improve onboarding and recovery for users who land on empty views by replacing terse “no data” lines with actionable, illustrated empty states that guide the next step. 
- Surface the most relevant next action (create an account, add a holding, or update cash) directly in the empty-state UI so users don’t have to hunt for the CTA.

### Description
- Replaced the bare accounts list empty text with a dashed `Card` that includes an icon, title, guidance copy, and an inline `Add Account` button that opens the account form in `src/components/accounts/accounts-list.tsx`.
- Upgraded the history empty state in `src/components/history/history-table.tsx` to an icon-led layout and added a `Go to Dashboard` CTA that links to `/`.
- Enhanced `TransactionHistory` to support configurable empty-state content and actions by adding `onEmptyAction`, `emptyActionLabel`, and `emptyDescription` props and rendering an icon + description + optional CTA in `src/components/accounts/transaction-history.tsx`.
- Wired account-specific behaviors from `src/components/accounts/account-detail.tsx` so investment accounts open the add-holding form and bank accounts scroll to the cash balance editor when the transaction-history CTA is used.
- Added localized strings for the new titles, descriptions, and CTA labels in `messages/en-US.json` and `messages/zh-TW.json`.

### Testing
- Attempted to run lint with `npm run lint` and it failed in this environment due to an `ERR_MODULE_NOT_FOUND` while resolving `eslint` from `eslint.config.mjs` (environment package resolution issue).
- Verified the application source builds of the changed files locally by static inspection and component wiring (no automated unit or E2E tests were executed in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db05d090a88321bc21bc1a8263d4a7)