### PR TITLE
feat(e2e): add Playwright smoke test suite (R21)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,22 +1,24 @@
 name: E2E Smoke Tests
 
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  deployment_status:
 
 jobs:
   e2e:
     name: Playwright smoke tests
+    # Vercel sets state=success when the preview is live and ready
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          # Check out the exact commit that was deployed
+          ref: ${{ github.event.deployment.sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -27,33 +29,12 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      # ------------------------------------------------------------------
-      # Run against a live preview deployment when the URL is supplied.
-      # The preview deployment must have VERCEL_ENV=preview and
-      # PREVIEW_AUTH_PASSWORD set to the same value as E2E_PASSWORD below.
-      # ------------------------------------------------------------------
-      - name: Run E2E tests (preview deployment)
-        if: vars.E2E_BASE_URL != ''
+      - name: Run E2E tests
         run: npm run test:e2e
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          # Vercel posts the live URL here automatically — no hardcoding needed
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
-
-      # ------------------------------------------------------------------
-      # Fallback: spin up a local dev server when no preview URL is set.
-      # playwright.config.ts webServer block starts Next.js automatically.
-      # ------------------------------------------------------------------
-      - name: Run E2E tests (local dev server)
-        if: vars.E2E_BASE_URL == ''
-        run: npm run test:e2e
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          AUTH_GOOGLE_ID: ${{ secrets.AUTH_GOOGLE_ID }}
-          AUTH_GOOGLE_SECRET: ${{ secrets.AUTH_GOOGLE_SECRET }}
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          # webServer env override sets VERCEL_ENV=preview + PREVIEW_AUTH_PASSWORD
-          E2E_PASSWORD: e2e-smoke-test
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: E2E Smoke Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  e2e:
+    name: Playwright smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # ------------------------------------------------------------------
+      # Run against a live preview deployment when the URL is supplied.
+      # The preview deployment must have VERCEL_ENV=preview and
+      # PREVIEW_AUTH_PASSWORD set to the same value as E2E_PASSWORD below.
+      # ------------------------------------------------------------------
+      - name: Run E2E tests (preview deployment)
+        if: vars.E2E_BASE_URL != ''
+        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+
+      # ------------------------------------------------------------------
+      # Fallback: spin up a local dev server when no preview URL is set.
+      # playwright.config.ts webServer block starts Next.js automatically.
+      # ------------------------------------------------------------------
+      - name: Run E2E tests (local dev server)
+        if: vars.E2E_BASE_URL == ''
+        run: npm run test:e2e
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          AUTH_GOOGLE_ID: ${{ secrets.AUTH_GOOGLE_ID }}
+          AUTH_GOOGLE_SECRET: ${{ secrets.AUTH_GOOGLE_SECRET }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          # webServer env override sets VERCEL_ENV=preview + PREVIEW_AUTH_PASSWORD
+          E2E_PASSWORD: e2e-smoke-test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/tests/e2e/.auth
 
 # next.js
 /.next/

--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -2,3 +2,4 @@
 - 2026-04-24: [ADD]: R3 — Add sliding-window rate limiter (`src/lib/rate-limit.ts`); apply to `/api/search` (60/min), `/api/exchange-rates` (30/min), and `/api/auth/*` (20/min via proxy middleware)
 - 2026-04-24: [ADD]: R14 — Add 5 s timeout + 2-retry exponential backoff (500 ms, 1.5 s) to Yahoo Finance and CoinGecko calls in `src/lib/services/price-service.ts`; per-symbol fallback isolation on Yahoo Finance batch failure
 - 2026-04-24: [ADD]: R20 — Add `.github/workflows/ci.yml`; runs `npm ci` → `prisma generate` → `lint` → `tsc --noEmit` → `next build` on every PR and push to master/main
+- 2026-04-24: [ADD]: R21 — Add Playwright smoke E2E suite (`playwright.config.ts`, `tests/e2e/global-setup.ts`, `tests/e2e/smoke.spec.ts`, `.github/workflows/e2e.yml`); covers unauthenticated redirect → login, account + holding creation, and dashboard net-worth card + trend chart; auth stubbed via preview-credentials provider

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -24,7 +24,7 @@
 | R18 | Structured logging via `pino` with `userId` / `requestId` context           | Observability         | 🟡 Medium | 3–4 hrs  | ❌ Not Done |
 | R19 | On-call playbook (Vercel log queries + baselines) in `README.md`            | Observability         | 🟡 Medium | 45 min   | ❌ Not Done |
 | R20 | `.github/workflows/ci.yml` — lint + `tsc --noEmit` + `next build` on PR     | Testing / CI          | 🔴 High   | 1 hr     | ✅ Done     |
-| R21 | Playwright smoke E2E — login, create account+holding, view dashboard        | Testing / CI          | 🔴 High   | 4–6 hrs  | ❌ Not Done |
+| R21 | Playwright smoke E2E — login, create account+holding, view dashboard        | Testing / CI          | 🔴 High   | 4–6 hrs  | ✅ Done     |
 | R22 | In-app help / FAQ modal + support link                                      | Product               | 🟡 Medium | 2–3 hrs  | ❌ Not Done |
 | R23 | Non-destructive data import (merge, not overwrite)                          | Product               | 🔴 High   | 3–4 hrs  | ❌ Not Done |
 | R24 | Rename `src/middleware.ts` → `src/proxy.ts` (Next.js 16)                    | Platform Config       | 🟢 Low    | 10 min   | ❌ Not Done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2481,6 +2482,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7265,6 +7282,21 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -10344,6 +10376,38 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/po-parser": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
@@ -49,6 +52,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000"
 const E2E_PASSWORD = process.env.E2E_PASSWORD ?? "e2e-smoke-test"
 
 export default defineConfig({
+  globalSetup: "./tests/e2e/global-setup",
   testDir: "./tests/e2e",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
@@ -19,16 +20,11 @@ export default defineConfig({
   },
   projects: [
     {
-      name: "setup",
-      testMatch: /global-setup\.ts/,
-    },
-    {
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
         storageState: "tests/e2e/.auth/user.json",
       },
-      dependencies: ["setup"],
     },
   ],
   ...(process.env.PLAYWRIGHT_TEST_BASE_URL

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000"
+const E2E_PASSWORD = process.env.E2E_PASSWORD ?? "e2e-smoke-test"
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /global-setup\.ts/,
+    },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "tests/e2e/.auth/user.json",
+      },
+      dependencies: ["setup"],
+    },
+  ],
+  ...(process.env.PLAYWRIGHT_TEST_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: "npm run dev",
+          url: BASE_URL,
+          reuseExistingServer: !process.env.CI,
+          env: {
+            VERCEL_ENV: "preview",
+            PREVIEW_AUTH_PASSWORD: E2E_PASSWORD,
+          },
+        },
+      }),
+})

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,42 @@
+import { chromium } from "@playwright/test"
+import path from "path"
+import fs from "fs"
+
+const authFile = path.join(__dirname, ".auth/user.json")
+
+/**
+ * Logs in once via the preview-credentials endpoint and saves storage state.
+ * All smoke tests that need authentication reuse this saved state.
+ *
+ * Requirements on the server:
+ *   VERCEL_ENV=preview
+ *   PREVIEW_AUTH_PASSWORD=<same value as E2E_PASSWORD env var here>
+ */
+async function globalSetup() {
+  const authDir = path.dirname(authFile)
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true })
+  }
+
+  const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000"
+  const password = process.env.E2E_PASSWORD ?? "e2e-smoke-test"
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  await page.goto(`${baseURL}/login`)
+
+  // Preview-mode password form (only shown when VERCEL_ENV=preview)
+  await page.waitForSelector('input[name="password"]', { timeout: 30_000 })
+  await page.fill('input[name="password"]', password)
+  await page.getByRole("button", { name: "Preview Login" }).click()
+
+  // Wait until we leave /login (dashboard redirect)
+  await page.waitForURL((url) => !url.pathname.includes("login"), { timeout: 30_000 })
+
+  await context.storageState({ path: authFile })
+  await browser.close()
+}
+
+export default globalSetup

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -19,7 +19,14 @@ async function globalSetup() {
   }
 
   const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000"
