### PR TITLE
Optimize dashboard charts with useMemo to prevent unnecessary recalculations

### DIFF
--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -93,7 +93,7 @@
 | 87 | Split `account-detail.tsx` into subcomponents | Code Quality | 🟡 Medium | 2-3 hrs | ✅ Done |
 | 88 | Skip fresh pairs in `/api/exchange-rates/refresh` | Performance | 🟡 Medium | 30 min | ❌ Not Done |
 | 89 | Parallelize initial queries in exchange-rate refresh | Performance | 🟢 Low | 10 min | ❌ Not Done |
-| 90 | Memoize derived data in chart components | Performance | 🟡 Medium | 30 min | ❌ Not Done |
+| 90 | Memoize derived data in chart components | Performance | 🟡 Medium | 30 min | ✅ Done |
 | 91 | Stabilize inline `tickFormatter`s in `TrendChart` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 92 | Batch `PriceCache` upserts via `$transaction` | Performance | 🔴 High | 30 min | ✅ Done |
 | 93 | Deduplicate `recentSnapshots` query in dashboard sections | Performance | 🟡 Medium | 15 min | ✅ Done |

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
@@ -19,24 +19,23 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
-  const assetAccounts = summary.accounts.filter((a) => a.type === "ASSET");
-
-  const categoryMap = new Map<string, number>();
-  for (const account of assetAccounts) {
-    const cat = account.category;
-    const current = categoryMap.get(cat) ?? 0;
-    categoryMap.set(cat, current + account.totalValueInBaseCurrency);
-  }
-
-  const total = Array.from(categoryMap.values()).reduce((a, b) => a + b, 0);
-  const data = Array.from(categoryMap.entries())
-    .map(([category, value]) => ({
-      name: t(`categories.${category}`, { defaultValue: category }),
-      value: Math.round(value * 100) / 100,
-      percentage: total > 0 ? ((value / total) * 100).toFixed(1) : "0",
-    }))
-    .filter((d) => d.value > 0)
-    .sort((a, b) => b.value - a.value);
+  const data = useMemo(() => {
+    const categoryMap = new Map<string, number>();
+    for (const account of summary.accounts) {
+      if (account.type !== "ASSET") continue;
+      const cat = account.category;
+      categoryMap.set(cat, (categoryMap.get(cat) ?? 0) + account.totalValueInBaseCurrency);
+    }
+    const total = Array.from(categoryMap.values()).reduce((a, b) => a + b, 0);
+    return Array.from(categoryMap.entries())
+      .map(([category, value]) => ({
+        name: t(`categories.${category}`, { defaultValue: category }),
+        value: Math.round(value * 100) / 100,
+        percentage: total > 0 ? ((value / total) * 100).toFixed(1) : "0",
+      }))
+      .filter((d) => d.value > 0)
+      .sort((a, b) => b.value - a.value);
+  }, [summary.accounts, t]);
 
   return (
     <Card>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
@@ -19,14 +19,16 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
   const { privacyMode } = usePrivacyMode();
   useEffect(() => setMounted(true), []);
 
-  const total = summary.currencyExposure.reduce((acc, curr) => acc + curr.value, 0);
-  const data = summary.currencyExposure
-    .map((exposure) => ({
-      name: exposure.currency,
-      value: Math.round(exposure.value * 100) / 100,
-      percentage: total > 0 ? ((exposure.value / total) * 100).toFixed(1) : "0",
-    }))
-    .filter((d) => d.value > 0);
+  const data = useMemo(() => {
+    const total = summary.currencyExposure.reduce((acc, curr) => acc + curr.value, 0);
+    return summary.currencyExposure
+      .map((exposure) => ({
+        name: exposure.currency,
+        value: Math.round(exposure.value * 100) / 100,
+        percentage: total > 0 ? ((exposure.value / total) * 100).toFixed(1) : "0",
+      }))
+      .filter((d) => d.value > 0);
+  }, [summary.currencyExposure]);
 
   return (
     <Card>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   XAxis,
@@ -38,13 +38,13 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
   useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - selectedRange.days);
 
-  const filtered =
-    hideRangeFilter || selectedRange.days === Infinity
-      ? snapshots
-      : snapshots.filter((s) => new Date(s.date) >= cutoff);
+  const filtered = useMemo(() => {
+    if (hideRangeFilter || selectedRange.days === Infinity) return snapshots;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - selectedRange.days);
+    return snapshots.filter((s) => new Date(s.date) >= cutoff);
+  }, [snapshots, selectedRange.days, hideRangeFilter]);
 
   return (
     <Card>


### PR DESCRIPTION
## Description
This PR optimizes three dashboard chart components by wrapping their data transformation logic with `useMemo` hooks. This prevents expensive calculations from running on every render, improving performance when parent components re-render but the input data hasn't changed.

### Changes
- **allocation-chart.tsx**: Wrapped category aggregation and data transformation logic in `useMemo` with dependencies on `summary.accounts` and `t`
- **currency-exposure-chart.tsx**: Wrapped currency exposure data transformation in `useMemo` with dependency on `summary.currencyExposure`
- **trend-chart.tsx**: Wrapped snapshot filtering logic in `useMemo` with dependencies on `snapshots`, `selectedRange.days`, and `hideRangeFilter`

### Type of Change
- [x] Performance optimization
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Changes are straightforward refactoring with no behavioral modifications
- [x] Existing component functionality remains unchanged
- [x] Dependencies are correctly specified for each `useMemo` hook

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No new warnings generated
- [x] Memoization dependencies are correctly specified

https://claude.ai/code/session_01C6PfCM2oVhiv6kxsy2bkC2