### PR TITLE
Promote cash-flow decomposition to KPI and add timestamp-aware FX aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ When you view your history chart or table, the system:
 
 This approach ensures that your trend lines always remain continuous and comparable, regardless of currency fluctuations or setting changes.
 
+### 3. Monthly Contributions vs Market Performance Decomposition
+The **Analysis** page includes a dedicated decomposition chart under the KPI cards:
+- **Contributions** = monthly net cash flow (DEPOSIT − WITHDRAWAL).
+- **Market Performance** = monthly net-worth delta − contributions.
+
+This ensures each month satisfies:
+`deltaNetWorth = contributions + marketPerformance`
+
+### 4. Transaction-time FX Conversion Behavior (Cash Flow)
+Cash-flow conversion resolves FX **per transaction timestamp** (each transaction passes its own `createdAt` into the FX resolver).
+
+Current implementation uses the latest cached FX table as the resolver source, so this remains a known v1 approximation for historical data. The timestamp-aware resolver contract is intentionally preserved so historical FX providers can be plugged in later without changing chart semantics.
+
 ## 📝 Roadmap
 
 - [SUGGESTIONS.md](./docs/SUGGESTIONS.md) — prioritized feature roadmap across the whole app.

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -122,7 +122,7 @@
     "topMoversAccount": "Account",
     "topMoversChange": "Change",
     "topMoversNoData": "Not enough history to show movers.",
-    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only."
+    "cashFlowNote": "Contributions include DEPOSIT/WITHDRAWAL only, converted per transaction timestamp with the latest cached FX rates."
   },
   "history": {
     "title": "Net Worth History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -122,7 +122,7 @@
     "topMoversAccount": "帳戶",
     "topMoversChange": "變化",
     "topMoversNoData": "歷史資料不足，無法顯示變動。",
-    "cashFlowNote": "貢獻僅反映現金存入與提領。"
+    "cashFlowNote": "貢獻僅包含存入/提領，並以每筆交易時間戳記逐筆換算（使用目前快取的最新匯率）。"
   },
   "history": {
     "title": "淨資產歷史",

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -173,13 +173,13 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
         <div className="space-y-6">
           <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
           <div className="premium-card">
-            <CashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
-          </div>
-          <div className="premium-card">
             <MonthlyChangeChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />
           </div>
           <div className="premium-card">
             <AssetsLiabilitiesChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />
+          </div>
+          <div className="premium-card">
+            <CashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
           </div>
           <div className="premium-card">
             <CategoryTrendChart

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -173,13 +173,13 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
         <div className="space-y-6">
           <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
           <div className="premium-card">
+            <CashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
+          </div>
+          <div className="premium-card">
             <MonthlyChangeChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />
           </div>
           <div className="premium-card">
             <AssetsLiabilitiesChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />
-          </div>
-          <div className="premium-card">
-            <CashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
           </div>
           <div className="premium-card">
             <CategoryTrendChart

--- a/src/lib/services/__tests__/cashflow-service.test.ts
+++ b/src/lib/services/__tests__/cashflow-service.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildCashFlowBuckets, type MonthlyBucket } from "../analysis-service.ts";
+import { aggregateMonthlyCashFlow } from "../cashflow-service.ts";
+
+test("aggregateMonthlyCashFlow converts each transaction using timestamp-aware FX resolver", () => {
+  const fxCalls: string[] = [];
+
+  const result = aggregateMonthlyCashFlow(
+    [
+      {
+        createdAt: new Date("2026-01-03T08:00:00.000Z"),
+        amount: 100,
+        type: "DEPOSIT",
+        accountCurrency: "EUR",
+      },
+      {
+        createdAt: new Date("2026-01-20T09:30:00.000Z"),
+        amount: 50,
+        type: "WITHDRAWAL",
+        accountCurrency: "EUR",
+      },
+      {
+        createdAt: new Date("2026-02-02T12:00:00.000Z"),
+        amount: 10_000,
+        type: "DEPOSIT",
+        accountCurrency: "JPY",
+      },
+    ],
+    "USD",
+    ({ fromCurrency, toCurrency, at }) => {
+      fxCalls.push(`${fromCurrency}->${toCurrency}@${at.toISOString()}`);
+      if (fromCurrency === "EUR") return 1.2;
+      if (fromCurrency === "JPY") return 0.01;
+      return 1;
+    },
+  );
+
+  assert.deepEqual(fxCalls, [
+    "EUR->USD@2026-01-03T08:00:00.000Z",
+    "EUR->USD@2026-01-20T09:30:00.000Z",
+    "JPY->USD@2026-02-02T12:00:00.000Z",
+  ]);
+
+  assert.deepEqual(result, [
+    { monthKey: "2026-01", contributions: 60 },
+    { monthKey: "2026-02", contributions: 100 },
+  ]);
+});
+
+test("buildCashFlowBuckets decomposes monthly delta into contributions + marketPerformance", () => {
+  const buckets: MonthlyBucket[] = [
+    {
+      monthKey: "2026-01",
+      endDate: "2026-01-31",
+      startNetWorth: 1000,
+      endNetWorth: 1200,
+      totalAssets: 1500,
+      totalLiabilities: 300,
+      deltaNetWorth: 200,
+      deltaPct: 20,
+      isEmpty: false,
+    },
+    {
+      monthKey: "2026-02",
+      endDate: "2026-02-28",
+      startNetWorth: 1200,
+      endNetWorth: 1000,
+      totalAssets: 1400,
+      totalLiabilities: 400,
+      deltaNetWorth: -200,
+      deltaPct: -16.7,
+      isEmpty: false,
+    },
+  ];
+
+  const result = buildCashFlowBuckets(
+    buckets,
+    [
+      { monthKey: "2026-01", contributions: 80 },
+      { monthKey: "2026-02", contributions: -40 },
+    ],
+    "en-US",
+  );
+
+  assert.equal(result[0].marketPerformance, 120);
+  assert.equal(result[1].marketPerformance, -160);
+  assert.equal(result[0].deltaNetWorth, result[0].contributions + result[0].marketPerformance);
+  assert.equal(result[1].deltaNetWorth, result[1].contributions + result[1].marketPerformance);
+});

