### PR TITLE
Set dark default theme and fix Settings language selector

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
       <body className="h-full flex flex-col md:flex-row overflow-hidden bg-background text-foreground">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
         >

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -28,12 +28,28 @@ export function SettingsForm({
   const activeLocale = useLocale();
   const [currency, setCurrency] = useState(currentCurrency);
   const [locale, setLocale] = useState<Locale>(
-    SUPPORTED_LOCALES.includes(activeLocale as Locale) ? (activeLocale as Locale) : DEFAULT_LOCALE
+    SUPPORTED_LOCALES.includes(currentLocale as Locale)
+      ? (currentLocale as Locale)
+      : SUPPORTED_LOCALES.includes(activeLocale as Locale)
+        ? (activeLocale as Locale)
+        : DEFAULT_LOCALE
   );
   const [saving, setSaving] = useState(false);
   const [savingLocale, setSavingLocale] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [snapshotting, setSnapshotting] = useState(false);
+
+  useEffect(() => {
+    if (SUPPORTED_LOCALES.includes(currentLocale as Locale)) {
+      setLocale(currentLocale as Locale);
+      return;
+    }
+    if (SUPPORTED_LOCALES.includes(activeLocale as Locale)) {
+      setLocale(activeLocale as Locale);
+      return;
+    }
+    setLocale(DEFAULT_LOCALE);
+  }, [activeLocale, currentLocale]);
 
   async function saveCurrency() {
     setSaving(true);


### PR DESCRIPTION
### Motivation
- Make the app load in dark mode by default for first-time users by changing the global theme default.  
- Fix a bug where the Preferences language selector could be in a stale state (e.g. Chinese shown and the Save button disabled) and prevent switching to English directly.  

### Description
- Change `ThemeProvider` `defaultTheme` from `system` to `dark` in `src/app/layout.tsx`.  
- Update `src/components/settings/settings-form.tsx` to initialize the `locale` state to prefer the persisted `currentLocale` before falling back to `activeLocale` or `DEFAULT_LOCALE`.  
- Add a `useEffect` to synchronize `locale` state when `currentLocale` or `activeLocale` change so the selector does not remain stale.  
- Import `useEffect` where required and keep other settings and save flows unchanged.  

### Testing
- Ran `npm run lint`, which failed in this environment due to resolver errors (`Cannot find package 'eslint'`), so linting could not be validated here.  
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e990eae218832192b04c5cdf787e59)