### PR TITLE
fix(auth): skip auth-gate redirect for /api/auth/* in middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,6 +46,7 @@ export default auth((req) => {
   if (req.nextUrl.pathname.startsWith("/api/auth")) {
     const limited = _authRateLimit(req);
     if (limited) return limited;
+    return;
   }
 
   const isLoggedIn = !!req.auth;


### PR DESCRIPTION
## Summary

- Fixes Google login redirect loop introduced by [#144](https://github.com/mike840609/asset_tracker/pull/144) (`309b95b`).
- Adds an early `return` in [src/proxy.ts](src/proxy.ts) after the `/api/auth/*` rate-limit check so those requests reach NextAuth's route handler instead of being caught by the auth-gate redirect.

## Root cause

PR #144 removed `api/auth` from the middleware `matcher` exclusion so the inline rate limiter could throttle `/api/auth/*` to 20 req/min/IP. But the middleware body still ran the standard auth-gate:

```ts
const isLoggedIn = !!req.auth;
const isPublicRoute = ["/login", "/privacy"].includes(req.nextUrl.pathname);
if (!isLoggedIn && !isPublicRoute) return Response.redirect(new URL("/login", ...));
```

When Google redirected back to `/api/auth/callback/google?code=...`, the session JWT had not yet been written (the callback handler is what writes it), so `req.auth` was `null`, the path was not in the public-route list, and middleware redirected the browser to `/login`. The NextAuth callback never ran → redirect loop.

## Fix

One-line change in `src/proxy.ts`: after the rate-limit check inside the `/api/auth` branch, `return` immediately so the auth-gate / locale-cookie logic is skipped for those paths.

## Test plan

- [x] `/login` renders.
- [x] `/accounts` while logged out → 302 to `/login` (auth gate still working).
- [x] `/api/auth/session` x 25 same IP → 20× `200` then 5× `429` (rate limiter still working, no longer 302→`/login`).
- [ ] Click "Continue with Google" in a real browser and confirm landing on `/` with a session cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)