### PR TITLE
fix(dashboard): serialize accounts before "use cache" boundary to fix Decimal error

### DIFF
--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -3,10 +3,9 @@ import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "./exchange-rate-service";
 import {
-  serializeAccount,
-  serializeHolding,
+  serializeAccountWithHoldings,
 } from "@/lib/types";
-import type { AccountWithValue, NetWorthSummary, HoldingWithPrice } from "@/lib/types";
+import type { AccountWithValue, NetWorthSummary, HoldingWithPrice, SerializedAccountWithHoldings } from "@/lib/types";
 
 /**
  * Structural account + holdings fetcher.
@@ -17,15 +16,16 @@ import type { AccountWithValue, NetWorthSummary, HoldingWithPrice } from "@/lib/
  * dynamic. React cache() dedupes concurrent calls within a single
  * render.
  */
-async function fetchUserAccountsWithHoldingsInner(userId: string) {
+async function fetchUserAccountsWithHoldingsInner(userId: string): Promise<SerializedAccountWithHoldings[]> {
   "use cache";
   cacheTag("accounts");
   cacheTag(`accounts:${userId}`);
   cacheLife("minutes");
-  return prisma.account.findMany({
+  const raw = await prisma.account.findMany({
     where: { userId, isActive: true },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
   });
+  return raw.map(serializeAccountWithHoldings);
 }
 
 export const fetchUserAccountsWithHoldings = cache(fetchUserAccountsWithHoldingsInner);
@@ -66,16 +66,16 @@ async function computeNetWorthSummary(
       missingPairs.add(`${account.currency}_${baseCurrency}`);
     }
 
-    const cashBalance = Number(account.cashBalance);
+    const cashBalance = account.cashBalance;
 
     const holdingsWithPrice: HoldingWithPrice[] = account.holdings.map((h) => {
       const cached = priceMap[h.symbol];
       const currentPrice = cached?.price ?? null;
-      const quantity = Number(h.quantity);
+      const quantity = h.quantity;
       const marketValue =
         currentPrice !== null ? currentPrice * quantity : null;
       return {
-        ...serializeHolding(h),
+        ...h,
         currentPrice,
         marketValue,
       };
@@ -94,7 +94,7 @@ async function computeNetWorthSummary(
     }
 
     accountsWithValue.push({
-      ...serializeAccount(account),
+      ...account,
       holdings: holdingsWithPrice,
       totalValue: 0, // will be filled after missing rates are resolved
       totalValueInBaseCurrency: 0,


### PR DESCRIPTION
## Summary

- `fetchUserAccountsWithHoldingsInner` (marked `"use cache"`) was returning raw Prisma `Account` objects containing `Decimal` fields (`cashBalance`, `holdings[].quantity`). Next.js 16's `"use cache"` directive uses React's RSC serialization format, which explicitly rejects `Decimal` instances — causing the dashboard to throw **"Only plain objects can be passed to Client Components from Server Components. Decimal objects are not supported."** on every load.
- Fixed by calling `.map(serializeAccountWithHoldings)` on the Prisma result before returning from the cached function, so the `"use cache"` boundary only ever sees plain objects.
- Updated `computeNetWorthSummary` to use the pre-serialized accounts directly (`...account`, `h.quantity`) instead of re-calling `serializeAccount`/`serializeHolding`, which would have thrown `toISOString is not a function` on already-string date fields.

## Root cause detail

All other `"use cache"` functions in the project already return plain types (`getCachedExchangeRates` → `Record<string, number>`, `getNormalizedHistory` → `NormalizedSnapshot[]`, `findSettings` → `Setting` with no Decimal fields). `fetchUserAccountsWithHoldingsInner` was the only one returning raw Prisma objects with Decimal instances.

## Test plan

- [ ] Navigate to the dashboard (`/`) — net worth cards, allocation chart, currency exposure chart, and accounts summary table all render without errors
- [ ] Confirm no "Only plain objects" error in the browser console or Next.js terminal output
- [ ] Confirm TypeScript passes: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)