### PR TITLE
chore(ci): bump checkout/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       CRON_SECRET: "ci-cron-secret"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## Summary
- GitHub deprecation warning: `actions/checkout@v4` and `actions/setup-node@v4` still run on Node.js 20, which will be force-migrated to Node 24 on 2026-06-02 and removed entirely on 2026-09-16.
- Bumping both to `v5`, which natively run on Node 24, silences the warning and gets us off the deprecation path.
- The workflow's own `node-version: "22"` (the Node version used to run our project) is unchanged — only the actions' own runtime moves.

## Test plan
- [ ] CI on this PR is green (lint, type-check, build all still pass)
- [ ] No deprecation warning in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)