### PR TITLE
Add validated runtime env module and replace direct env assertions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# PostgreSQL connection string
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?sslmode=require"
+
+# NextAuth/App auth secret (generate a long random value)
+AUTH_SECRET="replace-with-long-random-secret"
+
+# Google OAuth provider credentials
+AUTH_GOOGLE_ID="replace-with-google-oauth-client-id"
+AUTH_GOOGLE_SECRET="replace-with-google-oauth-client-secret"
+
+# Optional: auth callback proxy URL (used in some hosted/preview setups)
+# AUTH_REDIRECT_PROXY_URL="https://your-app-domain.example.com/api/auth"
+
+# Cron endpoint bearer token for /api/cron/snapshot
+CRON_SECRET="replace-with-cron-bearer-token"
+
+# Vercel deployment environment: development | preview | production
+# VERCEL_ENV="development"
+
+# Required only when VERCEL_ENV="preview"
+# PREVIEW_AUTH_PASSWORD="replace-with-preview-login-password"

--- a/docs/DOCS_REVIEW_SUGGESTIONS.md
+++ b/docs/DOCS_REVIEW_SUGGESTIONS.md
@@ -14,7 +14,7 @@ It is intended to be an execution-oriented backlog with dependency-aware orderin
 |---|-----------|----------|--------|--------|--------|
 | D1 | Enforce auth + ownership checks on all sensitive API routes | Security | 🔴 High | 1-2 hrs | ❌ Not Done |
 | D2 | Harden cron path (`CRON_SECRET` guard, timing-safe compare, controlled fan-out concurrency) | Security / Reliability | 🔴 High | 1-2 hrs | ❌ Not Done |
-| D3 | Add startup environment validation (`src/lib/env.ts`) | Reliability / DX | 🔴 High | 1 hr | ❌ Not Done |
+| D3 | Add startup environment validation (`src/lib/env.ts`) | Reliability / DX | 🔴 High | 1 hr | ✅ Done |
 | D4 | Add baseline tests (service-layer + API auth checks + 1 E2E smoke) | Testing | 🔴 High | 1-2 days | ❌ Not Done |
 | D5 | Complete caching hygiene (`Cache-Control`, `revalidateTag` coverage audit) | Performance | 🟡 Medium | 1-2 hrs | ❌ Not Done |
 | D6 | Finish accessibility quick wins (`aria-label`, keyboard semantics, non-color cues) | Accessibility | 🔴 High | 2-3 hrs | ❌ Not Done |

--- a/docs/SUGGESTIONS.md
+++ b/docs/SUGGESTIONS.md
@@ -32,12 +32,12 @@
 | 26 | Add test coverage (Vitest + Playwright) | Testing | 🔴 High | 8-12 hrs | ❌ Not Done |
 | 27 | Add error boundary pages (error.tsx / not-found.tsx) | Reliability | 🔴 High | 1-2 hrs | ❌ Not Done |
 | 28 | Fix missing auth checks on API routes | Security | 🔴 High | 30 min | ❌ Not Done |
-| 29 | Validate environment variables at startup | DX / Reliability | 🔴 High | 1 hr | ❌ Not Done |
+| 29 | Validate environment variables at startup | DX / Reliability | 🔴 High | 1 hr | ✅ Done |
 | 30 | Add structured logging (Pino) | Observability | 🟡 Medium | 3-4 hrs | ❌ Not Done |
 | 31 | Add API rate limiting | Security | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 | 32 | Validate query parameters with Zod | Security | 🟡 Medium | 1 hr | ❌ Not Done |
 | 33 | Add timeout guards to price service | Reliability | 🟡 Medium | 30 min | ❌ Not Done |
-| 34 | Add .env.example file | DX | 🟢 Low | 15 min | ❌ Not Done |
+| 34 | Add .env.example file | DX | 🟢 Low | 15 min | ✅ Done |
 | 35 | Utilize snapshot breakdown data in history service | Feature | 🟡 Medium | 2-3 hrs | ❌ Not Done |
 | 36 | Non-destructive data import (merge strategy) | Reliability | 🟡 Medium | 3-4 hrs | ❌ Not Done |
 | 37 | Expand supported currency list | Feature | 🟢 Low | 1 hr | ❌ Not Done |
@@ -57,7 +57,7 @@
 | 51 | Validate snapshots query parameters with Zod | Reliability | 🔴 High | 30-60 min | ❌ Not Done |
 | 52 | Add timeout guards to external pricing calls | Reliability | 🔴 High | 30-60 min | ❌ Not Done |
 | 53 | Make data import merge-first (non-destructive) by default | Reliability | 🔴 High | 3-4 hrs | ❌ Not Done |
-| 54 | Add startup environment validation module (`env.ts`) | DX / Reliability | 🔴 High | 1 hr | ❌ Not Done |
+| 54 | Add startup environment validation module (`env.ts`) | DX / Reliability | 🔴 High | 1 hr | ✅ Done |
 | 55 | Replace console logs with structured logging | Observability | 🟡 Medium | 2-4 hrs | ❌ Not Done |
 | 56 | Add baseline automated tests (unit/API/E2E smoke) | Testing | 🔴 High | 1-2 days | ❌ Not Done |
 | 57 | Improve accessibility semantics on controls/tables | Accessibility | 🟡 Medium | 2-3 hrs | ❌ Not Done |