--- a/src/lib/services/cashflow-service.ts
+++ b/src/lib/services/cashflow-service.ts
@@ -1,0 +1,45 @@
+import type { MonthlyContribution } from "./analysis-service";
+
+export interface CashFlowTransaction {
+  createdAt: Date;
+  amount: number;
+  type: "DEPOSIT" | "WITHDRAWAL";
+  accountCurrency: string;
+}
+
+export type ResolveTransactionFxRate = (params: {
+  fromCurrency: string;
+  toCurrency: string;
+  at: Date;
+}) => number;
+
+/**
+ * Aggregate transactions into monthly net contributions in a target base currency.
+ *
+ * FX is resolved per-transaction (using the transaction timestamp). This keeps the
+ * conversion hook compatible with historical FX providers while remaining fully
+ * deterministic for unit tests.
+ */
+export function aggregateMonthlyCashFlow(
+  transactions: CashFlowTransaction[],
+  baseCurrency: string,
+  resolveFxRate: ResolveTransactionFxRate,
+): MonthlyContribution[] {
+  const byMonth = new Map<string, number>();
+
+  for (const tx of transactions) {
+    const monthKey = tx.createdAt.toISOString().slice(0, 7);
+    const fx = resolveFxRate({
+      fromCurrency: tx.accountCurrency,
+      toCurrency: baseCurrency,
+      at: tx.createdAt,
+    });
+    const amountInBase = tx.amount * fx;
+    const signed = tx.type === "DEPOSIT" ? amountInBase : -amountInBase;
+    byMonth.set(monthKey, (byMonth.get(monthKey) ?? 0) + signed);
+  }
+
+  return Array.from(byMonth.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([monthKey, contributions]) => ({ monthKey, contributions }));
+}

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -261,13 +261,19 @@ export async function getMonthlyCashFlow(
     getAllExchangeRates(),
   ]);
 
