### PR TITLE
Improve chart responsiveness and spacing on mobile devices

### DIFF
--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -83,7 +83,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-medium">{t("assetsVsLiabilities")}</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-2 sm:px-4">
         {data.length === 0 ? (
           <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noData")}
@@ -92,10 +92,11 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
           <div className="h-[280px]" />
         ) : (
           <ResponsiveContainer width="100%" height={280}>
-            <BarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+            <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
               <XAxis dataKey="label" tick={{ fontSize: 12 }} />
               <YAxis
+                width={40}
                 tick={{ fontSize: 12 }}
                 tickFormatter={(v) =>
                   v >= 1000000

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -88,7 +88,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-medium">{t("monthlyChange")}</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-2 sm:px-4">
         {data.length === 0 ? (
           <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noData")}
@@ -97,10 +97,11 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
           <div className="h-[280px]" />
         ) : (
           <ResponsiveContainer width="100%" height={280}>
-            <BarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+            <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
               <XAxis dataKey="label" tick={{ fontSize: 12 }} />
               <YAxis
+                width={40}
                 tick={{ fontSize: 12 }}
                 tickFormatter={(v) =>
                   Math.abs(v) >= 1000000


### PR DESCRIPTION
## Description
Improves the responsive layout and spacing of chart components on mobile devices by:
- Adding responsive padding to `CardContent` (px-2 on mobile, sm:px-4 on larger screens)
- Reducing right margin in BarChart from 10 to 4 to prevent overflow on smaller screens
- Setting explicit YAxis width to 40px for consistent label rendering across screen sizes

These changes ensure charts display properly on mobile devices without content overflow while maintaining optimal spacing on larger screens.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Changes are straightforward layout/spacing adjustments
- [x] No functional logic changes
- [x] Responsive design improvements verified through visual inspection

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No new warnings generated

https://claude.ai/code/session_01XcfV26zNxa18qPtfhXbMSo