### PR TITLE
Add benchmark overlay to Analysis (S&P 500 & NASDAQ 100) with cached price model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern, high-performance net worth and investment tracker. Built with **Next.j
 - **🚀 Real-time Tracking**: Automatically fetch latest prices for Stocks, ETFs, and Cryptocurrencies (via Yahoo Finance + CoinGecko fallback).
 - **🌍 Multi-Currency Support**: Track assets in USD, TWD, EUR, and more. All values are automatically converted to your selected **Base Currency**.
 - **📈 Trend Visualization**: Interactive charts showing your net worth, assets, and liabilities over time.
+- **📉 Benchmark Overlay (Analysis)**: Compare monthly portfolio trend against normalized benchmark indices (S&P 500 / NASDAQ 100), with range-aware rebasing.
 - **🔄 Lossless History**: Snapshots store original account balances and currencies, allowing perfectly accurate history normalization even if you change your base currency later.
 - **🤖 Automated Snapshots**: Built-in Vercel Cron integration to automatically record your net worth daily.
 - **🌗 Light / Dark / System Theme**: Full theme support with smooth toggle.
@@ -94,6 +95,18 @@ When you view your history chart or table, the system:
 - **Legacy Support**: If a snapshot was taken before the lossless system was implemented, it converts the snapshot's total value from its original base currency to your current one.
 
 This approach ensures that your trend lines always remain continuous and comparable, regardless of currency fluctuations or setting changes.
+
+## 📊 Benchmark Overlay in Analysis
+
+The Analysis tab supports benchmark comparison overlays to contextualize monthly performance.
+
+- **Benchmarks**: S&P 500 (`^GSPC`, default) and NASDAQ 100 (`^NDX`)
+- **Normalization**: Benchmark values are rebased to `100` at the selected analysis range start
+- **Caching model**: Historical index closes are persisted in `BenchmarkPrice` (`symbol + date`) and refreshed on demand
+- **UI**: Selector + disclaimer tooltip to clarify portfolio-vs-index comparability limits
+
+> [!NOTE]
+> Benchmark comparison is intended for directional context only. Portfolio returns include contributions/withdrawals, leverage, and allocation differences that are not directly comparable to a single market index.
 
 ## 📝 Roadmap
 

--- a/docs/ANALYSIS_ROADMAP.md
+++ b/docs/ANALYSIS_ROADMAP.md
@@ -103,12 +103,18 @@ Reuse `aggregateMonthlyChange()` and add `aggregateYearlyChange()`.
 
 Download the visible analysis as CSV (simple) or PDF (nicer for reports). CSV first — drop-in `papaparse` + blob download. PDF via `@react-pdf/renderer` or screenshot-driven `html2canvas`.
 
-### 3.4 Benchmark Overlay — 🟢
+### 3.4 Benchmark Overlay — 🟢 ✅
 
 Plot the user's net-worth growth curve against a benchmark (S&P 500, or user's base-currency inflation) normalized to 100 at the period start.
 
-- **Data**: use Yahoo Finance 2 (already a dependency) to pull `^GSPC`, `^IXIC`, index history. Cache in a new `BenchmarkPrice` model or reuse `PriceCache`.
-- **Risk**: comparing apples to oranges (portfolio vs. equity index). Add a disclaimer tooltip.
+- **Shipped scope**:
+  - Added benchmark cache model `BenchmarkPrice` keyed by `(symbol, date)`.
+  - Added service layer benchmark fetch/cache flow in `src/lib/services/benchmark-service.ts`.
+  - Added range-aware normalization helper in `analysis-service.ts` (rebase to 100).
+  - Added Analysis UI benchmark selector (default S&P 500), overlay line on monthly chart, and disclaimer tooltip.
+  - Added i18n strings in both `en-US` and `zh-TW`.
+- **Data source**: Yahoo Finance 2 historical endpoint for `^GSPC` and `^NDX`.
+- **Known risk (still true)**: comparing apples to oranges (portfolio vs. equity index), mitigated with explicit UI disclaimer.
 
 ### 3.5 Volatility / Drawdown Indicator — 🟢
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -122,7 +122,12 @@
     "topMoversAccount": "Account",
     "topMoversChange": "Change",
     "topMoversNoData": "Not enough history to show movers.",
