### PR TITLE
feat: add Safari Add to Home Screen tutorial and apple touch icon

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -247,6 +247,16 @@
     "importSuccessTitle": "Import Successful",
     "importSuccessMessage": "Your data has been restored successfully. Please refresh the page to see the changes."
   },
+  "installApp": {
+    "title": "Add to Home Screen",
+    "description": "Access Asset Tracker like a native app directly from your home screen.",
+    "platform": "Works in Safari on iPhone and iPad",
+    "step1": "Open this page in Safari on your iPhone or iPad",
+    "step2Before": "Tap the Share button",
+    "step2After": "in the toolbar",
+    "step3": "Scroll down and tap \"Add to Home Screen\"",
+    "step4": "Tap \"Add\" — the app icon will appear on your home screen"
+  },
   "login": {
     "title": "Asset Tracker",
     "subtitle": "Securely access your financial portfolio",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -247,6 +247,16 @@
     "importSuccessTitle": "匯入成功",
     "importSuccessMessage": "您的資料已成功還原。請重新整理頁面以查看變更。"
   },
+  "installApp": {
+    "title": "加入主畫面",
+    "description": "將資產追蹤器加入主畫面，像原生 App 一樣快速啟動。",
+    "platform": "適用於 iPhone 和 iPad 的 Safari 瀏覽器",
+    "step1": "在 iPhone 或 iPad 上用 Safari 開啟本頁",
+    "step2Before": "點選",
+    "step2After": "工具列上的分享按鈕",
+    "step3": "往下捲動並點選「加入主畫面」",
+    "step4": "點選「新增」— App 圖示即會出現在主畫面上"
+  },
   "login": {
     "title": "資產追蹤",
     "subtitle": "安全地訪問您的財務投資組合",

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { SettingsForm } from "@/components/settings/settings-form";
 import { DataManagement } from "@/components/settings/data-management";
+import { InstallAppCard } from "@/components/settings/install-app-card";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
@@ -29,6 +30,7 @@ async function SettingsContent() {
         <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
         <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
         <DataManagement />
+        <InstallAppCard />
 
         <div className="mt-8 border-t pt-8 max-w-lg">
           <h3 className="text-lg font-medium text-red-500 mb-4">{t("dangerZone")}</h3>

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 180,
+          height: 180,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)",
+          borderRadius: 36,
+        }}
+      >
+        <svg width="110" height="110" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M8 20 L13.5 13.5 L17.5 17.5 L24 10"
+            stroke="white"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M20 10 L24 10 L24 14"
+            stroke="white"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+    ),
+    { width: 180, height: 180 },
+  );
+}

--- a/src/components/settings/install-app-card.tsx
+++ b/src/components/settings/install-app-card.tsx
@@ -1,0 +1,54 @@
+import { getTranslations } from "next-intl/server";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SmartphoneIcon } from "lucide-react";
+
+function ShareIcon() {
+  return (
+    <svg
+      viewBox="0 0 50 50"
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-4 w-4 shrink-0"
+      fill="#007AFF"
+      aria-hidden="true"
+    >
+      <path d="M30.3 13.7L25 8.4l-5.3 5.3-1.4-1.4L25 5.6l6.7 6.7z" />
+      <path d="M24 7h2v21h-2z" />
+      <path d="M35 40H15c-1.7 0-3-1.3-3-3V19c0-1.7 1.3-3 3-3h7v2h-7c-.6 0-1 .4-1 1v18c0 .6.4 1 1 1h20c.6 0 1-.4 1-1V19c0-.6-.4-1-1-1h-7v-2h7c1.7 0 3 1.3 3 3v18c0 1.7-1.3 3-3 3z" />
+    </svg>
+  );
+}
+
+export async function InstallAppCard() {
+  const t = await getTranslations("installApp");
+
+  return (
+    <div className="max-w-lg">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <SmartphoneIcon className="h-5 w-5" />
+            {t("title")}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">{t("description")}</p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            {t("platform")}
+          </p>
+          <ol className="list-decimal list-inside space-y-2">
+            <li className="text-sm">{t("step1")}</li>
+            <li className="text-sm">
+              <span className="inline-flex items-center gap-1.5">
+                {t("step2Before")}
+                <ShareIcon />
+                {t("step2After")}
+              </span>
+            </li>
+            <li className="text-sm">{t("step3")}</li>
+            <li className="text-sm">{t("step4")}</li>
+          </ol>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,5 +34,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico|apple-icon|icon).*)"],
 };


### PR DESCRIPTION
## Summary

- **Settings tutorial card** — Added `InstallAppCard` component between Data Management and Danger Zone with step-by-step Safari "Add to Home Screen" instructions. Step 2 renders the actual iOS Share SVG icon inline (colored `#007AFF`, iOS native blue) between the text.
- **Apple touch icon** — Added `src/app/apple-icon.tsx` using Next.js `ImageResponse` to generate a 180×180 PNG that matches the site's existing `icon.svg` (green gradient background + white trending chart). iOS will use this as the home screen icon instead of a webpage screenshot.
- **Middleware fix** — Added `/apple-icon` and `/icon` to the middleware exclusion list so Safari can fetch the icon without being redirected to the login page.
- **i18n** — All strings added in both `en-US` and `zh-TW` under a new `installApp` namespace.

## Test plan

- [ ] Navigate to `/settings` and confirm the "Add to Home Screen" card appears between Data Management and Danger Zone
- [ ] Confirm the iOS share icon (blue) appears inline in step 2 between the text
- [ ] Switch locale to `zh-TW` and confirm Chinese text renders correctly
- [ ] Open `/apple-icon` in a browser (unauthenticated) and confirm a 180×180 PNG is returned
- [ ] On an iPhone/iPad in Safari, use Add to Home Screen and confirm the green chart icon appears on the home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)