### PR TITLE
Revalidate Next cache tags after account/holding mutations and secure holdings endpoints

### DIFF
--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
@@ -5,6 +6,12 @@ import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
 type IdCtx = { params: Promise<{ id: string }> };
+
+function invalidateUserCaches(userId: string) {
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
+}
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
@@ -18,10 +25,7 @@ export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   return ok(holdings);
 });
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
   const body = await request.json();
   const parsed = createHoldingSchema.safeParse(body);
@@ -71,13 +75,11 @@ export async function POST(
     console.error(`Failed to fetch price for ${holding.symbol}:`, error);
   }
 
+  invalidateUserCaches(userId);
   return ok(holding, { status: 201 });
-}
+});
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id: _accountId } = await params;
   const body = await request.json();
   const parsed = updateHoldingSchema.safeParse(body);
@@ -104,18 +106,17 @@ export async function PATCH(
   }
 
   const holding = await prisma.holding.update({ where: { id }, data });
+  invalidateUserCaches(userId);
   return ok(holding);
-}
+});
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const DELETE = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id: _accountId } = await params;
   const body = await request.json();
   const { id } = body;
   if (!id) return failure("Holding ID required");
 
   await prisma.holding.delete({ where: { id } });
+  invalidateUserCaches(userId);
   return ok({ ok: true });
-}
+});

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,9 +1,16 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateAccountSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
 type IdCtx = { params: Promise<{ id: string }> };
+
+function invalidateUserCaches(userId: string) {
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
+}
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
@@ -44,11 +51,13 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
     where: { id, userId },
     data: parsed.data,
   });
+  invalidateUserCaches(userId);
   return ok(account);
 });
 
 export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
   await prisma.account.delete({ where: { id, userId } });
+  invalidateUserCaches(userId);
   return ok({ ok: true });
 });


### PR DESCRIPTION
### Motivation
- Ensure UI and server-rendered pages don't show stale data by revalidating cache tags after account and holding changes. 
- Standardize authentication handling on holdings endpoints so handlers can access the `userId` and enforce authorization. 

### Description
- Import `revalidateTag` and add a shared `invalidateUserCaches(userId)` helper that calls `revalidateTag` for `accounts:{userId}`, `net-worth:{userId}`, and `history:{userId}`. 
- Call `invalidateUserCaches(userId)` after account `PATCH`/`DELETE` and holding `POST`/`PATCH`/`DELETE` operations to trigger cache revalidation with the `max` option. 
- Convert holdings `POST`, `PATCH`, and `DELETE` handlers to use the `withAuth` wrapper so the `userId` is available; existing logic for price fetching and transaction logging is preserved. 

### Testing
- Ran the project test suite with `pnpm test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71a935c6c8321a5435104ac10cb0d)