### PR TITLE
Lazy-load dashboard pie charts (B2) — dynamic import AllocationChart & CurrencyExposureChart

### DIFF
--- a/docs/BUNDLE_ANALYSIS.md
+++ b/docs/BUNDLE_ANALYSIS.md
@@ -7,7 +7,7 @@ We leveraged `@next/bundle-analyzer` to inspect the client, server, and edge bun
 | # | Suggestion | Category | Impact | Effort | Status |
 |---|-----------|----------|--------|--------|--------|
 | B1 | Ensure `@prisma/client` and `@neondatabase/serverless` are strictly server-only | Bundle Size | 🔴 High | 15 min | ❌ Not Done |
-| B2 | Dynamic Import `AllocationChart` & `CurrencyExposureChart` | Bundle Size | 🔴 High | 30 min | ❌ Not Done |
+| B2 | Dynamic Import `AllocationChart` & `CurrencyExposureChart` | Bundle Size | 🔴 High | 30 min | ✅ Done (2026-04-20) |
 | B3 | Inspect `date-fns` usage for tree-shaking | Bundle Size | 🟡 Medium | 30 min | ❌ Not Done |
 | B4 | Audit `lucide-react` usage | Bundle Size | 🟡 Medium | 15 min | ❌ Not Done |
 | B5 | Monitor `recharts` library payload | Bundle Size | 🟡 Medium | 45 min | ❌ Not Done |

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -23,10 +23,10 @@ export const LazyTrendChart = dynamic(
 
 export const LazyAllocationChart = dynamic(
   () => import("./allocation-chart").then((m) => m.AllocationChart),
-  { loading: () => <ChartSkeleton /> }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 export const LazyCurrencyExposureChart = dynamic(
   () => import("./currency-exposure-chart").then((m) => m.CurrencyExposureChart),
-  { loading: () => <ChartSkeleton /> }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );


### PR DESCRIPTION
### Motivation
- Reduce initial client bundle size by deferring `recharts`-backed pie charts from the dashboard to client-only lazy-loaded chunks.
- Align `AllocationChart` and `CurrencyExposureChart` with the existing `TrendChart` dynamic-import pattern to avoid shipping chart code on the server-rendered/initial payload.

### Description
- Updated `src/components/dashboard/lazy-charts.tsx` to add `ssr: false` to the dynamic imports for `LazyAllocationChart` and `LazyCurrencyExposureChart` so both charts are loaded client-side only and use the same `ChartSkeleton` fallback as `LazyTrendChart`.
- Updated `docs/BUNDLE_ANALYSIS.md` to mark B2 as completed (`✅ Done (2026-04-20)`).
- No other behavioral changes to chart components; only the import/lazy-loading policy was modified.

### Testing
- Ran `npm run lint` which failed in this environment with `ERR_MODULE_NOT_FOUND` because the `eslint` package is not present in `node_modules` (linting could not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6006a7204832184b6829ed92b3416)