### PR TITLE
feat: implement R7 cookie/analytics consent banner

### DIFF
--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -5,3 +5,4 @@
 - 2026-04-24: [ADD]: R21 — Add Playwright smoke E2E suite (`playwright.config.ts`, `tests/e2e/global-setup.ts`, `tests/e2e/smoke.spec.ts`, `.github/workflows/e2e.yml`); covers unauthenticated redirect → login, account + holding creation, and dashboard net-worth card + trend chart; auth stubbed via preview-credentials provider
 - 2026-04-25: [MOD]: R9 — Verify Google OAuth consent screen is published & verified; marked as done in docs
 - 2026-04-25: [ADD]: R6 — Add `/terms` (Terms of Service) page
+- 2026-04-25: [ADD]: R7 — Add cookie / analytics consent banner and gate Vercel Analytics and Speed Insights

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -10,7 +10,7 @@
 | R4  | `crypto.timingSafeEqual` compare for `CRON_SECRET`                          | Security              | 🟡 Medium | 15 min   | ❌ Not Done |
 | R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ❌ Not Done |
 | R6  | Add `/terms` (Terms of Service) page                                        | Legal / Compliance    | 🔴 High   | 1–2 hrs  | ❌ Not Done |
-| R7  | Cookie / analytics consent banner                                           | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |
+| R7  | Cookie / analytics consent banner                                           | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ✅ Done     |
 | R8  | GDPR data-export + delete-account flows                                     | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R9  | Verify Google OAuth consent screen is published & verified                  | Legal / Compliance    | 🔴 High   | 30 min   | ✅ Done     |
 | R10 | Add support/contact email in footer + `/privacy`                            | Legal / Compliance    | 🟡 Medium | 15 min   | ❌ Not Done |

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,8 @@ import localFont from "next/font/local";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { CustomSpeedInsights } from "@/components/layout/speed-insights";
-import { Analytics } from "@vercel/analytics/next";
+import { CustomAnalytics } from "@/components/layout/analytics";
+import { ConsentBanner } from "@/components/layout/consent-banner";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { pickMessages } from "@/lib/i18n-utils";
@@ -102,8 +103,9 @@ export default function RootLayout({
             <LocaleProviders>{children}</LocaleProviders>
           </Suspense>
           <Toaster />
-          <Analytics />
+          <CustomAnalytics />
           <CustomSpeedInsights />
+          <ConsentBanner />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/layout/analytics.tsx
+++ b/src/components/layout/analytics.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Analytics } from "@vercel/analytics/next";
+import { hasConsent } from "@/lib/consent";
+
+export function CustomAnalytics() {
+  return (
+    <Analytics
+      beforeSend={(event) => {
+        if (!hasConsent()) return null;
+        if (event.url.includes("/login") || event.url.includes("/privacy")) {
+          return null;
+        }
+        return event;
+      }}
+    />
+  );
+}

--- a/src/components/layout/consent-banner.tsx
+++ b/src/components/layout/consent-banner.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState, startTransition } from "react";
+import { Button } from "@/components/ui/button";
+
+export function ConsentBanner() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    // Check if consent has already been given or rejected
+    const hasConsentCookie = document.cookie.includes("cookie-consent=");
+    if (!hasConsentCookie) {
+      startTransition(() => {
+        setShow(true);
+      });
+    }
+  }, []);
+
+  const handleAccept = () => {
+    // Set cookie for 1 year
+    document.cookie = "cookie-consent=true; path=/; max-age=31536000; SameSite=Lax";
+    setShow(false);
+  };
+
+  const handleReject = () => {
+    // Set cookie for 1 year
+    document.cookie = "cookie-consent=false; path=/; max-age=31536000; SameSite=Lax";
+    setShow(false);
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-background/80 backdrop-blur-md border-t shadow-lg flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div className="text-sm text-muted-foreground flex-1">
+        We use essential cookies to make our site work. With your consent, we may also use non-essential cookies to improve user experience and analyze website traffic.
+      </div>
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={handleReject}>
+          Reject non-essential
+        </Button>
+        <Button onClick={handleAccept}>
+          Accept
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/speed-insights.tsx
+++ b/src/components/layout/speed-insights.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { hasConsent } from "@/lib/consent";
 
 export function CustomSpeedInsights() {
   return (
     <SpeedInsights
       beforeSend={(data) => {
+        if (!hasConsent()) return null;
         if (data.url.includes("/login") || data.url.includes("/privacy")) {
           return null;
         }

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,4 @@
+export function hasConsent(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie.split("; ").includes("cookie-consent=true");
+}


### PR DESCRIPTION
Closes R7.

This PR implements the missing analytics and cookie consent banner as tracked in `RELEASE_READINESS.md`.

- Added `ConsentBanner` component at the bottom of the screen.
- Used `beforeSend` to gate both Vercel Analytics and Speed Insights until explicit consent is given.
- Updated `RELEASE_READINESS.md` and `LOG.md` accordingly.