-    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only."
+    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only.",
+    "benchmarkSelectorLabel": "Benchmark",
+    "benchmarkSP500": "S&P 500",
+    "benchmarkNasdaq100": "NASDAQ 100",
+    "benchmarkDisclaimerLabel": "Comparison notes",
+    "benchmarkDisclaimerText": "Benchmark overlays are normalized to 100 at the selected range start. Portfolio returns include cash flows, leverage, and asset mix differences, so they are not directly comparable to a single index."
   },
   "history": {
     "title": "Net Worth History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -122,7 +122,12 @@
     "topMoversAccount": "帳戶",
     "topMoversChange": "變化",
     "topMoversNoData": "歷史資料不足，無法顯示變動。",
-    "cashFlowNote": "貢獻僅反映現金存入與提領。"
+    "cashFlowNote": "貢獻僅反映現金存入與提領。",
+    "benchmarkSelectorLabel": "基準指數",
+    "benchmarkSP500": "標普 500",
+    "benchmarkNasdaq100": "那斯達克 100",
+    "benchmarkDisclaimerLabel": "比較說明",
+    "benchmarkDisclaimerText": "基準線會在所選區間起點重設為 100。投資組合績效包含現金流、槓桿與資產配置差異，因此無法與單一指數直接對比。"
   },
   "history": {
     "title": "淨資產歷史",

--- a/prisma/migrations/202604220001_add_benchmark_price_cache/migration.sql
+++ b/prisma/migrations/202604220001_add_benchmark_price_cache/migration.sql
@@ -1,0 +1,12 @@
+-- Create benchmark history cache table keyed by (symbol, date)
+CREATE TABLE "BenchmarkPrice" (
+  "symbol" TEXT NOT NULL,
+  "date" DATE NOT NULL,
+  "close" DECIMAL(18,8) NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'USD',
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "BenchmarkPrice_pkey" PRIMARY KEY ("symbol", "date")
+);
+
+CREATE INDEX "BenchmarkPrice_symbol_date_idx" ON "BenchmarkPrice"("symbol", "date" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -123,6 +123,17 @@ model PriceCache {
   @@index([updatedAt])
 }
 
+model BenchmarkPrice {
+  symbol    String
+  date      DateTime @db.Date
+  close     Decimal  @db.Decimal(18, 8)
+  currency  String   @default("USD")
+  updatedAt DateTime @updatedAt
+
+  @@id([symbol, date])
+  @@index([symbol, date(sort: Desc)])
+}
+
 model ExchangeRate {
   id           String   @id
   fromCurrency String

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -8,6 +8,7 @@ import {
   getRawHistoryWithBreakdown,
   getMonthlyCashFlow,
 } from "@/lib/services/history-service";
+import { BENCHMARK_OPTIONS, getBenchmarkSeries } from "@/lib/services/benchmark-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { AnalysisView } from "@/components/analysis/analysis-view";
 import AnalysisLoading from "./loading";
@@ -29,6 +30,18 @@ async function AnalysisContent() {
     getLocale(),
   ]);
 
+  const benchmarkFrom = snapshots[0]
+    ? new Date(`${snapshots[0].date}T00:00:00.000Z`)
+    : new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1));
+  const benchmarkTo = new Date();
+  const benchmarkEntries = await Promise.all(
+    BENCHMARK_OPTIONS.map(async (option) => ({
+      symbol: option.symbol,
+      labelKey: option.labelKey,
+      points: await getBenchmarkSeries(option.symbol, benchmarkFrom, benchmarkTo),
+    })),
+  );
+
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 animate-in fade-in duration-500">
@@ -42,6 +55,7 @@ async function AnalysisContent() {
           rawHistory={rawHistory}
           baseCurrency={settings.baseCurrency}
           locale={locale}
+          benchmarkEntries={benchmarkEntries}
         />
       </div>
     </NextIntlClientProvider>

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -219,7 +219,10 @@ export function AnalysisView({
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">{t("benchmarkSelectorLabel")}</span>
-          <Select value={selectedBenchmark} onValueChange={(value) => setSelectedBenchmark(value)}>
+          <Select
+            value={selectedBenchmark}
+            onValueChange={(value) => value && setSelectedBenchmark(value)}
+          >
             <SelectTrigger className="h-8 min-w-[220px]">
               <SelectValue />
             </SelectTrigger>

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
+import { CircleHelpIcon } from "lucide-react";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
 import type { RawHistoryData, SnapshotBreakdown } from "@/lib/services/history-service";
 import {
@@ -11,8 +12,21 @@ import {
   buildCashFlowBuckets,
   aggregateCategoryHistory,
   computeTopMovers,
+  getNormalizedBenchmarkSeries,
 } from "@/lib/services/analysis-service";
-import type { MonthlyContribution, CategoryDataPoint } from "@/lib/services/analysis-service";
+import type {
+  MonthlyContribution,
+  CategoryDataPoint,
+  BenchmarkSeriesPoint,
+} from "@/lib/services/analysis-service";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { MonthlyChangeChart } from "./monthly-change-chart";
 import { AssetsLiabilitiesChart } from "./assets-liabilities-chart";
 import { KpiTiles } from "./kpi-tiles";
@@ -26,6 +40,11 @@ interface Props {
   rawHistory: RawHistoryData;
   baseCurrency: string;
   locale: string;
+  benchmarkEntries: Array<{
+    symbol: string;
+    labelKey: "benchmarkSP500" | "benchmarkNasdaq100";
+    points: BenchmarkSeriesPoint[];
+  }>;
 }
 
 const ranges = [
@@ -46,9 +65,17 @@ function rangeCutoff(months: number): Date {
   return d;
 }
 
-export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency, locale }: Props) {
+export function AnalysisView({
+  snapshots,
+  cashFlowData,
+  rawHistory,
+  baseCurrency,
+  locale,
+  benchmarkEntries,
+}: Props) {
   const t = useTranslations("analysis");
   const [range, setRange] = useState<RangeLabel>("YTD");
+  const [selectedBenchmark, setSelectedBenchmark] = useState("^GSPC");
 
   const rangeLabelKey: Record<RangeLabel, string> = {
     YTD: "rangeYTD",
@@ -140,6 +167,31 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
     [filteredRawSnapshots, rawHistory.accounts]
   );
 
+  const benchmarkData = useMemo(() => {
+    const selected = benchmarkEntries.find((entry) => entry.symbol === selectedBenchmark);
+    if (!selected) return [];
+    const rangeEndIso = new Date(
+      Date.UTC(rangeEnd.getUTCFullYear(), rangeEnd.getUTCMonth() + 1, 0),
+    )
+      .toISOString()
+      .slice(0, 10);
+
+    const normalized = getNormalizedBenchmarkSeries(
+      selected.points,
+      rangeStartIso,
+      rangeEndIso,
+    );
+    const byMonth = new Map<string, number>();
+    for (const point of normalized) {
+      byMonth.set(point.date.slice(0, 7), point.normalized);
+    }
+
+    return buckets.map((bucket) => ({
+      monthKey: bucket.monthKey,
+      value: byMonth.get(bucket.monthKey) ?? null,
+    }));
+  }, [benchmarkEntries, selectedBenchmark, rangeStartIso, rangeEnd, buckets]);
+
   const hasData = snapshots.length > 0;
 
   return (
@@ -164,6 +216,32 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
           ))}
         </div>
       </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">{t("benchmarkSelectorLabel")}</span>
+          <Select value={selectedBenchmark} onValueChange={(value) => setSelectedBenchmark(value)}>
+            <SelectTrigger className="h-8 min-w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {benchmarkEntries.map((entry) => (
+                <SelectItem key={entry.symbol} value={entry.symbol}>
+                  {t(entry.labelKey)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Popover>
+          <PopoverTrigger className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+            <CircleHelpIcon className="size-3.5" />
+            {t("benchmarkDisclaimerLabel")}
+          </PopoverTrigger>
+          <PopoverContent sideOffset={8} className="w-80 text-xs leading-relaxed text-muted-foreground">
+            {t("benchmarkDisclaimerText")}
+          </PopoverContent>
+        </Popover>
+      </div>
 
       {!hasData ? (
         <div className="rounded-xl border border-dashed border-border/60 bg-card/50 p-12 text-center text-sm text-muted-foreground">
@@ -173,7 +251,13 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
         <div className="space-y-6">
           <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
           <div className="premium-card">
-            <MonthlyChangeChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />
+            <MonthlyChangeChart
+              buckets={buckets}
+              baseCurrency={baseCurrency}
+              locale={locale}
+              benchmarkData={benchmarkData}
+              benchmarkLabel={t(benchmarkEntries.find((entry) => entry.symbol === selectedBenchmark)?.labelKey ?? "benchmarkSP500")}
+            />
           </div>
           <div className="premium-card">
             <AssetsLiabilitiesChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from "react";
 import {
   Bar,
-  BarChart,
+  ComposedChart,
   CartesianGrid,
   Cell,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -25,10 +26,12 @@ interface Props {
   buckets: MonthlyBucket[];
   baseCurrency: string;
   locale: string;
+  benchmarkData: Array<{ monthKey: string; value: number | null }>;
+  benchmarkLabel: string;
 }
 
 interface TooltipPayload {
-  payload: MonthlyBucket & { label: string };
+  payload: MonthlyBucket & { label: string; benchmarkValue: number | null };
 }
 
 function ChangeTooltip({
@@ -37,12 +40,14 @@ function ChangeTooltip({
   baseCurrency,
   t,
   privacyMode,
+  benchmarkLabel,
 }: {
   active?: boolean;
   payload?: TooltipPayload[];
   baseCurrency: string;
   t: (key: string) => string;
   privacyMode?: boolean;
+  benchmarkLabel: string;
 }) {
   if (!active || !payload?.length) return null;
   const b = payload[0].payload;
@@ -85,19 +90,37 @@ function ChangeTooltip({
             b.deltaNetWorth >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
           }
         />
+        {b.benchmarkValue !== null && (
+          <ChartTooltipRow
+            label={benchmarkLabel}
+            value={`${b.benchmarkValue.toFixed(1)}`}
+            valueClassName="text-[var(--chart-4)]"
+          />
+        )}
       </div>
     </ChartTooltipContainer>
   );
 }
 
-export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
+export function MonthlyChangeChart({
+  buckets,
+  baseCurrency,
+  locale,
+  benchmarkData,
+  benchmarkLabel,
+}: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => setMounted(true), []);
 
-  const data = buckets.map((b) => ({ ...b, label: formatMonthLabel(b.monthKey, locale) }));
+  const benchmarkByMonth = new Map(benchmarkData.map((b) => [b.monthKey, b.value]));
+  const data = buckets.map((b) => ({
+    ...b,
+    label: formatMonthLabel(b.monthKey, locale),
+    benchmarkValue: benchmarkByMonth.get(b.monthKey) ?? null,
+  }));
 
   return (
     <Card className="border-0 bg-transparent shadow-none">
@@ -114,7 +137,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
         ) : (
           <div className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}>
           <ResponsiveContainer width="100%" height={280}>
-            <BarChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 20 }}>
+            <ComposedChart data={data} margin={{ top: 10, right: 4, left: 0, bottom: 20 }}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
               <XAxis dataKey="label" tick={{ fontSize: 12 }} angle={-45} textAnchor="end" height={60} />
               <YAxis
@@ -132,7 +155,14 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
               />
               <Tooltip
                 cursor={{ fill: "var(--muted)", opacity: 0.3 }}
-                content={<ChangeTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />}
+                content={
+                  <ChangeTooltip
+                    baseCurrency={baseCurrency}
+                    t={t}
+                    privacyMode={privacyMode}
+                    benchmarkLabel={benchmarkLabel}
+                  />
+                }
               />
               <Bar dataKey="deltaNetWorth" radius={[4, 4, 0, 0]}>
                 {data.map((entry) => (
@@ -149,7 +179,16 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
                   />
                 ))}
               </Bar>
-            </BarChart>
+              <Line
+                type="monotone"
+                dataKey="benchmarkValue"
+                name={benchmarkLabel}
+                stroke="var(--chart-4)"
+                strokeWidth={2}
+                dot={false}
+                connectNulls={false}
+              />
+            </ComposedChart>
           </ResponsiveContainer>
           </div>
         )}

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -259,6 +259,17 @@ export interface TopMover {
   percentChange: number | null;
 }
 
+export interface BenchmarkSeriesPoint {
+  symbol: string;
+  date: string;
+  close: number;
+}
+
+export interface NormalizedBenchmarkPoint {
+  date: string;
+  normalized: number;
+}
+
 // ---------------------------------------------------------------------------
 // Phase 2 pure functions (no DB access)
 // ---------------------------------------------------------------------------
@@ -358,4 +369,25 @@ export function computeTopMovers(
     .filter((m) => m.startValue !== 0 || m.endValue !== 0)
     .sort((a, b) => Math.abs(b.absoluteChange) - Math.abs(a.absoluteChange))
     .slice(0, 10);
+}
+
+/**
+ * Normalize a benchmark series to 100 at the first available point within the selected range.
+ * Returns empty when no data points exist in the range.
+ */
+export function getNormalizedBenchmarkSeries(
+  series: BenchmarkSeriesPoint[],
+  rangeStartIso: string,
+  rangeEndIso: string,
+): NormalizedBenchmarkPoint[] {
+  const inRange = series.filter((p) => p.date >= rangeStartIso && p.date <= rangeEndIso);
+  if (inRange.length === 0) return [];
+
+  const baseline = inRange[0].close;
+  if (baseline <= 0) return [];
+
+  return inRange.map((p) => ({
+    date: p.date,
+    normalized: (p.close / baseline) * 100,
+  }));
 }

--- a/src/lib/services/benchmark-service.ts
+++ b/src/lib/services/benchmark-service.ts
@@ -33,7 +33,6 @@ async function refreshBenchmarkRange(symbol: string, from: Date, to: Date): Prom
         symbol,
         date: new Date(Date.UTC(r.date!.getUTCFullYear(), r.date!.getUTCMonth(), r.date!.getUTCDate())),
         close: r.close!,
-        currency: r.currency ?? "USD",
       }));
 
     if (validRows.length === 0) return;
@@ -41,12 +40,11 @@ async function refreshBenchmarkRange(symbol: string, from: Date, to: Date): Prom
     for (const row of validRows) {
       await prisma.benchmarkPrice.upsert({
         where: { symbol_date: { symbol: row.symbol, date: row.date } },
-        update: { close: row.close, currency: row.currency, updatedAt: new Date() },
+        update: { close: row.close, updatedAt: new Date() },
         create: {
           symbol: row.symbol,
           date: row.date,
           close: row.close,
-          currency: row.currency,
         },
       });
     }

--- a/src/lib/services/benchmark-service.ts
+++ b/src/lib/services/benchmark-service.ts
@@ -1,0 +1,100 @@
+import { prisma } from "@/lib/prisma";
+
+export interface BenchmarkOption {
+  symbol: string;
+  labelKey: "benchmarkSP500" | "benchmarkNasdaq100";
+}
+
+export interface BenchmarkPricePoint {
+  symbol: string;
+  date: string;
+  close: number;
+}
+
+export const BENCHMARK_OPTIONS: BenchmarkOption[] = [
+  { symbol: "^GSPC", labelKey: "benchmarkSP500" },
+  { symbol: "^NDX", labelKey: "benchmarkNasdaq100" },
+];
+
+async function refreshBenchmarkRange(symbol: string, from: Date, to: Date): Promise<void> {
+  try {
+    const YahooFinance = (await import("yahoo-finance2")).default;
+    const yahooFinance = new YahooFinance();
+
+    const rows = await yahooFinance.historical(symbol, {
+      period1: from,
+      period2: to,
+      interval: "1d",
+    });
+
+    const validRows = rows
+      .filter((r) => !!r.date && typeof r.close === "number")
+      .map((r) => ({
+        symbol,
+        date: new Date(Date.UTC(r.date!.getUTCFullYear(), r.date!.getUTCMonth(), r.date!.getUTCDate())),
+        close: r.close!,
+        currency: r.currency ?? "USD",
+      }));
+
+    if (validRows.length === 0) return;
+
+    for (const row of validRows) {
+      await prisma.benchmarkPrice.upsert({
+        where: { symbol_date: { symbol: row.symbol, date: row.date } },
+        update: { close: row.close, currency: row.currency, updatedAt: new Date() },
+        create: row,
+      });
+    }
+  } catch (error) {
+    console.error(`Failed to refresh benchmark history for ${symbol}:`, error);
+  }
+}
+
+export async function getBenchmarkSeries(
+  symbol: string,
+  from: Date,
+  to: Date,
+): Promise<BenchmarkPricePoint[]> {
+  const normalizedFrom = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()));
+  const normalizedTo = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()));
+
+  const existing = await prisma.benchmarkPrice.findMany({
+    where: {
+      symbol,
+      date: {
+        gte: normalizedFrom,
+        lte: normalizedTo,
+      },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  const lastExisting = existing[existing.length - 1];
+  const needsRefresh =
+    existing.length === 0 ||
+    !lastExisting ||
+    lastExisting.date.getTime() < normalizedTo.getTime() - 1000 * 60 * 60 * 24 * 2;
+
+  if (needsRefresh) {
+    const refreshStart = new Date(normalizedFrom);
+    refreshStart.setUTCDate(refreshStart.getUTCDate() - 7);
+    await refreshBenchmarkRange(symbol, refreshStart, normalizedTo);
+  }
+
+  const rows = await prisma.benchmarkPrice.findMany({
+    where: {
+      symbol,
+      date: {
+        gte: normalizedFrom,
+        lte: normalizedTo,
+      },
+    },
+    orderBy: { date: "asc" },
+  });
+
+  return rows.map((r) => ({
+    symbol: r.symbol,
+    date: r.date.toISOString().slice(0, 10),
+    close: Number(r.close),
+  }));
+}

--- a/src/lib/services/benchmark-service.ts
+++ b/src/lib/services/benchmark-service.ts
@@ -42,7 +42,12 @@ async function refreshBenchmarkRange(symbol: string, from: Date, to: Date): Prom
       await prisma.benchmarkPrice.upsert({
         where: { symbol_date: { symbol: row.symbol, date: row.date } },
         update: { close: row.close, currency: row.currency, updatedAt: new Date() },
-        create: row,
+        create: {
+          symbol: row.symbol,
+          date: row.date,
+          close: row.close,
+          currency: row.currency,
+        },
       });
     }
   } catch (error) {


### PR DESCRIPTION
### Motivation

- Provide contextual benchmark overlays in the Analysis tab so users can compare portfolio monthly trends against common indices (S&P 500 / NASDAQ 100). 
- Cache historical index closes to avoid repeated external calls and to enable on-demand refresh and normalization across ranges.

### Description

- Added a new Prisma model `BenchmarkPrice` and migration SQL to persist historical index closes keyed by `(symbol, date)` with an index for descending date access. 
- Implemented `src/lib/services/benchmark-service.ts` to fetch historical index data from Yahoo Finance, upsert rows into the `BenchmarkPrice` table, and return a series for a requested date range, exposing `BENCHMARK_OPTIONS` and `getBenchmarkSeries`.
- Added `getNormalizedBenchmarkSeries` in `src/lib/services/analysis-service.ts` to rebase a benchmark series to `100` at the first available point within the selected range and exported related types for UI usage. 
- Wired the data through the Analysis server page (`src/app/(main)/analysis/page.tsx`) to fetch benchmark entries alongside snapshots and cash flow, and passed them into the client view. 
- Extended the Analysis client (`src/components/analysis/analysis-view.tsx`) with a benchmark selector, disclaimer popover, state handling for the selected benchmark, and logic to map normalized benchmark values to monthly buckets. 
- Updated the monthly chart (`src/components/analysis/monthly-change-chart.tsx`) to use a `ComposedChart` with a `Line` overlay for benchmark series and to surface benchmark values in the tooltip. 
- Added i18n keys in `messages/en-US.json` and `messages/zh-TW.json`, and documented the feature in `README.md` and `docs/ANALYSIS_ROADMAP.md`.

### Testing

- Performed a TypeScript build (`pnpm build` / `next build`) to validate types and bundling, which completed successfully. 
- Ran the existing automated test suite (`pnpm test`) and observed all tests passing against the modified codebase. 
- Validated the Prisma migration file was added and applied locally using `prisma migrate dev` to ensure the `BenchmarkPrice` table creation succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e869bfd4008321a8fc1380de82465f)