### PR TITLE
Extend TrendChart with assets and liabilities series

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -151,7 +151,9 @@
   "trendChart": {
     "title": "Net Worth Trend",
     "noData": "No data to display yet. Add accounts and your net worth will be tracked automatically at midnight (UTC+8).",
-    "seriesName": "Net Worth"
+    "seriesNetWorth": "Net Worth",
+    "seriesAssets": "Assets",
+    "seriesLiabilities": "Liabilities"
   },
   "allocationChart": {
     "title": "Asset Allocation",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -151,7 +151,9 @@
   "trendChart": {
     "title": "淨資產趨勢",
     "noData": "尚無資料。新增帳戶後，淨資產將於每日午夜（UTC+8）自動記錄。",
-    "seriesName": "淨資產"
+    "seriesNetWorth": "淨資產",
+    "seriesAssets": "資產",
+    "seriesLiabilities": "負債"
   },
   "allocationChart": {
     "title": "資產配置",

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -24,6 +24,13 @@ type SnapshotData = {
   totalLiabilities: number;
 };
 
+type TrendPoint = {
+  date: string;
+  netWorth: number;
+  assets: number;
+  liabilities: number;
+};
+
 function TrendTooltip({
   active,
   payload,
@@ -85,6 +92,23 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
     return snapshots.filter((s) => new Date(s.date) >= cutoff);
   }, [snapshots, selectedRange.days, hideRangeFilter]);
 
+  const chartData: TrendPoint[] = useMemo(
+    () =>
+      filtered.map((point) => ({
+        date: point.date,
+        netWorth: point.netWorth,
+        assets: point.totalAssets,
+        liabilities: point.totalLiabilities,
+      })),
+    [filtered],
+  );
+
+  const series = [
+    { dataKey: "netWorth", name: t("seriesNetWorth"), stroke: "var(--primary)", fill: "var(--primary)", fillOpacity: 0.12 },
+    { dataKey: "assets", name: t("seriesAssets"), stroke: "var(--chart-2)", fill: "var(--chart-2)", fillOpacity: 0.08 },
+    { dataKey: "liabilities", name: t("seriesLiabilities"), stroke: "var(--chart-5)", fill: "var(--chart-5)", fillOpacity: 0.06 },
+  ] as const;
+
   return (
     <Card className="border-0 bg-transparent shadow-none">
       <CardHeader className="flex flex-row items-center justify-between pb-2 px-2 sm:px-4">
@@ -108,16 +132,28 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
         )}
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
-        {filtered.length === 0 ? (
-          <div className="h-[250px] flex items-center justify-center text-muted-foreground text-sm">
+        <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {series.map((item) => (
+            <div key={item.dataKey} className="flex items-center gap-1.5">
+              <span
+                aria-hidden
+                className="inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: item.stroke }}
+              />
+              <span>{item.name}</span>
+            </div>
+          ))}
+        </div>
+        {!mounted ? (
+          <div className="h-[250px] rounded-md bg-muted/30 animate-pulse" />
+        ) : chartData.length === 0 ? (
+          <div className="h-[250px] rounded-md border border-dashed border-border/60 bg-muted/20 flex items-center justify-center text-center text-muted-foreground text-sm px-4">
             {t("noData")}
           </div>
-        ) : !mounted ? (
-          <div className="h-[250px]" />
         ) : (
           <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
           <ResponsiveContainer width="100%" height={250}>
-            <AreaChart data={filtered}>
+            <AreaChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
               <XAxis
                 dataKey="date"
@@ -147,17 +183,20 @@ export function TrendChart({ snapshots, baseCurrency = "USD", hideRangeFilter = 
                   />
                 }
               />
-              <Area
-                type="monotone"
-                dataKey="netWorth"
-                stroke="var(--primary)"
-                fill="var(--primary)"
-                fillOpacity={0.1}
-                strokeWidth={2}
-                name={t("seriesName")}
-                isAnimationActive={isAnimationActive}
-                onAnimationEnd={onAnimationEnd}
-              />
+              {series.map((item) => (
+                <Area
+                  key={item.dataKey}
+                  type="monotone"
+                  dataKey={item.dataKey}
+                  stroke={item.stroke}
+                  fill={item.fill}
+                  fillOpacity={item.fillOpacity}
+                  strokeWidth={2}
+                  name={item.name}
+                  isAnimationActive={isAnimationActive}
+                  onAnimationEnd={onAnimationEnd}
+                />
+              ))}
             </AreaChart>
           </ResponsiveContainer>
           </div>


### PR DESCRIPTION
### Motivation

- Surface per-point `assets` and `liabilities` alongside `netWorth` so the trend chart can show the breakdown over time. 
- Ensure the chart is readable without relying on color alone by adding explicit series labels and tooltip text. 
- Keep the chart layout stable during loading / empty states to avoid layout shifts.

### Description

- Introduced a `TrendPoint` shape and map incoming `SnapshotData` → `TrendPoint` so each chart point carries `assets` and `liabilities` in addition to `netWorth` (in `src/components/dashboard/trend-chart.tsx`).
- Render three `Area` series (`netWorth`, `assets`, `liabilities`) driven by a `series` array with translated names and explicit `name` values so tooltip rows are text-labeled (not color-only).
- Added an inline text legend above the chart that shows each series name with a colored marker to improve discoverability and accessibility.
- Reworked loading/empty states to use fixed-height placeholders (`250px`) and an animated skeleton so the chart area keeps a stable layout while mounting or when there is no data.
- Added i18n strings for the new series labels in both `messages/en-US.json` and `messages/zh-TW.json`.

### Testing

- Ran `npm run lint` which failed in this environment because project dependencies are not installed and ESLint cannot be resolved (`Error: Cannot find package 'eslint'`).
- No other automated test commands were executed in this environment (visual verification expected in a browser after installing deps and running the app).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8393c07348321ab6a40f2e0c15ef9)