### PR TITLE
feat: add preview-only credentials login for Vercel preview deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9585,6 +9585,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from "next-intl/server"
 
 export default async function LoginPage() {
   const t = await getTranslations("login")
+  const isPreview = process.env.VERCEL_ENV === "preview"
 
   return (
     <div className="flex min-h-screen w-full items-center justify-center relative overflow-hidden bg-slate-50">
@@ -14,7 +15,7 @@ export default async function LoginPage() {
 
       {/* Glassmorphism Card */}
       <div className="relative z-10 mx-auto flex w-full max-w-md flex-col justify-center space-y-8 p-10 bg-white/80 backdrop-blur-xl border border-white/60 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.1)] rounded-3xl animate-slide-in-bottom">
-        
+
         <div className="flex flex-col space-y-3 text-center">
           <div className="w-16 h-16 mx-auto rounded-xl flex items-center justify-center mb-4 relative group shadow-lg" style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}>
             <div className="absolute inset-0 rounded-xl blur-md bg-emerald-500/50 opacity-40 group-hover:opacity-70 transition-opacity duration-500 animate-pulse" style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}></div>
@@ -35,8 +36,8 @@ export default async function LoginPage() {
           }}
           className="pt-4"
         >
-          <Button 
-            className="w-full h-12 text-[15px] font-medium tracking-wide bg-white text-slate-700 hover:bg-slate-50 border border-slate-200 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 rounded-xl flex items-center justify-center gap-3" 
+          <Button
+            className="w-full h-12 text-[15px] font-medium tracking-wide bg-white text-slate-700 hover:bg-slate-50 border border-slate-200 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 rounded-xl flex items-center justify-center gap-3"
             type="submit"
           >
             <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -48,6 +49,42 @@ export default async function LoginPage() {
             {t("googleButton")}
           </Button>
         </form>
+
+        {isPreview && (
+          <>
+            <div className="flex items-center gap-3 pt-2">
+              <div className="flex-1 h-px bg-slate-200" />
+              <span className="text-xs text-slate-400 font-medium">Preview Mode</span>
+              <div className="flex-1 h-px bg-slate-200" />
+            </div>
+
+            <form
+              action={async (formData: FormData) => {
+                "use server"
+                await signIn("credentials", {
+                  password: formData.get("password") as string,
+                  redirectTo: "/",
+                })
+              }}
+            >
+              <div className="flex flex-col gap-3">
+                <input
+                  name="password"
+                  type="password"
+                  placeholder="Preview password"
+                  required
+                  className="h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500 transition-all"
+                />
+                <Button
+                  type="submit"
+                  className="w-full h-12 text-[15px] font-medium tracking-wide bg-amber-50 text-amber-700 hover:bg-amber-100 border border-amber-200 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 rounded-xl"
+                >
+                  Preview Login
+                </Button>
+              </div>
+            </form>
+          </>
+        )}
 
         <div className="text-center text-xs text-slate-400 pt-4 mb-[-1rem]">
           {t("footer")}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,10 +1,28 @@
 import NextAuth from "next-auth"
+import Credentials from "next-auth/providers/credentials"
 import authConfig from "./auth.config"
 import { customPrismaAdapter } from "@/lib/auth-adapter"
+import { prisma } from "@/lib/prisma"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
   adapter: customPrismaAdapter as any,
+  providers: [
+    ...authConfig.providers,
+    Credentials({
+      credentials: {
+        password: { label: "Password", type: "password" },
+      },
+      authorize: async (credentials) => {
+        if (process.env.VERCEL_ENV !== "preview") return null
+        const expected = process.env.PREVIEW_AUTH_PASSWORD
+        if (!expected || credentials?.password !== expected) return null
+        const user = await prisma.user.findFirst()
+        if (!user) return null
+        return { id: user.id, name: user.name, email: user.email, image: user.image }
+      },
+    }),
+  ],
   session: { strategy: "jwt" },
   callbacks: {
     session({ session, token }) {
@@ -12,6 +30,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.id = token.sub
       }
       return session
-    }
-  }
+    },
+  },
 })


### PR DESCRIPTION
## Summary

- Adds a password-protected Credentials provider to NextAuth that only activates on Vercel preview deployments (`VERCEL_ENV === "preview"`)
- On preview, the login page shows a "Preview Login" form with a password field below the Google sign-in button
- Credentials login queries the database for the first user and creates a real JWT session, so all app features work normally on previews
- Production is unaffected — the credentials provider returns `null` immediately when `VERCEL_ENV !== "preview"`

## Why

AI tools (Claude, Codex, GPT) create different branch names every PR, producing unpredictable Vercel preview URLs. Google OAuth doesn't support wildcard redirect URIs, so registering each preview URL manually is impractical. This approach bypasses Google OAuth entirely on previews without any external configuration per branch.

## Required Vercel setup (one-time)

Add env var in Vercel → Settings → Environment Variables:

| Key | Value | Scope |
|---|---|---|
| `PREVIEW_AUTH_PASSWORD` | any strong password | **Preview** only |

`VERCEL_ENV` is set automatically by Vercel — no action needed.

## Test plan

- [ ] Merge to master and verify a new preview deployment shows the "Preview Login" form on the login page
- [ ] Enter the preview password → confirm you're logged in as the real user and can use all features
- [ ] Verify production shows only the Google sign-in button (no preview form)
- [ ] Verify an incorrect password on preview returns to login without crashing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)