### PR TITLE
refactor: code quality improvements #78, #81, #83, #84, #85, #87

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -883,16 +883,16 @@ This allows CDN edges and the browser to serve the cached response for up to 1 h
 |---|-----------|----------|--------|--------|--------|
 | 76 | Extract `withAuth()` HOF for API routes | Code Quality | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 | 77 | Unify Yahoo Finance quote fetcher (stock + crypto) | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
-| 78 | Dedupe `normalizeSnapshots` in history-service | Code Quality | 🟡 Medium | 1 hr | ❌ Not Done |
+| 78 | Dedupe `normalizeSnapshots` in history-service | Code Quality | 🟡 Medium | 1 hr | ✅ Done |
 | 79 | Centralize exchange-rate upsert (`persistExchangeRate`) | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
 | 80 | Share chart tooltip/legend formatters | Code Quality | 🟡 Medium | 30 min | ❌ Not Done |
-| 81 | Extract `<HoldingSearch>` component | Code Quality | 🟡 Medium | 1-2 hrs | ❌ Not Done |
+| 81 | Extract `<HoldingSearch>` component | Code Quality | 🟡 Medium | 1-2 hrs | ✅ Done |
 | 82 | `formatQuantity()` helper in `currencies.ts` | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
-| 83 | Shared enum constants for Prisma/Zod | Code Quality | 🟡 Medium | 30 min | ❌ Not Done |
-| 84 | `Serialized<T>` type + `serializeModel` helper | Code Quality | 🟡 Medium | 1-2 hrs | ❌ Not Done |
-| 85 | Standardize API response shape | Code Quality | 🟡 Medium | 2-3 hrs | ❌ Not Done |
+| 83 | Shared enum constants for Prisma/Zod | Code Quality | 🟡 Medium | 30 min | ✅ Done |
+| 84 | `Serialized<T>` type + `serializeModel` helper | Code Quality | 🟡 Medium | 1-2 hrs | ✅ Done |
+| 85 | Standardize API response shape | Code Quality | 🟡 Medium | 2-3 hrs | ✅ Done |
 | 86 | `calculateBalanceDelta()` for cash-tx edits | Correctness | 🔴 High | 1 hr | ✅ Done |
-| 87 | Split `account-detail.tsx` into subcomponents | Code Quality | 🟡 Medium | 2-3 hrs | ❌ Not Done |
+| 87 | Split `account-detail.tsx` into subcomponents | Code Quality | 🟡 Medium | 2-3 hrs | ✅ Done |
 
 ---
 

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function POST(
   request: Request,
@@ -10,38 +10,22 @@ export async function POST(
   const { id } = await params;
   const body = await request.json();
   const parsed = createCashTransactionSchema.safeParse(body);
-
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   const { type, amount, note } = parsed.data;
 
-  // Verify account exists
-  const account = await prisma.account.findUnique({
-    where: { id },
-  });
+  const account = await prisma.account.findUnique({ where: { id } });
+  if (!account) return failure("Account not found", 404);
 
-  if (!account) {
-    return NextResponse.json({ error: "Account not found" }, { status: 404 });
-  }
-
-  // Create the transaction
   const transaction = await prisma.cashTransaction.create({
-    data: {
-      accountId: id,
-      type,
-      amount,
-      note,
-    },
+    data: { accountId: id, type, amount, note },
   });
 
-  // Update account balance
   const delta = calculateBalanceDelta(null, { type, amount });
   await prisma.account.update({
     where: { id },
     data: { cashBalance: { increment: delta } },
   });
 
-  return NextResponse.json(transaction, { status: 201 });
+  return ok(transaction, { status: 201 });
 }

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,25 +1,25 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
 import { auth } from "@/auth";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const { id } = await params;
   const account = await prisma.account.findUnique({ where: { id, userId: session.user.id } });
-  if (!account) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!account) return failure("Not found", 404);
 
   const holdings = await prisma.holding.findMany({
     where: { accountId: id, quantity: { gt: 0 } },
     orderBy: { symbol: "asc" },
   });
-  return NextResponse.json(holdings);
+  return ok(holdings);
 }
 
 export async function POST(
@@ -29,9 +29,7 @@ export async function POST(
   const { id } = await params;
   const body = await request.json();
   const parsed = createHoldingSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   // Check if holding already exists in this account
   const existing = await prisma.holding.findUnique({
@@ -48,20 +46,13 @@ export async function POST(
     });
   } else {
     holding = await prisma.holding.create({
-      data: {
-        accountId: id,
-        ...parsed.data,
-      },
+      data: { accountId: id, ...parsed.data },
     });
   }
 
   // Log the transaction
   await prisma.holdingTransaction.create({
-    data: {
-      holdingId: holding.id,
-      type: "BUY",
-      quantity: parsed.data.quantity,
-    },
+    data: { holdingId: holding.id, type: "BUY", quantity: parsed.data.quantity },
   });
 
   // Auto-fetch the market price for the holding
@@ -84,7 +75,7 @@ export async function POST(
     console.error(`Failed to fetch price for ${holding.symbol}:`, error);
   }
 
-  return NextResponse.json(holding, { status: 201 });
+  return ok(holding, { status: 201 });
 }
 
 export async function PATCH(
@@ -94,9 +85,7 @@ export async function PATCH(
   const { id: _accountId } = await params;
   const body = await request.json();
   const parsed = updateHoldingSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   const { id, ...data } = parsed.data;
 
@@ -118,11 +107,8 @@ export async function PATCH(
     }
   }
 
-  const holding = await prisma.holding.update({
-    where: { id },
-    data,
-  });
-  return NextResponse.json(holding);
+  const holding = await prisma.holding.update({ where: { id }, data });
+  return ok(holding);
 }
 
 export async function DELETE(
@@ -132,10 +118,8 @@ export async function DELETE(
   const { id: _accountId } = await params;
   const body = await request.json();
   const { id } = body;
-  if (!id) {
-    return NextResponse.json({ error: "Holding ID required" }, { status: 400 });
-  }
+  if (!id) return failure("Holding ID required");
 
   await prisma.holding.delete({ where: { id } });
-  return NextResponse.json({ ok: true });
+  return ok({ ok: true });
 }

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,24 +1,22 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { updateAccountSchema } from "@/lib/validators";
 import { auth } from "@/auth";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const { id } = await params;
   const account = await prisma.account.findUnique({
     where: { id, userId: session.user.id },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
   });
-  if (!account) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-  return NextResponse.json(account);
+  if (!account) return failure("Not found", 404);
+  return ok(account);
 }
 
 export async function PATCH(
@@ -26,19 +24,15 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const { id } = await params;
   const body = await request.json();
   const parsed = updateAccountSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   const existingAccount = await prisma.account.findUnique({ where: { id, userId: session.user.id } });
-  if (!existingAccount) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  if (!existingAccount) return failure("Not found", 404);
 
   // If cashBalance is being updated to a new value, log it as an EDIT transaction
   if (
@@ -60,7 +54,7 @@ export async function PATCH(
     where: { id, userId: session.user.id },
     data: parsed.data,
   });
-  return NextResponse.json(account);
+  return ok(account);
 }
 
 export async function DELETE(
@@ -68,9 +62,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const { id } = await params;
   await prisma.account.delete({ where: { id, userId: session.user.id } });
-  return NextResponse.json({ ok: true });
+  return ok({ ok: true });
 }

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function PATCH(
   request: Request,
@@ -18,13 +18,11 @@ export async function PATCH(
 
   if (holdingTx) {
     if (holdingTx.holding.accountId !== accountId) {
-      return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+      return failure("Transaction not found", 404);
     }
 
     const parsed = updateTransactionSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-    }
+    if (!parsed.success) return validationError(parsed.error);
 
     const { id, ...data } = parsed.data;
 
@@ -49,7 +47,7 @@ export async function PATCH(
       },
     });
 
-    return NextResponse.json(updatedTx);
+    return ok(updatedTx);
   }
 
   const cashTx = await prisma.cashTransaction.findUnique({
@@ -59,7 +57,7 @@ export async function PATCH(
 
   if (cashTx) {
     if (cashTx.accountId !== accountId) {
-      return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+      return failure("Transaction not found", 404);
     }
 
     // Since UI might send `quantity` for amount, let's map it if `amount` is missing.
@@ -68,9 +66,7 @@ export async function PATCH(
     }
 
     const parsed = updateCashTransactionSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-    }
+    if (!parsed.success) return validationError(parsed.error);
 
     const { id, ...data } = parsed.data;
 
@@ -100,10 +96,10 @@ export async function PATCH(
       },
     });
 
-    return NextResponse.json(updatedTx);
+    return ok(updatedTx);
   }
 
