### PR TITLE
perf: implement Vercel performance suggestions V2, V4, V5, V6

### DIFF
--- a/docs/VERCEL_ANALYSIS.md
+++ b/docs/VERCEL_ANALYSIS.md
@@ -5,14 +5,14 @@
 | # | Suggestion | Category | Impact | Effort | Status |
 |---|-----------|----------|--------|--------|--------|
 | V1 | Rename `src/middleware.ts` → `src/proxy.ts` (Next.js 16 convention) | Deprecation | 🟢 Low | 10 min | ❌ Not Done |
-| V2 | Remove duplicate `prisma generate` (postinstall + build) | Build Perf | 🟢 Low | 5 min | ❌ Not Done |
+| V2 | Remove duplicate `prisma generate` (postinstall + build) | Build Perf | 🟢 Low | 5 min | ✅ Done |
 | V3 | Upgrade `prisma` + `@prisma/client` 7.6.0 → 7.7.0 | Maintenance | 🟢 Low | 10 min | ❌ Not Done |
-| V4 | Set `maxDuration: 60` for `/api/cron/snapshot` in `vercel.json` | Reliability | 🔴 High | 10 min | ❌ Not Done |
-| V5 | Pin `regions` in `vercel.json` to match Neon region | Performance | 🟡 Medium | 15 min | ❌ Not Done |
-| V6 | Hover/viewport prefetch in sidebar (replace eager all-routes prefetch) | Performance | 🟡 Medium | 30 min | ❌ Not Done |
+| V4 | Set `maxDuration: 60` for `/api/cron/snapshot` in `vercel.json` | Reliability | 🔴 High | 10 min | ✅ Done |
+| V5 | Pin `regions` in `vercel.json` to match Neon region (`sin1`) | Performance | 🟡 Medium | 15 min | ✅ Done |
+| V6 | Hover/viewport prefetch in sidebar (replace eager all-routes prefetch) | Performance | 🟡 Medium | 30 min | ✅ Done |
 | V7 | Suppress yahoo-finance2 consent notices in `price-service.ts` | Observability | 🟢 Low | 15 min | ❌ Not Done |
 | V8 | Evaluate edge runtime for `/api/search` + `/api/exchange-rates` | Performance | 🟡 Medium | 1-2 hrs | ❌ Not Done |
-| V9 | Verify `@vercel/speed-insights` + `@vercel/analytics` are mounted | Observability | 🟢 Low | 15 min | ❌ Not Done |
+| V9 | Verify `@vercel/speed-insights` + `@vercel/analytics` are mounted | Observability | 🟢 Low | 15 min | ✅ Done |
 | V10 | Add `/api/health` endpoint | Observability | 🟡 Medium | 30 min | ❌ Not Done |
 | V11 | Verify Vercel Cron `/api/cron/snapshot` is firing daily | Reliability | 🔴 High | 15 min | ❌ Not Done |
 | V12 | Structured error logging in `price-service.ts` | Observability | 🟡 Medium | 1 hr | ❌ Not Done |

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -24,14 +24,6 @@ export function Sidebar() {
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
-  // Prefetch all routes on mount for instant tab switching
-  useEffect(() => {
-    navItems.forEach((item) => {
-      router.prefetch(item.href);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router]);
-
   return (
     <aside className="hidden md:flex w-64 flex-col border-r bg-sidebar/80 backdrop-blur-md text-sidebar-foreground glass z-10 shrink-0">
       <div className="p-6">
@@ -49,6 +41,9 @@ export function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              prefetch={false}
+              onMouseEnter={() => router.prefetch(item.href)}
+              onFocus={() => router.prefetch(item.href)}
               className={cn(
                 "group relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200",
                 isActive

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,13 @@
 {
+  "buildCommand": "next build",
+  "regions": ["iad1"],
   "crons": [
     {
       "path": "/api/cron/snapshot",
       "schedule": "30 21 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "src/app/api/cron/snapshot/route.ts": { "maxDuration": 60 }
+  }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "next build",
-  "regions": ["iad1"],
+  "regions": ["sin1"],
   "crons": [
     {
       "path": "/api/cron/snapshot",


### PR DESCRIPTION
## Summary

Implements the performance-focused suggestions from `docs/VERCEL_ANALYSIS.md`.

- **V2 (Build Perf):** Add `"buildCommand": "next build"` to `vercel.json` to override the Vercel project setting that was running `npx prisma generate && next build`. The `postinstall` hook already runs `prisma generate` during `npm install`, so the build-time invocation was redundant (~200ms + log noise saved per deploy).
- **V4 (Reliability):** Add `functions.maxDuration = 60` for `src/app/api/cron/snapshot/route.ts`. The Hobby-tier default is 10s; the snapshot job refreshes all prices and writes a row per user, which will exceed that as data grows.
- **V5 (Performance):** Pin `"regions": ["sin1"]` — Neon is in AWS ap-southeast-1 (Singapore). Without a pin, Vercel may route function invocations to a distant region, adding 150–200ms of cross-region latency to every database query.
- **V6 (Performance):** Remove the `useEffect` in `Sidebar` that called `router.prefetch()` for all five routes on every mount. Replace with `prefetch={false}` + `onMouseEnter`/`onFocus` handlers per link. This eliminates the 3–5× duplicate RSC prefetch storm observed in runtime logs on every navigation and after `POST /settings`.

## Not included

- **V8** — `/api/search` uses `yahoo-finance2` (Node.js only); `/api/exchange-rates` uses Prisma via the `ws` package (also Node.js only). Edge runtime would require re-architecting the data layer.
- **V9** — Already implemented: `<Analytics />` and `<SpeedInsights />` are present in `src/app/layout.tsx`.
- **V15** — Requires a real `du -sh .next/cache/*` audit after a local build to avoid accidentally slowing deploys.

## Test plan

- [ ] Verify Vercel build log no longer shows a second `prisma generate` run
- [ ] Confirm deployed functions show region `sin1` in Vercel dashboard
- [ ] Navigate between sidebar routes and check runtime logs — prefetch requests should only appear after hovering a link, not on page load
- [ ] Trigger `/api/cron/snapshot` manually and confirm it completes within 60s without timeout

https://claude.ai/code/session_0178eVua9n47ruvisUuKStaP