### PR TITLE
feat: trim Speed Insights telemetry (V32)

### DIFF
--- a/docs/VERCEL_ANALYSIS.md
+++ b/docs/VERCEL_ANALYSIS.md
@@ -35,7 +35,7 @@
 | V29 | Re-enable SSR for `AllocationChart` + `CurrencyExposureChart` (drop `ssr: false`) so the chart card shell + localized title ship in server HTML instead of waiting for hydration | Speed Insights · LCP | 🟡 Medium | 30 min | ✅ Done |
 | V30 | Wrap `router.refresh()` + inline-edit state setters in `startTransition` across `transaction-history.tsx`, `edit-holding-dialog.tsx`, `quick-add-holding.tsx`, `holding-form.tsx` (extend V25 beyond privacy/theme toggles) | Speed Insights · INP | 🟡 Medium | 45 min | ✅ Done |
 | V31 | Add `next.config.ts` `images.formats = ["image/avif", "image/webp"]` + `remotePatterns` for `lh3.googleusercontent.com` so any avatar render is optimized | Speed Insights · LCP | 🟢 Low | 15 min | ✅ Done |
-| V32 | Configure `<SpeedInsights beforeSend={…}>` to drop `/login` + `/privacy` from telemetry (score quality + cost) | Observability | 🟢 Low | 15 min | ❌ Not Done |
+| V32 | Configure `<SpeedInsights beforeSend={…}>` to drop `/login` + `/privacy` from telemetry (score quality + cost) | Observability | 🟢 Low | 15 min | ✅ Done |
 | V33 | Ship `@next/bundle-analyzer` (supersedes V22) — prerequisite for measuring any further client-JS Speed Insights wins | Observability | 🟢 Low | 30 min | ❌ Not Done |
 
 ## Methodology

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import localFont from "next/font/local";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/layout/theme-provider";
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { CustomSpeedInsights } from "@/components/layout/speed-insights";
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
@@ -69,7 +69,7 @@ async function LocaleHtml({
             {children}
             <Toaster />
             <Analytics />
-            <SpeedInsights />
+            <CustomSpeedInsights />
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/components/layout/speed-insights.tsx
+++ b/src/components/layout/speed-insights.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+export function CustomSpeedInsights() {
+  return (
+    <SpeedInsights
+      beforeSend={(data) => {
+        if (data.url.includes("/login") || data.url.includes("/privacy")) {
+          return null;
+        }
+        return data;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Implements V32 from VERCEL_ANALYSIS.md to drop /login and /privacy from telemetry by using a client-side SpeedInsights wrapper.