### PR TITLE
fix: exclude OG and Twitter image routes from auth middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,5 +34,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico|apple-icon|icon).*)"],
+  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico|apple-icon|icon|opengraph-image|twitter-image).*)"],
 };


### PR DESCRIPTION
## Summary

- OG/Twitter image URLs (`/opengraph-image.png`, `/twitter-image.png`) were returning 302 redirects to `/login` for unauthenticated requests
- Social media scrapers (LinkedIn, Twitter, opengraph.xyz, etc.) can't authenticate, so they got the login redirect instead of the image
- Added `opengraph-image` and `twitter-image` to the negative lookahead in the `proxy.ts` middleware matcher

## Root Cause

`src/proxy.ts` matcher excluded `_next/static`, `favicon.ico`, etc. but not the file-based OG image routes that Next.js serves from `src/app/`.

## Test Plan

- [ ] Deploy to Vercel
- [ ] `curl -sI https://assets-tracker-ct.vercel.app/opengraph-image.png?...` should return 200, not 302
- [ ] Paste `https://assets-tracker-ct.vercel.app` into [opengraph.xyz](https://www.opengraph.xyz) and confirm preview image loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)