### PR TITLE
fix(dashboard): revert chart card height changes from c8d7a76

### DIFF
--- a/docs/VERCEL_ANALYSIS.md
+++ b/docs/VERCEL_ANALYSIS.md
@@ -26,7 +26,7 @@
 | V20 | `Cache-Control: public, max-age=31536000, immutable` for `/public/*` | Performance | 🟢 Low | 15 min | ❌ Not Done |
 | V21 | Audit `revalidateTag` after `POST /accounts`, `/holdings`, `/transactions` | Performance | 🟡 Medium | 1–2 hrs | ❌ Not Done |
 | V22 | Add `@next/bundle-analyzer` + baseline dashboard RSC payload | Observability | 🟢 Low | 30 min | ❌ Not Done |
-| V23 | Reserve `min-h` / `aspect-ratio` on chart cards (CLS fix) | Speed Insights · CLS | 🔴 High | 30 min | ✅ Done |
+| V23 | Reserve `min-h` / `aspect-ratio` on chart cards (CLS fix) | Speed Insights · CLS | 🔴 High | 30 min | ❌ Not Done |
 | V24 | Preload Geist Sans `.woff2` + `content-visibility: auto` on below-fold cards | Speed Insights · LCP/FCP | 🟡 Medium | 45 min | ✅ Done |
 | V25 | `startTransition` + memoize privacy/theme-toggle consumers | Speed Insights · INP | 🟡 Medium | 1 hr | ✅ Done |
 | V26 | Extend V18's PPR pattern to `/settings` and `/` (per-user cache key) | Speed Insights · TTFB | 🟡 Medium | 1–2 hrs | ✅ Done |

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -38,11 +38,11 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   }, [summary.accounts, t]);
 
   return (
-    <Card className="[content-visibility:auto] [contain-intrinsic-size:320px_600px]">
+    <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-medium">{t("allocationChart.title")}</CardTitle>
       </CardHeader>
-      <CardContent className="min-h-[320px]">
+      <CardContent>
         {data.length === 0 ? (
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
             {t("allocationChart.noAssets")}

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -31,11 +31,11 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
   }, [summary.currencyExposure]);
 
   return (
-    <Card className="[content-visibility:auto] [contain-intrinsic-size:320px_600px]">
+    <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-base font-medium">{t("title")}</CardTitle>
       </CardHeader>
-      <CardContent className="min-h-[320px]">
+      <CardContent>
         {data.length === 0 ? (
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noExposure")}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -51,7 +51,7 @@ function ChartsSkeleton() {
               <div className="h-5 w-32 bg-muted animate-pulse rounded" />
             </CardHeader>
             <CardContent>
-              <div className="h-[320px] bg-muted animate-pulse rounded" />
+              <div className="h-[250px] bg-muted animate-pulse rounded" />
             </CardContent>
           </Card>
         </div>

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -30,7 +30,7 @@ export function DashboardSkeleton() {
               <div className="h-5 w-32 bg-muted animate-pulse rounded" />
             </CardHeader>
             <CardContent>
-              <div className="h-[320px] bg-muted animate-pulse rounded" />
+              <div className="h-[250px] bg-muted animate-pulse rounded" />
             </CardContent>
           </Card>
         ))}

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -10,7 +10,7 @@ function ChartSkeleton() {
         <div className="h-5 w-32 bg-muted animate-pulse rounded" />
       </CardHeader>
       <CardContent>
-        <div className="h-[320px] bg-muted animate-pulse rounded" />
+        <div className="h-[250px] bg-muted animate-pulse rounded" />
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -68,7 +68,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
           </div>
         )}
       </CardHeader>
-      <CardContent className="min-h-[320px]">
+      <CardContent>
         {filtered.length === 0 ? (
           <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noData")}


### PR DESCRIPTION
## Summary

- Removes `[content-visibility:auto] [contain-intrinsic-size:320px_600px]` from `Card` in allocation, currency-exposure charts (was forcing incorrect 600px height)
- Removes `min-h-[320px]` from `CardContent` in all three chart components
- Reverts skeleton placeholder heights from `h-[320px]` back to `h-[250px]`

Restores layout to the correct state at commit `6750ea26`.

## Test plan
- [ ] Dashboard chart cards render at natural height
- [ ] Skeleton loading placeholders match chart card height

🤖 Generated with [Claude Code](https://claude.com/claude-code)