### PR TITLE
Add privacy mode and privacy policy page

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -284,7 +284,29 @@
     "title": "Asset Tracker",
     "subtitle": "Securely access your financial portfolio",
     "googleButton": "Continue with Google",
-    "footer": "By continuing, you agree to secure your data privately."
+    "trust1": "Google OAuth — we never store your password",
+    "trust2": "Your data is private & never sold",
+    "trust3": "Only you can see your portfolio",
+    "footerBefore": "Your data stays private. Read our",
+    "footerLink": "Privacy Policy"
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "subtitle": "How Asset Tracker handles your data",
+    "backToLogin": "← Back to Login",
+    "section1Title": "What we collect",
+    "section1Body": "When you sign in with Google, we receive your name, email address, and profile picture. Any financial data (accounts, holdings, balances) is entered by you manually and stored in your private database.",
+    "section2Title": "What we don't collect",
+    "section2Body": "We never access your real bank or brokerage accounts. We do not collect your passwords, browsing history, location, or contacts.",
+    "section3Title": "Third-party services",
+    "section3Body": "We fetch public market prices from Yahoo Finance and CoinGecko using only the ticker symbols you enter. No personal information is sent to these services.",
+    "section4Title": "Data sharing",
+    "section4Body": "Your data is never sold, rented, or shared with third parties for any purpose.",
+    "section5Title": "Your control",
+    "section5Body": "You can export all your data or delete your account at any time from the Settings page.",
+    "section6Title": "Authentication",
+    "section6Body": "Sign-in is handled entirely by Google OAuth. We receive only a secure session token — your Google password is never shared with or stored by this app.",
+    "lastUpdated": "Last updated: April 2026"
   },
   "transactionHistory": {
     "title": "Transaction History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -284,7 +284,29 @@
     "title": "資產追蹤",
     "subtitle": "安全地訪問您的財務投資組合",
     "googleButton": "使用 Google 帳號繼續",
-    "footer": "繼續操作即表示您同意私密地保護您的數據。"
+    "trust1": "Google OAuth — 我們絕不儲存您的密碼",
+    "trust2": "您的資料私密保存，絕不出售",
+    "trust3": "只有您能查看自己的投資組合",
+    "footerBefore": "您的資料受到保護。閱讀我們的",
+    "footerLink": "隱私政策"
+  },
+  "privacy": {
+    "title": "隱私政策",
+    "subtitle": "資產追蹤如何處理您的資料",
+    "backToLogin": "← 返回登入",
+    "section1Title": "我們收集的資料",
+    "section1Body": "當您使用 Google 登入時，我們會取得您的姓名、電子郵件地址和個人頭像。任何財務資料（帳戶、持倉、餘額）均由您手動輸入並儲存在您的私人資料庫中。",
+    "section2Title": "我們不收集的資料",
+    "section2Body": "我們絕不存取您真實的銀行或券商帳戶。我們不收集您的密碼、瀏覽歷史、位置或聯絡人資訊。",
+    "section3Title": "第三方服務",
+    "section3Body": "我們僅使用您輸入的股票代號，從 Yahoo Finance 和 CoinGecko 獲取公開市場價格。不會將任何個人資訊傳送至這些服務。",
+    "section4Title": "資料共享",
+    "section4Body": "您的資料絕不會以任何方式出售、出租或與第三方共享。",
+    "section5Title": "您的控制權",
+    "section5Body": "您可以隨時在設定頁面匯出所有資料或刪除帳號。",
+    "section6Title": "身份驗證",
+    "section6Body": "登入完全由 Google OAuth 處理。我們只接收安全的工作階段令牌，您的 Google 密碼絕不會被本應用程式接收或儲存。",
+    "lastUpdated": "最後更新：2026 年 4 月"
   },
   "transactionHistory": {
     "title": "交易紀錄",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import { Sidebar, MobileNav } from "@/components/layout/sidebar";
 import { MobileHeader } from "@/components/layout/mobile-header";
+import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
 
 export default function MainLayout({
   children,
@@ -7,13 +8,13 @@ export default function MainLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <>
+    <PrivacyModeProvider>
       <Sidebar />
       <main className="flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full">
         <MobileHeader />
         <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
       </main>
       <MobileNav />
-    </>
+    </PrivacyModeProvider>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -12,6 +12,7 @@ const CLIENT_NAMESPACES = [
   "allocationChart",
   "currencyExposure",
   "accountsSummary",
+  "netWorthCard",
   "categories",
   "common",
 ];

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,9 @@
 import { Suspense } from "react"
 import { signIn } from "@/auth"
 import { Button } from "@/components/ui/button"
-import { TrendingUp } from "lucide-react"
+import { TrendingUp, Lock, ShieldCheck, EyeOff } from "lucide-react"
 import { getTranslations } from "next-intl/server"
+import Link from "next/link"
 
 async function LoginContent() {
   const t = await getTranslations("login")
@@ -51,6 +52,22 @@ async function LoginContent() {
           </Button>
         </form>
 
+        {/* Trust badges */}
+        <div className="flex flex-col gap-2 pt-2">
+          <div className="flex items-center gap-2.5 text-xs text-slate-500">
+            <Lock className="w-3.5 h-3.5 shrink-0 text-emerald-500" />
+            <span>{t("trust1")}</span>
+          </div>
+          <div className="flex items-center gap-2.5 text-xs text-slate-500">
+            <ShieldCheck className="w-3.5 h-3.5 shrink-0 text-emerald-500" />
+            <span>{t("trust2")}</span>
+          </div>
+          <div className="flex items-center gap-2.5 text-xs text-slate-500">
+            <EyeOff className="w-3.5 h-3.5 shrink-0 text-emerald-500" />
+            <span>{t("trust3")}</span>
+          </div>
+        </div>
+
         {isPreview && (
           <>
             <div className="flex items-center gap-3 pt-2">
@@ -87,8 +104,12 @@ async function LoginContent() {
           </>
         )}
 
-        <div className="text-center text-xs text-slate-400 pt-4 mb-[-1rem]">
-          {t("footer")}
+        <div className="text-center text-xs text-slate-400 pt-2 mb-[-1rem]">
+          {t("footerBefore")}{" "}
+          <Link href="/privacy" className="underline hover:text-slate-600 transition-colors">
+            {t("footerLink")}
+          </Link>
+          .
         </div>
       </div>
     </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,90 @@
+import { Suspense } from "react"
+import { getTranslations } from "next-intl/server"
+import Link from "next/link"
+import { ShieldCheck } from "lucide-react"
+
+async function PrivacyContent() {
+  const t = await getTranslations("privacy")
+
+  const sections = [
+    { title: t("section1Title"), body: t("section1Body") },
+    { title: t("section2Title"), body: t("section2Body") },
+    { title: t("section3Title"), body: t("section3Body") },
+    { title: t("section4Title"), body: t("section4Body") },
+    { title: t("section5Title"), body: t("section5Body") },
+    { title: t("section6Title"), body: t("section6Body") },
+  ]
+
+  return (
+    <div className="flex min-h-screen w-full items-start justify-center relative overflow-hidden bg-slate-50 py-12 px-4">
+      {/* Background elements */}
+      <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] rounded-full bg-primary/10 blur-3xl pointer-events-none -z-10" />
+      <div className="absolute bottom-[-10%] right-[-5%] w-[40%] h-[40%] rounded-full bg-chart-4/10 blur-3xl pointer-events-none -z-10" />
+
+      <div className="relative z-10 w-full max-w-2xl bg-white/80 backdrop-blur-xl border border-white/60 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.1)] rounded-3xl p-10 space-y-8">
+
+        {/* Header */}
+        <div className="flex flex-col space-y-3 text-center">
+          <div className="w-16 h-16 mx-auto rounded-xl flex items-center justify-center shadow-lg" style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}>
+            <ShieldCheck className="w-7 h-7 text-white" strokeWidth={2} />
+          </div>
+          <h1 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
+            {t("title")}
+          </h1>
+          <p className="text-sm text-slate-500 font-medium">
+            {t("subtitle")}
+          </p>
+        </div>
+
+        {/* Sections */}
+        <div className="space-y-6">
+          {sections.map((section) => (
+            <div key={section.title} className="space-y-1.5">
+              <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wide">
+                {section.title}
+              </h2>
+              <p className="text-sm text-slate-600 leading-relaxed">
+                {section.body}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="pt-2 border-t border-slate-100 flex items-center justify-between">
+          <p className="text-xs text-slate-400">{t("lastUpdated")}</p>
+          <Link
+            href="/login"
+            className="text-xs text-slate-500 hover:text-slate-700 underline transition-colors"
+          >
+            {t("backToLogin")}
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function PrivacyPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen w-full items-center justify-center bg-slate-50">
+        <div className="w-full max-w-2xl rounded-3xl bg-white/80 p-10 animate-pulse space-y-6">
+          <div className="flex flex-col items-center space-y-3">
+            <div className="w-16 h-16 rounded-xl bg-emerald-100" />
+            <div className="h-8 w-48 rounded bg-slate-200" />
+            <div className="h-4 w-56 rounded bg-slate-100" />
+          </div>
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-4 w-32 rounded bg-slate-200" />
+              <div className="h-12 w-full rounded bg-slate-100" />
+            </div>
+          ))}
+        </div>
+      </div>
+    }>
+      <PrivacyContent />
+    </Suspense>
+  )
+}

--- a/src/components/accounts/account-stat-cards.tsx
+++ b/src/components/accounts/account-stat-cards.tsx
@@ -1,8 +1,13 @@
+"use client";
+
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { InlineBalanceEditor } from "./inline-balance-editor";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+
+const HIDDEN = "***";
 
 interface AccountStatCardsProps {
   account: SerializedAccountWithHoldings;
@@ -12,6 +17,7 @@ interface AccountStatCardsProps {
 
 export function AccountStatCards({ account, totalHoldingsValue, onSaveBalance }: AccountStatCardsProps) {
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
   const isBrokerage = account.category === "BROKERAGE" || account.category === "CRYPTO_WALLET";
   const isBank = account.category === "BANK";
   const totalValue = account.cashBalance + totalHoldingsValue;
@@ -23,7 +29,7 @@ export function AccountStatCards({ account, totalHoldingsValue, onSaveBalance }:
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground">{t("accountDetail.marketValue")}</p>
             <p className="text-2xl font-bold mt-1">
-              {formatCurrency(totalHoldingsValue, account.currency)}
+              {privacyMode ? HIDDEN : formatCurrency(totalHoldingsValue, account.currency)}
             </p>
           </CardContent>
         </Card>
@@ -73,7 +79,7 @@ export function AccountStatCards({ account, totalHoldingsValue, onSaveBalance }:
         <CardContent className="pt-6">
           <p className="text-sm text-muted-foreground">{t("accountDetail.totalValue")}</p>
           <p className="text-2xl font-bold mt-1">
-            {formatCurrency(totalValue, account.currency)}
+            {privacyMode ? HIDDEN : formatCurrency(totalValue, account.currency)}
           </p>
         </CardContent>
       </Card>
@@ -92,7 +98,7 @@ export function AccountStatCards({ account, totalHoldingsValue, onSaveBalance }:
         <CardContent className="pt-6">
           <p className="text-sm text-muted-foreground">{t("accountDetail.holdingsValue")}</p>
           <p className="text-2xl font-bold mt-1">
-            {formatCurrency(totalHoldingsValue, account.currency)}
+            {privacyMode ? HIDDEN : formatCurrency(totalHoldingsValue, account.currency)}
           </p>
         </CardContent>
       </Card>

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -12,7 +12,10 @@ import { AccountForm } from "./account-form";
 import { QuickAddHolding } from "./quick-add-holding";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+
+const HIDDEN = "***";
 
 const CATEGORY_ICONS: Record<string, string> = {
   BANK: "🏦",
@@ -275,6 +278,7 @@ function CategorySection({
   isSelecting: boolean;
 }) {
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
   const colors = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.OTHER;
   const icon = CATEGORY_ICONS[category] ?? "📁";
   const label = t(`categories.${category}`, { defaultValue: category });
@@ -312,7 +316,7 @@ function CategorySection({
         <div className="flex items-center gap-3 flex-shrink-0">
           <div className="text-right">
             <p className="text-sm font-bold tabular-nums">
-              {formatCurrency(totalInBaseCurrency, baseCurrency)}
+              {privacyMode ? HIDDEN : formatCurrency(totalInBaseCurrency, baseCurrency)}
             </p>
           </div>
           <svg
@@ -366,6 +370,7 @@ function AccountCardWithHoldings({
   onToggle: () => void;
   isSelecting: boolean;
 }) {
+  const { privacyMode } = usePrivacyMode();
   const displayValue = getAccountValue(account, priceMap, ratesMap);
   const displayCurrency = account.currency;
   const rate = displayCurrency === baseCurrency ? 1 : (ratesMap[`${displayCurrency}_${baseCurrency}`] ?? 1);
@@ -397,14 +402,14 @@ function AccountCardWithHoldings({
               <div className="flex flex-col items-end">
                 <div className="flex items-center gap-2">
                   <p className="text-lg font-bold tabular-nums text-foreground">
-                    {formatCurrency(convertedValue, baseCurrency)}
+                    {privacyMode ? HIDDEN : formatCurrency(convertedValue, baseCurrency)}
                   </p>
                   <Badge variant="secondary" className="bg-foreground text-background hover:bg-foreground/90">{baseCurrency}</Badge>
                 </div>
                 {displayCurrency !== baseCurrency && (
                   <div className="flex items-center gap-2 mt-1">
                     <p className="text-sm font-medium text-muted-foreground tabular-nums">
-                      {formatCurrency(displayValue, displayCurrency)}
+                      {privacyMode ? HIDDEN : formatCurrency(displayValue, displayCurrency)}
                     </p>
                     <span className="text-xs font-semibold text-muted-foreground uppercase">{displayCurrency}</span>
                   </div>
@@ -426,7 +431,7 @@ function AccountCardWithHoldings({
                           {formatQuantity(h.quantity, h.assetType)}
                         </span>
                         <span className="text-sm font-medium tabular-nums w-20 text-right">
-                          {h.marketValue !== null ? formatCurrency(h.marketValue, account.currency) : "—"}
+                          {privacyMode ? HIDDEN : h.marketValue !== null ? formatCurrency(h.marketValue, account.currency) : "—"}
                         </span>
                       </div>
                     </div>

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TableCell, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -8,7 +10,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { formatCurrency, formatQuantity } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { SerializedHolding } from "@/lib/types";
+
+const HIDDEN = "***";
 
 export interface HoldingWithPrice extends SerializedHolding {
   currentPrice: number | null;
@@ -25,6 +30,7 @@ interface HoldingRowProps {
 
 export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, onDelete }: HoldingRowProps) {
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
   return (
     <TableRow key={h.id}>
       <TableCell className="font-mono font-medium">{h.symbol}</TableCell>
@@ -39,17 +45,17 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
         {formatQuantity(h.quantity, h.assetType)}
       </TableCell>
       <TableCell className="text-right">
-        {h.currentPrice !== null
+        {privacyMode ? HIDDEN : h.currentPrice !== null
           ? formatCurrency(h.currentPrice, h.currency || "USD")
           : "—"}
       </TableCell>
       <TableCell className="text-right font-medium">
-        {h.marketValue !== null
+        {privacyMode ? HIDDEN : h.marketValue !== null
           ? formatCurrency(h.marketValue, accountCurrency)
           : "—"}
       </TableCell>
       <TableCell className="text-right text-muted-foreground">
-        {h.marketValue !== null && totalValue > 0
+        {privacyMode ? "—" : h.marketValue !== null && totalValue > 0
           ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
           : "—"}
       </TableCell>

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { formatCurrency, formatNumber } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
 interface InlineBalanceEditorProps {
   currentBalance: number;
@@ -22,6 +23,7 @@ export function InlineBalanceEditor({
   const [balance, setBalance] = useState("");
   const [note, setNote] = useState("");
   const [saving, setSaving] = useState(false);
+  const { privacyMode } = usePrivacyMode();
 
   async function handleSave() {
     if (balance.trim() === "") {
@@ -83,7 +85,7 @@ export function InlineBalanceEditor({
       className="text-2xl font-bold mt-1 cursor-pointer hover:text-primary"
       onClick={() => setEditing(true)}
     >
-      {formatCurrency(currentBalance, currency)}
+      {privacyMode ? "***" : formatCurrency(currentBalance, currency)}
     </p>
   );
 }

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
@@ -35,11 +36,13 @@ function AssetsTooltip({
   payload,
   baseCurrency,
   t,
+  privacyMode,
 }: {
   active?: boolean;
   payload?: Array<{ payload: AssetsTooltipEntry }>;
   baseCurrency: string;
   t: (key: string) => string;
+  privacyMode?: boolean;
 }) {
   if (!active || !payload?.length) return null;
   const entry = payload[0].payload;
@@ -56,11 +59,11 @@ function AssetsTooltip({
       <div className="font-medium">{entry.label}</div>
       <div className="flex justify-between gap-4">
         <span className="text-muted-foreground">{t("seriesAssets")}</span>
-        <span className="tabular-nums">{formatCurrency(entry.assets, baseCurrency)}</span>
+        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(entry.assets, baseCurrency)}</span>
       </div>
       <div className="flex justify-between gap-4">
         <span className="text-muted-foreground">{t("seriesLiabilities")}</span>
-        <span className="tabular-nums">{formatCurrency(entry.liabilities, baseCurrency)}</span>
+        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(entry.liabilities, baseCurrency)}</span>
       </div>
     </div>
   );
@@ -68,6 +71,7 @@ function AssetsTooltip({
 
 export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
+  const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -106,7 +110,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
                       : String(v)
                 }
               />
-              <Tooltip content={<AssetsTooltip baseCurrency={baseCurrency} t={t} />} />
+              <Tooltip content={<AssetsTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />} />
               <Legend wrapperStyle={{ fontSize: 12 }} />
               <Bar
                 dataKey="assets"

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -95,37 +95,42 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
         ) : !mounted ? (
           <div className="h-[280px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={280}>
-            <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-              <YAxis
-                width={40}
-                tick={{ fontSize: 12 }}
-                tickFormatter={(v) =>
-                  v >= 1000000
-                    ? `${(v / 1000000).toFixed(1)}M`
-                    : v >= 1000
-                      ? `${(v / 1000).toFixed(0)}K`
-                      : String(v)
-                }
-              />
-              <Tooltip content={<AssetsTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />} />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
-              <Bar
-                dataKey="assets"
-                name={t("seriesAssets")}
-                fill="var(--chart-1)"
-                radius={[4, 4, 0, 0]}
-              />
-              <Bar
-                dataKey="liabilities"
-                name={t("seriesLiabilities")}
-                fill="var(--destructive)"
-                radius={[4, 4, 0, 0]}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10" />
+            )}
+            <ResponsiveContainer width="100%" height={280}>
+              <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                <YAxis
+                  width={40}
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={(v) =>
+                    v >= 1000000
+                      ? `${(v / 1000000).toFixed(1)}M`
+                      : v >= 1000
+                        ? `${(v / 1000).toFixed(0)}K`
+                        : String(v)
+                  }
+                />
+                <Tooltip content={<AssetsTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar
+                  dataKey="assets"
+                  name={t("seriesAssets")}
+                  fill="var(--chart-1)"
+                  radius={[4, 4, 0, 0]}
+                />
+                <Bar
+                  dataKey="liabilities"
+                  name={t("seriesLiabilities")}
+                  fill="var(--destructive)"
+                  radius={[4, 4, 0, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { AnalysisKpis } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
@@ -57,15 +58,18 @@ function signed(n: number, currency: string): string {
 
 export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
+  const { privacyMode } = usePrivacyMode();
   const dash = "—";
+  const hidden = "***";
 
-  const bestValue = kpis.best ? signed(kpis.best.deltaNetWorth, baseCurrency) : dash;
-  const bestSub = kpis.best ? formatMonthLabel(kpis.best.monthKey, locale) : undefined;
-  const worstValue = kpis.worst ? signed(kpis.worst.deltaNetWorth, baseCurrency) : dash;
-  const worstSub = kpis.worst ? formatMonthLabel(kpis.worst.monthKey, locale) : undefined;
+  const bestValue = privacyMode ? hidden : kpis.best ? signed(kpis.best.deltaNetWorth, baseCurrency) : dash;
+  const bestSub = privacyMode ? undefined : kpis.best ? formatMonthLabel(kpis.best.monthKey, locale) : undefined;
+  const worstValue = privacyMode ? hidden : kpis.worst ? signed(kpis.worst.deltaNetWorth, baseCurrency) : dash;
+  const worstSub = privacyMode ? undefined : kpis.worst ? formatMonthLabel(kpis.worst.monthKey, locale) : undefined;
 
-  const ytdSub =
-    kpis.ytdPct === null ? undefined : `${kpis.ytdPct >= 0 ? "+" : ""}${kpis.ytdPct.toFixed(1)}%`;
+  const ytdSub = privacyMode
+    ? undefined
+    : kpis.ytdPct === null ? undefined : `${kpis.ytdPct >= 0 ? "+" : ""}${kpis.ytdPct.toFixed(1)}%`;
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -73,24 +77,24 @@ export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
         title={t("bestMonth")}
         value={bestValue}
         subtitle={bestSub}
-        tone={kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"}
+        tone={privacyMode ? "neutral" : kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"}
       />
       <Tile
         title={t("worstMonth")}
         value={worstValue}
         subtitle={worstSub}
-        tone={kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"}
+        tone={privacyMode ? "neutral" : kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"}
       />
       <Tile
         title={t("avgMonthly")}
-        value={signed(kpis.avgMonthlyDelta, baseCurrency)}
-        tone={toneFor(kpis.avgMonthlyDelta)}
+        value={privacyMode ? hidden : signed(kpis.avgMonthlyDelta, baseCurrency)}
+        tone={privacyMode ? "neutral" : toneFor(kpis.avgMonthlyDelta)}
       />
       <Tile
         title={t("ytdGrowth")}
-        value={signed(kpis.ytdDelta, baseCurrency)}
+        value={privacyMode ? hidden : signed(kpis.ytdDelta, baseCurrency)}
         subtitle={ytdSub}
-        tone={toneFor(kpis.ytdDelta)}
+        tone={privacyMode ? "neutral" : toneFor(kpis.ytdDelta)}
       />
     </div>
   );

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -99,6 +99,10 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
         ) : !mounted ? (
           <div className="h-[280px]" />
         ) : (
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10" />
+            )}
           <ResponsiveContainer width="100%" height={280}>
             <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
@@ -135,6 +139,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
@@ -32,11 +33,13 @@ function ChangeTooltip({
   payload,
   baseCurrency,
   t,
+  privacyMode,
 }: {
   active?: boolean;
   payload?: TooltipPayload[];
   baseCurrency: string;
   t: (key: string) => string;
+  privacyMode?: boolean;
 }) {
   if (!active || !payload?.length) return null;
   const b = payload[0].payload;
@@ -55,11 +58,11 @@ function ChangeTooltip({
       <div className="font-medium">{b.label}</div>
       <div className="flex justify-between gap-4">
         <span className="text-muted-foreground">{t("tooltipStart")}</span>
-        <span className="tabular-nums">{formatCurrency(b.startNetWorth, baseCurrency)}</span>
+        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(b.startNetWorth, baseCurrency)}</span>
       </div>
       <div className="flex justify-between gap-4">
         <span className="text-muted-foreground">{t("tooltipEnd")}</span>
-        <span className="tabular-nums">{formatCurrency(b.endNetWorth, baseCurrency)}</span>
+        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(b.endNetWorth, baseCurrency)}</span>
       </div>
       <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
         <span className="text-muted-foreground">{t("tooltipChange")}</span>
@@ -68,8 +71,7 @@ function ChangeTooltip({
             b.deltaNetWorth >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
           }`}
         >
-          {sign}
-          {formatCurrency(b.deltaNetWorth, baseCurrency)} ({pct})
+          {privacyMode ? "***" : `${sign}${formatCurrency(b.deltaNetWorth, baseCurrency)} (${pct})`}
         </span>
       </div>
     </div>
@@ -78,6 +80,7 @@ function ChangeTooltip({
 
 export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
+  const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -113,7 +116,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
               />
               <Tooltip
                 cursor={{ fill: "var(--muted)", opacity: 0.3 }}
-                content={<ChangeTooltip baseCurrency={baseCurrency} t={t} />}
+                content={<ChangeTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />}
               />
               <Bar dataKey="deltaNetWorth" radius={[4, 4, 0, 0]}>
                 {data.map((entry) => (

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -15,7 +15,10 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
+
+const HIDDEN = "••••••";
 
 type SortField = "name" | "category" | "value" | "percentage";
 type SortOrder = "asc" | "desc";
@@ -24,6 +27,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   const [sortField, setSortField] = useState<SortField>("value");
   const [sortDirection, setSortDirection] = useState<SortOrder>("desc");
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -126,10 +130,10 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
           {t(`categories.${account.category}`, { defaultValue: account.category })}
         </TableCell>
         <TableCell className="text-right text-muted-foreground tabular-nums">
-          {getPercentage(account).toFixed(1)}%
+          {privacyMode ? "—" : `${getPercentage(account).toFixed(1)}%`}
         </TableCell>
         <TableCell className="text-right font-medium tabular-nums">
-          {formatCurrency(account.totalValueInBaseCurrency, summary.baseCurrency)}
+          {privacyMode ? HIDDEN : formatCurrency(account.totalValueInBaseCurrency, summary.baseCurrency)}
         </TableCell>
       </TableRow>
     ));
@@ -157,7 +161,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
                     </td>
                     <td />
                     <td className="px-1 sm:px-4 py-2 text-right text-sm tabular-nums">
-                      {formatCurrency(summary.totalAssets, summary.baseCurrency)}
+                      {privacyMode ? HIDDEN : formatCurrency(summary.totalAssets, summary.baseCurrency)}
                     </td>
                   </tr>
                 </tfoot>
@@ -183,7 +187,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
                     </td>
                     <td />
                     <td className="px-1 sm:px-4 py-2 text-right text-sm tabular-nums">
-                      {formatCurrency(summary.totalLiabilities, summary.baseCurrency)}
+                      {privacyMode ? HIDDEN : formatCurrency(summary.totalLiabilities, summary.baseCurrency)}
                     </td>
                   </tr>
                 </tfoot>

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -18,7 +18,7 @@ import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 
-const HIDDEN = "••••••";
+const HIDDEN = "***";
 
 type SortField = "name" | "category" | "value" | "percentage";
 type SortOrder = "asc" | "desc";

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -15,6 +17,7 @@ const COLORS = [
 export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const assetAccounts = summary.accounts.filter((a) => a.type === "ASSET");
@@ -49,28 +52,35 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={250}>
-            <PieChart>
-              <Pie
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={90}
-                paddingAngle={2}
-                dataKey="value"
-              >
-                {data.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-              <Legend formatter={createPieLegendFormatter()} />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
+                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
+              </div>
+            )}
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {data.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Legend formatter={createPieLegendFormatter()} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -15,6 +16,7 @@ const COLORS = [
 export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const assetAccounts = summary.accounts.filter((a) => a.type === "ASSET");
@@ -49,28 +51,33 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={250}>
-            <PieChart>
-              <Pie
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={90}
-                paddingAngle={2}
-                dataKey="value"
-              >
-                {data.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-              <Legend formatter={createPieLegendFormatter()} />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10" />
+            )}
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {data.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Legend formatter={createPieLegendFormatter()} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -3,9 +3,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
-import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -17,7 +15,6 @@ const COLORS = [
 export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations();
-  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const assetAccounts = summary.accounts.filter((a) => a.type === "ASSET");
@@ -52,35 +49,28 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className="relative">
-            {privacyMode && (
-              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
-                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
-              </div>
-            )}
-            <ResponsiveContainer width="100%" height={250}>
-              <PieChart>
-                <Pie
-                  data={data}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={60}
-                  outerRadius={90}
-                  paddingAngle={2}
-                  dataKey="value"
-                >
-                  {data.map((_, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={COLORS[index % COLORS.length]}
-                    />
-                  ))}
-                </Pie>
-                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-                <Legend formatter={createPieLegendFormatter()} />
-              </PieChart>
-            </ResponsiveContainer>
-          </div>
+          <ResponsiveContainer width="100%" height={250}>
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={90}
+                paddingAngle={2}
+                dataKey="value"
+              >
+                {data.map((_, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+              <Legend formatter={createPieLegendFormatter()} />
+            </PieChart>
+          </ResponsiveContainer>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -15,6 +17,7 @@ const COLORS = [
 export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("currencyExposure");
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const total = summary.currencyExposure.reduce((acc, curr) => acc + curr.value, 0);
@@ -39,28 +42,35 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={250}>
-            <PieChart>
-              <Pie
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={90}
-                paddingAngle={2}
-                dataKey="value"
-              >
-                {data.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-              <Legend formatter={createPieLegendFormatter()} />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
+                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
+              </div>
+            )}
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {data.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Legend formatter={createPieLegendFormatter()} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -3,9 +3,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
-import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -17,7 +15,6 @@ const COLORS = [
 export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("currencyExposure");
-  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const total = summary.currencyExposure.reduce((acc, curr) => acc + curr.value, 0);
@@ -42,35 +39,28 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className="relative">
-            {privacyMode && (
-              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
-                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
-              </div>
-            )}
-            <ResponsiveContainer width="100%" height={250}>
-              <PieChart>
-                <Pie
-                  data={data}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={60}
-                  outerRadius={90}
-                  paddingAngle={2}
-                  dataKey="value"
-                >
-                  {data.map((_, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={COLORS[index % COLORS.length]}
-                    />
-                  ))}
-                </Pie>
-                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-                <Legend formatter={createPieLegendFormatter()} />
-              </PieChart>
-            </ResponsiveContainer>
-          </div>
+          <ResponsiveContainer width="100%" height={250}>
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={90}
+                paddingAngle={2}
+                dataKey="value"
+              >
+                {data.map((_, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+              <Legend formatter={createPieLegendFormatter()} />
+            </PieChart>
+          </ResponsiveContainer>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
 
@@ -15,6 +16,7 @@ const COLORS = [
 export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("currencyExposure");
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const total = summary.currencyExposure.reduce((acc, curr) => acc + curr.value, 0);
@@ -39,28 +41,33 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={250}>
-            <PieChart>
-              <Pie
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={90}
-                paddingAngle={2}
-                dataKey="value"
-              >
-                {data.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
-              <Legend formatter={createPieLegendFormatter()} />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10" />
+            )}
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {data.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Legend formatter={createPieLegendFormatter()} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 
-const HIDDEN = "••••••";
+const HIDDEN = "***";
 
 export function NetWorthCard({
   summary,

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -1,9 +1,14 @@
+"use client";
+
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { NetWorthSummary } from "@/lib/types";
 
-export async function NetWorthCard({
+const HIDDEN = "••••••";
+
+export function NetWorthCard({
   summary,
   previousNetWorth,
 }: {
@@ -11,7 +16,8 @@ export async function NetWorthCard({
   previousNetWorth?: number;
 }) {
   const { totalAssets, totalLiabilities, netWorth, baseCurrency } = summary;
-  const t = await getTranslations("netWorthCard");
+  const t = useTranslations("netWorthCard");
+  const { privacyMode } = usePrivacyMode();
 
   const delta = previousNetWorth !== undefined ? netWorth - previousNetWorth : null;
   const pct =
@@ -29,9 +35,9 @@ export async function NetWorthCard({
         <CardContent className="pt-6">
           <p className="text-sm font-medium text-muted-foreground">{t("netWorth")}</p>
           <p className="text-3xl font-bold tracking-tight mt-1">
-            {formatCurrency(netWorth, baseCurrency)}
+            {privacyMode ? HIDDEN : formatCurrency(netWorth, baseCurrency)}
           </p>
-          {delta !== null && pct !== null && (
+          {!privacyMode && delta !== null && pct !== null && (
             <p className={`text-sm font-medium mt-1 ${deltaColor}`}>
               {deltaSign}{formatCurrency(delta, baseCurrency)}{" "}
               ({deltaSign}{pct.toFixed(2)}%)
@@ -43,7 +49,7 @@ export async function NetWorthCard({
         <CardContent className="pt-6">
           <p className="text-sm font-medium text-muted-foreground">{t("totalAssets")}</p>
           <p className="text-2xl font-semibold text-green-600 mt-1">
-            {formatCurrency(totalAssets, baseCurrency)}
+            {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency)}
           </p>
         </CardContent>
       </Card>
@@ -51,7 +57,7 @@ export async function NetWorthCard({
         <CardContent className="pt-6">
           <p className="text-sm font-medium text-muted-foreground">{t("totalLiabilities")}</p>
           <p className="text-2xl font-semibold text-red-600 mt-1">
-            {formatCurrency(totalLiabilities, baseCurrency)}
+            {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency)}
           </p>
         </CardContent>
       </Card>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -11,7 +11,9 @@ import {
   Area,
   AreaChart,
 } from "recharts";
+import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { createCurrencyTooltipFormatter } from "@/lib/chart-formatters";
 
 type SnapshotData = {
@@ -33,6 +35,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
   const [range, setRange] = useState("All");
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("trendChart");
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
@@ -74,6 +77,12 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
+                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
+              </div>
+            )}
           <ResponsiveContainer width="100%" height={250}>
             <AreaChart data={filtered}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
@@ -107,6 +116,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
               />
             </AreaChart>
           </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -12,6 +12,7 @@ import {
   AreaChart,
 } from "recharts";
 import { useTranslations } from "next-intl";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { createCurrencyTooltipFormatter } from "@/lib/chart-formatters";
 
 type SnapshotData = {
@@ -33,6 +34,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
   const [range, setRange] = useState("All");
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("trendChart");
+  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
@@ -74,6 +76,10 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
+          <div className="relative">
+            {privacyMode && (
+              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10" />
+            )}
           <ResponsiveContainer width="100%" height={250}>
             <AreaChart data={filtered}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
@@ -107,6 +113,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
               />
             </AreaChart>
           </ResponsiveContainer>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -11,9 +11,7 @@ import {
   Area,
   AreaChart,
 } from "recharts";
-import { EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { createCurrencyTooltipFormatter } from "@/lib/chart-formatters";
 
 type SnapshotData = {
@@ -35,7 +33,6 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
   const [range, setRange] = useState("All");
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("trendChart");
-  const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
@@ -77,12 +74,6 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className="relative">
-            {privacyMode && (
-              <div className="absolute inset-0 backdrop-blur-sm bg-background/30 rounded-lg z-10 flex items-center justify-center">
-                <EyeOff className="h-6 w-6 text-muted-foreground opacity-50" />
-              </div>
-            )}
           <ResponsiveContainer width="100%" height={250}>
             <AreaChart data={filtered}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
@@ -116,7 +107,6 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
               />
             </AreaChart>
           </ResponsiveContainer>
-          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
 type SnapshotRow = {
   id: string;
@@ -29,6 +30,7 @@ type Props = {
 
 export function HistoryTable({ snapshots, baseCurrency }: Props) {
   const t = useTranslations("history");
+  const { privacyMode } = usePrivacyMode();
 
   const rows = useMemo(() => {
     return [...snapshots].reverse().map((snap, idx, arr) => ({
@@ -70,13 +72,13 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                       })}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatCurrency(row.netWorth, baseCurrency)}
+                      {privacyMode ? "***" : formatCurrency(row.netWorth, baseCurrency)}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatCurrency(row.totalAssets, baseCurrency)}
+                      {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatCurrency(row.totalLiabilities, baseCurrency)}
+                      {privacyMode ? "***" : formatCurrency(row.totalLiabilities, baseCurrency)}
                     </TableCell>
                     <TableCell
                       className={cn(
@@ -88,7 +90,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                             : "text-red-500 dark:text-red-400"
                       )}
                     >
-                      {row.change === null
+                      {privacyMode ? "***" : row.change === null
                         ? "—"
                         : (row.change >= 0 ? "+" : "") +
                           formatCurrency(row.change, baseCurrency)}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { Eye, EyeOff } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
+import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
 
 export function MobileHeader() {
   const t = useTranslations("app");
+  const { privacyMode, togglePrivacyMode } = usePrivacyMode();
 
   return (
     <header className="md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between">
@@ -14,7 +17,14 @@ export function MobileHeader() {
         </h1>
         <p className="text-[10px] text-muted-foreground font-medium -mt-1 opacity-80 uppercase tracking-wider">{t("subtitleMobile")}</p>
       </div>
-      <div className="scale-90 origin-right">
+      <div className="flex items-center gap-1 scale-90 origin-right">
+        <button
+          onClick={togglePrivacyMode}
+          title={privacyMode ? "Show values" : "Hide values"}
+          className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
         <ThemeToggle />
       </div>
     </header>

--- a/src/components/layout/privacy-mode-context.tsx
+++ b/src/components/layout/privacy-mode-context.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect } from "react";
+
+interface PrivacyModeContextType {
+  privacyMode: boolean;
+  togglePrivacyMode: () => void;
+}
+
+const PrivacyModeContext = createContext<PrivacyModeContextType>({
+  privacyMode: false,
+  togglePrivacyMode: () => {},
+});
+
+export function PrivacyModeProvider({ children }: { children: React.ReactNode }) {
+  const [privacyMode, setPrivacyMode] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem("privacy-mode");
+    setPrivacyMode(stored === "true");
+  }, []);
+
+  const togglePrivacyMode = () => {
+    setPrivacyMode((prev) => {
+      const next = !prev;
+      localStorage.setItem("privacy-mode", String(next));
+      return next;
+    });
+  };
+
+  return (
+    <PrivacyModeContext.Provider
+      value={{ privacyMode: mounted ? privacyMode : false, togglePrivacyMode }}
+    >
+      {children}
+    </PrivacyModeContext.Provider>
+  );
+}
+
+export function usePrivacyMode() {
+  return useContext(PrivacyModeContext);
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { BarChart3, Copy, History, LayoutDashboard, Settings } from "lucide-react";
+import { BarChart3, Copy, Eye, EyeOff, History, LayoutDashboard, Settings } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
+import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -13,6 +14,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const t = useTranslations();
+  const { privacyMode, togglePrivacyMode } = usePrivacyMode();
 
   const navItems = [
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
@@ -69,7 +71,21 @@ export function Sidebar() {
       <div className="p-4 border-t border-border/50 bg-background/30 backdrop-blur-md">
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">v0.1.0</span>
-          <ThemeToggle />
+          <div className="flex items-center gap-1">
+            <button
+              onClick={togglePrivacyMode}
+              title={privacyMode ? "Show values" : "Hide values"}
+              className={cn(
+                "inline-flex items-center justify-center rounded-md p-1.5 text-sm transition-all duration-200",
+                privacyMode
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+            <ThemeToggle />
+          </div>
         </div>
       </div>
     </aside>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,14 +6,14 @@ const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
-  const isAuthRoute = req.nextUrl.pathname === "/login";
+  const isPublicRoute = ["/login", "/privacy"].includes(req.nextUrl.pathname);
 
-  if (!isLoggedIn && !isAuthRoute) {
+  if (!isLoggedIn && !isPublicRoute) {
     const newUrl = new URL("/login", req.nextUrl.origin);
     return Response.redirect(newUrl);
   }
 
-  if (isLoggedIn && isAuthRoute) {
+  if (isLoggedIn && req.nextUrl.pathname === "/login") {
     const newUrl = new URL("/", req.nextUrl.origin);
     return Response.redirect(newUrl);
   }


### PR DESCRIPTION
## Description
This PR adds a privacy mode feature that allows users to hide sensitive financial data in the dashboard, along with a comprehensive privacy policy page. The privacy mode can be toggled via a button in the sidebar and mobile header, and when enabled, it blurs/hides numerical values across charts and account summaries.

### Changes
- **New Privacy Mode Context**: Created `PrivacyModeContext` to manage privacy mode state globally with localStorage persistence
- **Privacy Policy Page**: Added `/privacy` route with localized content (English and Traditional Chinese) explaining data collection, third-party services, and user controls
- **Dashboard Privacy**: Applied privacy mode masking to:
  - Net worth card (hides net worth, assets, liabilities, and delta calculations)
  - Accounts summary table (hides percentages and values)
  - Allocation chart (blurs pie chart with overlay)
  - Currency exposure chart (blurs pie chart with overlay)
  - Trend chart (blurs area chart with overlay)
- **UI Updates**: 
  - Added privacy toggle button (eye/eye-off icon) to sidebar and mobile header
  - Updated login page with trust badges highlighting security features
  - Added link to privacy policy in login footer
- **Middleware**: Updated to allow unauthenticated access to `/privacy` route
- **Layout**: Wrapped main layout with `PrivacyModeProvider` to enable privacy mode across dashboard

### Type of Change
- [x] New feature
- [x] Documentation update

## Testing
- Privacy mode toggle persists across page reloads via localStorage
- All dashboard components properly mask/blur data when privacy mode is enabled
- Privacy policy page renders correctly with proper localization
- Unauthenticated users can access privacy policy without login
- Existing dashboard functionality unaffected when privacy mode is disabled

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Updated localization files (en-US.json, zh-TW.json)
- [x] No new warnings generated
- [x] Privacy mode context properly integrated with existing components

https://claude.ai/code/session_013YBJXxBs9dUWKVWh13JXB5