@@ -107,7 +107,7 @@
 | 101 | Clarify "Growth" definition with Tooltips | UX | 🟢 Low | 30 min | ❌ Not Done |
 | 102 | Remove/Tweak "P&L" or "Trading" jargon | UX | 🟡 Medium | 1 hr | ❌ Not Done |
 | 103 | Scope exchange-rate refresh to current user context | Correctness / Multi-tenant | 🔴 High | 1-2 hrs | ❌ Not Done |
-| 104 | Guard cron secret misconfiguration in snapshot route | Security / Reliability | 🔴 High | 15-30 min | ❌ Not Done |
+| 104 | Guard cron secret misconfiguration in snapshot route | Security / Reliability | 🔴 High | 15-30 min | ✅ Done |
 | 105 | Add concurrency limits to daily snapshot cron fan-out | Reliability / Performance | 🟡 Medium | 1-2 hrs | ❌ Not Done |
 | 106 | Move transactions API to cursor/keyset pagination | Performance | 🔴 High | 2-3 hrs | ❌ Not Done |
 | 107 | Cache `/api/search` symbol lookups with short TTL | Performance | 🟡 Medium | 1 hr | ❌ Not Done |
@@ -151,12 +151,12 @@
 51. **Validate `/api/snapshots` query params with Zod** (`from`, `to`, `currency`) and return `400` for invalid values.
 52. **Add timeout guards in `price-service.ts`** for Yahoo and CoinGecko calls to avoid long-hanging refresh operations.
 53. **Change import default to merge/upsert strategy** in `POST /api/settings/data`; keep destructive replace as explicit opt-in.
-54. **Add startup env validation** via `src/lib/env.ts` instead of direct non-null assertions on `process.env`.
+54. ✅ **Add startup env validation** via `src/lib/env.ts` instead of direct non-null assertions on `process.env`.
 55. **Adopt structured logging** (e.g., Pino) to replace scattered `console.*` for production debugging/monitoring.
 56. **Establish baseline automated tests** (unit + API integration + one E2E smoke path).
 57. **Improve accessibility semantics** on icon-only controls and sortable tables (`aria-label`, `aria-expanded`, `aria-sort`, keyboard handlers).
 103. **Scope `/api/exchange-rates/refresh` to the authenticated user**. The current implementation uses `setting.findFirst()` and all account currencies globally, which can pick another user's base currency and trigger unnecessary cross-tenant work.
-104. **Fail fast when `CRON_SECRET` is missing** in `/api/cron/snapshot`. Current string comparison allows `Authorization: Bearer undefined` when secret is not configured.
+104. ✅ **Fail fast when `CRON_SECRET` is missing** in `/api/cron/snapshot`. Current string comparison allows `Authorization: Bearer undefined` when secret is not configured.
 105. **Limit snapshot cron concurrency** (batch/chunk users instead of `Promise.all` across all users) to reduce API burst load and DB contention as tenant count grows.
 106. **Replace offset pagination with cursor/keyset pagination** for `/api/accounts/[id]/transactions` to avoid growing `OFFSET` scan costs on deep history pages.
 107. **Add short-lived caching to `/api/search` Yahoo lookups** (e.g., 30–120s per normalized query) to reduce repetitive external requests from frequent typing/search interactions.

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -3,10 +3,11 @@ import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { refreshAllPrices } from "@/lib/services/price-service";
 import { ok, failure } from "@/lib/api-responses";
+import { CRON_SECRET } from "@/lib/env";
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (authHeader !== `Bearer ${CRON_SECRET}`) {
     return new Response("Unauthorized", { status: 401 });
   }
 

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,13 +1,14 @@
 import GoogleProvider from "next-auth/providers/google"
 import type { NextAuthConfig } from "next-auth"
+import { AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, AUTH_REDIRECT_PROXY_URL } from "@/lib/env"
 
 export default {
   trustHost: true,
-  redirectProxyUrl: process.env.AUTH_REDIRECT_PROXY_URL,
+  redirectProxyUrl: AUTH_REDIRECT_PROXY_URL,
   providers: [
     GoogleProvider({
-      clientId: process.env.AUTH_GOOGLE_ID!,
-      clientSecret: process.env.AUTH_GOOGLE_SECRET!,
+      clientId: AUTH_GOOGLE_ID,
+      clientSecret: AUTH_GOOGLE_SECRET,
     }),
   ],
 } satisfies NextAuthConfig

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,7 @@ import Credentials from "next-auth/providers/credentials"
 import authConfig from "./auth.config"
 import { customPrismaAdapter } from "@/lib/auth-adapter"
 import { prisma } from "@/lib/prisma"
