### PR TITLE
perf: lazy-load AccountForm and QuickAddHolding in AccountsList

### DIFF
--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -101,7 +101,7 @@
 | 95 | Add `Cache-Control` headers to `GET /api/exchange-rates` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | 96 | Prefetch high-traffic routes in accounts list | Performance | 🟡 Medium | 15 min | ❌ Not Done |
 | 97 | Scope cron `refreshAllPrices` to per-user symbols | Performance | 🟡 Medium | 1 hr | ❌ Not Done |
-| 98 | Lazy-load `AccountForm` / `QuickAddHolding` dialogs | Performance | 🟡 Medium | 30 min | ❌ Not Done |
+| 98 | Lazy-load `AccountForm` / `QuickAddHolding` dialogs | Performance | 🟡 Medium | 30 min | ✅ Done |
 | 99 | Add `useMemo` to `getAccountValue` in `AccountsList` | Performance | 🟡 Medium | 15 min | ❌ Not Done |
 | 100 | Update Onboarding Empty State Text | UX | 🟢 Low | 15 min | ❌ Not Done |
 | 101 | Clarify "Growth" definition with Tooltips | UX | 🟢 Low | 30 min | ❌ Not Done |
@@ -1582,7 +1582,7 @@ This filters out holdings with zero quantity (already sold) and holdings in arch
 - **Affected files:** `src/lib/services/price-service.ts`
 
 
-### 98. Lazy-Load `AccountForm` / `QuickAddHolding` Dialogs
+### 98. Lazy-Load `AccountForm` / `QuickAddHolding` Dialogs ✅ Done
 
 **File:** `src/components/accounts/accounts-list.tsx` (lines 11–12, 249–250)
 

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -2,18 +2,25 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { formatCurrency, formatQuantity } from "@/lib/currencies";
-import { AccountForm } from "./account-form";
-import { QuickAddHolding } from "./quick-add-holding";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+
+const AccountForm = dynamic(
+  () => import("./account-form").then((m) => m.AccountForm)
+);
+
+const QuickAddHolding = dynamic(
+  () => import("./quick-add-holding").then((m) => m.QuickAddHolding)
+);
 
 const HIDDEN = "***";
 
@@ -203,7 +210,6 @@ export function AccountsList({
             {assetsByCategory.map(({ category, accounts: catAccounts }) => (
               <CategorySection
                 key={`asset_${category}`}
-                type="ASSET"
                 category={category}
                 accounts={catAccounts}
                 priceMap={priceMap}
@@ -229,7 +235,6 @@ export function AccountsList({
             {liabilitiesByCategory.map(({ category, accounts: catAccounts }) => (
               <CategorySection
                 key={`liability_${category}`}
-                type="LIABILITY"
                 category={category}
                 accounts={catAccounts}
                 priceMap={priceMap}
@@ -246,14 +251,26 @@ export function AccountsList({
         </div>
       )}
 
-      <AccountForm open={showForm} onClose={() => setShowForm(false)} defaultCurrency={baseCurrency} />
-      <QuickAddHolding open={showQuickAdd} onClose={() => setShowQuickAdd(false)} accounts={accounts} defaultCurrency={baseCurrency} />
+      {showForm && (
+        <AccountForm
+          open={showForm}
+          onClose={() => setShowForm(false)}
+          defaultCurrency={baseCurrency}
+        />
+      )}
+      {showQuickAdd && (
+        <QuickAddHolding
+          open={showQuickAdd}
+          onClose={() => setShowQuickAdd(false)}
+          accounts={accounts}
+          defaultCurrency={baseCurrency}
+        />
+      )}
     </div>
   );
 }
 
 function CategorySection({
-  type,
   category,
   accounts,
   priceMap,
@@ -265,7 +282,6 @@ function CategorySection({
   onToggleSelect,
   isSelecting,
 }: {
-  type: string;
   category: string;
   accounts: SerializedAccountWithHoldings[];
   priceMap: Record<string, number>;


### PR DESCRIPTION
### Motivation
- Reduce initial bundle size and improve page load performance by deferring heavy dialog components until they are needed, matching suggestion #98 in `docs/SUGGESTIONS.md`.

### Description
- Replaced static imports of `AccountForm` and `QuickAddHolding` with `next/dynamic` so the dialog components are code-split and loaded on demand via `dynamic()` in `src/components/accounts/accounts-list.tsx`.
- Only mount each dialog when opened by conditionally rendering them based on `showForm` / `showQuickAdd`, which prevents their subtrees from being included in the initial render.
- Removed an unused `type` prop from `CategorySection` callsites and its prop typing as a small lint cleanup.

### Testing
- Ran `npm run lint -- src/components/accounts/accounts-list.tsx` and the lint check passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1eb7ba1548321956edc6778b3aaca)