### PR TITLE
R14: add timeout + retry guards on Yahoo Finance / CoinGecko calls

### DIFF
--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -1,3 +1,4 @@
 - 2026-04-24: [ADD]: R1 — Add baseline security headers (HSTS, XFO, XCTO, Referrer-Policy, Permissions-Policy) to `next.config.ts`
 - 2026-04-24: [ADD]: R3 — Add sliding-window rate limiter (`src/lib/rate-limit.ts`); apply to `/api/search` (60/min), `/api/exchange-rates` (30/min), and `/api/auth/*` (20/min via proxy middleware)
+- 2026-04-24: [ADD]: R14 — Add 5 s timeout + 2-retry exponential backoff (500 ms, 1.5 s) to Yahoo Finance and CoinGecko calls in `src/lib/services/price-service.ts`; per-symbol fallback isolation on Yahoo Finance batch failure
 - 2026-04-24: [ADD]: R20 — Add `.github/workflows/ci.yml`; runs `npm ci` → `prisma generate` → `lint` → `tsc --noEmit` → `next build` on every PR and push to master/main

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -17,7 +17,7 @@
 | R11 | Add `error.tsx`, `global-error.tsx`, `not-found.tsx`                        | Reliability           | 🔴 High   | 1–2 hrs  | ❌ Not Done |
 | R12 | Add `/api/health` endpoint                                                  | Reliability           | 🟡 Medium | 30 min   | ❌ Not Done |
 | R13 | Verify Vercel Cron `/api/cron/snapshot` fires daily in production           | Reliability           | 🔴 High   | 15 min   | ❌ Not Done |
-| R14 | Timeout + retry guards on Yahoo Finance / CoinGecko calls                   | Reliability           | 🔴 High   | 30–60 min| ❌ Not Done |
+| R14 | Timeout + retry guards on Yahoo Finance / CoinGecko calls                   | Reliability           | 🔴 High   | 30–60 min| ✅ Done     |
 | R15 | Switch Prisma `db push` → `migrate deploy` (committed migrations)           | Reliability           | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R16 | Document Neon backup / PITR SLA in `README.md`                              | Reliability           | 🟡 Medium | 30 min   | ❌ Not Done |
 | R17 | Ship Sentry (or equivalent) for error aggregation + alerts                  | Observability         | 🔴 High   | 1–2 hrs  | ❌ Not Done |

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,6 +1,44 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 
+const FETCH_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isRetryable(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "AbortError" || err.name === "TimeoutError") return true;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("etimedout") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("fetch failed") ||
+    msg.includes("timed out") ||
+    /\b5\d\d\b/.test(err.message)
+  );
+}
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt < RETRY_DELAYS_MS.length && isRetryable(err)) {
+        await sleep(RETRY_DELAYS_MS[attempt]);
+      } else {
+        break;
+      }
+    }
+  }
+  throw lastError;
+}
+
 const COINGECKO_IDS: Record<string, string> = {
   BTC: "bitcoin",
   ETH: "ethereum",
@@ -30,10 +68,21 @@ async function fetchYahooQuotes(
   const results = new Map<string, { price: number; currency: string }>();
   if (symbols.length === 0) return results;
 
-  try {
-    const YahooFinance = (await import("yahoo-finance2")).default;
-    const yahooFinance = new YahooFinance();
-    const quotes = await yahooFinance.quote(symbols);
+  const YahooFinance = (await import("yahoo-finance2")).default;
+  const yahooFinance = new YahooFinance();
+
+  const fetchSymbols = async (syms: string[]) => {
+    const quotes = await withRetry(() =>
+      Promise.race([
+        yahooFinance.quote(syms),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Yahoo Finance request timed out")),
+            FETCH_TIMEOUT_MS
+          )
+        ),
+      ])
+    );
     for (const q of Array.isArray(quotes) ? quotes : [quotes]) {
       if (q?.regularMarketPrice && q.symbol) {
         results.set(q.symbol, {
@@ -42,8 +91,22 @@ async function fetchYahooQuotes(
         });
       }
     }
-  } catch (error) {
-    console.error("Yahoo Finance fetch failed:", error);
+  };
+
+  try {
+    await fetchSymbols(symbols);
+  } catch (batchErr) {
+    // Batch failed after retries — fall back to per-symbol to isolate bad tickers
+    console.error("Yahoo Finance batch fetch failed, retrying per-symbol:", batchErr);
+    await Promise.allSettled(
+      symbols.map(async (symbol) => {
+        try {
+          await fetchSymbols([symbol]);
+        } catch (err) {
+          console.error(`Yahoo Finance fetch failed for ${symbol}:`, err);
+        }
+      })
+    );
   }
 
   return results;
@@ -79,17 +142,25 @@ export async function fetchCryptoPrices(
 
     const ids = symbolMap.map((s) => s.geckoId).filter(Boolean);
     if (ids.length > 0) {
+      const url = `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=usd`;
       try {
-        const res = await fetch(
-          `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=usd`,
-          { next: { revalidate: 60, tags: ["prices:crypto"] } }
-        );
-        if (res.ok) {
-          const data = await res.json();
-          for (const { original, geckoId } of symbolMap) {
-            if (data[geckoId]?.usd) {
-              results.set(original, { price: data[geckoId].usd, currency: "USD" });
-            }
+        const data = await withRetry(async () => {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+          try {
+            const res = await fetch(url, {
+              signal: controller.signal,
+              next: { revalidate: 60, tags: ["prices:crypto"] },
+            } as RequestInit);
+            if (!res.ok) throw new Error(`CoinGecko returned HTTP ${res.status}`);
+            return res.json() as Promise<Record<string, { usd: number }>>;
+          } finally {
+            clearTimeout(timeoutId);
+          }
+        });
+        for (const { original, geckoId } of symbolMap) {
+          if (data[geckoId]?.usd) {
+            results.set(original, { price: data[geckoId].usd, currency: "USD" });
           }
         }
       } catch (error) {


### PR DESCRIPTION
- 5 s AbortController/Promise.race timeout per HTTP call
- 2 retries (500 ms, 1.5 s backoff) on AbortError / 5xx / network errors
- Per-symbol fallback: if Yahoo Finance batch fails after retries, retries
  each symbol individually via Promise.allSettled so one bad ticker cannot
  block the rest
- CoinGecko: fresh AbortController per attempt so retries are not pre-cancelled
- Marks R14 ✅ Done in docs/RELEASE_READINESS.md

https://claude.ai/code/session_01XeeA2eLWX3Ytt1GYuY44LJ