### PR TITLE
feat: eliminate Phase 1→2 waterfall in DashboardContent (#72)

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -671,7 +671,7 @@ Emoji without `aria-hidden="true"` are announced by screen readers using their U
 | # | Suggestion | Category | Impact | Effort | Status |
 |---|-----------|----------|--------|--------|--------|
 | 71 | Wrap `getOrCreateSettings` in `React.cache()` | Performance | 🟡 Medium | 15 min | ✅ Done |
-| 72 | Eliminate Phase 1→Phase 2 waterfall in `DashboardContent` | Performance | 🟡 Medium | 1 hr | ❌ Not Done |
+| 72 | Eliminate Phase 1→Phase 2 waterfall in `DashboardContent` | Performance | 🟡 Medium | 1 hr | ✅ Done |
 | 73 | Cache `getNetWorthSummary` with Next.js `unstable_cache` | Performance | 🔴 High | 1-2 hrs | ✅ Done |
 | 74 | Add granular Suspense boundaries inside `DashboardContent` | Performance | 🔴 High | 2-3 hrs | ✅ Done |
 | 75 | Add `Cache-Control` headers to `GET /api/exchange-rates` | Performance | 🟢 Low | 15 min | ❌ Not Done |
@@ -754,6 +754,11 @@ const cachedPrices = userSymbols.length > 0
 This eliminates one full DB round-trip from the critical path. Requires refactoring `getNetWorthSummary` and `getNormalizedHistory` to accept pre-fetched data as parameters (or extracting their computation logic into pure functions).
 
 - **Affected files:** `src/components/dashboard/dashboard-content.tsx`, `src/lib/services/net-worth-service.ts`, `src/lib/services/history-service.ts`
+
+**Implementation (2026-04-12):**
+- Extracted `fetchUserAccountsWithHoldings(userId)` as a React `cache()`-memoised function in `net-worth-service.ts`; `computeNetWorthSummary` now calls it internally, giving the React per-request deduplication needed for the warm-up pattern.
+- Updated `DashboardContent` to fire `fetchUserAccountsWithHoldings(userId)` and `getAllExchangeRates()` immediately (without awaiting) so their DB queries run in parallel with the Phase 1 `Promise.all`. Because `getCachedNetWorthSummary` on a cache-miss calls the same React-cached functions, it receives already-resolved results, eliminating the hidden waterfall.
+- Moved `recentSnapshots` and `latestPrice` fetches into the Phase 1 `Promise.all` — they don't depend on `baseCurrency` and no longer need to wait for Phase 1 to complete before starting.
 
 
 ### 73. Cache `getNetWorthSummary` with Next.js `unstable_cache`

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -4,7 +4,8 @@ import { NetWorthCard } from "@/components/dashboard/net-worth-card";
 import { LazyAllocationChart, LazyCurrencyExposureChart } from "@/components/dashboard/lazy-charts";
 import { AccountsSummary } from "@/components/dashboard/accounts-summary";
 import { DashboardActions } from "@/components/dashboard/dashboard-actions";
-import { getCachedNetWorthSummary } from "@/lib/services/net-worth-service";
+import { getCachedNetWorthSummary, fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
+import { getAllExchangeRates } from "@/lib/services/exchange-rate-service";
 import { redirect } from "next/navigation";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
@@ -12,20 +13,20 @@ import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 export async function DashboardContent({ userId }: { userId: string }) {
-  const [dbUser, settings] = await Promise.all([
+  // Fire DB-independent queries immediately so the React per-render cache is
+  // warm when getCachedNetWorthSummary reaches them on a cold start.
+  // These do not need baseCurrency; only the final computation does.
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  fetchUserAccountsWithHoldings(userId);
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  getAllExchangeRates();
+
+  // All remaining Phase-1 queries run in parallel with the pre-fetches above.
+  // recentSnapshots and latestPrice are moved here from Phase 2 since they
+  // also don't require baseCurrency.
+  const [dbUser, settings, recentSnapshots, latestPrice] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     getOrCreateSettings(userId),
-  ]);
-
-  if (!dbUser) redirect("/api/auth/signout");
-
-  const baseCurrency = settings.baseCurrency;
-
-  // Fetch summary (cached, fast on repeat loads) and meta queries in parallel.
-  // The 2 most recent snapshots give us the previous-period delta and last-snapshot
-  // date without loading the full history — that is deferred to TrendChartSection.
-  const [summary, recentSnapshots, latestPrice] = await Promise.all([
-    getCachedNetWorthSummary(userId, baseCurrency),
     prisma.netWorthSnapshot.findMany({
       where: { userId },
       orderBy: { date: "desc" },
@@ -37,6 +38,14 @@ export async function DashboardContent({ userId }: { userId: string }) {
       select: { updatedAt: true },
     }),
   ]);
+
+  if (!dbUser) redirect("/api/auth/signout");
+
+  const baseCurrency = settings.baseCurrency;
+
+  // On a cache hit this is instant; on a cache miss the accounts and exchange-rate
+  // queries inside it resolve from the React cache populated above.
+  const summary = await getCachedNetWorthSummary(userId, baseCurrency);
 
   // Empty state for new users with no accounts yet
   if (summary.accounts.length === 0) {

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "./exchange-rate-service";
@@ -7,16 +8,28 @@ import {
 } from "@/lib/types";
 import type { AccountWithValue, NetWorthSummary, HoldingWithPrice } from "@/lib/types";
 
+/**
+ * React-cached account + holdings fetcher.
+ * Memoised per server render so concurrent calls with the same userId
+ * (e.g. an early pre-fetch in DashboardContent and the later call inside
+ * computeNetWorthSummary) share a single database round-trip.
+ */
+export const fetchUserAccountsWithHoldings = cache((userId: string) =>
+  prisma.account.findMany({
+    where: { userId, isActive: true },
+    include: { holdings: { where: { quantity: { gt: 0 } } } },
+  })
+);
+
 async function computeNetWorthSummary(
   userId: string,
   baseCurrency: string
 ): Promise<NetWorthSummary> {
-  // Phase 1: load accounts and exchange rates in parallel
+  // Load accounts and exchange rates in parallel.
+  // Both are React-cached, so if DashboardContent already fired these
+  // calls without awaiting, we get the memoised results here for free.
   const [accounts, allRatesMap] = await Promise.all([
-    prisma.account.findMany({
-      where: { userId, isActive: true },
-      include: { holdings: { where: { quantity: { gt: 0 } } } },
-    }),
+    fetchUserAccountsWithHoldings(userId),
     getAllExchangeRates(),
   ]);
 


### PR DESCRIPTION
Fire fetchUserAccountsWithHoldings and getAllExchangeRates immediately
(without awaiting) so their DB queries run concurrently with the Phase 1
Promise.all. Both functions are React-cached, so getCachedNetWorthSummary
on a cache miss reuses the already-resolving promises instead of starting
new round-trips after settings are known.

Also move recentSnapshots and latestPrice into the Phase 1 Promise.all —
they have no baseCurrency dependency and no longer need to wait for Phase 1
to complete before starting.

https://claude.ai/code/session_0142muiw8RGKPJEdx8DMwY2H