### PR TITLE
chore: implement bundle-analysis B7 & B8 server-only boundaries

### DIFF
--- a/src/lib/api-responses.ts
+++ b/src/lib/api-responses.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import type { z } from "zod";
+
+type ZodErrorLike = {
+  flatten: () => unknown;
+};
 
 /** Successful response — wraps data in a `{ data }` envelope. */
 export const ok = <T>(data: T, init?: ResponseInit) =>
@@ -10,7 +13,7 @@ export const failure = (message: string, status = 400) =>
   NextResponse.json({ error: { message } }, { status });
 
 /** Zod validation failure — includes flattened issues for field-level display. */
-export const validationError = (zodError: z.ZodError) =>
+export const validationError = (zodError: ZodErrorLike) =>
   NextResponse.json(
     { error: { message: "Validation failed", issues: zodError.flatten() } },
     { status: 400 }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@/lib/prisma";
 
 const COINGECKO_IDS: Record<string, string> = {
@@ -150,4 +151,3 @@ export async function refreshAllPrices(): Promise<{
 
   return { updated, errors };
 }
-

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { z } from "zod";
 import {
   ACCOUNT_TYPES,


### PR DESCRIPTION
### Motivation
- Apply recommendations B7 and B8 from `docs/BUNDLE_ANALYSIS.md` to prevent `zod` and `yahoo-finance2` from leaking into client bundles by enforcing server-only boundaries.
- Reduce accidental coupling to `zod` in shared helpers so validation types do not pull the library into client-side code.

### Description
- Added `import "server-only";` to `src/lib/validators.ts` to force Zod schemas to be server-only.
- Added `import "server-only";` to `src/lib/services/price-service.ts` to ensure `yahoo-finance2` usage remains server-side.
- Replaced the direct `zod` type import in `src/lib/api-responses.ts` with a structural `ZodErrorLike` type and updated `validationError` to accept that type, removing an explicit `zod` dependency from the shared response helper.

### Testing
- Ran `npm run lint`, which failed in this environment due to missing/unresolvable `eslint` rather than code errors in the changes.
- Attempted to install `server-only` via `npm install server-only@latest`, which failed with a `403 Forbidden` from the registry in this environment, but code uses the Next.js `server-only` import pattern as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6343a08648321a64de13b7bf02a8f)