### PR TITLE
refactor: code quality improvements #76, #79, #80

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -881,11 +881,11 @@ This allows CDN edges and the browser to serve the cached response for up to 1 h
 
 | # | Suggestion | Category | Impact | Effort | Status |
 |---|-----------|----------|--------|--------|--------|
-| 76 | Extract `withAuth()` HOF for API routes | Code Quality | 🟡 Medium | 2-3 hrs | ❌ Not Done |
+| 76 | Extract `withAuth()` HOF for API routes | Code Quality | 🟡 Medium | 2-3 hrs | ✅ Done |
 | 77 | Unify Yahoo Finance quote fetcher (stock + crypto) | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
 | 78 | Dedupe `normalizeSnapshots` in history-service | Code Quality | 🟡 Medium | 1 hr | ✅ Done |
-| 79 | Centralize exchange-rate upsert (`persistExchangeRate`) | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
-| 80 | Share chart tooltip/legend formatters | Code Quality | 🟡 Medium | 30 min | ❌ Not Done |
+| 79 | Centralize exchange-rate upsert (`persistExchangeRate`) | Code Quality | 🟢 Low | 30 min | ✅ Done |
+| 80 | Share chart tooltip/legend formatters | Code Quality | 🟡 Medium | 30 min | ✅ Done |
 | 81 | Extract `<HoldingSearch>` component | Code Quality | 🟡 Medium | 1-2 hrs | ✅ Done |
 | 82 | `formatQuantity()` helper in `currencies.ts` | Code Quality | 🟢 Low | 30 min | ❌ Not Done |
 | 83 | Shared enum constants for Prisma/Zod | Code Quality | 🟡 Medium | 30 min | ✅ Done |

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,18 +1,14 @@
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
-import { auth } from "@/auth";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
+type IdCtx = { params: Promise<{ id: string }> };
 
+export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
-  const account = await prisma.account.findUnique({ where: { id, userId: session.user.id } });
+  const account = await prisma.account.findUnique({ where: { id, userId } });
   if (!account) return failure("Not found", 404);
 
   const holdings = await prisma.holding.findMany({
@@ -20,7 +16,7 @@ export async function GET(
     orderBy: { symbol: "asc" },
   });
   return ok(holdings);
-}
+});
 
 export async function POST(
   request: Request,

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,37 +1,27 @@
 import { prisma } from "@/lib/prisma";
 import { updateAccountSchema } from "@/lib/validators";
-import { auth } from "@/auth";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
+type IdCtx = { params: Promise<{ id: string }> };
 
+export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
   const account = await prisma.account.findUnique({
-    where: { id, userId: session.user.id },
+    where: { id, userId },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
   });
   if (!account) return failure("Not found", 404);
   return ok(account);
-}
+});
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
   const body = await request.json();
   const parsed = updateAccountSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
 
-  const existingAccount = await prisma.account.findUnique({ where: { id, userId: session.user.id } });
+  const existingAccount = await prisma.account.findUnique({ where: { id, userId } });
   if (!existingAccount) return failure("Not found", 404);
 
   // If cashBalance is being updated to a new value, log it as an EDIT transaction
@@ -51,20 +41,14 @@ export async function PATCH(
   }
 
   const account = await prisma.account.update({
-    where: { id, userId: session.user.id },
+    where: { id, userId },
     data: parsed.data,
   });
   return ok(account);
-}
+});
 
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
-  await prisma.account.delete({ where: { id, userId: session.user.id } });
+  await prisma.account.delete({ where: { id, userId } });
   return ok({ ok: true });
-}
+});

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,24 +1,18 @@
 import { prisma } from "@/lib/prisma";
 import { createAccountSchema } from "@/lib/validators";
-import { auth } from "@/auth";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const GET = withAuth(async (_req, _ctx, userId) => {
   const accounts = await prisma.account.findMany({
-    where: { userId: session.user.id },
+    where: { userId },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
     orderBy: { createdAt: "desc" },
   });
   return ok(accounts);
-}
+});
 
