### PR TITLE
fix: remove explicit OG image paths that conflicted with file-based metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,21 +32,12 @@ export const metadata: Metadata = {
     description: "Track your net worth, assets, and investments",
     url: "https://assets-tracker-ct.vercel.app",
     siteName: "Assets Tracker",
-    images: [
-      {
-        url: "/opengraph-image.png",
-        width: 1200,
-        height: 630,
-        alt: "Assets Tracker",
-      },
-    ],
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "Assets Tracker",
     description: "Track your net worth, assets, and investments",
-    images: ["/twitter-image.png"],
   },
 };
 


### PR DESCRIPTION
## Summary

- Removed the explicit `images` arrays from `openGraph` and `twitter` metadata in `src/app/layout.tsx`
- The explicit paths (`/opengraph-image.png`, `/twitter-image.png`) resolved from `public/` — but the image files live in `src/app/`, causing social media scrapers to get 404s and show no preview image
- Next.js App Router now auto-discovers `src/app/opengraph-image.png` and `src/app/twitter-image.png` and generates correct absolute URLs with cache-busting hashes

## Root Cause

Two metadata approaches were in conflict:
1. **File-based convention** — images in `src/app/` (Next.js auto-generates OG tags)
2. **Explicit metadata** — `images` arrays in the `metadata` export (overrides file-based, but pointed to non-existent `public/` paths)

The explicit declaration always wins and was producing broken URLs.

## Test Plan

- [ ] Deploy to Vercel
- [ ] Paste `https://assets-tracker-ct.vercel.app/` into [opengraph.xyz](https://www.opengraph.xyz) and confirm the preview image loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)