### PR TITLE
fix(ci): regenerate package-lock.json with npm 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9556,6 +9556,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",


### PR DESCRIPTION
## Summary
- Master's CI was still failing with `EUSAGE / Missing: @swc/helpers@0.5.21 from lock file` after [#155](https://github.com/mike840609/asset_tracker/pull/155).
- Root cause: the lock file was regenerated locally with npm 11, but CI's Node 22 ships with npm 10, and the two versions disagree on whether to materialize the optional peer dep `@swc/helpers` (pulled in by `next-intl`) into the lock tree. npm 10 expects it, npm 11 omits it — so npm 10's `npm ci` rejects an npm-11-written lock.
- Regenerated `package-lock.json` with `npm@10` (`npx -y npm@10 install --package-lock-only --ignore-scripts`) so the file matches what CI's resolver expects.

## Test plan
- [x] `npx -y npm@10 ci` succeeds locally (matches CI's npm version)
- [x] `@swc/helpers@0.5.21` now present in the lock tree
- [ ] GitHub Actions CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)