### PR TITLE
security: add baseline headers (R1) and API rate limiting (R3)

### DIFF
--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -1,0 +1,2 @@
+- 2026-04-24: [ADD]: R1 — Add baseline security headers (HSTS, XFO, XCTO, Referrer-Policy, Permissions-Policy) to `next.config.ts`
+- 2026-04-24: [ADD]: R3 — Add sliding-window rate limiter (`src/lib/rate-limit.ts`); apply to `/api/search` (60/min), `/api/exchange-rates` (30/min), and `/api/auth/*` (20/min via proxy middleware)

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -4,9 +4,9 @@
 
 | #   | Suggestion                                                                  | Category              | Impact    | Effort   | Status      |
 |-----|-----------------------------------------------------------------------------|-----------------------|-----------|----------|-------------|
-| R1  | Add baseline security headers (HSTS, XFO, XCTO, Referrer-Policy, Permissions-Policy) | Security              | 🔴 High   | 1 hr     | ❌ Not Done |
+| R1  | Add baseline security headers (HSTS, XFO, XCTO, Referrer-Policy, Permissions-Policy) | Security              | 🔴 High   | 1 hr     | ✅ Done     |
 | R2  | Content-Security-Policy (Report-Only → enforce)                             | Security              | 🔴 High   | 2–3 hrs  | ❌ Not Done |
-| R3  | Rate limit `/api/search`, `/api/exchange-rates`, `/api/auth/*`              | Security              | 🔴 High   | 2–3 hrs  | ❌ Not Done |
+| R3  | Rate limit `/api/search`, `/api/exchange-rates`, `/api/auth/*`              | Security              | 🔴 High   | 2–3 hrs  | ✅ Done     |
 | R4  | `crypto.timingSafeEqual` compare for `CRON_SECRET`                          | Security              | 🟡 Medium | 15 min   | ❌ Not Done |
 | R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ❌ Not Done |
 | R6  | Add `/terms` (Terms of Service) page                                        | Legal / Compliance    | 🔴 High   | 1–2 hrs  | ❌ Not Done |

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,27 @@ const nextConfig: NextConfig = {
           key: "X-DNS-Prefetch-Control",
           value: "on",
         },
+        // R1 — Baseline security headers
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+        {
+          key: "X-Frame-Options",
+          value: "DENY",
+        },
+        {
+          key: "X-Content-Type-Options",
+          value: "nosniff",
+        },
+        {
+          key: "Referrer-Policy",
+          value: "strict-origin-when-cross-origin",
+        },
+        {
+          key: "Permissions-Policy",
+          value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+        },
       ],
     },
   ],

--- a/src/app/api/exchange-rates/route.ts
+++ b/src/app/api/exchange-rates/route.ts
@@ -1,7 +1,11 @@
 import { prisma } from "@/lib/prisma";
 import { ok } from "@/lib/api-responses";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 
