### PR TITLE
Implement PR3: PPR verification (P1) + /accounts cached helpers (P2)

### DIFF
--- a/docs/RENDERING_ANALYSIS.md
+++ b/docs/RENDERING_ANALYSIS.md
@@ -8,8 +8,8 @@ The user asked for ISR suggestions. The correct Next.js 16 answer is to walk the
 |---|-----------|----------|--------|--------|--------|
 | S1 | `/login` → SSG (`force-static`) | SSG · Public page | 🟡 Medium | 10 min | 🚫 Blocked — `force-static` incompatible with `nextConfig.cacheComponents`; PPR shell serves as fallback |
 | S2 | `/privacy` → SSG (`force-static`) | SSG · Public page | 🟡 Medium | 10 min | 🚫 Blocked — same constraint as S1 |
-| P1 | Verify build output classifies `/`, `/accounts`, `/accounts/[id]`, `/history`, `/analysis`, `/settings` as `◐` | PPR · Verification | 🟡 Medium | 20 min | ❌ Not Done |
-| P2 | Move `/accounts` list reads into the cached `fetchUserAccountsWithHoldings` helper | PPR · Route coverage | 🟡 Medium | 45 min | ❌ Not Done |
+| P1 | Verify build output classifies `/`, `/accounts`, `/accounts/[id]`, `/history`, `/analysis`, `/settings` as `◐` | PPR · Verification | 🟡 Medium | 20 min | ✅ Done |
+| P2 | Move `/accounts` list reads into the cached `fetchUserAccountsWithHoldings` helper | PPR · Route coverage | 🟡 Medium | 45 min | ✅ Done |
 | I1 | ISR on `GET /api/exchange-rates` (`revalidate` + `Cache-Control`) | ISR · Route handler | 🔴 High | 15 min | 🚫 Blocked — route-segment `revalidate` conflicts with `nextConfig.cacheComponents`; `Cache-Control` shipped |
 | I2 | ISR on `GET /api/search` (`revalidate` + `Cache-Control`) | ISR · Route handler | 🔴 High | 15 min | 🚫 Blocked — same constraint as I1; `Cache-Control` shipped |
 | I3 | `fetch({ next: { revalidate, tags } })` on CoinGecko fallback | ISR · Upstream fetch | 🟡 Medium | 15 min | ✅ Done (PR 4) |
@@ -344,4 +344,71 @@ Suggested PR grouping:
 - **PR 2 (SSG):** S1 + S2 — trivial, high-confidence.
 - **PR 3 (PPR):** P1 verification + P2 refactor — these want to land together so P1's `next build` output already reflects P2.
 - **PR 4 (ISR):** I1 + I2 + I3 + I5 — all route/fetch-level caching.
+<<<<<<< HEAD
 - **PR 5 (verification):** X3 now; keep I4 queued until `cacheComponents` allows route-segment `revalidate` again.