-  return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+  return failure("Transaction not found", 404);
 }
 
 export async function DELETE(
@@ -119,7 +115,7 @@ export async function DELETE(
 
   if (holdingTx) {
     if (holdingTx.holding.accountId !== accountId) {
-      return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+      return failure("Transaction not found", 404);
     }
 
     const newHoldingQty = Number(holdingTx.holding.quantity) - Number(holdingTx.quantity);
@@ -128,11 +124,8 @@ export async function DELETE(
       data: { quantity: newHoldingQty },
     });
 
-    await prisma.holdingTransaction.delete({
-      where: { id: transactionId },
-    });
-
-    return NextResponse.json({ ok: true });
+    await prisma.holdingTransaction.delete({ where: { id: transactionId } });
+    return ok({ ok: true });
   }
 
   const cashTx = await prisma.cashTransaction.findUnique({
@@ -142,7 +135,7 @@ export async function DELETE(
 
   if (cashTx) {
     if (cashTx.accountId !== accountId) {
-      return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+      return failure("Transaction not found", 404);
     }
 
     const delta = calculateBalanceDelta({ type: cashTx.type, amount: Number(cashTx.amount) }, null);
@@ -151,11 +144,9 @@ export async function DELETE(
       data: { cashBalance: { increment: delta } },
     });
 
-    await prisma.cashTransaction.delete({
-       where: { id: transactionId }
-    });
-    return NextResponse.json({ ok: true });
+    await prisma.cashTransaction.delete({ where: { id: transactionId } });
+    return ok({ ok: true });
   }
 
-  return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+  return failure("Transaction not found", 404);
 }

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { ok } from "@/lib/api-responses";
 
 interface UnifiedRow {
   id: string;
@@ -63,5 +63,5 @@ export async function GET(
     ...(row.holdingId ? { holdingId: row.holdingId, holding: holdingsMap.get(row.holdingId) ?? null } : {}),
   }));
 
-  return NextResponse.json(result);
+  return ok(result);
 }

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,54 +1,49 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createAccountSchema } from "@/lib/validators";
 import { auth } from "@/auth";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  
+  if (!session?.user?.id) return failure("Unauthorized", 401);
+
   const accounts = await prisma.account.findMany({
     where: { userId: session.user.id },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
     orderBy: { createdAt: "desc" },
   });