-export async function DELETE(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const DELETE = withAuth(async (request, _ctx, userId) => {
   const body = await request.json();
   const ids: string[] = body.ids;
   if (!Array.isArray(ids) || ids.length === 0) {
@@ -28,22 +22,19 @@ export async function DELETE(request: Request) {
   await prisma.account.deleteMany({
     where: {
       id: { in: ids },
-      userId: session.user.id,
+      userId,
     },
   });
   return ok({ ok: true });
-}
+});
 
-export async function POST(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const POST = withAuth(async (request, _ctx, userId) => {
   const body = await request.json();
   const parsed = createAccountSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
 
   const account = await prisma.account.create({
-    data: { ...parsed.data, userId: session.user.id },
+    data: { ...parsed.data, userId },
   });
   return ok(account, { status: 201 });
-}
+});

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -1,15 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { auth } from "@/auth";
 import { dataImportSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
-  const userId = session.user.id;
-
+export const GET = withAuth(async (_req, _ctx, userId) => {
   try {
     const data = await prisma.user.findUnique({
       where: { id: userId },
@@ -46,14 +41,9 @@ export async function GET() {
     console.error("Export error:", error);
     return failure("Failed to export data", 500);
   }
-}
+});
 
-export async function POST(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
-  const userId = session.user.id;
-
+export const POST = withAuth(async (request, _ctx, userId) => {
   try {
     const body = await request.json();
     const parsed = dataImportSchema.safeParse(body);
@@ -171,4 +161,4 @@ export async function POST(request: Request) {
     console.error("Import error:", error);
     return failure(error instanceof Error ? error.message : "Failed to import data", 500);
   }
-}
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,23 +1,16 @@
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateSettingsSchema } from "@/lib/validators";
-import { auth } from "@/auth";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { ok, failure, validationError } from "@/lib/api-responses";
+import { ok, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
-  const settings = await getOrCreateSettings(session.user.id);
+export const GET = withAuth(async (_req, _ctx, userId) => {
+  const settings = await getOrCreateSettings(userId);
   return ok(settings);
-}
+});
 
-export async function PATCH(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
-  const userId = session.user.id;
+export const PATCH = withAuth(async (request, _ctx, userId) => {
   const body = await request.json();
   const parsed = updateSettingsSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
@@ -49,4 +42,4 @@ export async function PATCH(request: Request) {
   }
 
   return response;
-}
+});

--- a/src/app/api/snapshots/route.ts
+++ b/src/app/api/snapshots/route.ts
@@ -1,12 +1,9 @@
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { getFullNormalizedHistory } from "@/lib/services/history-service";
-import { auth } from "@/auth";
-import { ok, failure } from "@/lib/api-responses";
+import { ok } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function GET(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const GET = withAuth(async (request, _ctx, userId) => {
   const { searchParams } = new URL(request.url);
   const from = searchParams.get("from");
   const to = searchParams.get("to");
@@ -16,16 +13,13 @@ export async function GET(request: Request) {
   if (from) options.from = new Date(from);
   if (to) options.to = new Date(to);
 
-  const snapshots = await getFullNormalizedHistory(session.user.id, baseCurrency, options);
+  const snapshots = await getFullNormalizedHistory(userId, baseCurrency, options);
   return ok(snapshots);
-}
+});
 
-export async function POST(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) return failure("Unauthorized", 401);
-
+export const POST = withAuth(async (request, _ctx, userId) => {
   const body = await request.json().catch(() => ({}));
   const baseCurrency = body.baseCurrency ?? "USD";
-  const snapshot = await createSnapshot(session.user.id, baseCurrency);
+  const snapshot = await createSnapshot(userId, baseCurrency);
   return ok(snapshot, { status: 201 });
-}
+});

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
 import type { NetWorthSummary } from "@/lib/types";
+import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
 const COLORS = [
   "#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6",
@@ -66,31 +67,8 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                   />
                 ))}
               </Pie>
-              <Tooltip
-                formatter={(value: any, name: any, props: any) => {
-                  const formattedValue = new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: summary.baseCurrency,
-                  }).format(Number(value || 0));
-                  const percentage = props?.payload?.percentage || "0";
-                  return [`${formattedValue} (${percentage}%)`, name];
-                }}
-              />
-              <Legend
-                formatter={(value, entry: any) => {
-                  const percentage = entry?.payload?.percentage;
-                  return (
-                    <span className="inline-flex items-baseline gap-1.5 ml-1 select-none">
-                      <span className="font-medium text-foreground">{value}</span>
-                      {percentage && (
-                        <span className="text-sm font-normal text-muted-foreground tabular-nums">
-                          {percentage}%
-                        </span>
-                      )}
-                    </span>
-                  );
-                }}
-              />
+              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+              <Legend formatter={createPieLegendFormatter()} />
             </PieChart>
           </ResponsiveContainer>
         )}

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -5,9 +5,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
 import type { NetWorthSummary } from "@/lib/types";
+import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
 const COLORS = [
-  "#8b5cf6", "#ec4899", "#f59e0b", "#3b82f6", "#10b981", 
+  "#8b5cf6", "#ec4899", "#f59e0b", "#3b82f6", "#10b981",
   "#ef4444", "#06b6d4", "#84cc16", "#f97316",
 ];
 
@@ -56,31 +57,8 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
                   />
                 ))}
               </Pie>