-  return aggregateMonthlyCashFlow(
-    transactions.map((tx) => ({
+  const cashFlowTransactions = transactions
+    .filter((tx): tx is typeof tx & { type: "DEPOSIT" | "WITHDRAWAL" } => (
+      tx.type === "DEPOSIT" || tx.type === "WITHDRAWAL"
+    ))
+    .map((tx) => ({
       createdAt: tx.createdAt,
       amount: Number(tx.amount),
       type: tx.type,
       accountCurrency: tx.account.currency,
-    })),
+    }));
+
+  return aggregateMonthlyCashFlow(
+    cashFlowTransactions,
     baseCurrency,
     ({ fromCurrency, toCurrency }) => resolveRate(allRatesMap, fromCurrency, toCurrency) ?? 1,
   );

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
 import type { NetWorthSnapshot } from "@/generated/prisma/client";
 import type { MonthlyContribution } from "./analysis-service";
+import { aggregateMonthlyCashFlow } from "./cashflow-service";
 
 export interface NormalizedSnapshot {
   id: string;
@@ -236,7 +237,10 @@ export async function getRawHistoryWithBreakdown(
 
 /**
  * Aggregate CashTransaction (DEPOSIT/WITHDRAWAL) records into per-month net
- * contribution amounts, converted to baseCurrency at current rates (v1 drift).
+ * contribution amounts, converted to baseCurrency with per-transaction FX
+ * resolution. The resolver currently uses the latest cached rates (v1 drift),
+ * but is invoked with each transaction timestamp so the behavior is compatible
+ * with historical-rate resolvers.
  *
  * EDIT-type transactions are excluded — they represent balance corrections,
  * not real cash flows.
@@ -257,17 +261,14 @@ export async function getMonthlyCashFlow(
     getAllExchangeRates(),
   ]);
 
-  const byMonth = new Map<string, number>();
-
-  for (const tx of transactions) {
-    const monthKey = tx.createdAt.toISOString().slice(0, 7); // "YYYY-MM"
-    const rate = resolveRate(allRatesMap, tx.account.currency, baseCurrency) ?? 1;
-    const amount = Number(tx.amount) * rate;
-    const signed = tx.type === "DEPOSIT" ? amount : -amount;
-    byMonth.set(monthKey, (byMonth.get(monthKey) ?? 0) + signed);
-  }
-
-  return Array.from(byMonth.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([monthKey, contributions]) => ({ monthKey, contributions }));
+  return aggregateMonthlyCashFlow(
+    transactions.map((tx) => ({
+      createdAt: tx.createdAt,
+      amount: Number(tx.amount),
+      type: tx.type,
+      accountCurrency: tx.account.currency,
+    })),
+    baseCurrency,
+    ({ fromCurrency, toCurrency }) => resolveRate(allRatesMap, fromCurrency, toCurrency) ?? 1,
+  );
 }


### PR DESCRIPTION
### Motivation
- Make monthly contributions vs market-performance an explicit KPI-adjacent chart so users can see cash-flow decomposition immediately under KPI tiles. 
- Ensure cash-flow FX conversion semantics are explicit, testable, and future-proof for historical FX providers by resolving FX per transaction timestamp. 

### Description
- Added a new helper `aggregateMonthlyCashFlow` in `src/lib/services/cashflow-service.ts` that aggregates transactions into monthly contributions and accepts a timestamp-aware FX resolver. 
- Updated `getMonthlyCashFlow` in `src/lib/services/history-service.ts` to use the new helper and to pass a resolver that currently falls back to the latest cached rates (preserving v1 behavior) while invoking it with each transaction `createdAt`. 
- Promoted the cash-flow decomposition chart to appear directly under the KPI tiles in the Analysis view (`src/components/analysis/analysis-view.tsx`) so it is first-class under KPI. 
- Added unit tests in `src/lib/services/__tests__/cashflow-service.test.ts` verifying per-transaction FX resolver invocation and the decomposition identity (`deltaNetWorth = contributions + marketPerformance`), and updated i18n strings and `README.md` to document the behavior. 

### Testing
- Ran the unit tests with `node --test --experimental-strip-types src/lib/services/__tests__/cashflow-service.test.ts`, which passed. 
- Ran `npm run lint` in this environment but linting failed due to the `eslint` package not being resolvable in the container (environment/package limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8393281c48321baef67693f116dfc)