### PR TITLE
Remove "max" revalidation option from all revalidateTag calls

### DIFF
--- a/docs/RENDERING_ANALYSIS.md
+++ b/docs/RENDERING_ANALYSIS.md
@@ -15,8 +15,8 @@ The user asked for ISR suggestions. The correct Next.js 16 answer is to walk the
 | I3 | `fetch({ next: { revalidate, tags } })` on CoinGecko fallback | ISR · Upstream fetch | 🟡 Medium | 15 min | ❌ Not Done |
 | I4 | Route-segment `revalidate` backstop on PPR routes | ISR · Backstop | 🟢 Low | 15 min | ❌ Not Done |
 | I5 | Document the `fetch({ next: { revalidate } })` pattern on upstream FX APIs | ISR · Reference | 🟢 Low | 10 min | ❌ Not Done |
-| X1 | Verify / trim `revalidateTag(tag, "max")` second argument | Prereq · Correctness | 🔴 High | 15 min | ❌ Not Done |
-| X2 | Add `revalidateTag("snapshots")` after cron snapshot creation | Prereq · Invalidation | 🔴 High | 10 min | ❌ Not Done |
+| X1 | Verify / trim `revalidateTag(tag, "max")` second argument | Prereq · Correctness | 🔴 High | 15 min | ✅ Done |
+| X2 | Add `revalidateTag("snapshots")` after cron snapshot creation | Prereq · Invalidation | 🔴 High | 10 min | ✅ Done |
 | X3 | Commit the `next build` classification snippet to this doc | Verification | 🟢 Low | 10 min | ❌ Not Done |
 
 ## Methodology

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -8,9 +8,10 @@ import { withAuth } from "@/lib/api-handler";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`);
-  revalidateTag(`net-worth:${userId}`);
-  revalidateTag(`history:${userId}`);
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -8,9 +8,9 @@ import { withAuth } from "@/lib/api-handler";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`);
+  revalidateTag(`net-worth:${userId}`);
+  revalidateTag(`history:${userId}`);
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -7,9 +7,9 @@ import { withAuth } from "@/lib/api-handler";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`);
+  revalidateTag(`net-worth:${userId}`);
+  revalidateTag(`history:${userId}`);
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -7,9 +7,10 @@ import { withAuth } from "@/lib/api-handler";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`);
-  revalidateTag(`net-worth:${userId}`);
-  revalidateTag(`history:${userId}`);
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -5,8 +5,9 @@ import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`);
-  revalidateTag(`net-worth:${userId}`);
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
 }
 
 export const GET = withAuth(async (_req, _ctx, userId) => {

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -5,8 +5,8 @@ import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
 function invalidateUserCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`);
+  revalidateTag(`net-worth:${userId}`);
 }
 
 export const GET = withAuth(async (_req, _ctx, userId) => {

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -14,7 +14,8 @@ export async function GET(request: Request) {
     // 1. Refresh all prices first to ensure the snapshot is accurate
     console.log("Cron: Refreshing prices...");
     await refreshAllPrices();
-    revalidateTag("net-worth");
+    // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+    revalidateTag("net-worth", "max");
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({
@@ -31,9 +32,9 @@ export async function GET(request: Request) {
     );
 
     // 4. Invalidate snapshot/history caches now that new rows exist
-    revalidateTag("snapshots");
+    revalidateTag("snapshots", "max");
     for (const user of users) {
-      revalidateTag(`history:${user.id}`);
+      revalidateTag(`history:${user.id}`, "max");
     }
 
     return ok({

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
     // 1. Refresh all prices first to ensure the snapshot is accurate
     console.log("Cron: Refreshing prices...");
     await refreshAllPrices();
-    revalidateTag("net-worth", "max");
+    revalidateTag("net-worth");
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({
@@ -29,6 +29,12 @@ export async function GET(request: Request) {
         return createSnapshot(user.id, baseCurrency);
       })
     );
+
+    // 4. Invalidate snapshot/history caches now that new rows exist
+    revalidateTag("snapshots");
+    for (const user of users) {
+      revalidateTag(`history:${user.id}`);
+    }
 
     return ok({
       success: true,

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -21,6 +21,6 @@ export async function POST() {
   ]);
   const totalUpdated = results.reduce((a, b) => a + b, 0);
 
-  revalidateTag("exchange-rates", "max");
+  revalidateTag("exchange-rates");
   return ok({ updated: totalUpdated, baseCurrency });
 }

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -21,6 +21,7 @@ export async function POST() {
   ]);
   const totalUpdated = results.reduce((a, b) => a + b, 0);
 
-  revalidateTag("exchange-rates");
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag("exchange-rates", "max");
   return ok({ updated: totalUpdated, baseCurrency });
 }

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -4,6 +4,7 @@ import { ok } from "@/lib/api-responses";
 
 export async function POST() {
   const result = await refreshAllPrices();
-  revalidateTag("net-worth");
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag("net-worth", "max");
   return ok(result);
 }

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -4,6 +4,6 @@ import { ok } from "@/lib/api-responses";
 
 export async function POST() {
   const result = await refreshAllPrices();
-  revalidateTag("net-worth", "max");
+  revalidateTag("net-worth");
   return ok(result);
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -28,11 +28,12 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
     },
   });
 
-  revalidateTag(`settings:${userId}`);
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag(`settings:${userId}`, "max");
   // If the base currency changed, the cached net-worth summary for this
   // user is stale (values are denominated in the old currency).
   if (parsed.data.baseCurrency !== undefined) {
-    revalidateTag(`net-worth:${userId}`);
+    revalidateTag(`net-worth:${userId}`, "max");
   }
 
   const response = ok(settings);

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -28,11 +28,11 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
     },
   });
 
-  revalidateTag(`settings:${userId}`, "max");
+  revalidateTag(`settings:${userId}`);
   // If the base currency changed, the cached net-worth summary for this
   // user is stale (values are denominated in the old currency).
   if (parsed.data.baseCurrency !== undefined) {
-    revalidateTag(`net-worth:${userId}`, "max");
+    revalidateTag(`net-worth:${userId}`);
   }
 
   const response = ok(settings);


### PR DESCRIPTION
## Description
Removes the `"max"` option from all `revalidateTag()` calls throughout the codebase. This simplifies the cache revalidation logic by using the default revalidation behavior instead of explicitly specifying the maximum age option.

Additionally, adds cache invalidation for snapshot and user history caches in the cron snapshot endpoint after new snapshot rows are created, ensuring these caches stay in sync with the database.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests
- [x] All tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No new warnings generated

## Related Issues
Closes #

https://claude.ai/code/session_013bK2xnyxgWe7pQUmm8V8hN