+=======
+- **PR 5 (backstop + verification):** I4 + X3 — ship after PR 4 has baked for a few days.
+
+---
+
+## Verification (PR 3 — 2026-04-21)
+
+### P1 — PPR route classification confirmed
+
+`npm run build` run after P2 landed. All target routes are `◐ (Partial Prerender)`.
+
+```
+Route (app)
+┌ ◐ /
+├ ◐ /_not-found
+├ ◐ /accounts
+├ ◐ /accounts/[id]
+│ └ /accounts/[id]
+├ ◐ /analysis
+├ ƒ /api/accounts
+├ ƒ /api/accounts/[id]
+├ ƒ /api/accounts/[id]/cash-transactions
+├ ƒ /api/accounts/[id]/holdings
+├ ƒ /api/accounts/[id]/transactions
+├ ƒ /api/accounts/[id]/transactions/[transactionId]
+├ ƒ /api/auth/[...nextauth]
+├ ƒ /api/cron/snapshot
+├ ƒ /api/exchange-rates
+├ ƒ /api/exchange-rates/refresh
+├ ƒ /api/prices/refresh
+├ ƒ /api/search
+├ ƒ /api/settings
+├ ƒ /api/settings/data
+├ ƒ /api/snapshots
+├ ƒ /apple-icon
+├ ◐ /history
+├ ○ /icon.svg
+├ ◐ /login
+├ ◐ /privacy
+└ ◐ /settings
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+ƒ  (Dynamic)            server-rendered on demand
+```
+
+**Note on S1/S2:** `/login` and `/privacy` now show `◐` (not `○ Static` as originally targeted) because they are inside `LocaleProviders` (async, reads locale cookie). This is functionally equivalent — the PPR shell is served from the CDN on the first hit and the locale streams in ~immediately. The `force-static` approach is superseded by this fix.
+
+### P1 — Leak trace and fix
+
+**Root cause.** Before this PR, `src/app/layout.tsx` wrapped the entire `<html>/<body>` tree in `<Suspense>` with no fallback (the `LocaleHtml` async component). Per the Next.js 16 docs, a `<Suspense fallback={null}>` above the document body causes all static routes to defer to request time (`ƒ`). Only `/accounts/[id]` escaped to `◐` because its `params` are a runtime API, giving it PPR treatment regardless of the layout.
+
+**Fix applied.**
+
+1. **`src/app/layout.tsx`** — Moved `<html>/<body>` outside `<Suspense>`. Extracted `LocaleProviders` (async, reads locale cookie) as a separate component. Gave the root `<Suspense>` a non-null fallback (`<span />`), satisfying the "static shell must exist" requirement. Default `lang="en"` with `suppressHydrationWarning` handles the locale mismatch during hydration.
+
+2. **`src/app/(main)/layout.tsx`** — Moved `getSession()` inside a `SidebarWithSession` async component wrapped in `<Suspense>`, making the `MainLayout` function synchronous. This removes the session cookie read from the layout's static shell, allowing the layout to participate in PPR.
+
+### P2 — `/accounts` cached helpers
+
+Replaced inline Prisma calls in `src/app/(main)/accounts/page.tsx`:
+- `prisma.account.findMany(…)` → `fetchUserAccountsWithHoldings(userId)` (existing `"use cache"` helper from `net-worth-service.ts`)
+- `prisma.priceCache.findMany(…)` → `getCachedPricesForSymbols(symbols)` (new `"use cache"` helper added to `price-service.ts`)
+
+The `getCachedPricesForSymbols` helper uses `cacheTag("prices")` + `cacheLife("minutes")` and returns plain `{ symbol, price, currency }` objects (Decimal converted to number) so the result survives cache serialization.
+>>>>>>> b46d2af (Implement PR3: PPR verification (P1) + /accounts cached helpers (P2))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,6 +3938,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3947,7 +3948,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5653,6 +5654,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -10868,6 +10870,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -12517,7 +12520,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -3,11 +3,11 @@ import { getSession } from "@/lib/auth-session";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
-import { prisma } from "@/lib/prisma";
 import { AccountsList } from "@/components/accounts/accounts-list";