-export async function GET() {
+export async function GET(request: Request) {
+  const limited = rateLimitCheckWithPrune(request, { limit: 30, prefix: "exchange-rates" });
+  if (limited) return limited;
+
   const rates = await prisma.exchangeRate.findMany();
   return ok(rates, {
     headers: {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,4 +1,5 @@
 import { ok } from "@/lib/api-responses";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 
 type SearchResult = {
   symbol: string;
@@ -46,6 +47,9 @@ function inferCurrency(symbol: string, exchange: string): string {
 }
 
 export async function GET(request: Request) {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "search" });
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
   const query = searchParams.get("q")?.trim();
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,104 @@
+/**
+ * R3 — Sliding-window rate limiter (zero external dependencies).
+ *
+ * Uses a module-level Map so the state is shared across requests that hit the
+ * same warm serverless instance. On Vercel Node.js runtime this provides
+ * meaningful per-IP throttling; cold starts reset the window, which is an
+ * acceptable trade-off until Upstash / Vercel KV is wired in.
+ *
+ * Usage:
+ *   const limited = rateLimitCheck(request, { limit: 60, windowMs: 60_000 });
+ *   if (limited) return limited;          // 429 response
+ */
+
+interface RateLimitOptions {
+  /** Maximum requests allowed within the window. */
+  limit: number;
+  /** Sliding-window duration in milliseconds. Default: 60 000 (1 min). */
+  windowMs?: number;
+  /** Identifier prefix to namespace the key in the shared store. */
+  prefix?: string;
+}
+
+interface WindowEntry {
+  count: number;
+  resetAt: number;
+}
+
+// Module-level store — shared across warm invocations on the same instance.
+const store = new Map<string, WindowEntry>();
+
+/** Extract the best available IP from the request headers. */
+function getClientIp(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return "unknown";
+}
+
+/**
+ * Check the rate limit for the incoming request.
+ *
+ * @returns A 429 Response if the limit is exceeded, otherwise `null`.
+ */
+export function rateLimitCheck(
+  request: Request,
+  options: RateLimitOptions
+): Response | null {
+  const { limit, windowMs = 60_000, prefix = "rl" } = options;
+  const ip = getClientIp(request);
+  const key = `${prefix}:${ip}`;
+  const now = Date.now();
+
+  const entry = store.get(key);
+
+  if (!entry || now >= entry.resetAt) {
+    // First request in window (or expired window) — initialise.
+    store.set(key, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+
+  entry.count += 1;
+
+  if (entry.count > limit) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    return new Response(
+      JSON.stringify({ error: { message: "Too many requests" } }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(retryAfter),
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Remaining": "0",
+          "X-RateLimit-Reset": String(Math.ceil(entry.resetAt / 1000)),
+        },
+      }
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Periodically prune expired entries to prevent unbounded Map growth.
+ * Called lazily on each check; runs at most once per minute.
+ */
+let lastPruned = 0;
+function maybePrune() {
+  const now = Date.now();
+  if (now - lastPruned < 60_000) return;
+  lastPruned = now;
+  for (const [key, entry] of store) {
+    if (now >= entry.resetAt) store.delete(key);
+  }
+}
+
+// Attach prune to the check function so callers don't need to think about it.
+const _originalCheck = rateLimitCheck;
+export function rateLimitCheckWithPrune(
+  request: Request,
+  options: RateLimitOptions
+): Response | null {
+  maybePrune();
+  return _originalCheck(request, options);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,50 @@ import { NextResponse } from "next/server";
 
 const { auth } = NextAuth(authConfig);
 
+// ---------------------------------------------------------------------------
+// R3 — Inline rate limiter for /api/auth/* (20 req/min per IP).
+// Inlined here because Edge middleware runs in its own isolated module graph.
+// ---------------------------------------------------------------------------
+interface _RLEntry { count: number; resetAt: number }
+const _authRLStore = new Map<string, _RLEntry>();
+
+function _authRateLimit(request: Request): Response | null {
+  const xff = request.headers.get("x-forwarded-for");
+  const ip = xff ? xff.split(",")[0].trim() : "unknown";
+  const now = Date.now();
+  const windowMs = 60_000;
+  const limit = 20;
+  const entry = _authRLStore.get(ip);
+
+  if (!entry || now >= entry.resetAt) {
+    _authRLStore.set(ip, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+  entry.count += 1;
+  if (entry.count > limit) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    return new Response(
+      JSON.stringify({ error: { message: "Too many requests" } }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(retryAfter),
+        },
+      }
+    );
+  }
+  return null;
+}
+// ---------------------------------------------------------------------------
+
 export default auth((req) => {
+  // Rate-limit auth callbacks before any NextAuth processing.
+  if (req.nextUrl.pathname.startsWith("/api/auth")) {
+    const limited = _authRateLimit(req);
+    if (limited) return limited;
+  }
+
   const isLoggedIn = !!req.auth;
   const isPublicRoute = ["/login", "/privacy"].includes(req.nextUrl.pathname);
 
@@ -34,5 +77,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api/auth|api/cron|_next/static|_next/image|favicon.ico|apple-icon|icon|opengraph-image|twitter-image).*)"],
+  matcher: ["/((?!api/cron|_next/static|_next/image|favicon.ico|apple-icon|icon|opengraph-image|twitter-image).*)"],
 };


### PR DESCRIPTION
## Summary

Implements two launch-blocker items from `docs/RELEASE_READINESS.md`.

---

### R1 — Baseline security headers

**File:** `next.config.ts`

Adds five security headers applied to all routes (`/:path*`):

| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` |

---

### R3 — API rate limiting

**New file:** `src/lib/rate-limit.ts`  
Zero-dependency sliding-window limiter using a module-level `Map`. Returns `429` with `Retry-After` and `X-RateLimit-*` headers when exceeded.

| Route | Limit | Rationale |
|---|---|---|
| `/api/search` | 60 req/min/IP | Protects Yahoo Finance quota |
| `/api/exchange-rates` | 30 req/min/IP | DB read throttle |
| `/api/auth/*` | 20 req/min/IP | Inlined in `src/proxy.ts` middleware |

> **Note:** The middleware matcher was updated to include `/api/auth` so auth callbacks are now intercepted and rate-limited before NextAuth processes them.

> **Upgrade path:** When Upstash/Vercel KV is added, swap the store in `rate-limit.ts` to `@upstash/ratelimit` — no changes needed in the route files.

---

### Verification

```bash
# Confirm headers are present after deploy:
curl -sI https://assets-tracker-ct.vercel.app/ | grep -i 'strict-transport\|x-frame\|x-content\|referrer\|permissions'

# Trigger a 429 on /api/search:
for i in $(seq 61); do curl -s -o /dev/null -w "%{http_code}\n" https://assets-tracker-ct.vercel.app/api/search?q=AAPL; done | tail -5
```