-  const password = process.env.E2E_PASSWORD ?? "e2e-smoke-test"
+  const password = process.env.E2E_PASSWORD || "e2e-smoke-test"
+
+  if (process.env.CI && !process.env.E2E_PASSWORD) {
+    throw new Error(
+      "E2E_PASSWORD is empty. Set the GitHub Actions secret E2E_PASSWORD to the " +
+      "same value as PREVIEW_AUTH_PASSWORD on the Vercel deployment.",
+    )
+  }
 
   const browser = await chromium.launch()
   const context = await browser.newContext()

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -30,9 +30,9 @@ test("1. unauthenticated visitor is redirected to /login and can sign in", async
   await page.goto("/")
   await expect(page).toHaveURL(/\/login/, { timeout: 15_000 })
 
-  // Login page must show the Google OAuth button
+  // Login page must show the Google OAuth button (translation: "Continue with Google")
   await expect(
-    page.getByRole("button", { name: /sign in with google/i }),
+    page.getByRole("button", { name: /continue with google/i }),
   ).toBeVisible()
 
   // Sign in via preview-credentials (the OAuth stub for CI)
@@ -119,9 +119,11 @@ test("2. create an account, add a holding manually, and see it in the list", asy
   await accountCard.hover()
   const checkbox = accountCard.locator("..").locator('[role="checkbox"]').first()
   await checkbox.check()
+  // Register the dialog handler BEFORE the click — confirm() fires synchronously
+  // when the button is clicked, so a handler registered after would miss it and
+  // Playwright would auto-dismiss the dialog (= delete cancelled).
+  page.once("dialog", (d) => d.accept())
   await page.getByRole("button", { name: /delete \(1\)/i }).click()
-  // Confirm the browser dialog
-  page.on("dialog", (d) => d.accept())
   await expect(page.getByText(accountName)).not.toBeVisible({ timeout: 10_000 })
 })
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * R21 — Playwright smoke E2E
+ *
+ * Covers the three must-work paths:
+ *   1. Unauthenticated visitor → /login → sign-in (preview-credentials stub) → /
+ *   2. Create account → add holding via symbol search → holding appears
+ *   3. Dashboard loads with net-worth card + trend chart
+ *
+ * Auth strategy: Google OAuth is stubbed via Next.js's built-in
+ * Credentials provider, enabled when VERCEL_ENV=preview.  This avoids
+ * needing real Google tokens in CI while still exercising the full
+ * NextAuth session-creation path.  The global-setup logs in once and
+ * saves storage state; tests 2 & 3 reuse that state.
+ */
+
+import { test, expect, type Page } from "@playwright/test"
+
+// ---------------------------------------------------------------------------
+// Path 1 — Auth: unauthenticated redirect → login → sign-in → dashboard
+// ---------------------------------------------------------------------------
+
+test("1. unauthenticated visitor is redirected to /login and can sign in", async ({
+  browser,
+}) => {
+  // Fresh context — no cookies, no stored session
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  // Visiting the root without auth should redirect to /login
+  await page.goto("/")
+  await expect(page).toHaveURL(/\/login/, { timeout: 15_000 })
+
+  // Login page must show the Google OAuth button
+  await expect(
+    page.getByRole("button", { name: /sign in with google/i }),
+  ).toBeVisible()
+
+  // Sign in via preview-credentials (the OAuth stub for CI)
+  await page.fill('input[name="password"]', process.env.E2E_PASSWORD ?? "e2e-smoke-test")
+  await page.getByRole("button", { name: "Preview Login" }).click()
+
+  // After sign-in the user should land on the dashboard (root path)
+  await page.waitForURL((url) => !url.pathname.includes("login"), {
+    timeout: 30_000,
+  })
+  await expect(page).not.toHaveURL(/\/login/)
+
+  await ctx.close()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers used by paths 2 & 3  (these tests run with the saved auth state)
+// ---------------------------------------------------------------------------
+
+async function waitForPageReady(page: Page) {
+  await page.waitForLoadState("networkidle", { timeout: 20_000 })
+}
+
+// ---------------------------------------------------------------------------
+// Path 2 — Create account → add holding → holding appears
+// ---------------------------------------------------------------------------
+
+test("2. create an account, add a holding manually, and see it in the list", async ({
+  page,
+}) => {
+  await page.goto("/accounts")
+  await waitForPageReady(page)
+
+  // ── Create account ──────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Add Account" }).click()
+
+  // Dialog must be visible
+  await expect(page.getByRole("dialog")).toBeVisible()
+
+  const accountName = `E2E Brokerage ${Date.now()}`
+  await page.fill('input[placeholder="e.g. Chase Checking"]', accountName)
+
+  // Change category to Brokerage so we can add stock holdings to it
+  await page.getByRole("combobox").filter({ hasText: /bank|brokerage/i }).first().click()
+  await page.getByRole("option", { name: "Brokerage" }).click()
+
+  await page.getByRole("button", { name: "Create Account" }).click()
+
+  // Account card should appear
+  await expect(page.getByText(accountName)).toBeVisible({ timeout: 15_000 })
+
+  // ── Add holding ─────────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Add Item" }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+
+  // Skip the search step and enter the ticker manually
+  await page.getByRole("button", { name: "Enter manually" }).click()
+
+  const symbol = `TSTT${Date.now().toString().slice(-4)}` // unique-ish symbol
+  await page.fill('input[placeholder="e.g. AAPL"]', symbol)
+  await page.fill('input[placeholder="e.g. Apple Inc."]', "E2E Test Corp")
+  await page.fill('input[placeholder="e.g. 100"]', "5")
+
+  await page.getByRole("button", { name: "Next" }).click()
+
+  // Account-selection step: choose the account we just created
+  // If it's the only matching account it is pre-selected; otherwise pick it.
+  const selectTrigger = page.getByRole("combobox").filter({ hasText: /choose an account/i })
+  if (await selectTrigger.isVisible()) {
+    await selectTrigger.click()
+    await page.getByRole("option", { name: accountName }).click()
+  }
+
+  await page.getByRole("button", { name: "Add Holding" }).click()
+
+  // Holding symbol must appear somewhere on the page
+  await expect(page.getByText(symbol)).toBeVisible({ timeout: 15_000 })
+
+  // ── Cleanup: delete the test account ────────────────────────────────────
+  // Select the account checkbox and delete it so test runs stay idempotent
+  const accountCard = page.locator("a", { hasText: accountName })
+  await accountCard.hover()
+  const checkbox = accountCard.locator("..").locator('[role="checkbox"]').first()
+  await checkbox.check()
+  await page.getByRole("button", { name: /delete \(1\)/i }).click()
+  // Confirm the browser dialog
+  page.on("dialog", (d) => d.accept())
+  await expect(page.getByText(accountName)).not.toBeVisible({ timeout: 10_000 })
+})
+
+// ---------------------------------------------------------------------------
+// Path 3 — Dashboard: net-worth card + trend chart visible
+// ---------------------------------------------------------------------------
+
+test("3. dashboard renders the net-worth card and trend chart section", async ({
+  page,
+}) => {
+  await page.goto("/")
+  await waitForPageReady(page)
+
+  // Net-worth card: the heading "Net Worth" is rendered inside the card
+  await expect(
+    page.getByRole("heading", { name: /net worth/i }).first(),
+  ).toBeVisible({ timeout: 15_000 })
+
+  // Total-assets sub-card label
+  await expect(page.getByText(/total assets/i).first()).toBeVisible({
+    timeout: 15_000,
+  })
+
+  // Trend-chart section heading
+  await expect(page.getByText(/net worth trend/i).first()).toBeVisible({
+    timeout: 15_000,
+  })
+})

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -22,8 +22,8 @@ import { test, expect, type Page } from "@playwright/test"
 test("1. unauthenticated visitor is redirected to /login and can sign in", async ({
   browser,
 }) => {
-  // Fresh context — no cookies, no stored session
-  const ctx = await browser.newContext()
+  // Fresh context with no cookies — must not inherit the project storageState
+  const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } })
   const page = await ctx.newPage()
 
   // Visiting the root without auth should redirect to /login
@@ -92,8 +92,10 @@ test("2. create an account, add a holding manually, and see it in the list", asy
   await page.getByRole("button", { name: "Enter manually" }).click()
 
   const symbol = `TSTT${Date.now().toString().slice(-4)}` // unique-ish symbol
-  await page.fill('input[placeholder="e.g. AAPL"]', symbol)
+  // Fill name BEFORE symbol: the name input is inside {!symbol && ...} in the component
+  // and disappears as soon as the symbol field has a value.
   await page.fill('input[placeholder="e.g. Apple Inc."]', "E2E Test Corp")
+  await page.fill('input[placeholder="e.g. AAPL"]', symbol)
   await page.fill('input[placeholder="e.g. 100"]', "5")
 
   await page.getByRole("button", { name: "Next" }).click()
@@ -133,10 +135,8 @@ test("3. dashboard renders the net-worth card and trend chart section", async ({
   await page.goto("/")
   await waitForPageReady(page)
 
-  // Net-worth card: the heading "Net Worth" is rendered inside the card
-  await expect(
-    page.getByRole("heading", { name: /net worth/i }).first(),
-  ).toBeVisible({ timeout: 15_000 })
+  // Net-worth card: the label is a <p>, not a heading element
+  await expect(page.getByText(/net worth/i).first()).toBeVisible({ timeout: 15_000 })
 
   // Total-assets sub-card label
   await expect(page.getByText(/total assets/i).first()).toBeVisible({


### PR DESCRIPTION
Implements the three must-work paths from R21:
1. Unauthenticated visitor → /login → sign-in (preview-credentials
   OAuth stub) → dashboard
2. Create account → add holding via manual entry → holding appears
3. Dashboard loads with net-worth card + trend chart

Key files:
- playwright.config.ts — project config with webServer (local dev) /
  PLAYWRIGHT_TEST_BASE_URL (CI preview) switch, storageState project
- tests/e2e/global-setup.ts — one-time preview-credentials login,
  saves cookies to tests/e2e/.auth/user.json for reuse
- tests/e2e/smoke.spec.ts — three smoke tests with cleanup
- .github/workflows/e2e.yml — runs on PR/push to main; uploads HTML
  report as artifact; supports both local and preview-URL modes

The preview-credentials Credentials provider (VERCEL_ENV=preview +
PREVIEW_AUTH_PASSWORD) is used as the Google OAuth stub in CI so tests
pass without real Google tokens.  Set E2E_BASE_URL (repo variable) to
point at a live preview deployment URL; leave it unset to fall back to
a local dev server started by Playwright webServer.

https://claude.ai/code/session_011fmjzHiowQs3C11METCGar