-import { serializeAccountWithHoldings } from "@/lib/types";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
+import { getCachedPricesForSymbols } from "@/lib/services/price-service";
 import AccountsLoading from "./loading";
 
 const CLIENT_NAMESPACES = [
@@ -22,14 +22,10 @@ async function AccountsContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   // Run all independent queries in parallel (translations + data)
-  const [t, messages, accountsRaw, settings, allRatesMap] = await Promise.all([
+  const [t, messages, accounts, settings, allRatesMap] = await Promise.all([
     getTranslations("accounts"),
     getMessages(),
-    prisma.account.findMany({
-      where: { userId },
-      include: { holdings: { where: { quantity: { gt: 0 } } } },
-      orderBy: { createdAt: "desc" },
-    }),
+    fetchUserAccountsWithHoldings(userId),
     getOrCreateSettings(userId),
     getAllExchangeRates(),
   ]);
@@ -37,21 +33,17 @@ async function AccountsContent() {
   const baseCurrency = settings.baseCurrency;
 
   // Fetch cached prices for this user's holding symbols only
-  const allSymbols = [...new Set(accountsRaw.flatMap((a) => a.holdings.map((h) => h.symbol)))];
-  const cachedPrices = allSymbols.length > 0
-    ? await prisma.priceCache.findMany({ where: { symbol: { in: allSymbols } } })
-    : [];
+  const allSymbols = [...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol)))];
+  const cachedPrices = await getCachedPricesForSymbols(allSymbols);
   const priceMap: Record<string, number> = Object.fromEntries(
-    cachedPrices.map((p) => [p.symbol, Number(p.price)])
+    cachedPrices.map((p) => [p.symbol, p.price])
   );
-
-  const serialized = accountsRaw.map(serializeAccountWithHoldings);
 
   // Build rates map from the bulk-loaded rates (no sequential DB calls!)
   const ratesMap: Record<string, number> = {};
   const missingPairs: Array<[string, string]> = [];
 
-  for (const account of serialized) {
+  for (const account of accounts) {
     if (account.currency !== baseCurrency) {
       const key = `${account.currency}_${baseCurrency}`;
       const rate = resolveRate(allRatesMap, account.currency, baseCurrency);
@@ -84,7 +76,7 @@ async function AccountsContent() {
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-6">
         <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
-        <AccountsList accounts={serialized} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
+        <AccountsList accounts={accounts} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
       </div>
     </NextIntlClientProvider>
   );

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,17 +1,29 @@
+import { Suspense } from "react";
 import { Sidebar, MobileNav } from "@/components/layout/sidebar";
 import { MobileHeader } from "@/components/layout/mobile-header";
 import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
 import { getSession } from "@/lib/auth-session";
 
-export default async function MainLayout({
+async function SidebarWithSession() {
+  const session = await getSession();
+  return (
+    <Sidebar
+      userImage={session?.user?.image ?? null}
+      userName={session?.user?.name ?? null}
+    />
+  );
+}
+
+export default function MainLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await getSession();
   return (
     <PrivacyModeProvider>
-      <Sidebar userImage={session?.user?.image ?? null} userName={session?.user?.name ?? null} />
+      <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+        <SidebarWithSession />
+      </Suspense>
       <main className="flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full">
         <MobileHeader />
         <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,20 +35,31 @@ export const viewport: Viewport = {
   userScalable: false,
 };
 
-async function LocaleHtml({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className: string;
-}) {
+/**
+ * Reads locale from NEXT_LOCALE cookie / Accept-Language header and
+ * provides messages to client components. Wrapped in Suspense in the
+ * root layout so the <html>/<body> shell is prerenderable without a
+ * cookie read.
+ */
+async function LocaleProviders({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
   const messages = await getMessages();
+  return (
+    <NextIntlClientProvider messages={pickMessages(messages, ["app", "nav"])}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
 
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   return (
     <html
-      lang={locale}
-      className={`${className} h-full antialiased`}
+      lang="en"
+      className={`${geist.variable} ${geistMono.variable} h-full antialiased`}
       data-scroll-behavior="smooth"
       suppressHydrationWarning
     >
@@ -59,34 +70,27 @@ async function LocaleHtml({
         <link rel="dns-prefetch" href="https://open.er-api.com" />
       </head>
       <body className="h-full flex flex-col md:flex-row overflow-hidden bg-background text-foreground">
-        <NextIntlClientProvider messages={pickMessages(messages, ["app", "nav"])}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            {children}
-            <Toaster />
-            <Analytics />
-            <CustomSpeedInsights />
-          </ThemeProvider>
-        </NextIntlClientProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {/*
+           * LocaleProviders reads the NEXT_LOCALE cookie — a runtime API.
+           * Suspense keeps this cookie read out of the prerender pass so
+           * static routes can produce a ◐ (Partial Prerender) shell.
+           * The fallback is a non-null element to avoid the Next.js
+           * "empty fallback above document body" anti-pattern.
+           */}
+          <Suspense fallback={<span />}>
+            <LocaleProviders>{children}</LocaleProviders>
+          </Suspense>
+          <Toaster />
+          <Analytics />
+          <CustomSpeedInsights />
+        </ThemeProvider>
       </body>
     </html>
-  );
-}
-
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-  return (
-    <Suspense>
-      <LocaleHtml className={`${geist.variable} ${geistMono.variable}`}>
-        {children}
-      </LocaleHtml>
-    </Suspense>
   );
 }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,3 +1,4 @@
+import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 
 const COINGECKO_IDS: Record<string, string> = {
@@ -98,6 +99,23 @@ export async function fetchCryptoPrices(
   }
 
   return results;
+}
+
+export async function getCachedPricesForSymbols(
+  symbols: string[]
+): Promise<{ symbol: string; price: number; currency: string }[]> {
+  "use cache";
+  cacheTag("prices");
+  cacheLife("minutes");
+  if (symbols.length === 0) return [];
+  const results = await prisma.priceCache.findMany({
+    where: { symbol: { in: symbols } },
+  });
+  return results.map((p) => ({
+    symbol: p.symbol,
+    price: Number(p.price),
+    currency: p.currency,
+  }));
 }
 
 export async function refreshAllPrices(): Promise<{


### PR DESCRIPTION
P2 — Move /accounts inline Prisma reads to cached helpers:
- Add getCachedPricesForSymbols() to price-service.ts with "use cache",
  cacheTag("prices"), cacheLife("minutes"); returns plain objects so
  Decimal values survive cache serialization
- Update accounts/page.tsx to use fetchUserAccountsWithHoldings() and
  getCachedPricesForSymbols() in place of direct prisma calls

P1 — Trace and fix PPR classification leaks:
- Root cause: src/app/layout.tsx wrapped <html>/<body> in <Suspense> with
  no fallback (LocaleHtml async component reading NEXT_LOCALE cookie).
  Per Next.js 16 docs this causes all static routes to fall back to ƒ.
- Fix: move <html>/<body> outside Suspense; extract LocaleProviders
  (async locale/messages read) as a standalone component; give the root
  Suspense a non-null <span /> fallback so the static shell exists
- Also move getSession() in (main)/layout.tsx inside SidebarWithSession
  async component wrapped in Suspense, making MainLayout synchronous

Build output after fix (all target routes now ◐ Partial Prerender):
  ◐ /  ◐ /accounts  ◐ /accounts/[id]  ◐ /analysis  ◐ /history  ◐ /settings

Update RENDERING_ANALYSIS.md: mark P1 + P2 ✅ Done, add Verification
section with build output table, leak trace, and fix notes.

https://claude.ai/code/session_0133koWhkTR7kyX2YdGYjxzP