### PR TITLE
feat: improve chart tooltip readability in dark mode

### DIFF
--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -17,6 +17,7 @@ import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 
 interface Props {
   buckets: MonthlyBucket[];
@@ -46,26 +47,28 @@ function AssetsTooltip({
 }) {
   if (!active || !payload?.length) return null;
   const entry = payload[0].payload;
+
   if (entry.isEmpty) {
     return (
-      <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md">
-        <div className="font-medium">{entry.label}</div>
-        <div className="text-muted-foreground">{t("noDataMonth")}</div>
-      </div>
+      <ChartTooltipContainer title={entry.label}>
+        <div className="text-[11px] text-muted-foreground">{t("noDataMonth")}</div>
+      </ChartTooltipContainer>
     );
   }
+
   return (
-    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1">
-      <div className="font-medium">{entry.label}</div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("seriesAssets")}</span>
-        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(entry.assets, baseCurrency)}</span>
-      </div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("seriesLiabilities")}</span>
-        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(entry.liabilities, baseCurrency)}</span>
-      </div>
-    </div>
+    <ChartTooltipContainer title={entry.label}>
+      <ChartTooltipRow
+        label={t("seriesAssets")}
+        value={privacyMode ? "***" : formatCurrency(entry.assets, baseCurrency)}
+        indicatorColor="var(--chart-1)"
+      />
+      <ChartTooltipRow
+        label={t("seriesLiabilities")}
+        value={privacyMode ? "***" : formatCurrency(entry.liabilities, baseCurrency)}
+        indicatorColor="var(--destructive)"
+      />
+    </ChartTooltipContainer>
   );
 }
 

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -18,6 +18,8 @@ import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
+
 interface Props {
   buckets: MonthlyBucket[];
   baseCurrency: string;
@@ -43,38 +45,43 @@ function ChangeTooltip({
 }) {
   if (!active || !payload?.length) return null;
   const b = payload[0].payload;
+
   if (b.isEmpty) {
     return (
-      <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md">
-        <div className="font-medium">{b.label}</div>
-        <div className="text-muted-foreground">{t("noDataMonth")}</div>
-      </div>
+      <ChartTooltipContainer title={b.label}>
+        <div className="text-[11px] text-muted-foreground">{t("noDataMonth")}</div>
+      </ChartTooltipContainer>
     );
   }
-  const pct = b.deltaPct === null ? "—" : `${b.deltaPct >= 0 ? "+" : ""}${b.deltaPct.toFixed(1)}%`;
+
+  const pct =
+    b.deltaPct === null ? "—" : `${b.deltaPct >= 0 ? "+" : ""}${b.deltaPct.toFixed(1)}%`;
   const sign = b.deltaNetWorth >= 0 ? "+" : "";
+
   return (
-    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1">
-      <div className="font-medium">{b.label}</div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("tooltipStart")}</span>
-        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(b.startNetWorth, baseCurrency)}</span>
-      </div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("tooltipEnd")}</span>
-        <span className="tabular-nums">{privacyMode ? "***" : formatCurrency(b.endNetWorth, baseCurrency)}</span>
-      </div>
-      <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
-        <span className="text-muted-foreground">{t("tooltipChange")}</span>
-        <span
-          className={`tabular-nums font-medium ${
+    <ChartTooltipContainer title={b.label}>
+      <ChartTooltipRow
+        label={t("tooltipStart")}
+        value={privacyMode ? "***" : formatCurrency(b.startNetWorth, baseCurrency)}
+      />
+      <ChartTooltipRow
+        label={t("tooltipEnd")}
+        value={privacyMode ? "***" : formatCurrency(b.endNetWorth, baseCurrency)}
+      />
+      <div className="pt-1.5 mt-1.5 border-t border-border/40">
+        <ChartTooltipRow
+          label={t("tooltipChange")}
+          value={
+            privacyMode
+              ? "***"
+              : `${sign}${formatCurrency(b.deltaNetWorth, baseCurrency)} (${pct})`
+          }
+          valueClassName={
             b.deltaNetWorth >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
-          }`}
-        >
-          {privacyMode ? "***" : `${sign}${formatCurrency(b.deltaNetWorth, baseCurrency)} (${pct})`}
-        </span>
+          }
+        />
       </div>
-    </div>
+    </ChartTooltipContainer>
   );
 }
 

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -5,8 +5,40 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { NetWorthSummary } from "@/lib/types";
-import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
+import { createPieLegendFormatter } from "@/lib/chart-formatters";
+
+function AllocationTooltip({
+  active,
+  payload,
+  baseCurrency,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: any[];
+  baseCurrency: string;
+  privacyMode: boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0];
+  const percentage = entry.payload.percentage;
+
+  return (
+    <ChartTooltipContainer title={entry.name}>
+      <ChartTooltipRow
+        label="Value"
+        value={
+          privacyMode
+            ? "***"
+            : `${formatCurrency(entry.value, baseCurrency)} (${percentage}%)`
+        }
+        indicatorColor={entry.fill || entry.color}
+      />
+    </ChartTooltipContainer>
+  );
+}
 
 const COLORS = [
   "#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6",
@@ -72,7 +104,14 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                     />
                   ))}
                 </Pie>