-              <Tooltip
-                formatter={(value: any, name: any, props: any) => {
-                  const formattedValue = new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: summary.baseCurrency,
-                  }).format(Number(value || 0));
-                  const percentage = props?.payload?.percentage || "0";
-                  return [`${formattedValue} (${percentage}%)`, name];
-                }}
-              />
-              <Legend
-                formatter={(value, entry: any) => {
-                  const percentage = entry?.payload?.percentage;
-                  return (
-                    <span className="inline-flex items-baseline gap-1.5 ml-1 select-none">
-                      <span className="font-medium text-foreground">{value}</span>
-                      {percentage && (
-                        <span className="text-sm font-normal text-muted-foreground tabular-nums">
-                          {percentage}%
-                        </span>
-                      )}
-                    </span>
-                  );
-                }}
-              />
+              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+              <Legend formatter={createPieLegendFormatter()} />
             </PieChart>
           </ResponsiveContainer>
         )}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -12,6 +12,7 @@ import {
   AreaChart,
 } from "recharts";
 import { useTranslations } from "next-intl";
+import { createCurrencyTooltipFormatter } from "@/lib/chart-formatters";
 
 type SnapshotData = {
   date: string;
@@ -94,14 +95,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
                       : v.toString()
                 }
               />
-              <Tooltip
-                formatter={(value) =>
-                  new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: baseCurrency,
-                  }).format(Number(value))
-                }
-              />
+              <Tooltip formatter={createCurrencyTooltipFormatter(baseCurrency)} />
               <Area
                 type="monotone"
                 dataKey="netWorth"

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -1,0 +1,12 @@
+import { auth } from "@/auth";
+import { failure } from "@/lib/api-responses";
+
+export function withAuth<Ctx = unknown>(
+  handler: (req: Request, ctx: Ctx, userId: string) => Promise<Response>
+) {
+  return async (req: Request, ctx: Ctx): Promise<Response> => {
+    const session = await auth();
+    if (!session?.user?.id) return failure("Unauthorized", 401);
+    return handler(req, ctx, session.user.id);
+  };
+}

--- a/src/lib/chart-formatters.tsx
+++ b/src/lib/chart-formatters.tsx
@@ -1,0 +1,40 @@
+import { formatCurrency } from "@/lib/currencies";
+
+/** Currency formatter for area/line chart tooltips (e.g. TrendChart). */
+export function createCurrencyTooltipFormatter(currency: string) {
+  return (value: unknown) => formatCurrency(Number(value ?? 0), currency);
+}
+
+/**
+ * Tooltip formatter for pie charts that pre-compute `percentage` on each
+ * data point. Returns the Recharts `[label, name]` tuple format.
+ */
+export function createPieTooltipFormatter(currency: string) {
+  return (
+    value: number | string | ReadonlyArray<number | string> | undefined,
+    name: string | number | undefined,
+    props: { payload?: { percentage?: string } }
+  ): [string, string | number] => {
+    const formatted = formatCurrency(Number(value ?? 0), currency);
+    const pct = props?.payload?.percentage ?? "0";
+    return [`${formatted} (${pct}%)`, name ?? ""];
+  };
+}
+
+/** Legend formatter for pie charts — renders name + percentage badge. */
+export function createPieLegendFormatter() {
+  // eslint-disable-next-line react/display-name
+  return (value: string, entry: { payload?: { percentage?: string } }) => {
+    const percentage = entry?.payload?.percentage;
+    return (
+      <span className="inline-flex items-baseline gap-1.5 ml-1 select-none">
+        <span className="font-medium text-foreground">{value}</span>
+        {percentage && (
+          <span className="text-sm font-normal text-muted-foreground tabular-nums">
+            {percentage}%
+          </span>
+        )}
+      </span>
+    );
+  };
+}

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -106,6 +106,23 @@ export async function fetchExchangeRates(
 }
 
 /**
+ * Upsert a single exchange rate into the DB.
+ * Errors are caught and logged as warnings so callers are never blocked.
+ */
+async function persistExchangeRate(from: string, to: string, rate: number): Promise<void> {
+  const id = `${from}_${to}`;
+  try {
+    await prisma.exchangeRate.upsert({
+      where: { id },
+      update: { rate, updatedAt: new Date() },
+      create: { id, fromCurrency: from, toCurrency: to, rate },
+    });
+  } catch (error) {
+    console.warn(`Failed to persist exchange rate ${from}->${to}`, error);
+  }
+}
+
+/**
  * Refresh all exchange rates for a base currency and persist to DB.
  * Uses batched concurrent upserts instead of sequential writes.
  */
