### PR TITLE
Migrate service-layer reads to Next.js 16 "use cache" directive

### DIFF
--- a/docs/VERCEL_ANALYSIS.md
+++ b/docs/VERCEL_ANALYSIS.md
@@ -30,6 +30,13 @@
 | V24 | Preload Geist Sans `.woff2` + `content-visibility: auto` on below-fold cards | Speed Insights · LCP/FCP | 🟡 Medium | 45 min | ✅ Done |
 | V25 | `startTransition` + memoize privacy/theme-toggle consumers | Speed Insights · INP | 🟡 Medium | 1 hr | ✅ Done |
 | V26 | Extend V18's PPR pattern to `/settings` and `/` (per-user cache key) | Speed Insights · TTFB | 🟡 Medium | 1–2 hrs | ✅ Done |
+| V27 | Convert `/`, `/accounts`, `/analysis`, `/history`, `/settings` from `ƒ` → `◐` by adding the Next.js 16 `"use cache"` directive to service-layer reads (executes what V18+V26 proposed but didn't land in the route classifier) | Speed Insights · TTFB | 🔴 High | 1–2 hrs | ✅ Done |
+| V28 | `<link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous">` for Analytics + Speed Insights | Speed Insights · LCP/FCP | 🟢 Low | 5 min | ✅ Done |
+| V29 | Re-enable SSR for `AllocationChart` + `CurrencyExposureChart` (drop `ssr: false`) so the chart card shell + localized title ship in server HTML instead of waiting for hydration | Speed Insights · LCP | 🟡 Medium | 30 min | ✅ Done |
+| V30 | Wrap `router.refresh()` + inline-edit state setters in `startTransition` across `transaction-history.tsx`, `edit-holding-dialog.tsx`, `quick-add-holding.tsx`, `holding-form.tsx` (extend V25 beyond privacy/theme toggles) | Speed Insights · INP | 🟡 Medium | 45 min | ❌ Not Done |
+| V31 | Add `next.config.ts` `images.formats = ["image/avif", "image/webp"]` + `remotePatterns` for `lh3.googleusercontent.com` so any avatar render is optimized | Speed Insights · LCP | 🟢 Low | 15 min | ❌ Not Done |
+| V32 | Configure `<SpeedInsights beforeSend={…}>` to drop `/login` + `/privacy` from telemetry (score quality + cost) | Observability | 🟢 Low | 15 min | ❌ Not Done |
+| V33 | Ship `@next/bundle-analyzer` (supersedes V22) — prerequisite for measuring any further client-JS Speed Insights wins | Observability | 🟢 Low | 30 min | ❌ Not Done |
 
 ## Methodology
 
@@ -817,6 +824,252 @@ tags.
 `src/app/(main)/settings/page.tsx`,
 `src/lib/services/settings-service.ts` (or similar),
 `src/lib/services/net-worth-service.ts`.
+
+---
+
+## Addendum — 2026-04-19 Re-Pull (V27–V33)
+
+A third read of the Vercel MCP connector against production deployment
+`dpl_GiNydqzEuRBeKv7iw8hVgWrbvPQd` (commit `1c0c953`, 2026-04-19)
+surfaced a critical gap: **V26 was marked ✅ Done but the build output
+still classifies `/`, `/accounts`, `/analysis`, `/history`, `/settings`
+as `ƒ (Dynamic)`.** Only `/accounts/[id]` is `◐ (Partial Prerender)`.
+V26 added per-user `cacheTag()` calls to the existing `unstable_cache`
+wrappers, but **no file in the repo used the Next.js 16 `"use cache"`
+directive** (grep confirms zero hits), so the Cache Components layer
+never adopted those routes.
+
+Items V27–V33 address the remaining Speed-Insights headroom across
+every Core Web Vital. V27–V29 ship in this same pass; V30–V33 are
+queued follow-ups.
+
+### V27 — Flip five routes to Partial Prerender via `"use cache"`
+
+**Observation.** Despite `cacheComponents: true` in `next.config.ts`,
+no service-layer read declared `"use cache"`. The routes never opted
+into PPR and every visit paid a Neon round-trip from `sin1`. Build
+output at `dpl_GiNydqzEuRBeKv7iw8hVgWrbvPQd` confirmed `ƒ /`,
+`ƒ /accounts`, `ƒ /analysis`, `ƒ /history`, `ƒ /settings`.
+
+**Recommendation.** Keep React `cache()` wrappers (per-render dedup)
+and replace `unstable_cache` with the Next.js 16 `"use cache"`
+directive on the structural reads the pages await. Tags and
+`cacheLife("minutes")` migrate across:
+
+```ts
+// src/lib/services/settings-service.ts
+async function findSettings(userId: string) {
+  "use cache";
+  cacheTag("settings");
+  cacheTag(`settings:${userId}`);
+  cacheLife("minutes");
+  return prisma.setting.findUnique({ where: { userId } });
+}
+```
+
+`getLocale()` reads cookies, so the create-fallback branch stays
+outside the cached function. Same pattern applied to
+`fetchUserAccountsWithHoldings`, `getCachedExchangeRates`,
+`getNormalizedHistory`, and `fetchFullHistoryCached`. The existing
+mutation-layer `revalidateTag` calls (`accounts:${userId}`,
+`settings:${userId}`, `net-worth:${userId}`, `exchange-rates`,
+`net-worth`, `snapshots`) already match the new tags — no API-route
+changes needed.
+
+**Critical files.** `src/lib/services/settings-service.ts`,
+`src/lib/services/net-worth-service.ts`,
+`src/lib/services/exchange-rate-service.ts`,
+`src/lib/services/history-service.ts`.
+
+---
+
+### V28 — Preconnect to `va.vercel-scripts.com`
+
+**Observation.** `src/app/layout.tsx` mounts `<Analytics />` and
+`<SpeedInsights />` which load their runtime from
+`https://va.vercel-scripts.com`. The head block had
+`dns-prefetch` entries for the FX-rate APIs but nothing for the
+Vercel scripts origin — first-time visitors on cellular pay the full
+TLS handshake before the analytics script starts.
+
+**Recommendation.** Add two lines next to the existing
+`dns-prefetch` entries:
+
+```tsx
+<link
+  rel="preconnect"
+  href="https://va.vercel-scripts.com"
+  crossOrigin="anonymous"
+/>
+<link rel="dns-prefetch" href="https://va.vercel-scripts.com" />
+```
+
+The `crossOrigin="anonymous"` attribute is required so the preconnect
+matches the script's CORS mode. Verify with DevTools → Network →
+`va.vercel-scripts.com` TLS handshake starts alongside HTML parse.
+
+**Critical files.** `src/app/layout.tsx`.
+
+---
+
+### V29 — SSR the pie-chart card shells
+
+**Observation.**
+`src/components/dashboard/lazy-charts.tsx` wrapped
+`AllocationChart` and `CurrencyExposureChart` in
+`dynamic(..., { ssr: false })`. The server sent the generic
+`<ChartSkeleton />` placeholder; the real card title and shell only
+rendered after client hydration. Because recharts'
+`ResponsiveContainer` uses `ResizeObserver`, the chart SVG itself
+does need a client pass — but the card header with the localized
+title does not.
+
+**Recommendation.** Drop `ssr: false` from both Lazy exports:
+
+```ts
+export const LazyAllocationChart = dynamic(
+  () => import("./allocation-chart").then((m) => m.AllocationChart),
+  { loading: () => <ChartSkeleton /> },
+);
+export const LazyCurrencyExposureChart = dynamic(
+  () => import("./currency-exposure-chart").then((m) => m.CurrencyExposureChart),
+  { loading: () => <ChartSkeleton /> },
+);
+```
+
+With SSR enabled the server renders the real `Card` + `CardHeader`
++ localized title in HTML. The chart's internal
+`mounted`-gated `<ResponsiveContainer>` still waits for the client,
+but the visible card title ships immediately — shifting the LCP
+candidate to a server-rendered element. `TrendChart` stays
+`ssr: false` because its line-chart animation logic has historically
+collided with hydration.
+
+**Critical files.** `src/components/dashboard/lazy-charts.tsx`.
+
+---
+
+### V30 — Extend `startTransition` to transaction/holding mutators
+
+**Observation.** V25 wrapped privacy/theme toggles in
+`startTransition`. Inline-edit submit paths on `/accounts/[id]`
+still call `router.refresh()` synchronously after every save —
+`src/components/accounts/transaction-history.tsx:131,152`,
+`src/components/accounts/edit-holding-dialog.tsx:98`,
+`src/components/accounts/quick-add-holding.tsx:158`,
+`src/components/accounts/holding-form.tsx:97`. On a 50+ holding
+account each click blocks the next frame while React re-renders the
+whole table.
+
+**Recommendation.** Wrap `router.refresh()` + optimistic state
+setters in `startTransition`:
+
+```tsx
+import { startTransition } from "react";
+// …
+startTransition(() => {
+  router.refresh();
+  onSuccess?.();
+});
+```
+
+Measure with the Vercel Speed Insights dashboard → Interactions
+panel; INP should move below 200ms on mid-range Android devices.
+
+**Critical files.** `src/components/accounts/transaction-history.tsx`,
+`src/components/accounts/edit-holding-dialog.tsx`,
+`src/components/accounts/quick-add-holding.tsx`,
+`src/components/accounts/holding-form.tsx`,
+`src/components/accounts/account-detail.tsx`.
+
+---
+
+### V31 — Optimize remote avatar images
+
+**Observation.** `next.config.ts` has no `images` block, so any
+`next/image` rendering a Google avatar (`lh3.googleusercontent.com`,
+set by NextAuth for Google OAuth users) would fail with
+"unconfigured host". AVIF/WebP formats are off by default on Next.js
+16 — every avatar request ships PNG even though modern browsers
+support AVIF.
+
+**Recommendation.**
+
+```ts
+// next.config.ts
+images: {
+  formats: ["image/avif", "image/webp"],
+  remotePatterns: [
+    { protocol: "https", hostname: "lh3.googleusercontent.com" },
+  ],
+},
+```
+
+Pair with `<Image src={session.user.image} priority width={32} height={32} />`
+in the sidebar user block (if added) so the above-fold avatar
+preloads.
+
+**Critical files.** `next.config.ts`,
+`src/components/layout/sidebar.tsx` (if/when an avatar lands).
+
+---
+
+### V32 — Trim Speed Insights telemetry
+
+**Observation.** `<SpeedInsights />` currently samples every page at
+100%, including `/login` (single-purpose OAuth redirect) and
+`/privacy` (legal copy). Both inflate the sampling budget without
+providing actionable score data.
+
+**Recommendation.**
+
+```tsx
+<SpeedInsights
+  beforeSend={(data) => {
+    if (data.url.includes("/login") || data.url.includes("/privacy")) {
+      return null;
+    }
+    return data;
+  }}
+/>
+```
+
+On Pro tier, set `sampleRate={0.5}` once traffic exceeds 10k
+page-views/day. Neither change affects Lighthouse lab scores — this
+is a cost + signal-to-noise cleanup.
+
+**Critical files.** `src/app/layout.tsx`.
+
+---
+
+### V33 — Ship `@next/bundle-analyzer`
+
+**Observation.** V22 recommended bundle-analyzer for baseline
+measurement but never landed. Without it, the team can't prove that
+`optimizePackageImports` is actually trimming recharts / lucide /
+date-fns, and any future client-JS win (V30, dynamic form loaders,
+etc.) has no before/after evidence.
+
+**Recommendation.**
+
+```bash
+npm i -D @next/bundle-analyzer
+```
+
+```ts
+// next.config.ts
+import withBundleAnalyzer from "@next/bundle-analyzer";
+const analyzer = withBundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
+export default analyzer(withNextIntl(nextConfig));
+```
+
+Commit the `ANALYZE=true npm run build` baseline (dashboard route
+JS, shared chunks, largest single module) to this doc. Re-run on
+every Speed Insights PR to quantify client-JS movement.
+
+**Critical files.** `next.config.ts`, `package.json`, this doc.
 
 ---
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,8 @@ async function LocaleHtml({
       suppressHydrationWarning
     >
       <head>
+        <link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://va.vercel-scripts.com" />
         <link rel="dns-prefetch" href="https://api.frankfurter.app" />
         <link rel="dns-prefetch" href="https://open.er-api.com" />
       </head>

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -23,10 +23,10 @@ export const LazyTrendChart = dynamic(
 
 export const LazyAllocationChart = dynamic(
   () => import("./allocation-chart").then((m) => m.AllocationChart),
-  { ssr: false, loading: () => <ChartSkeleton /> }
+  { loading: () => <ChartSkeleton /> }
 );
 
 export const LazyCurrencyExposureChart = dynamic(
   () => import("./currency-exposure-chart").then((m) => m.CurrencyExposureChart),
-  { ssr: false, loading: () => <ChartSkeleton /> }
+  { loading: () => <ChartSkeleton /> }
 );

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -1,31 +1,32 @@
 import { cache } from "react";
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 
 /** How long to wait (ms) before giving up on external rate APIs */
 const RATE_FETCH_TIMEOUT_MS = 1200;
 
 /**
- * Data-cached exchange rates fetcher (5-minute TTL).
- * Returns a plain object (JSON-serializable) for the data cache layer.
+ * Cache Components read of all exchange rates.
+ * Returns a plain object (`"use cache"` compatible). Invalidated by
+ * the `exchange-rates` tag on refresh + cron snapshot.
  */
-const getCachedExchangeRates = unstable_cache(
-  async (): Promise<Record<string, number>> => {
-    const rates = await prisma.exchangeRate.findMany();
-    const map: Record<string, number> = {};
-    for (const r of rates) {
-      map[`${r.fromCurrency}_${r.toCurrency}`] = Number(r.rate);
-    }
-    return map;
-  },
-  ["exchange-rates"],
-  { revalidate: 300, tags: ["exchange-rates"] }
-);
+async function getCachedExchangeRates(): Promise<Record<string, number>> {
+  "use cache";
+  cacheTag("exchange-rates");
+  cacheLife("minutes");
+  const rates = await prisma.exchangeRate.findMany();
+  const map: Record<string, number> = {};
+  for (const r of rates) {
+    map[`${r.fromCurrency}_${r.toCurrency}`] = Number(r.rate);
+  }
+  return map;
+}
 
 /**
  * Load ALL cached exchange rates.
- * Uses the data cache (5-min TTL) and React cache() for per-render dedup.
- * Returns a Map keyed by "FROM_TO" (e.g. "USD_TWD").
+ * Uses the Cache Components layer (invalidated by the `exchange-rates`
+ * tag) plus React cache() for per-render dedup. Returns a Map keyed
+ * by "FROM_TO" (e.g. "USD_TWD").
  */
 export const getAllExchangeRates = cache(async (): Promise<Map<string, number>> => {
   const rates = await getCachedExchangeRates();

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
 import type { NetWorthSnapshot } from "@/generated/prisma/client";
@@ -50,14 +50,21 @@ function normalizeSnapshots(
 }
 
 /**
- * Fetch and normalize net worth history for a user.
- * Converts all snapshots to the current target base currency.
- * Defaults to the last 90 days if no date range is specified.
+ * Cache Components read of the default (last-90-day) normalized
+ * history. Tagged both globally (`snapshots`, `net-worth`) and
+ * per-user (`history:${userId}`) so cron snapshot + account mutations
+ * can invalidate cleanly.
  */
-async function computeNormalizedHistory(
+export async function getNormalizedHistory(
   userId: string,
   targetBaseCurrency: string,
 ): Promise<NormalizedSnapshot[]> {
+  "use cache";
+  cacheTag("snapshots");
+  cacheTag("net-worth");
+  cacheTag(`history:${userId}`);
+  cacheLife("minutes");
+
   const fromDate = new Date();
   fromDate.setDate(fromDate.getDate() - DEFAULT_HISTORY_DAYS);
 
@@ -73,29 +80,52 @@ async function computeNormalizedHistory(
 }
 
 /**
- * Cached version of normalized history (60-second TTL, invalidated by "snapshots" tag).
- * Used by the dashboard trend chart for fast repeated loads.
- */
-export const getNormalizedHistory = unstable_cache(
-  computeNormalizedHistory,
-  ["normalized-history"],
-  { revalidate: 60, tags: ["snapshots", "net-worth"] }
-);
-
-/**
- * Full history fetch (uncached, no date limit) for pages that need the complete history.
+ * Full history fetch for pages that need the complete history.
+ * Uses `"use cache"` only when no custom range is supplied; a custom
+ * range short-circuits to a raw DB call so the cache key isn't
+ * polluted by arbitrary window selections.
  */
 export async function getFullNormalizedHistory(
   userId: string,
   targetBaseCurrency: string,
   options?: { from?: Date; to?: Date }
 ): Promise<NormalizedSnapshot[]> {
-  const where: { userId: string; date?: { gte?: Date; lte?: Date } } = { userId };
   if (options?.from || options?.to) {
-    where.date = {};
-    if (options.from) where.date.gte = options.from;
-    if (options.to) where.date.lte = options.to;
+    return fetchFullHistoryRange(userId, targetBaseCurrency, options);
   }
+  return fetchFullHistoryCached(userId, targetBaseCurrency);
+}
+
+async function fetchFullHistoryCached(
+  userId: string,
+  targetBaseCurrency: string,
+): Promise<NormalizedSnapshot[]> {
+  "use cache";
+  cacheTag("snapshots");
+  cacheTag("net-worth");
+  cacheTag(`history:${userId}`);
+  cacheLife("minutes");
+
+  const [snapshotsRaw, allRatesMap] = await Promise.all([
+    prisma.netWorthSnapshot.findMany({
+      where: { userId },
+      orderBy: { date: "asc" },
+    }),
+    getAllExchangeRates(),
+  ]);
+
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
+}
+
+async function fetchFullHistoryRange(
+  userId: string,
+  targetBaseCurrency: string,
+  options: { from?: Date; to?: Date },
+): Promise<NormalizedSnapshot[]> {
+  const where: { userId: string; date?: { gte?: Date; lte?: Date } } = { userId };
+  where.date = {};
+  if (options.from) where.date.gte = options.from;
+  if (options.to) where.date.lte = options.to;
 
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -1,5 +1,5 @@
 import { cache } from "react";
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "./exchange-rate-service";
 import {
@@ -10,26 +10,25 @@ import type { AccountWithValue, NetWorthSummary, HoldingWithPrice } from "@/lib/
 
 /**
  * Structural account + holdings fetcher.
- * Data-cached per user so the dashboard's "list of accounts/holdings"
- * shape — which rarely changes — is served from the CDN cache even
- * though the downstream net-worth computation (which multiplies by
- * current prices) stays dynamic. React cache() dedupes concurrent
- * calls within a single render.
+ * Uses the Next.js 16 `"use cache"` directive so the dashboard's
+ * "list of accounts/holdings" shape — which rarely changes — is
+ * served from the Cache Components layer while the downstream
+ * net-worth computation (which multiplies by current prices) stays
+ * dynamic. React cache() dedupes concurrent calls within a single
+ * render.
  */
-export const fetchUserAccountsWithHoldings = cache((userId: string) =>
-  unstable_cache(
-    () =>
-      prisma.account.findMany({
-        where: { userId, isActive: true },
-        include: { holdings: { where: { quantity: { gt: 0 } } } },
-      }),
-    ["user-accounts-with-holdings", userId],
-    {
-      revalidate: 300,
-      tags: ["accounts", `accounts:${userId}`],
-    },
-  )(),
-);
+async function fetchUserAccountsWithHoldingsInner(userId: string) {
+  "use cache";
+  cacheTag("accounts");
+  cacheTag(`accounts:${userId}`);
+  cacheLife("minutes");
+  return prisma.account.findMany({
+    where: { userId, isActive: true },
+    include: { holdings: { where: { quantity: { gt: 0 } } } },
+  });
+}
+
+export const fetchUserAccountsWithHoldings = cache(fetchUserAccountsWithHoldingsInner);
 
 async function computeNetWorthSummary(
   userId: string,

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -1,45 +1,45 @@
 import { cache } from "react";
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getLocale } from "next-intl/server";
 import { getLocaleDefaultCurrency } from "../currencies";
 
 /**
- * Inner settings fetcher — plain async function, no cache wrappers here.
- * Falls back to creating default settings if none exist.
+ * Cached read of user settings. Opts this request branch into the Next.js
+ * 16 Cache Components layer so pages that only need settings (e.g.
+ * `/settings`, the dashboard shell) can prerender the structural HTML
+ * and stream only the dynamic islands.
+ *
+ * The create-fallback path is kept outside this function because
+ * `getLocale()` reads cookies and cannot be called inside a cached
+ * function.
  */
+async function findSettings(userId: string) {
+  "use cache";
+  cacheTag("settings");
+  cacheTag(`settings:${userId}`);
+  cacheLife("minutes");
+  return prisma.setting.findUnique({ where: { userId } });
+}
+
 async function getOrCreateSettingsInner(userId: string) {
-  let settings = await prisma.setting.findUnique({ where: { userId } });
+  const existing = await findSettings(userId);
+  if (existing) return existing;
 
-  if (!settings) {
-    const locale = await getLocale();
-    const baseCurrency = getLocaleDefaultCurrency(locale);
+  const locale = await getLocale();
+  const baseCurrency = getLocaleDefaultCurrency(locale);
 
-    settings = await prisma.setting.create({
-      data: {
-        userId,
-        locale,
-        baseCurrency,
-      },
-    });
-  }
-
-  return settings;
+  return prisma.setting.create({
+    data: {
+      userId,
+      locale,
+      baseCurrency,
+    },
+  });
 }
 
 /**
- * Data-cached settings fetcher (5-minute TTL).
- * Tagged both broadly (`settings`) and per-user (`settings:${userId}`) so
- * `/settings` can rely on a cached read and be invalidated for just the
- * mutating user. React cache() dedupes within a single render.
+ * Per-render dedup via React cache(). Cross-request caching is handled
+ * by the `"use cache"` directive on `findSettings`.
  */
-export const getOrCreateSettings = cache((userId: string) =>
-  unstable_cache(
-    () => getOrCreateSettingsInner(userId),
-    ["user-settings", userId],
-    {
-      revalidate: 300,
-      tags: ["settings", `settings:${userId}`],
-    },
-  )(),
-);
+export const getOrCreateSettings = cache(getOrCreateSettingsInner);


### PR DESCRIPTION
## Description

Implements V27–V29 from the Vercel performance analysis roadmap. Converts five routes (`/`, `/accounts`, `/analysis`, `/history`, `/settings`) from dynamic (`ƒ`) to partial prerender (`◐`) by adopting the Next.js 16 `"use cache"` directive in service-layer reads. Also enables SSR for pie charts and adds preconnect to Vercel Analytics origin.

### Changes

**V27 — Cache Components via `"use cache"` directive:**
- Replaced `unstable_cache` wrappers with `"use cache"` + `cacheTag()` + `cacheLife("minutes")` in:
  - `settings-service.ts`: `findSettings()` now opts into Cache Components
  - `net-worth-service.ts`: `fetchUserAccountsWithHoldingsInner()` uses `"use cache"`
  - `exchange-rate-service.ts`: `getCachedExchangeRates()` uses `"use cache"`
  - `history-service.ts`: `getNormalizedHistory()` and `fetchFullHistoryCached()` use `"use cache"`
- Kept existing `cacheTag` names (`settings:${userId}`, `accounts:${userId}`, `exchange-rates`, `snapshots`, `net-worth`) so mutation-layer `revalidateTag` calls remain unchanged
- Extracted custom-range history fetch to `fetchFullHistoryRange()` (uncached) to avoid polluting the cache key with arbitrary date windows

**V28 — Preconnect to Analytics origin:**
- Added `<link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />` to `layout.tsx` head
- Added fallback `dns-prefetch` for older browsers
- Eliminates TLS handshake delay for Analytics/Speed Insights script load on first-time visitors

**V29 — SSR pie-chart card shells:**
- Removed `ssr: false` from `LazyAllocationChart` and `LazyCurrencyExposureChart` in `lazy-charts.tsx`
- Server now renders card headers + localized titles in HTML; client hydration handles only the `ResponsiveContainer` resize logic
- Shifts LCP candidate to server-rendered content
- `LazyTrendChart` remains `ssr: false` due to historical hydration collision with animation logic

### Type of Change
- [x] New feature (Cache Components adoption)
- [x] Performance optimization

## Testing
- No new tests added; changes are configuration/directive migrations
- Existing service-layer tests continue to pass (cache behavior is transparent to callers)
- Verify via Vercel deployment build output: `/`, `/accounts`, `/analysis`, `/history`, `/settings` should now show `◐ (Partial Prerender)` instead of `ƒ (Dynamic)`
- Speed Insights dashboard should show TTFB improvement on repeat visits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] Cache tag names match existing mutation-layer `revalidateTag` calls
- [x] No breaking changes to service-layer APIs
- [x] Documentation updated (VERCEL_ANALYSIS.md with V27–V33 roadmap)

## Related Issues
Addresses critical gap identified in V26: routes were marked done but never actually opted into Partial Prerender due to missing `"use cache"` directives.

https://claude.ai/code/session_016HYqAxKxwqSCkewjcYKD9f