### PR TITLE
Add `server-only` guards and Neon WebSocket server setup to keep server libs out of client bundles

### DIFF
--- a/docs/BUNDLE_ANALYSIS.md
+++ b/docs/BUNDLE_ANALYSIS.md
@@ -6,14 +6,14 @@ We leveraged `@next/bundle-analyzer` to inspect the client, server, and edge bun
 
 | # | Suggestion | Category | Impact | Effort | Status |
 |---|-----------|----------|--------|--------|--------|
-| B1 | Ensure `@prisma/client` and `@neondatabase/serverless` are strictly server-only | Bundle Size | 🔴 High | 15 min | ❌ Not Done |
+| B1 | Ensure `@prisma/client` and `@neondatabase/serverless` are strictly server-only | Bundle Size | 🔴 High | 15 min | ✅ Done |
 | B2 | Dynamic Import `AllocationChart` & `CurrencyExposureChart` | Bundle Size | 🔴 High | 30 min | ❌ Not Done |
 | B3 | Inspect `date-fns` usage for tree-shaking | Bundle Size | 🟡 Medium | 30 min | ❌ Not Done |
 | B4 | Audit `lucide-react` usage | Bundle Size | 🟡 Medium | 15 min | ❌ Not Done |
 | B5 | Monitor `recharts` library payload | Bundle Size | 🟡 Medium | 45 min | ❌ Not Done |
 | B6 | Lazy-load `sonner` Toaster | Bundle Size | 🟡 Medium | 15 min | ❌ Not Done |
 | B7 | Restrict `zod` to Server Actions/API routes | Bundle Size | 🔴 High | 1 hr | ❌ Not Done |
-| B8 | Opt-out `yahoo-finance2` from client bundle via `server-only` | Bundle Size | 🔴 High | 15 min | ❌ Not Done |
+| B8 | Opt-out `yahoo-finance2` from client bundle via `server-only` | Bundle Size | 🔴 High | 15 min | ✅ Done |
 | B9 | Evaluate `next-intl` dictionary loading per route | Bundle Size | 🟡 Medium | 30 min | ❌ Not Done |
 | B10 | Migrate `swr` fetching to RSCs (Server Components) | Bundle Size | 🟡 Medium | 1 hr | ❌ Not Done |
 | B11 | Lazy-load `cmdk` (Command Palette) | Bundle Size | 🟡 Medium | 15 min | ❌ Not Done |
@@ -39,7 +39,9 @@ Findings sourced from running `@next/bundle-analyzer` against the project locall
 
 **Critical files:**
 - `src/lib/prisma.ts`
-- Missing `npm i server-only`
+- `src/lib/neon-server.ts`
+- Added `import "server-only";` guard in both server-only data-layer modules to cover Prisma and Neon imports
+- Expanded `server-only` guards to auth/session and data service modules that import Prisma/Neon-backed data paths (`auth.ts`, `auth-adapter.ts`, `auth-session.ts`, `services/{exchange-rate,history,net-worth,price,settings,snapshot}-service.ts`)
 
 ---
 
@@ -120,6 +122,8 @@ Convert static imports to `next/dynamic` ones with suspense fallbacks, avoiding 
 
 **Critical files:**
 - `src/lib/services/price-service.ts`
+- `src/app/api/search/route.ts`
+- Added `import "server-only";` guard where `yahoo-finance2` is imported (directly or via service wrappers)
 
 ---
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { ok } from "@/lib/api-responses";
 
 type SearchResult = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import NextAuth from "next-auth"
 import Credentials from "next-auth/providers/credentials"
 import authConfig from "./auth.config"

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "./prisma";
 

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { auth } from "@/auth";
 

--- a/src/lib/neon-server.ts
+++ b/src/lib/neon-server.ts
@@ -1,0 +1,6 @@
+import "server-only";
+import { neonConfig } from "@neondatabase/serverless";
+import ws from "ws";
+
+// Ensure Neon uses WebSockets in Node.js runtime.
+neonConfig.webSocketConstructor = ws;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,10 +1,7 @@
+import "server-only";
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
-import { neonConfig } from "@neondatabase/serverless";
-import ws from "ws";
-
-// Enable WebSocket connections for non-edge environments (Node.js)
-neonConfig.webSocketConstructor = ws;
+import "@/lib/neon-server";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@/lib/prisma";
 
 const COINGECKO_IDS: Record<string, string> = {

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@/lib/prisma";
 import { getNetWorthSummary } from "./net-worth-service";
 


### PR DESCRIPTION
### Motivation
- Prevent large server-only dependencies (e.g. `@prisma/client`, `@neondatabase/serverless`, `yahoo-finance2`) from leaking into client bundles and inflating initial payloads. 
- Ensure Neon uses a Node WebSocket constructor in non-edge runtimes to avoid duplicating ws setup across files. 
- Reflect completed bundle-analysis actions in the docs for stricter server boundaries. 

### Description
- Added `import "server-only";` guards to server-side entry points and services to enforce server-only import boundaries across the app, including `src/auth.ts`, `src/app/api/search/route.ts`, `src/lib/auth-adapter.ts`, `src/lib/auth-session.ts`, and multiple `src/lib/services/*` files. 
- Introduced a new `src/lib/neon-server.ts` that sets `neonConfig.webSocketConstructor = ws` and updated `src/lib/prisma.ts` to import that module instead of inlining the WebSocket setup. 
- Updated service modules (`exchange-rate-service.ts`, `history-service.ts`, `net-worth-service.ts`, `price-service.ts`, `settings-service.ts`, `snapshot-service.ts`) to include server-only guards so database/price-fetching logic is opt-in server-side. 
- Updated `docs/BUNDLE_ANALYSIS.md` to mark suggestions B1 and B8 as completed and documented the `server-only` changes in the write-up. 

### Testing
- Ran the bundle analysis with `@next/bundle-analyzer` and regenerated the analyzer reports (`.next/analyze/*`), which were used to verify server-only assets were excluded; this completed successfully. 
- Performed a TypeScript typecheck with `tsc --noEmit` to validate imports and signatures, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f91185008321b31ae164d68c1221)