+import { PREVIEW_AUTH_PASSWORD, VERCEL_ENV } from "@/lib/env"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
@@ -14,8 +15,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         password: { label: "Password", type: "password" },
       },
       authorize: async (credentials) => {
-        if (process.env.VERCEL_ENV !== "preview") return null
-        const expected = process.env.PREVIEW_AUTH_PASSWORD
+        if (VERCEL_ENV !== "preview") return null
+        const expected = PREVIEW_AUTH_PASSWORD
         if (!expected || credentials?.password !== expected) return null
         const user = await prisma.user.findFirst()
         if (!user) return null

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,62 @@
+import "server-only"
+import { z } from "zod"
+
+const envSchema = z
+  .object({
+    DATABASE_URL: z
+      .string()
+      .trim()
+      .min(1, "is required")
+      .refine((value) => /^postgres(ql)?:\/\//.test(value), "must be a valid PostgreSQL connection string"),
+    AUTH_SECRET: z.string().trim().min(1, "is required"),
+    AUTH_GOOGLE_ID: z.string().trim().min(1, "is required"),
+    AUTH_GOOGLE_SECRET: z.string().trim().min(1, "is required"),
+    CRON_SECRET: z.string().trim().min(1, "is required"),
+    AUTH_REDIRECT_PROXY_URL: z.string().url("must be a valid URL").optional(),
+    PREVIEW_AUTH_PASSWORD: z.string().trim().min(1, "must not be empty").optional(),
+    VERCEL_ENV: z.enum(["production", "preview", "development"]).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.VERCEL_ENV === "preview" && !value.PREVIEW_AUTH_PASSWORD) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["PREVIEW_AUTH_PASSWORD"],
+        message: "is required when VERCEL_ENV is \"preview\"",
+      })
+    }
+  })
+
+const parsedEnv = envSchema.safeParse({
+  DATABASE_URL: process.env.DATABASE_URL,
+  AUTH_SECRET: process.env.AUTH_SECRET,
+  AUTH_GOOGLE_ID: process.env.AUTH_GOOGLE_ID,
+  AUTH_GOOGLE_SECRET: process.env.AUTH_GOOGLE_SECRET,
+  CRON_SECRET: process.env.CRON_SECRET,
+  AUTH_REDIRECT_PROXY_URL: process.env.AUTH_REDIRECT_PROXY_URL,
+  PREVIEW_AUTH_PASSWORD: process.env.PREVIEW_AUTH_PASSWORD,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+})
+
+if (!parsedEnv.success) {
+  const issues = parsedEnv.error.issues
+    .map((issue) => {
+      const key = issue.path.join(".") || "(unknown)"
+      return `- ${key}: ${issue.message}`
+    })
+    .join("\n")
+
+  throw new Error(`Invalid environment variables:\n${issues}`)
+}
+
+export const env = parsedEnv.data
+
+export const {
+  DATABASE_URL,
+  AUTH_SECRET,
+  AUTH_GOOGLE_ID,
+  AUTH_GOOGLE_SECRET,
+  CRON_SECRET,
+  AUTH_REDIRECT_PROXY_URL,
+  PREVIEW_AUTH_PASSWORD,
+  VERCEL_ENV,
+} = env

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
 import { neonConfig } from "@neondatabase/serverless";
 import ws from "ws";
+import { DATABASE_URL } from "@/lib/env";
 
 // Enable WebSocket connections for non-edge environments (Node.js)
 neonConfig.webSocketConstructor = ws;
@@ -11,7 +12,7 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient() {
-  const connectionString = process.env.DATABASE_URL!;
+  const connectionString = DATABASE_URL;
   // PrismaNeon takes a PoolConfig and manages the pool internally
   const adapter = new PrismaNeon({ connectionString });
   return new PrismaClient({ adapter });


### PR DESCRIPTION
### Motivation
- Centralize and validate runtime environment variables to fail fast with clear diagnostics instead of crashing later due to non-null `process.env` assertions. 
- Prevent unsafe behavior when critical secrets (e.g., `CRON_SECRET`) are missing and enforce preview-only password when `VERCEL_ENV` is `preview`.
- Improve developer onboarding by providing a `.env.example` that lists all required keys.

### Description
- Add a server-only `src/lib/env.ts` that uses `zod` to validate `DATABASE_URL`, `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `CRON_SECRET`, optional `AUTH_REDIRECT_PROXY_URL`, `PREVIEW_AUTH_PASSWORD`, and `VERCEL_ENV`, with a conditional requirement for `PREVIEW_AUTH_PASSWORD` when `VERCEL_ENV === 'preview'`.
- Export the validated `env` object and typed constants such as `DATABASE_URL`, `CRON_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, etc., from `src/lib/env.ts`.
- Replace direct `process.env.X!` usages with imports from `@/lib/env` in `src/auth.config.ts`, `src/auth.ts`, `src/lib/prisma.ts`, and `src/app/api/cron/snapshot/route.ts` so the app uses typed, validated values at runtime.
- Add `.env.example` containing all schema-aligned keys and explanatory comments for each variable.

### Testing
- Ran `npm run lint` which attempted to run `eslint` but failed in this environment with `ERR_MODULE_NOT_FOUND: Cannot find package 'eslint'`, so linting could not complete here.
- Performed automated code searches to confirm direct `process.env` non-null assertions for the targeted keys were replaced with imports from `@/lib/env`.
- No additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8327effc083218d50c10d28b24b36)