### PR TITLE
Disable chart interactions while privacy (hide) mode is enabled

### DIFF
--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -98,7 +98,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
         ) : !mounted ? (
           <div className="h-[280px]" />
         ) : (
-          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm" : ""}`}>
+          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
             <ResponsiveContainer width="100%" height={280}>
               <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -110,7 +110,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
         ) : !mounted ? (
           <div className="h-[280px]" />
         ) : (
-          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm" : ""}`}>
+          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
           <ResponsiveContainer width="100%" height={280}>
             <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -82,7 +82,7 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm" : ""}`}>
+          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
             <ResponsiveContainer width="100%" height={250}>
               <PieChart>
                 <Pie

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -75,7 +75,7 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm" : ""}`}>
+          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
             <ResponsiveContainer width="100%" height={250}>
               <PieChart>
                 <Pie

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -113,7 +113,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
         ) : !mounted ? (
           <div className="h-[250px]" />
         ) : (
-          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm" : ""}`}>
+          <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
           <ResponsiveContainer width="100%" height={250}>
             <AreaChart data={filtered}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />


### PR DESCRIPTION
### Motivation
- When privacy/hide mode blurs chart values the charts should also not respond to hover/clicks so hidden data cannot be revealed via tooltips or interactions. 

### Description
- Added `pointer-events-none select-none` to the chart wrapper when `privacyMode` is true to disable pointer interactions and text selection for chart surfaces. 
- Applied the change consistently to `TrendChart`, `AllocationChart`, and `CurrencyExposureChart` under `src/components/dashboard/` and to `MonthlyChangeChart` and `AssetsLiabilitiesChart` under `src/components/analysis/`. 
- This is a purely UI interaction change and does not alter data flow, tooltips' content logic, or privacy-mode state handling. 

### Testing
- Ran `npm run lint`; linting failed in this environment due to an `eslint` resolution error (`eslint.config.mjs` cannot find the local `eslint` package). 
- No other automated tests were executed in this environment; the change is small and limited to CSS class additions on chart wrappers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6282095b88321a8bf9c307e95728f)