### PR TITLE
security: enforce account/holding ownership on every mutation route (R5)

### DIFF
--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -1,2 +1,3 @@
 - 2026-04-24: [ADD]: R1 — Add baseline security headers (HSTS, XFO, XCTO, Referrer-Policy, Permissions-Policy) to `next.config.ts`
 - 2026-04-24: [ADD]: R3 — Add sliding-window rate limiter (`src/lib/rate-limit.ts`); apply to `/api/search` (60/min), `/api/exchange-rates` (30/min), and `/api/auth/*` (20/min via proxy middleware)
+- 2026-04-25: [MOD]: R5 — Enforce account/holding ownership on every mutation route; wrap `cash-transactions` POST, `transactions` GET, and `transactions/[transactionId]` PATCH/DELETE with `withAuth`; add `{ id, userId }` ownership guards to `holdings` PATCH/DELETE; close IDOR across all mutation routes

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -8,7 +8,7 @@
 | R2  | Content-Security-Policy (Report-Only → enforce)                             | Security              | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R3  | Rate limit `/api/search`, `/api/exchange-rates`, `/api/auth/*`              | Security              | 🔴 High   | 2–3 hrs  | ✅ Done     |
 | R4  | `crypto.timingSafeEqual` compare for `CRON_SECRET`                          | Security              | 🟡 Medium | 15 min   | ❌ Not Done |
-| R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ❌ Not Done |
+| R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ✅ Done     |
 | R6  | Add `/terms` (Terms of Service) page                                        | Legal / Compliance    | 🔴 High   | 1–2 hrs  | ❌ Not Done |
 | R7  | Cookie / analytics consent banner                                           | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R8  | GDPR data-export + delete-account flows                                     | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -1,12 +1,20 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+type IdCtx = { params: Promise<{ id: string }> };
+
+function invalidateUserCaches(userId: string) {
+  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
+}
+
+export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
   const body = await request.json();
   const parsed = createCashTransactionSchema.safeParse(body);
@@ -14,7 +22,8 @@ export async function POST(
 
   const { type, amount, note } = parsed.data;
 
-  const account = await prisma.account.findUnique({ where: { id } });
+  // Verify the account belongs to the authenticated user
+  const account = await prisma.account.findUnique({ where: { id, userId } });
   if (!account) return failure("Account not found", 404);
 
   const transaction = await prisma.cashTransaction.create({
@@ -27,5 +36,6 @@ export async function POST(
     data: { cashBalance: { increment: delta } },
   });
 
+  invalidateUserCaches(userId);
   return ok(transaction, { status: 201 });
-}
+});

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -87,21 +87,25 @@ export const PATCH = withAuth<IdCtx>(async (request, _ctx, userId) => {
 
   const { id, ...data } = parsed.data;
 
+  // Verify the holding belongs to an account owned by the authenticated user
+  const existing = await prisma.holding.findUnique({
+    where: { id },
+    include: { account: { select: { userId: true } } },
+  });
+  if (!existing || existing.account.userId !== userId) return failure("Not found", 404);
+
   // Log quantity change as EDIT transaction
   if (data.quantity !== undefined) {
-    const existing = await prisma.holding.findUnique({ where: { id } });
-    if (existing) {
-      const diff = data.quantity - Number(existing.quantity);
-      if (diff !== 0) {
-        await prisma.holdingTransaction.create({
-          data: {
-            holdingId: id,
-            type: "EDIT",
-            quantity: diff,
-            note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
-          },
-        });
-      }
+    const diff = data.quantity - Number(existing.quantity);
+    if (diff !== 0) {
+      await prisma.holdingTransaction.create({
+        data: {
+          holdingId: id,
+          type: "EDIT",
+          quantity: diff,
+          note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
+        },
+      });
     }
   }
 
@@ -114,6 +118,13 @@ export const DELETE = withAuth<IdCtx>(async (request, _ctx, userId) => {
   const body = await request.json();
   const { id } = body;
   if (!id) return failure("Holding ID required");
+
+  // Verify the holding belongs to an account owned by the authenticated user
+  const holding = await prisma.holding.findUnique({
+    where: { id },
+    include: { account: { select: { userId: true } } },
+  });
+  if (!holding || holding.account.userId !== userId) return failure("Not found", 404);
 
   await prisma.holding.delete({ where: { id } });
   invalidateUserCaches(userId);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -2,13 +2,17 @@ import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string; transactionId: string }> }
-) {
+type TxCtx = { params: Promise<{ id: string; transactionId: string }> };
+
+export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
   const body = await request.json();
+
+  // Verify the account belongs to the authenticated user
+  const account = await prisma.account.findUnique({ where: { id: accountId, userId }, select: { id: true } });
+  if (!account) return failure("Not found", 404);
 
   // Determine if it's a HoldingTransaction or CashTransaction
   const holdingTx = await prisma.holdingTransaction.findUnique({
@@ -100,13 +104,14 @@ export async function PATCH(
   }
 
   return failure("Transaction not found", 404);
-}
+});
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: Promise<{ id: string; transactionId: string }> }
-) {
+export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
+
+  // Verify the account belongs to the authenticated user
+  const account = await prisma.account.findUnique({ where: { id: accountId, userId }, select: { id: true } });
+  if (!account) return failure("Not found", 404);
 
   const holdingTx = await prisma.holdingTransaction.findUnique({
     where: { id: transactionId },
@@ -149,4 +154,4 @@ export async function DELETE(
   }
 
   return failure("Transaction not found", 404);
-}
+});

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
-import { ok } from "@/lib/api-responses";
+import { ok, failure } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
 interface UnifiedRow {
   id: string;
@@ -11,11 +12,15 @@ interface UnifiedRow {
   holdingId: string | null;
 }
 
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+type IdCtx = { params: Promise<{ id: string }> };
+
+export const GET = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
+
+  // Verify the account belongs to the authenticated user
+  const account = await prisma.account.findUnique({ where: { id, userId }, select: { id: true } });
+  if (!account) return failure("Not found", 404);
+
   const { searchParams } = new URL(request.url);
 
   const page = Math.max(1, Number(searchParams.get("page") || "1"));
@@ -64,4 +69,4 @@ export async function GET(
   }));
 
   return ok(result);