-  return NextResponse.json(accounts);
+  return ok(accounts);
 }
 
 export async function DELETE(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const body = await request.json();
   const ids: string[] = body.ids;
   if (!Array.isArray(ids) || ids.length === 0) {
-    return NextResponse.json({ error: "ids array required" }, { status: 400 });
+    return failure("ids array required");
   }
-  
-  await prisma.account.deleteMany({ 
-    where: { 
+
+  await prisma.account.deleteMany({
+    where: {
       id: { in: ids },
-      userId: session.user.id 
-    } 
+      userId: session.user.id,
+    },
   });
-  return NextResponse.json({ ok: true });
+  return ok({ ok: true });
 }
 
 export async function POST(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const body = await request.json();
   const parsed = createAccountSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   const account = await prisma.account.create({
-    data: {
-      ...parsed.data,
-      userId: session.user.id
-    },
+    data: { ...parsed.data, userId: session.user.id },
   });
-  return NextResponse.json(account, { status: 201 });
+  return ok(account, { status: 201 });
 }

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { refreshAllPrices } from "@/lib/services/price-service";
+import { ok, failure } from "@/lib/api-responses";
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -14,7 +14,6 @@ export async function GET(request: Request) {
     // 1. Refresh all prices first to ensure the snapshot is accurate
     console.log("Cron: Refreshing prices...");
     await refreshAllPrices();
-    // Invalidate cached net worth summaries so snapshots use fresh prices
     revalidateTag("net-worth", "max");
 
     // 2. Get all users and their settings
@@ -30,18 +29,14 @@ export async function GET(request: Request) {
         return createSnapshot(user.id, baseCurrency);
       })
     );
-    const results = snapshots.map((s) => s.id);
 
-    return NextResponse.json({
+    return ok({
       success: true,
-      snapshotIds: results,
+      snapshotIds: snapshots.map((s) => s.id),
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
     console.error("Cron snapshot failed:", error);
-    return NextResponse.json(
-      { success: false, error: "Internal Server Error" },
-      { status: 500 }
-    );
+    return failure("Internal Server Error", 500);
   }
 }

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -1,13 +1,12 @@
-import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { ok } from "@/lib/api-responses";
 
 export async function POST() {
   const settings = await prisma.setting.findFirst();
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
-  // Refresh rates for base currency and all account currencies in parallel
   const accounts = await prisma.account.findMany({
     select: { currency: true },
     distinct: ["currency"],
@@ -16,13 +15,12 @@ export async function POST() {
     .map((a) => a.currency)
     .filter((c) => c !== baseCurrency);
 
-  // Refresh rates for all account currencies in parallel
   const results = await Promise.all([
     refreshExchangeRates(baseCurrency),
     ...otherCurrencies.map((currency) => refreshExchangeRates(currency)),
   ]);
   const totalUpdated = results.reduce((a, b) => a + b, 0);
-  
+
   revalidateTag("exchange-rates", "max");
-  return NextResponse.json({ updated: totalUpdated, baseCurrency });
+  return ok({ updated: totalUpdated, baseCurrency });
 }

--- a/src/app/api/exchange-rates/route.ts
+++ b/src/app/api/exchange-rates/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { ok } from "@/lib/api-responses";
 
 export async function GET() {
   const rates = await prisma.exchangeRate.findMany();
-  return NextResponse.json(rates);
+  return ok(rates);
 }

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { refreshAllPrices } from "@/lib/services/price-service";
+import { ok } from "@/lib/api-responses";
 
 export async function POST() {
   const result = await refreshAllPrices();
   revalidateTag("net-worth", "max");
-  return NextResponse.json(result);
+  return ok(result);
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { ok } from "@/lib/api-responses";
 
 type SearchResult = {
   symbol: string;
@@ -33,38 +33,13 @@ function inferCurrency(symbol: string, exchange: string): string {
   if (symbol.endsWith(".KS") || symbol.endsWith(".KQ")) return "KRW";
 
   const exchangeCurrencyMap: Record<string, string> = {
-    NMS: "USD",
-    NYQ: "USD",
-    NGM: "USD",
-    NCM: "USD",
-    PCX: "USD",
-    ASE: "USD",
-    TAI: "TWD",
-    TWO: "TWD",
-    HKG: "HKD",
-    TYO: "JPY",
-    LSE: "GBP",
-    KSC: "KRW",
-    KOE: "KRW",
-    SHH: "CNY",
-    SHZ: "CNY",
-    FRA: "EUR",
-    GER: "EUR",
-    PAR: "EUR",
-    AMS: "EUR",
-    ASX: "AUD",
-    TSE: "CAD",
-    CNQ: "CAD",
-    SES: "SGD",
-    BKK: "THB",
-    SAO: "BRL",
-    BMV: "MXN",
-    OSL: "NOK",
-    STO: "SEK",
-    CPH: "DKK",
-    NZE: "NZD",
-    NSI: "INR",
-    BOM: "INR",
+    NMS: "USD", NYQ: "USD", NGM: "USD", NCM: "USD", PCX: "USD", ASE: "USD",
+    TAI: "TWD", TWO: "TWD", HKG: "HKD", TYO: "JPY", LSE: "GBP",
+    KSC: "KRW", KOE: "KRW", SHH: "CNY", SHZ: "CNY",
+    FRA: "EUR", GER: "EUR", PAR: "EUR", AMS: "EUR",
+    ASX: "AUD", TSE: "CAD", CNQ: "CAD", SES: "SGD",
+    BKK: "THB", SAO: "BRL", BMV: "MXN", OSL: "NOK",
+    STO: "SEK", CPH: "DKK", NZE: "NZD", NSI: "INR", BOM: "INR",
   };
 
   return exchangeCurrencyMap[exchange] || "USD";
@@ -75,7 +50,7 @@ export async function GET(request: Request) {
   const query = searchParams.get("q")?.trim();
 
   if (!query || query.length < 1) {
-    return NextResponse.json([]);
+    return ok([] as SearchResult[]);
   }
 
   try {
@@ -100,9 +75,9 @@ export async function GET(request: Request) {
         currency: inferCurrency(q.symbol as string, (q.exchange as string) || ""),
       }));
 
-    return NextResponse.json(quotes);
+    return ok(quotes);
   } catch (error) {
     console.error("Search failed:", error);
-    return NextResponse.json([]);
+    return ok([] as SearchResult[]);
   }
 }

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -2,12 +2,11 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { dataImportSchema } from "@/lib/validators";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const userId = session.user.id;
 
@@ -18,11 +17,7 @@ export async function GET() {
         appSettings: true,
         appAccounts: {
           include: {
-            holdings: {
-              include: {
-                transactions: true,
-              },
-            },
+            holdings: { include: { transactions: true } },
             cashTransactions: true,
           },
         },
@@ -30,9 +25,7 @@ export async function GET() {
       },
     });
 
-    if (!data) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
+    if (!data) return failure("User not found", 404);
 
     const exportData = {
       version: "1.0",
@@ -42,22 +35,22 @@ export async function GET() {
       snapshots: data.snapshots,
     };
 
+    // Return as a raw JSON file download — NOT wrapped in ok() so the blob
+    // content matches the dataImportSchema format for round-trip import.
     return NextResponse.json(exportData, {
       headers: {
-        "Content-Disposition": `attachment; filename="asset-tracker-backup-${new Date().toISOString().split('T')[0]}.json"`,
+        "Content-Disposition": `attachment; filename="asset-tracker-backup-${new Date().toISOString().split("T")[0]}.json"`,
       },
     });
   } catch (error) {
     console.error("Export error:", error);
-    return NextResponse.json({ error: "Failed to export data" }, { status: 500 });
+    return failure("Failed to export data", 500);
   }
 }
 
 export async function POST(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const userId = session.user.id;
 
@@ -67,13 +60,7 @@ export async function POST(request: Request) {
 
     if (!parsed.success) {
       console.error("Validation error:", parsed.error.format());
-      return NextResponse.json(
-        { 
-          error: "Invalid data format", 
-          details: parsed.error.issues.map((e: any) => `${e.path.join('.')}: ${e.message}`).join(', ')
-        }, 
-        { status: 400 }
-      );
+      return validationError(parsed.error);
     }
 
     const importData = parsed.data;
@@ -131,9 +118,9 @@ export async function POST(request: Request) {
               },
             });
 
-            // Holding Transactions
             if (Array.isArray(h.transactions) && h.transactions.length > 0) {
               await tx.holdingTransaction.createMany({
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 data: h.transactions.map((t: any) => ({
                   holdingId: newHolding.id,
                   type: t.type,
@@ -149,6 +136,7 @@ export async function POST(request: Request) {
         // Cash Transactions
         if (Array.isArray(acc.cashTransactions) && acc.cashTransactions.length > 0) {
           await tx.cashTransaction.createMany({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             data: acc.cashTransactions.map((t: any) => ({
               accountId: newAccount.id,
               type: t.type,
@@ -163,6 +151,7 @@ export async function POST(request: Request) {
       // 4. Import snapshots
       if (Array.isArray(importData.snapshots) && importData.snapshots.length > 0) {
         await tx.netWorthSnapshot.createMany({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           data: importData.snapshots.map((s: any) => ({
             userId,
             date: new Date(s.date),
@@ -175,16 +164,11 @@ export async function POST(request: Request) {
           })),
         });
       }
-    }, {
-      timeout: 30000, // Increase timeout for potentially large imports
-    });
+    }, { timeout: 30000 });
 
-    return NextResponse.json({ ok: true });
+    return ok({ ok: true });
   } catch (error) {
     console.error("Import error:", error);
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Failed to import data" },
-      { status: 500 }
-    );
+    return failure(error instanceof Error ? error.message : "Failed to import data", 500);
   }
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,29 +1,26 @@
-import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateSettingsSchema } from "@/lib/validators";
 import { auth } from "@/auth";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { ok, failure, validationError } from "@/lib/api-responses";
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  const userId = session.user.id;
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
-  const settings = await getOrCreateSettings(userId);
-  return NextResponse.json(settings);
+  const settings = await getOrCreateSettings(session.user.id);
+  return ok(settings);
 }
 
 export async function PATCH(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  const userId = session.user.id;
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
+  const userId = session.user.id;
   const body = await request.json();
   const parsed = updateSettingsSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
-  }
+  if (!parsed.success) return validationError(parsed.error);
 
   const settings = await prisma.setting.upsert({
     where: { userId },
@@ -38,10 +35,9 @@ export async function PATCH(request: Request) {
     },
   });
 
-  // Invalidate cached settings so pages pick up the new values immediately
   revalidateTag("settings", "max");
 
-  const response = NextResponse.json(settings);
+  const response = ok(settings);
 
   // Set locale cookie so next-intl picks it up on the next request
   if (parsed.data.locale) {

--- a/src/app/api/snapshots/route.ts
+++ b/src/app/api/snapshots/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from "next/server";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { getFullNormalizedHistory } from "@/lib/services/history-service";
 import { auth } from "@/auth";
+import { ok, failure } from "@/lib/api-responses";
 
 export async function GET(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const { searchParams } = new URL(request.url);
   const from = searchParams.get("from");
@@ -17,15 +17,15 @@ export async function GET(request: Request) {
   if (to) options.to = new Date(to);
 
   const snapshots = await getFullNormalizedHistory(session.user.id, baseCurrency, options);
-  return NextResponse.json(snapshots);
+  return ok(snapshots);
 }
 
 export async function POST(request: Request) {
   const session = await auth();
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) return failure("Unauthorized", 401);
 
   const body = await request.json().catch(() => ({}));
   const baseCurrency = body.baseCurrency ?? "USD";
   const snapshot = await createSnapshot(session.user.id, baseCurrency);
-  return NextResponse.json(snapshot, { status: 201 });
+  return ok(snapshot, { status: 201 });
 }

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -11,22 +11,17 @@ import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
-  TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { formatCurrency, formatNumber } from "@/lib/currencies";
+import { formatCurrency } from "@/lib/currencies";
 import { HoldingForm } from "./holding-form";
 import { EditHoldingDialog } from "./edit-holding-dialog";
 import { TransactionHistory } from "./transaction-history";
-import { InlineBalanceEditor } from "./inline-balance-editor";
+import { AccountStatCards } from "./account-stat-cards";
+import { HoldingRow } from "./holding-row";
+import type { HoldingWithPrice } from "./holding-row";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/types";
@@ -64,7 +59,7 @@ export function AccountDetail({
     }
   };
 
-  const holdingsWithValue = account.holdings.map((h) => {
+  const holdingsWithValue: HoldingWithPrice[] = account.holdings.map((h) => {
     const price = priceMap[h.symbol] ?? null;
     const hc = h.currency || "USD";
     const rate = hc === account.currency ? 1 : ratesMap[`${hc}_${account.currency}`] ?? 1;
@@ -112,8 +107,8 @@ export function AccountDetail({
     if (sortField !== field) return <ArrowUpDown className="ml-1 h-3.5 w-3.5 text-muted-foreground opacity-50" />;
     return sortDirection === "asc" ? <ArrowUp className="ml-1 h-3.5 w-3.5" /> : <ArrowDown className="ml-1 h-3.5 w-3.5" />;
   };
-  const isBrokerage = account.category === "BROKERAGE" || account.category === "CRYPTO_WALLET";
-  const totalValue = account.cashBalance + totalHoldingsValue;
+
+  const isBank = account.category === "BANK";
 
   async function saveBalance(newBalance: number, note?: string) {
     await fetch(`/api/accounts/${account.id}`, {
@@ -143,7 +138,7 @@ export function AccountDetail({
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(err.error || t("accountDetail.updateFailed"));
+        throw new Error(err.error?.message || t("accountDetail.updateFailed"));
       }
 
       toast.success(t("accountDetail.accountUpdated"));
@@ -187,8 +182,6 @@ export function AccountDetail({
       toast.error(t("accountDetail.holdingDeleteFailed"));
     }
   }
-
-  const isBank = account.category === "BANK";
 
   return (
     <>
@@ -242,79 +235,11 @@ export function AccountDetail({
         </Button>
       </div>
 
-      {isBrokerage ? (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.marketValue")}</p>
-              <p className="text-2xl font-bold mt-1">
-                {formatCurrency(totalHoldingsValue, account.currency)}
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.holdingsCount")}</p>
-              <p className="text-2xl font-bold mt-1">{holdingsWithValue.length}</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
-              <InlineBalanceEditor
-                currentBalance={account.cashBalance}
-                currency={account.currency}
-                notePlaceholder={t("accountDetail.notePlaceholderDeposit")}
-                onSave={saveBalance}
-              />
-            </CardContent>
-          </Card>
-        </div>
-      ) : isBank ? (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
-              <InlineBalanceEditor
-                currentBalance={account.cashBalance}
-                currency={account.currency}
-                notePlaceholder={t("accountDetail.notePlaceholderSalary")}
-                onSave={saveBalance}
-              />
-            </CardContent>
-          </Card>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.totalValue")}</p>
-              <p className="text-2xl font-bold mt-1">
-                {formatCurrency(totalValue, account.currency)}
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
-              <InlineBalanceEditor
-                currentBalance={account.cashBalance}
-                currency={account.currency}
-                notePlaceholder={t("accountDetail.notePlaceholderSalary")}
-                onSave={saveBalance}
-              />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">{t("accountDetail.holdingsValue")}</p>
-              <p className="text-2xl font-bold mt-1">
-                {formatCurrency(totalHoldingsValue, account.currency)}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-      )}
+      <AccountStatCards
+        account={account}
+        totalHoldingsValue={totalHoldingsValue}
+        onSaveBalance={saveBalance}
+      />
 
       {!isBank && (
         <Card>
@@ -333,49 +258,49 @@ export function AccountDetail({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead 
+                    <TableHead
                       className="cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("symbol")}
                     >
                       <div className="flex items-center">{t("accountDetail.colSymbol")} <SortIcon field="symbol" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("name")}
                     >
                       <div className="flex items-center">{t("accountDetail.colName")} <SortIcon field="name" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("assetType")}
                     >
                       <div className="flex items-center">{t("accountDetail.colType")} <SortIcon field="assetType" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("currency")}
                     >
                       <div className="flex items-center">{t("accountDetail.colCurrency")} <SortIcon field="currency" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="text-right cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("quantity")}
                     >
                       <div className="flex items-center justify-end">{t("accountDetail.colQty")} <SortIcon field="quantity" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="text-right cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("currentPrice")}
                     >
                       <div className="flex items-center justify-end">{t("accountDetail.colPrice")} <SortIcon field="currentPrice" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="text-right cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("marketValue")}
                     >
                       <div className="flex items-center justify-end">{t("accountDetail.colValue")} <SortIcon field="marketValue" /></div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="text-right cursor-pointer select-none hover:bg-accent/50"
                       onClick={() => handleSort("percentage")}
                     >
@@ -386,52 +311,14 @@ export function AccountDetail({
                 </TableHeader>
                 <TableBody>
                   {sortedHoldings.map((h) => (
-                    <TableRow key={h.id}>
-                      <TableCell className="font-mono font-medium">{h.symbol}</TableCell>
-                      <TableCell>{h.name}</TableCell>
-                      <TableCell>
-                        <Badge variant="secondary">{h.assetType}</Badge>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{h.currency || "USD"}</Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {formatNumber(h.quantity, h.assetType === "CRYPTO" ? 7 : 2)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {h.currentPrice !== null
-                          ? formatCurrency(h.currentPrice, h.currency || "USD")
-                          : "—"}
-                      </TableCell>
-                      <TableCell className="text-right font-medium">
-                        {h.marketValue !== null
-                          ? formatCurrency(h.marketValue, account.currency)
-                          : "—"}
-                      </TableCell>
-                      <TableCell className="text-right text-muted-foreground">
-                        {h.marketValue !== null && totalHoldingsValue > 0
-                          ? `${((h.marketValue / totalHoldingsValue) * 100).toFixed(1)}%`
-                          : "—"}
-                      </TableCell>
-                      <TableCell>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 hover:bg-accent hover:text-accent-foreground">
-                            ...
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={() => setEditingHolding(h)}>
-                              {t("common.edit")}
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="text-destructive"
-                              onClick={() => deleteHolding(h.id)}
-                            >
-                              {t("common.delete")}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </TableCell>
-                    </TableRow>
+                    <HoldingRow
+                      key={h.id}
+                      holding={h}
+                      totalValue={totalHoldingsValue}
+                      accountCurrency={account.currency}
+                      onEdit={setEditingHolding}
+                      onDelete={deleteHolding}
+                    />
                   ))}
                 </TableBody>
               </Table>

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -71,7 +71,7 @@ export function AccountForm({
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(err.error?.fieldErrors?.name?.[0] || t("accountForm.createFailed"));
+        throw new Error(err.error?.issues?.fieldErrors?.name?.[0] || t("accountForm.createFailed"));
       }
 
       toast.success(t("accountForm.created"));

--- a/src/components/accounts/account-stat-cards.tsx
+++ b/src/components/accounts/account-stat-cards.tsx
@@ -1,0 +1,101 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/currencies";
+import { InlineBalanceEditor } from "./inline-balance-editor";
+import { useTranslations } from "next-intl";
+import type { SerializedAccountWithHoldings } from "@/lib/types";
+
+interface AccountStatCardsProps {
+  account: SerializedAccountWithHoldings;
+  totalHoldingsValue: number;
+  onSaveBalance: (newBalance: number, note?: string) => Promise<void>;
+}
+
+export function AccountStatCards({ account, totalHoldingsValue, onSaveBalance }: AccountStatCardsProps) {
+  const t = useTranslations();
+  const isBrokerage = account.category === "BROKERAGE" || account.category === "CRYPTO_WALLET";
+  const isBank = account.category === "BANK";
+  const totalValue = account.cashBalance + totalHoldingsValue;
+
+  if (isBrokerage) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">{t("accountDetail.marketValue")}</p>
+            <p className="text-2xl font-bold mt-1">
+              {formatCurrency(totalHoldingsValue, account.currency)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">{t("accountDetail.holdingsCount")}</p>
+            <p className="text-2xl font-bold mt-1">{account.holdings.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
+            <InlineBalanceEditor
+              currentBalance={account.cashBalance}
+              currency={account.currency}
+              notePlaceholder={t("accountDetail.notePlaceholderDeposit")}
+              onSave={onSaveBalance}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (isBank) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
+            <InlineBalanceEditor
+              currentBalance={account.cashBalance}
+              currency={account.currency}
+              notePlaceholder={t("accountDetail.notePlaceholderSalary")}
+              onSave={onSaveBalance}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Investment / other
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">{t("accountDetail.totalValue")}</p>
+          <p className="text-2xl font-bold mt-1">
+            {formatCurrency(totalValue, account.currency)}
+          </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">{t("accountDetail.cashBalance")}</p>
+          <InlineBalanceEditor
+            currentBalance={account.cashBalance}
+            currency={account.currency}
+            notePlaceholder={t("accountDetail.notePlaceholderSalary")}
+            onSave={onSaveBalance}
+          />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">{t("accountDetail.holdingsValue")}</p>
+          <p className="text-2xl font-bold mt-1">
+            {formatCurrency(totalHoldingsValue, account.currency)}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -89,7 +89,7 @@ export function EditHoldingDialog({
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(JSON.stringify(err.error) || "Failed");
+        throw new Error(err.error?.message || "Failed");
       }
 
       toast.success("Holding updated");

--- a/src/components/accounts/holding-form.tsx
+++ b/src/components/accounts/holding-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -13,14 +13,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
-
-type SearchResult = {
-  symbol: string;
-  name: string;
-  exchange: string;
-  type: string;
-  currency: string;
-};
+import { HoldingSearch } from "./holding-search";
+import type { SearchResult } from "./holding-search";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -46,14 +40,6 @@ export function HoldingForm({
   const [loading, setLoading] = useState(false);
   const [step, setStep] = useState<"search" | "confirm">("search");
 
-  // Search state
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [showResults, setShowResults] = useState(false);
-  const searchRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
-
   // Selected holding state
   const [symbol, setSymbol] = useState("");
   const [name, setName] = useState("");
@@ -61,62 +47,21 @@ export function HoldingForm({
   const [assetType, setAssetType] = useState("STOCK");
   const [currency, setCurrency] = useState("USD");
 
-  // Close dropdown on outside click
-  useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
-        setShowResults(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, []);
-
-  const searchTickers = useCallback(async (q: string) => {
-    if (q.length < 1) {
-      setResults([]);
-      setShowResults(false);
-      return;
-    }
-
-    setSearching(true);
-    try {
-      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
-      const data: SearchResult[] = await res.json();
-      setResults(data);
-      setShowResults(data.length > 0);
-    } catch {
-      setResults([]);
-    } finally {
-      setSearching(false);
-    }
-  }, []);
-
-  function handleQueryChange(value: string) {
-    setQuery(value);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => searchTickers(value), 300);
-  }
-
   function selectResult(result: SearchResult) {
     setSymbol(result.symbol);
     setName(result.name);
     setAssetType(result.type);
     setCurrency(result.currency);
-    setShowResults(false);
     setStep("confirm");
   }
 
   function resetForm() {
     setStep("search");
-    setQuery("");
-    setResults([]);
     setSymbol("");
     setName("");
     setQuantity("");
     setAssetType("STOCK");
     setCurrency("USD");
-    setShowResults(false);
   }
 
   function handleClose() {
@@ -143,7 +88,7 @@ export function HoldingForm({
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(JSON.stringify(err.error) || "Failed");
+        throw new Error(err.error?.message || "Failed");
       }
 
       toast.success(`Added ${symbol}`);
@@ -170,59 +115,7 @@ export function HoldingForm({
 
         {step === "search" ? (
           <div className="space-y-4">
-            <div ref={searchRef} className="relative">
-              <div className="space-y-2">
-                <Label>Search by name or ticker symbol</Label>
-                <div className="relative">
-                  <Input
-                    value={query}
-                    onChange={(e) => handleQueryChange(e.target.value)}
-                    placeholder="e.g. Apple, TSMC, 2330, BTC..."
-                    autoFocus
-                  />
-                  {searching && (
-                    <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {showResults && (
-                <div className="absolute z-50 w-full mt-1 rounded-lg border bg-popover shadow-lg max-h-72 overflow-y-auto">
-                  {results.map((r) => (
-                    <button
-                      key={r.symbol}
-                      type="button"
-                      className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
-                      onClick={() => selectResult(r)}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono font-semibold text-sm">
-                            {r.symbol}
-                          </span>
-                          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                            {r.type}
-                          </Badge>
-                        </div>
-                        <p className="text-xs text-muted-foreground truncate mt-0.5">
-                          {r.name}
-                        </p>
-                      </div>
-                      <div className="text-right shrink-0">
-                        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                          {r.currency}
-                        </Badge>
-                        <p className="text-[10px] text-muted-foreground mt-0.5">
-                          {r.exchange}
-                        </p>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <HoldingSearch onSelect={selectResult} autoFocus />
 
             {/* Manual entry fallback */}
             <div className="pt-2 border-t">

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -1,0 +1,78 @@
+import { TableCell, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { formatCurrency, formatNumber } from "@/lib/currencies";
+import { useTranslations } from "next-intl";
+import type { SerializedHolding } from "@/lib/types";
+
+export interface HoldingWithPrice extends SerializedHolding {
+  currentPrice: number | null;
+  marketValue: number | null;
+}
+
+interface HoldingRowProps {
+  holding: HoldingWithPrice;
+  totalValue: number;
+  accountCurrency: string;
+  onEdit: (holding: HoldingWithPrice) => void;
+  onDelete: (holdingId: string) => void;
+}
+
+export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, onDelete }: HoldingRowProps) {
+  const t = useTranslations();
+  const quantityDecimals = h.assetType === "CRYPTO" ? 7 : 2;
+
+  return (
+    <TableRow key={h.id}>
+      <TableCell className="font-mono font-medium">{h.symbol}</TableCell>
+      <TableCell>{h.name}</TableCell>
+      <TableCell>
+        <Badge variant="secondary">{h.assetType}</Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">{h.currency || "USD"}</Badge>
+      </TableCell>
+      <TableCell className="text-right">
+        {formatNumber(h.quantity, quantityDecimals)}
+      </TableCell>
+      <TableCell className="text-right">
+        {h.currentPrice !== null
+          ? formatCurrency(h.currentPrice, h.currency || "USD")
+          : "—"}
+      </TableCell>
+      <TableCell className="text-right font-medium">
+        {h.marketValue !== null
+          ? formatCurrency(h.marketValue, accountCurrency)
+          : "—"}
+      </TableCell>
+      <TableCell className="text-right text-muted-foreground">
+        {h.marketValue !== null && totalValue > 0
+          ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
+          : "—"}
+      </TableCell>
+      <TableCell>
+        <DropdownMenu>
+          <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 hover:bg-accent hover:text-accent-foreground">
+            ...
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(h)}>
+              {t("common.edit")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={() => onDelete(h.id)}
+            >
+              {t("common.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/accounts/holding-search.tsx
+++ b/src/components/accounts/holding-search.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+
+export type SearchResult = {
+  symbol: string;
+  name: string;
+  exchange: string;
+  type: string;
+  currency: string;
+};
+
+interface HoldingSearchProps {
+  onSelect: (result: SearchResult) => void;
+  label?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+export function HoldingSearch({
+  onSelect,
+  label = "Search by name or ticker symbol",
+  placeholder = "e.g. Apple, TSMC, 2330, BTC...",
+  autoFocus = false,
+}: HoldingSearchProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const searchTickers = useCallback(async (q: string) => {
+    if (q.length < 1) {
+      setResults([]);
+      setShowResults(false);
+      return;
+    }
+    setSearching(true);
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      const { data }: { data: SearchResult[] } = await res.json();
+      setResults(data);
+      setShowResults(data.length > 0);
+    } catch {
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => searchTickers(value), 300);
+  }
+
+  function handleSelect(result: SearchResult) {
+    setShowResults(false);
+    onSelect(result);
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="space-y-2">
+        <Label>{label}</Label>
+        <div className="relative">
+          <Input
+            value={query}
+            onChange={(e) => handleQueryChange(e.target.value)}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+          />
+          {searching && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showResults && (
+        <div className="absolute z-50 w-full mt-1 rounded-lg border bg-popover shadow-lg max-h-72 overflow-y-auto">
+          {results.map((r) => (
+            <button
+              key={r.symbol}
+              type="button"
+              className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
+              onClick={() => handleSelect(r)}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono font-semibold text-sm">{r.symbol}</span>
+                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                    {r.type}
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground truncate mt-0.5">{r.name}</p>
+              </div>
+              <div className="text-right shrink-0">
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  {r.currency}
+                </Badge>
+                <p className="text-[10px] text-muted-foreground mt-0.5">{r.exchange}</p>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/accounts/quick-add-holding.tsx
+++ b/src/components/accounts/quick-add-holding.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -22,14 +22,8 @@ import {
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
-
-type SearchResult = {
-  symbol: string;
-  name: string;
-  exchange: string;
-  type: string;
-  currency: string;
-};
+import { HoldingSearch } from "./holding-search";
+import type { SearchResult } from "./holding-search";
 
 const ASSET_TYPE_KEYS = ["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OTHER"] as const;
 
@@ -58,14 +52,6 @@ export function QuickAddHolding({
   const [loading, setLoading] = useState(false);
   const [step, setStep] = useState<"search" | "confirm" | "account">("search");
 
-  // Search state
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [showResults, setShowResults] = useState(false);
-  const searchRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
-
   // Selected holding state
   const [symbol, setSymbol] = useState("");
   const [name, setName] = useState("");
@@ -76,62 +62,23 @@ export function QuickAddHolding({
   // Account selection state
   const [selectedAccountId, setSelectedAccountId] = useState("");
 
-  useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
-        setShowResults(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, []);
-
-  const searchTickers = useCallback(async (q: string) => {
-    if (q.length < 1) {
-      setResults([]);
-      setShowResults(false);
-      return;
-    }
-    setSearching(true);
-    try {
-      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
-      const data: SearchResult[] = await res.json();
-      setResults(data);
-      setShowResults(data.length > 0);
-    } catch {
-      setResults([]);
-    } finally {
-      setSearching(false);
-    }
-  }, []);
-
-  function handleQueryChange(value: string) {
-    setQuery(value);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => searchTickers(value), 300);
-  }
-
   function selectResult(result: SearchResult) {
     setSymbol(result.symbol);
     setName(result.name);
     setAssetType(result.type);
     setCurrency(result.currency);
-    setShowResults(false);
     setStep("confirm");
   }
 
   function resetForm() {
     setStep("search");
-    setQuery("");
-    setResults([]);
     setSymbol("");
     setName("");
     setQuantity("");
     setAssetType("STOCK");
     setCurrency(defaultCurrency);
-    setShowResults(false);
     setSelectedAccountId("");
-}
+  }
 
   function handleClose() {
     resetForm();
@@ -178,7 +125,7 @@ export function QuickAddHolding({
           }),
         });
         if (!res.ok) throw new Error(t("quickAddHolding.createAccountFailed"));
-        const newAccount = await res.json();
+        const { data: newAccount } = await res.json();
         accountId = newAccount.id;
       }
 
@@ -199,10 +146,7 @@ export function QuickAddHolding({
         let message = t("quickAddHolding.addFailed");
         try {
           const err = await res.json();
-          message =
-            typeof err.error === "string"
-              ? err.error
-              : JSON.stringify(err.error) || message;
+          message = err.error?.message || message;
         } catch {
           // Response body may not be valid JSON
         }
@@ -241,65 +185,12 @@ export function QuickAddHolding({
 
         {step === "search" && (
           <div className="space-y-4">
-            <div ref={searchRef} className="relative">
-              <div className="space-y-2">
-                <Label>{t("quickAddHolding.labelSearch")}</Label>
-                <div className="relative">
-                  <Input
-                    value={query}
-                    onChange={(e) => handleQueryChange(e.target.value)}
-                    placeholder={t("quickAddHolding.placeholderSearch")}
-                    autoFocus
-                  />
-                  {searching && (
-                    <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {showResults && (
-                <div className="absolute z-50 w-full mt-1 rounded-lg border bg-popover shadow-lg max-h-72 overflow-y-auto">
-                  {results.map((r) => (
-                    <button
-                      key={r.symbol}
-                      type="button"
-                      className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
-                      onClick={() => selectResult(r)}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono font-semibold text-sm">
-                            {r.symbol}
-                          </span>
-                          <Badge
-                            variant="secondary"
-                            className="text-[10px] px-1.5 py-0"
-                          >
-                            {r.type}
-                          </Badge>
-                        </div>
-                        <p className="text-xs text-muted-foreground truncate mt-0.5">
-                          {r.name}
-                        </p>
-                      </div>
-                      <div className="text-right shrink-0">
-                        <Badge
-                          variant="outline"
-                          className="text-[10px] px-1.5 py-0"
-                        >
-                          {r.currency}
-                        </Badge>
-                        <p className="text-[10px] text-muted-foreground mt-0.5">
-                          {r.exchange}
-                        </p>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <HoldingSearch
+              onSelect={selectResult}
+              label={t("quickAddHolding.labelSearch")}
+              placeholder={t("quickAddHolding.placeholderSearch")}
+              autoFocus
+            />
 
             <div className="pt-2 border-t">
               <p className="text-xs text-muted-foreground mb-3">

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -66,7 +66,7 @@ export function TransactionHistory({ accountId, isBank, refreshTrigger }: { acco
   const [editDate, setEditDate] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const fetcher = (url: string) => fetch(url).then((res) => res.json());
+  const fetcher = (url: string) => fetch(url).then((res) => res.json()).then((r) => r.data);
 
   const getKey = (pageIndex: number, previousPageData: SerializedTransaction[]) => {
     if (previousPageData && !previousPageData.length) return null; // reached the end

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -43,7 +43,7 @@ export function DashboardActions({
         fetch("/api/prices/refresh", { method: "POST" }),
         fetch("/api/exchange-rates/refresh", { method: "POST" }),
       ]);
-      const priceData = await priceRes.json();
+      const { data: priceData } = await priceRes.json();
       toast.success(t("refreshSuccess", { count: priceData.updated }));
       router.refresh();
     } catch {

--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -91,11 +91,8 @@ export function DataManagement() {
           });
 
           if (!response.ok) {
-            const data = await response.json();
-            const errorMessage = data.details 
-              ? `${data.error}: ${data.details.split(',').slice(0, 3).join(', ')}${data.details.split(',').length > 3 ? '...' : ''}`
-              : data.error || "Import failed";
-            throw new Error(errorMessage);
+            const body = await response.json();
+            throw new Error(body.error?.message || "Import failed");
           }
 
           setShowSuccessDialog(true);

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -75,7 +75,7 @@ export function SettingsForm({
     setRefreshing(true);
     try {
       const res = await fetch("/api/prices/refresh", { method: "POST" });
-      const data = await res.json();
+      const { data } = await res.json();
       toast.success(t("toast.pricesUpdated", { count: data.updated }));
       router.refresh();
     } catch {

--- a/src/lib/api-responses.ts
+++ b/src/lib/api-responses.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+
+/** Successful response — wraps data in a `{ data }` envelope. */
+export const ok = <T>(data: T, init?: ResponseInit) =>
+  NextResponse.json({ data }, init);
+
+/** Error response — wraps message in a `{ error: { message } }` envelope. */
+export const failure = (message: string, status = 400) =>
+  NextResponse.json({ error: { message } }, { status });
+
+/** Zod validation failure — includes flattened issues for field-level display. */
+export const validationError = (zodError: z.ZodError) =>
+  NextResponse.json(
+    { error: { message: "Validation failed", issues: zodError.flatten() } },
+    { status: 400 }
+  );

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -1,0 +1,26 @@
+export const ACCOUNT_TYPES = ["ASSET", "LIABILITY"] as const;
+
+export const ACCOUNT_CATEGORIES = [
+  "BANK",
+  "BROKERAGE",
+  "CRYPTO_WALLET",
+  "PROPERTY",
+  "VEHICLE",
+  "CREDIT_CARD",
+  "LOAN",
+  "MORTGAGE",
+  "OTHER",
+] as const;
+
+export const HOLDING_ASSET_TYPES = [
+  "STOCK",
+  "ETF",
+  "CRYPTO",
+  "MUTUAL_FUND",
+  "BOND",
+  "OTHER",
+] as const;
+
+export const HOLDING_TRANSACTION_TYPES = ["BUY", "SELL", "EDIT"] as const;
+
+export const CASH_TRANSACTION_TYPES = ["DEPOSIT", "WITHDRAWAL", "EDIT"] as const;

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,6 +1,7 @@
 import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
+import type { NetWorthSnapshot } from "@/generated/prisma/client";
 
 export interface NormalizedSnapshot {
   id: string;
@@ -13,6 +14,40 @@ export interface NormalizedSnapshot {
 
 /** Default history window: last 90 days. Keeps the query fast for the dashboard. */
 const DEFAULT_HISTORY_DAYS = 90;
+
+/**
+ * Pure transformation: convert and dedupe raw snapshots into NormalizedSnapshot[].
+ * If multiple snapshots exist for the same date (e.g. from a currency change),
+ * prefers the one whose baseCurrency already matches the target, otherwise the latest seen.
+ */
+function normalizeSnapshots(
+  snapshots: NetWorthSnapshot[],
+  allRatesMap: Map<string, number>,
+  targetBaseCurrency: string,
+): NormalizedSnapshot[] {
+  const normalizedMap = new Map<string, NormalizedSnapshot>();
+
+  for (const s of snapshots) {
+    const dateStr = s.date.toISOString().split("T")[0];
+    const rate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
+
+    const normalized: NormalizedSnapshot = {
+      id: s.id,
+      date: dateStr,
+      netWorth: Number(s.netWorth) * rate,
+      totalAssets: Number(s.totalAssets) * rate,
+      totalLiabilities: Number(s.totalLiabilities) * rate,
+      baseCurrency: targetBaseCurrency,
+    };
+
+    const existing = normalizedMap.get(dateStr);
+    if (!existing || s.baseCurrency === targetBaseCurrency) {
+      normalizedMap.set(dateStr, normalized);
+    }
+  }
+
+  return Array.from(normalizedMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
 
 /**
  * Fetch and normalize net worth history for a user.
@@ -34,37 +69,7 @@ async function computeNormalizedHistory(
     getAllExchangeRates(),
   ]);
 
-  const normalizedMap = new Map<string, NormalizedSnapshot>();
-
-  for (const s of snapshotsRaw) {
-    const dateStr = s.date.toISOString().split("T")[0];
-    let netWorth = Number(s.netWorth);
-    let totalAssets = Number(s.totalAssets);
-    let totalLiabilities = Number(s.totalLiabilities);
-
-    const snapshotRate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
-    netWorth *= snapshotRate;
-    totalAssets *= snapshotRate;
-    totalLiabilities *= snapshotRate;
-
-    const normalized: NormalizedSnapshot = {
-      id: s.id,
-      date: dateStr,
-      netWorth,
-      totalAssets,
-      totalLiabilities,
-      baseCurrency: targetBaseCurrency,
-    };
-
-    // If multiple snapshots exist for the same date (e.g. from currency change),
-    // prefer the one that already matched the target currency, or the latest one seen.
-    const existing = normalizedMap.get(dateStr);
-    if (!existing || s.baseCurrency === targetBaseCurrency) {
-      normalizedMap.set(dateStr, normalized);
-    }
-  }
-
-  return Array.from(normalizedMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
 }
 
 /**
@@ -100,33 +105,5 @@ export async function getFullNormalizedHistory(
     getAllExchangeRates(),
   ]);
 
-  const normalizedMap = new Map<string, NormalizedSnapshot>();
-
-  for (const s of snapshotsRaw) {
-    const dateStr = s.date.toISOString().split("T")[0];
-    let netWorth = Number(s.netWorth);
-    let totalAssets = Number(s.totalAssets);
-    let totalLiabilities = Number(s.totalLiabilities);
-
-    const snapshotRate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
-    netWorth *= snapshotRate;
-    totalAssets *= snapshotRate;
-    totalLiabilities *= snapshotRate;
-
-    const normalized: NormalizedSnapshot = {
-      id: s.id,
-      date: dateStr,
-      netWorth,
-      totalAssets,
-      totalLiabilities,
-      baseCurrency: targetBaseCurrency,
-    };
-
-    const existing = normalizedMap.get(dateStr);
-    if (!existing || s.baseCurrency === targetBaseCurrency) {
-      normalizedMap.set(dateStr, normalized);
-    }
-  }
-
-  return Array.from(normalizedMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,23 +1,73 @@
 import type { Account, Holding, HoldingTransaction } from "@/generated/prisma/client";
 
-// Serialized types where Prisma Decimal fields are converted to number
-// These are safe to pass from Server Components to Client Components
-export type SerializedAccount = Omit<Account, "cashBalance" | "createdAt" | "updatedAt"> & {
-  cashBalance: number;
-  createdAt: string;
-  updatedAt: string;
+// ---------------------------------------------------------------------------
+// Generic serialization utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a Prisma model type to its serialized form:
+ * - Decimal fields → number
+ * - Date fields   → string (ISO)
+ * - All other fields pass through unchanged
+ */
+export type Serialized<
+  T,
+  DecimalKeys extends keyof T = never,
+  DateKeys extends keyof T = never,
+> = {
+  [K in keyof T]: K extends DecimalKeys ? number : K extends DateKeys ? string : T[K];
 };
 
-export type SerializedHolding = Omit<Holding, "quantity" | "createdAt" | "updatedAt"> & {
-  quantity: number;
-  currency: string;
-  createdAt: string;
-  updatedAt: string;
-};
+/**
+ * Converts a Prisma model instance to its serialized form.
+ * Coerces Decimal fields via Number() and Date fields via .toISOString().
+ * Safe to pass from Server Components to Client Components.
+ */
+export function serializeModel<
+  T extends object,
+  D extends keyof T,
+  Dt extends keyof T,
+>(
+  obj: T,
+  opts: { decimals: readonly D[]; dates: readonly Dt[] },
+): Serialized<T, D, Dt> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj) as (keyof T & string)[]) {
+    if ((opts.decimals as readonly (keyof T)[]).includes(key)) {
+      result[key] = Number(obj[key]);
+    } else if ((opts.dates as readonly (keyof T)[]).includes(key)) {
+      result[key] = (obj[key] as unknown as Date).toISOString();
+    } else {
+      result[key] = obj[key];
+    }
+  }
+  return result as Serialized<T, D, Dt>;
+}
+
+// ---------------------------------------------------------------------------
+// Serialized model types
+// ---------------------------------------------------------------------------
+
+export type SerializedAccount = Serialized<Account, "cashBalance", "createdAt" | "updatedAt">;
+
+export type SerializedHolding = Serialized<Holding, "quantity", "createdAt" | "updatedAt">;
 
 export type SerializedAccountWithHoldings = SerializedAccount & {
   holdings: SerializedHolding[];
 };
+
+export type SerializedTransaction = Serialized<HoldingTransaction, "quantity", "createdAt"> & {
+  holding?: {
+    symbol: string;
+    name: string;
+    currency: string;
+    assetType: string;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Calculation types
+// ---------------------------------------------------------------------------
 
 export type HoldingWithPrice = SerializedHolding & {
   currentPrice: number | null;
@@ -46,46 +96,22 @@ export type AllocationItem = {
   color: string;
 };
 
-export type SerializedTransaction = Omit<HoldingTransaction, "quantity" | "createdAt"> & {
-  quantity: number;
-  createdAt: string;
-  holding?: {
-    symbol: string;
-    name: string;
-    currency: string;
-    assetType: string;
-  };
-};
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
 
-// Serialization helpers — explicitly construct plain objects
-// (spreading Prisma model instances doesn't strip Decimal/Date properly)
 export function serializeAccount(account: Account): SerializedAccount {
-  return {
-    id: account.id,
-    userId: account.userId,
-    name: account.name,
-    type: account.type,
-    category: account.category,
-    currency: account.currency,
-    cashBalance: Number(account.cashBalance),
-    isActive: account.isActive,
-    createdAt: account.createdAt.toISOString(),
-    updatedAt: account.updatedAt.toISOString(),
-  };
+  return serializeModel(account, {
+    decimals: ["cashBalance"] as const,
+    dates: ["createdAt", "updatedAt"] as const,
+  });
 }
 
 export function serializeHolding(holding: Holding): SerializedHolding {
-  return {
-    id: holding.id,
-    accountId: holding.accountId,
-    symbol: holding.symbol,
-    name: holding.name,
-    quantity: Number(holding.quantity),
-    currency: holding.currency,
-    assetType: holding.assetType,
-    createdAt: holding.createdAt.toISOString(),
-    updatedAt: holding.updatedAt.toISOString(),
-  };
+  return serializeModel(holding, {
+    decimals: ["quantity"] as const,
+    dates: ["createdAt", "updatedAt"] as const,
+  });
 }
 
 export function serializeAccountWithHoldings(

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,19 +1,16 @@
 import { z } from "zod";
+import {
+  ACCOUNT_TYPES,
+  ACCOUNT_CATEGORIES,
+  HOLDING_ASSET_TYPES,
+  HOLDING_TRANSACTION_TYPES,
+  CASH_TRANSACTION_TYPES,
+} from "./enums";
 
 export const createAccountSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
-  type: z.enum(["ASSET", "LIABILITY"]),
-  category: z.enum([
-    "BANK",
-    "BROKERAGE",
-    "CRYPTO_WALLET",
-    "PROPERTY",
-    "VEHICLE",
-    "CREDIT_CARD",
-    "LOAN",
-    "MORTGAGE",
-    "OTHER",
-  ]),
+  type: z.enum(ACCOUNT_TYPES),
+  category: z.enum(ACCOUNT_CATEGORIES),
   currency: z.string().length(3),
   cashBalance: z.number().default(0),
 });
@@ -29,7 +26,7 @@ export const createHoldingSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   quantity: z.number().positive("Quantity must be positive"),
   currency: z.string().length(3).default("USD"),
-  assetType: z.enum(["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OTHER"]),
+  assetType: z.enum(HOLDING_ASSET_TYPES),
 });
 
 export const updateHoldingSchema = z.object({
@@ -42,9 +39,7 @@ export const updateHoldingSchema = z.object({
     .optional(),
   name: z.string().min(1).max(100).optional(),
   quantity: z.number().positive().optional(),
-  assetType: z
-    .enum(["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OTHER"])
-    .optional(),
+  assetType: z.enum(HOLDING_ASSET_TYPES).optional(),
 });
 
 export const updateSettingsSchema = z.object({
@@ -55,20 +50,20 @@ export const updateSettingsSchema = z.object({
 export const updateTransactionSchema = z.object({
   id: z.string(),
   quantity: z.number().optional(),
-  type: z.enum(["BUY", "SELL", "EDIT"]).optional(),
+  type: z.enum(HOLDING_TRANSACTION_TYPES).optional(),
   note: z.string().optional().nullable(),
   createdAt: z.string().optional(), // Using string for ISO dates
 });
 
 export const createCashTransactionSchema = z.object({
-  type: z.enum(["DEPOSIT", "WITHDRAWAL", "EDIT"]),
+  type: z.enum(CASH_TRANSACTION_TYPES),
   amount: z.number(),
   note: z.string().optional().nullable(),
 });
 
 export const updateCashTransactionSchema = z.object({
   id: z.string(),
-  type: z.enum(["DEPOSIT", "WITHDRAWAL", "EDIT"]).optional(),
+  type: z.enum(CASH_TRANSACTION_TYPES).optional(),
   amount: z.number().optional(),
   note: z.string().optional().nullable(),
   createdAt: z.string().optional(),
@@ -84,11 +79,8 @@ export const dataImportSchema = z.object({
   }).optional().nullable(),
   accounts: z.array(z.object({
     name: z.string().min(1),
-    type: z.enum(["ASSET", "LIABILITY"]),
-    category: z.enum([
-      "BANK", "BROKERAGE", "CRYPTO_WALLET", "PROPERTY", "VEHICLE", 
-      "CREDIT_CARD", "LOAN", "MORTGAGE", "OTHER"
-    ]),
+    type: z.enum(ACCOUNT_TYPES),
+    category: z.enum(ACCOUNT_CATEGORIES),
     currency: z.string().length(3),
     cashBalance: decimalSchema,
     isActive: z.boolean().default(true),
@@ -99,18 +91,18 @@ export const dataImportSchema = z.object({
       name: z.string().min(1),
       quantity: decimalSchema,
       currency: z.string().length(3),
-      assetType: z.enum(["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OTHER"]),
+      assetType: z.enum(HOLDING_ASSET_TYPES),
       createdAt: z.string().optional(),
       updatedAt: z.string().optional(),
       transactions: z.array(z.object({
-        type: z.enum(["BUY", "SELL", "EDIT"]),
+        type: z.enum(HOLDING_TRANSACTION_TYPES),
         quantity: decimalSchema,
         note: z.string().optional().nullable(),
         createdAt: z.string().optional(),
       })).optional(),
     })).optional(),
     cashTransactions: z.array(z.object({
-      type: z.enum(["DEPOSIT", "WITHDRAWAL", "EDIT"]),
+      type: z.enum(CASH_TRANSACTION_TYPES),
       amount: decimalSchema,
       note: z.string().optional().nullable(),
       createdAt: z.string().optional(),


### PR DESCRIPTION
## Summary

- **#78** – Extract `normalizeSnapshots()` in `history-service.ts`: pure helper owns rate conversion + date deduplication; both entry points delegate to it
- **#81** – Extract `<HoldingSearch>` component: new `holding-search.tsx` owns query state, debounce, outside-click, and result-row JSX; removes ~80 lines of duplication from `HoldingForm` and `QuickAddHolding`
- **#83** – Shared enum constants (`enums.ts`): `ACCOUNT_TYPES`, `ACCOUNT_CATEGORIES`, `HOLDING_ASSET_TYPES`, `HOLDING_TRANSACTION_TYPES`, `CASH_TRANSACTION_TYPES` as `const` tuples; `validators.ts` references them via `z.enum(CONSTANT)`, eliminating 5 duplicate inline arrays
- **#84** – `Serialized<T>` utility type + `serializeModel` helper: mapped type replaces `Omit`+intersection pattern; `serializeAccount` and `serializeHolding` become single `serializeModel(...)` calls
- **#85** – Standardize API response shape via `api-responses.ts`: `ok()`, `failure()`, `validationError()` enforce a single `{ data }` / `{ error: { message, issues? } }` envelope across all 13 route files; all client fetch calls updated to match
- **#87** – Split `account-detail.tsx` into subcomponents: `<AccountStatCards>` owns the three conditional stat-card blocks; `<HoldingRow>` owns per-row decimal/percentage/dropdown logic; `AccountDetail` is a thin client wrapper for dialog and mutation state

## Test plan

- [ ] Account detail page loads with correct stat cards for BROKERAGE, BANK, and investment accounts
- [ ] Holdings table sorts and renders correctly; edit/delete dropdown works
- [ ] Holding search (ticker autocomplete) works in both `HoldingForm` and `QuickAddHolding`
- [ ] Creating, editing, and deleting accounts, holdings, and transactions succeeds
- [ ] Transaction history pagination loads and edit/delete work
- [ ] Dashboard price refresh shows correct updated count toast
- [ ] Settings currency/locale save and prices/snapshot actions work
- [ ] Data export downloads a valid JSON file; re-importing it succeeds
- [ ] No TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)