### PR TITLE
fix(charts): disable Recharts animations on mobile for instant interactivity

### DIFF
--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
@@ -76,6 +77,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
+  const isAnimationActive = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
   const data = buckets.map((b) => ({
@@ -123,12 +125,14 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
                   name={t("seriesAssets")}
                   fill="var(--chart-1)"
                   radius={[4, 4, 0, 0]}
+                  isAnimationActive={isAnimationActive}
                 />
                 <Bar
                   dataKey="liabilities"
                   name={t("seriesLiabilities")}
                   fill="var(--destructive)"
                   radius={[4, 4, 0, 0]}
+                  isAnimationActive={isAnimationActive}
                 />
               </BarChart>
             </ResponsiveContainer>

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
@@ -93,6 +94,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
+  const isAnimationActive = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
   const data = buckets.map((b) => ({ ...b, label: formatMonthLabel(b.monthKey, locale) }));
@@ -132,7 +134,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
                 cursor={{ fill: "var(--muted)", opacity: 0.3 }}
                 content={<ChangeTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />}
               />
-              <Bar dataKey="deltaNetWorth" radius={[4, 4, 0, 0]}>
+              <Bar dataKey="deltaNetWorth" radius={[4, 4, 0, 0]} isAnimationActive={isAnimationActive}>
                 {data.map((entry) => (
                   <Cell
                     key={entry.monthKey}

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -6,6 +6,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recha
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieLegendFormatter } from "@/lib/chart-formatters";
@@ -49,6 +50,7 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const [mounted, setMounted] = useState(false);
   const t = useTranslations();
   const { privacyMode } = usePrivacyMode();
+  const isAnimationActive = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
   const data = useMemo(() => {
@@ -93,6 +95,7 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                   outerRadius={90}
                   paddingAngle={2}
                   dataKey="value"
+                  isAnimationActive={isAnimationActive}
                 >
                   {data.map((_, index) => (
                     <Cell

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -6,6 +6,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recha
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { NetWorthSummary } from "@/lib/types";
 import { createPieLegendFormatter } from "@/lib/chart-formatters";
@@ -49,6 +50,7 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("currencyExposure");
   const { privacyMode } = usePrivacyMode();
+  const isAnimationActive = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
   const data = useMemo(() => {
@@ -86,6 +88,7 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
                   outerRadius={90}
                   paddingAngle={2}
                   dataKey="value"
+                  isAnimationActive={isAnimationActive}
                 >
                   {data.map((_, index) => (
                     <Cell

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 
 type SnapshotData = {
@@ -72,6 +73,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
   const [mounted, setMounted] = useState(false);
   const t = useTranslations("trendChart");
   const { privacyMode } = usePrivacyMode();
+  const isAnimationActive = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
   const selectedRange = ranges.find((r) => r.label === range)!;
@@ -153,6 +155,7 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
                 fillOpacity={0.1}
                 strokeWidth={2}
                 name={t("seriesName")}
+                isAnimationActive={isAnimationActive}
               />
             </AreaChart>
           </ResponsiveContainer>

--- a/src/hooks/use-chart-animation.ts
+++ b/src/hooks/use-chart-animation.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useChartAnimation(): boolean {
+  const [isAnimationActive, setIsAnimationActive] = useState(true);
+
+  useEffect(() => {
+    const coarse = window.matchMedia("(pointer: coarse)");
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const update = () => {
+      setIsAnimationActive(!coarse.matches && !reducedMotion.matches);
+    };
+
+    update();
+    coarse.addEventListener("change", update);
+    reducedMotion.addEventListener("change", update);
+
+    return () => {
+      coarse.removeEventListener("change", update);
+      reducedMotion.removeEventListener("change", update);
+    };
+  }, []);
+
+  return isAnimationActive;
+}


### PR DESCRIPTION
## Summary

- Adds `src/hooks/use-chart-animation.ts` — a shared hook that returns `false` when the device has a coarse pointer (`pointer: coarse`, i.e. touch/mobile) or the user has `prefers-reduced-motion: reduce` set
- Passes `isAnimationActive={isAnimationActive}` to the Recharts series component in all 5 chart files: `AllocationChart` (`<Pie>`), `CurrencyExposureChart` (`<Pie>`), `TrendChart` (`<Area>`), `MonthlyChangeChart` (`<Bar>`), `AssetsLiabilitiesChart` (both `<Bar>`s)

## Why

Recharts default entry animations (pie ~400ms, area ~1500ms) defer hit-test registration until the animation completes. On mobile, this means tapping a pie chart slice right after the page loads either misses or fires on the wrong element — the user has to wait for the animation to finish before the chart is interactive. Desktop keeps the animated entry unchanged.

## SSR Safety

The hook initialises with `useState(true)` to match the Recharts default, avoiding hydration mismatches. Detection runs inside `useEffect` after hydration — both the `mounted` guard and the animation hook fire in the same post-hydration batch, so charts never render with a stale `isAnimationActive` value.

## Test plan

- [ ] Open the dashboard on a mobile browser (or Chrome DevTools with touch emulation enabled)
- [ ] Immediately tap a pie chart slice on page load — it should respond without waiting for an animation
- [ ] Reload on desktop — pie and area charts should still animate in on load
- [ ] Toggle `prefers-reduced-motion: reduce` in the OS/browser — animations should be disabled on desktop too

🤖 Generated with [Claude Code](https://claude.com/claude-code)