-}
+});


### PR DESCRIPTION
## Summary

Closes the IDOR (Insecure Direct Object Reference) vulnerabilities identified in `RELEASE_READINESS.md#R5`. Any authenticated user could previously read or mutate another user's accounts, holdings, or transactions by guessing an ID.

## Vulnerabilities Closed

| Route | Method | Issue | Fix |
|---|---|---|---|
| `accounts/[id]/holdings` | PATCH | Fetched holding by `id` alone — no `userId` guard | `findUnique` joined with `account`, asserts `account.userId === userId` |
| `accounts/[id]/holdings` | DELETE | Same — deleted any holding by `id` | Same ownership check before delete |
| `accounts/[id]/cash-transactions` | POST | No session check at all; account lookup had no `userId` filter | Wrapped with `withAuth`; account lookup now uses `{ id, userId }` |
| `accounts/[id]/transactions` | GET | Completely unauthenticated — anyone could read any account's history | Wrapped with `withAuth` + ownership check before raw SQL |
| `accounts/[id]/transactions/[transactionId]` | PATCH | No session check; only validated `accountId` in URL, not ownership | `withAuth` + `account.findUnique({ id, userId })` up front |
| `accounts/[id]/transactions/[transactionId]` | DELETE | Same | Same |

## Pattern

All guards use:
```ts
const account = await prisma.account.findUnique({ where: { id, userId } });
if (!account) return failure("Not found", 404);
```

Prisma returns `null` if either condition fails, so a single DB call both ownership-checks and confirms existence. Returning `404` (not `403`) avoids leaking whether a resource exists for a different user.

## Bonus

- `cash-transactions/route.ts` was missing cache revalidation entirely — added `accounts`, `net-worth`, and `history` tag invalidation on POST.
- Holdings `PATCH` now reuses the ownership `findUnique` result for the quantity diff calculation, eliminating a redundant DB round-trip.

## Verification

- `tsc --noEmit` passes cleanly ✅
- `RELEASE_READINESS.md` R5 marked ✅ Done