-                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Tooltip
+                  content={
+                    <AllocationTooltip
+                      baseCurrency={summary.baseCurrency}
+                      privacyMode={privacyMode}
+                    />
+                  }
+                />
                 <Legend formatter={createPieLegendFormatter()} />
               </PieChart>
             </ResponsiveContainer>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -5,8 +5,40 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { NetWorthSummary } from "@/lib/types";
-import { createPieTooltipFormatter, createPieLegendFormatter } from "@/lib/chart-formatters";
+import { createPieLegendFormatter } from "@/lib/chart-formatters";
+
+function ExposureTooltip({
+  active,
+  payload,
+  baseCurrency,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: any[];
+  baseCurrency: string;
+  privacyMode: boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0];
+  const percentage = entry.payload.percentage;
+
+  return (
+    <ChartTooltipContainer title={entry.name}>
+      <ChartTooltipRow
+        label="Value"
+        value={
+          privacyMode
+            ? "***"
+            : `${formatCurrency(entry.value, baseCurrency)} (${percentage}%)`
+        }
+        indicatorColor={entry.fill || entry.color}
+      />
+    </ChartTooltipContainer>
+  );
+}
 
 const COLORS = [
   "#8b5cf6", "#ec4899", "#f59e0b", "#3b82f6", "#10b981",
@@ -65,7 +97,14 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
                     />
                   ))}
                 </Pie>
-                <Tooltip formatter={createPieTooltipFormatter(summary.baseCurrency)} />
+                <Tooltip
+                  content={
+                    <ExposureTooltip
+                      baseCurrency={summary.baseCurrency}
+                      privacyMode={privacyMode}
+                    />
+                  }
+                />
                 <Legend formatter={createPieLegendFormatter()} />
               </PieChart>
             </ResponsiveContainer>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -13,7 +13,8 @@ import {
 } from "recharts";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
-import { createCurrencyTooltipFormatter } from "@/lib/chart-formatters";
+import { formatCurrency } from "@/lib/currencies";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 
 type SnapshotData = {
   date: string;
@@ -21,6 +22,42 @@ type SnapshotData = {
   totalAssets: number;
   totalLiabilities: number;
 };
+
+function TrendTooltip({
+  active,
+  payload,
+  label,
+  baseCurrency,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: any[];
+  label?: string;
+  baseCurrency: string;
+  privacyMode: boolean;
+}) {
+  if (!active || !payload?.length || !label) return null;
+
+  const date = new Date(label);
+  const formattedDate = date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <ChartTooltipContainer title={formattedDate}>
+      {payload.map((entry, i) => (
+        <ChartTooltipRow
+          key={i}
+          label={entry.name}
+          value={privacyMode ? "***" : formatCurrency(entry.value, baseCurrency)}
+          indicatorColor={entry.color || entry.stroke}
+        />
+      ))}
+    </ChartTooltipContainer>
+  );
+}
 
 const ranges = [
   { label: "1M", days: 30 },
@@ -101,7 +138,14 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
                       : v.toString()
                 }
               />
-              <Tooltip formatter={createCurrencyTooltipFormatter(baseCurrency)} />
+              <Tooltip
+                content={
+                  <TrendTooltip
+                    baseCurrency={baseCurrency}
+                    privacyMode={privacyMode}
+                  />
+                }
+              />
               <Area
                 type="monotone"
                 dataKey="netWorth"

--- a/src/components/ui/chart-tooltip.tsx
+++ b/src/components/ui/chart-tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+
+interface ChartTooltipRowProps {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  valueClassName?: string;
+  indicatorColor?: string;
+}
+
+export function ChartTooltipRow({
+  label,
+  value,
+  valueClassName,
+  indicatorColor,
+}: ChartTooltipRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-6 text-[11px] leading-relaxed">
+      <div className="flex items-center gap-1.5 min-w-0">
+        {indicatorColor && (
+          <div
+            className="h-1.5 w-1.5 shrink-0 rounded-[2px]"
+            style={{ backgroundColor: indicatorColor }}
+          />
+        )}
+        <span className="text-muted-foreground truncate">{label}</span>
+      </div>
+      <span className={`font-medium tabular-nums whitespace-nowrap ${valueClassName || "text-foreground"}`}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface ChartTooltipContainerProps {
+  title?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function ChartTooltipContainer({
+  title,
+  children,
+  className = "",
+}: ChartTooltipContainerProps) {
+  return (
+    <div
+      className={`rounded-lg border border-border/60 bg-popover/95 backdrop-blur-md px-3 py-2.5 shadow-xl ring-1 ring-black/5 dark:ring-white/5 space-y-1.5 min-w-[140px] ${className}`}
+    >
+      {title && (
+        <div className="font-semibold text-xs text-foreground/90 pb-1 border-b border-border/40 mb-1.5">
+          {title}
+        </div>
+      )}
+      <div className="space-y-1">
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR standardizes chart tooltips across the app, fixing readability issues in dark mode by using a custom themed tooltip component with glassmorphism and proper contrast.