### PR TITLE
perf: deduplicate recentSnapshots query via React cache() (#93)

### DIFF
--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -96,7 +96,7 @@
 | 90 | Memoize derived data in chart components | Performance | 🟡 Medium | 30 min | ❌ Not Done |
 | 91 | Stabilize inline `tickFormatter`s in `TrendChart` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 92 | Batch `PriceCache` upserts via `$transaction` | Performance | 🔴 High | 30 min | ✅ Done |
-| 93 | Deduplicate `recentSnapshots` query in dashboard sections | Performance | 🟡 Medium | 15 min | ❌ Not Done |
+| 93 | Deduplicate `recentSnapshots` query in dashboard sections | Performance | 🟡 Medium | 15 min | ✅ Done |
 | 94 | Parallelize account detail page waterfall | Performance | 🟡 Medium | 15 min | ❌ Not Done |
 | 95 | Add `Cache-Control` headers to `GET /api/exchange-rates` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 96 | Prefetch high-traffic routes in accounts list | Performance | 🟡 Medium | 15 min | ❌ Not Done |

--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -97,7 +97,7 @@
 | 91 | Stabilize inline `tickFormatter`s in `TrendChart` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 92 | Batch `PriceCache` upserts via `$transaction` | Performance | 🔴 High | 30 min | ✅ Done |
 | 93 | Deduplicate `recentSnapshots` query in dashboard sections | Performance | 🟡 Medium | 15 min | ✅ Done |
-| 94 | Parallelize account detail page waterfall | Performance | 🟡 Medium | 15 min | ❌ Not Done |
+| 94 | Parallelize account detail page waterfall | Performance | 🟡 Medium | 15 min | ✅ Done |
 | 95 | Add `Cache-Control` headers to `GET /api/exchange-rates` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 96 | Prefetch high-traffic routes in accounts list | Performance | 🟡 Medium | 15 min | ❌ Not Done |
 | 97 | Scope cron `refreshAllPrices` to per-user symbols | Performance | 🟡 Medium | 1 hr | ❌ Not Done |

--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -13,7 +13,11 @@ const CLIENT_NAMESPACES = ["accountDetail", "common", "categories", "transaction
 
 async function AccountDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  // Fetch account first to know which symbols to filter prices by
+
+  // Kick off independent queries before awaiting the account
+  const ratesP = getAllExchangeRates();
+  const messagesP = getMessages();
+
   const account = await prisma.account.findUnique({
     where: { id },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
@@ -23,11 +27,11 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
 
   const symbols = account.holdings.map((h) => h.symbol);
 
-  // Parallel: load filtered prices, exchange rates, and messages
+  // cachedPrices needs symbols from account; ratesP and messagesP are already in-flight
   const [allRatesMap, cachedPrices, messages] = await Promise.all([
-    getAllExchangeRates(),
+    ratesP,
     prisma.priceCache.findMany({ where: { symbol: { in: symbols } } }),
-    getMessages(),
+    messagesP,
   ]);
 
   const priceMap = Object.fromEntries(

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Suspense, cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { NetWorthCard } from "@/components/dashboard/net-worth-card";
 import { LazyAllocationChart, LazyCurrencyExposureChart } from "@/components/dashboard/lazy-charts";
@@ -11,6 +11,15 @@ import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+const fetchRecentSnapshots = cache((userId: string) =>
+  prisma.netWorthSnapshot.findMany({
+    where: { userId },
+    orderBy: { date: "desc" },
+    take: 2,
+    select: { date: true, netWorth: true, baseCurrency: true },
+  })
+);
 
 const CARD_CLASS =
   "bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg";
@@ -84,12 +93,7 @@ async function DashboardActionsSection({
   baseCurrency: string;
 }) {
   const [recentSnapshots, latestPrice] = await Promise.all([
-    prisma.netWorthSnapshot.findMany({
-      where: { userId },
-      orderBy: { date: "desc" },
-      take: 2,
-      select: { date: true, netWorth: true, baseCurrency: true },
-    }),
+    fetchRecentSnapshots(userId),
     prisma.priceCache.findFirst({
       orderBy: { updatedAt: "desc" },
       select: { updatedAt: true },
@@ -121,12 +125,7 @@ async function NetWorthSection({
 }) {
   const [summary, recentSnapshots] = await Promise.all([
     getCachedNetWorthSummary(userId, baseCurrency),
-    prisma.netWorthSnapshot.findMany({
-      where: { userId },
-      orderBy: { date: "desc" },
-      take: 2,
-      select: { date: true, netWorth: true, baseCurrency: true },
-    }),
+    fetchRecentSnapshots(userId),
   ]);
 
   if (summary.accounts.length === 0) return null;


### PR DESCRIPTION
Both DashboardActionsSection and NetWorthSection issued the same
prisma.netWorthSnapshot.findMany query independently. Because they live
in separate <Suspense> boundaries, React's cache() dedup did not apply,
causing two identical DB round-trips on every dashboard render.

Extracts the query into a module-scope fetchRecentSnapshots helper
wrapped in cache(), so both sections share a single DB round-trip
within the same server render — matching the fetchUserAccountsWithHoldings
pattern already used in net-worth-service.ts.

https://claude.ai/code/session_01XQ1WfaUiaMfWSRECckaiNU