@@ -116,16 +133,7 @@ export async function refreshExchangeRates(baseCurrency: string): Promise<number
   if (entries.length === 0) return 0;
 
   // Batch upserts concurrently (instead of sequential loop)
-  await Promise.all(
-    entries.map(([toCurrency, rate]) => {
-      const id = `${baseCurrency}_${toCurrency}`;
-      return prisma.exchangeRate.upsert({
-        where: { id },
-        update: { rate, updatedAt: new Date() },
-        create: { id, fromCurrency: baseCurrency, toCurrency, rate },
-      });
-    })
-  );
+  await Promise.all(entries.map(([toCurrency, rate]) => persistExchangeRate(baseCurrency, toCurrency, rate)));
 
   return entries.length;
 }
@@ -157,25 +165,15 @@ export const getExchangeRate = cache(async function getExchangeRate(
   const fetchAndStore = async (): Promise<number> => {
     const rates = await fetchExchangeRates(from);
     if (rates[to]) {
-      const id = `${from}_${to}`;
       // Fire-and-forget: don't block on persisting
-      prisma.exchangeRate.upsert({
-        where: { id },
-        update: { rate: rates[to], updatedAt: new Date() },
-        create: { id, fromCurrency: from, toCurrency: to, rate: rates[to] },
-      }).catch(() => {});
+      void persistExchangeRate(from, to, rates[to]);
       return rates[to];
     }
 
     const reverseRates = await fetchExchangeRates(to);
     if (reverseRates[from]) {
       const rate = 1 / reverseRates[from];
-      const id = `${from}_${to}`;
-      prisma.exchangeRate.upsert({
-        where: { id },
-        update: { rate, updatedAt: new Date() },
-        create: { id, fromCurrency: from, toCurrency: to, rate },
-      }).catch(() => {});
+      void persistExchangeRate(from, to, rate);
       return rate;
     }
 
@@ -224,12 +222,7 @@ export async function resolveMissingRates(
         if (rates[to] !== undefined) {
           ratesMap[key] = rates[to];
           // Fire-and-forget persist
-          const id = key;
-          prisma.exchangeRate.upsert({
-            where: { id },
-            update: { rate: rates[to], updatedAt: new Date() },
-            create: { id, fromCurrency: from, toCurrency: to, rate: rates[to] },
-          }).catch(() => {});
+          void persistExchangeRate(from, to, rates[to]);
         }
       }
     })


### PR DESCRIPTION
## Summary

- **#76 — `withAuth()` HOF for API routes**: Extracts the repeated 3-line auth check into a single wrapper in `src/lib/api-handler.ts`. Applied to 6 route files (`accounts`, `accounts/[id]`, `accounts/[id]/holdings`, `settings`, `settings/data`, `snapshots`). Removes ~40 lines of boilerplate and guarantees a consistent 401 response shape across all protected endpoints.
- **#79 — Centralize `persistExchangeRate()`**: Replaces 4 copies of the inline `prisma.exchangeRate.upsert(...)` pattern in `exchange-rate-service.ts` with a single module-private helper. Fire-and-forget callers use `void persistExchangeRate(...)` and now get a `console.warn` on failure instead of silently swallowing errors.
- **#80 — Shared chart formatters**: New `src/lib/chart-formatters.tsx` exports `createCurrencyTooltipFormatter`, `createPieTooltipFormatter`, and `createPieLegendFormatter`. All three dashboard charts (`trend-chart`, `allocation-chart`, `currency-exposure-chart`) now use these instead of inline `Intl.NumberFormat` implementations.

## Test plan

- [ ] Dashboard loads and all three charts render correctly with tooltips and legend percentages
- [ ] Authenticated API routes (`/api/accounts`, `/api/settings`, `/api/snapshots`) return 401 for unauthenticated requests and correct data when authenticated
- [ ] Exchange rate refresh (`POST /api/exchange-rates/refresh`) still persists rates to DB
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)