### PR TITLE
fix: enforce account/holding ownership on every mutation route (R5)

### DIFF
--- a/docs/LOG.md
+++ b/docs/LOG.md
@@ -5,4 +5,4 @@
 - 2026-04-24: [ADD]: R21 — Add Playwright smoke E2E suite (`playwright.config.ts`, `tests/e2e/global-setup.ts`, `tests/e2e/smoke.spec.ts`, `.github/workflows/e2e.yml`); covers unauthenticated redirect → login, account + holding creation, and dashboard net-worth card + trend chart; auth stubbed via preview-credentials provider
 - 2026-04-25: [MOD]: R9 — Verify Google OAuth consent screen is published & verified; marked as done in docs
 - 2026-04-25: [ADD]: R6 — Add `/terms` (Terms of Service) page
-
+- 2026-04-25: [MOD]: R5 — Enforce account/holding ownership on every mutation route (`holdings`, `transactions`, `cash-transactions`)

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -8,7 +8,7 @@
 | R2  | Content-Security-Policy (Report-Only → enforce)                             | Security              | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R3  | Rate limit `/api/search`, `/api/exchange-rates`, `/api/auth/*`              | Security              | 🔴 High   | 2–3 hrs  | ✅ Done     |
 | R4  | `crypto.timingSafeEqual` compare for `CRON_SECRET`                          | Security              | 🟡 Medium | 15 min   | ❌ Not Done |
-| R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ❌ Not Done |
+| R5  | Enforce account/holding ownership on every mutation route                   | Security              | 🔴 High   | 1–2 hrs  | ✅ Done     |
 | R6  | Add `/terms` (Terms of Service) page                                        | Legal / Compliance    | 🔴 High   | 1–2 hrs  | ✅ Done     |
 | R7  | Cookie / analytics consent banner                                           | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |
 | R8  | GDPR data-export + delete-account flows                                     | Legal / Compliance    | 🔴 High   | 2–3 hrs  | ❌ Not Done |

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -2,11 +2,11 @@ import { prisma } from "@/lib/prisma";
 import { createCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+type IdCtx = { params: Promise<{ id: string }> };
+
+export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
   const body = await request.json();
   const parsed = createCashTransactionSchema.safeParse(body);
@@ -14,7 +14,7 @@ export async function POST(
 
   const { type, amount, note } = parsed.data;
 
-  const account = await prisma.account.findUnique({ where: { id } });
+  const account = await prisma.account.findUnique({ where: { id, userId } });
   if (!account) return failure("Account not found", 404);
 
   const transaction = await prisma.cashTransaction.create({
@@ -28,4 +28,4 @@ export async function POST(
   });
 
   return ok(transaction, { status: 201 });
-}
+});

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -32,6 +32,9 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   const parsed = createHoldingSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
 
+  const account = await prisma.account.findUnique({ where: { id, userId } });
+  if (!account) return failure("Account not found", 404);
+
   // Check if holding already exists in this account
   const existing = await prisma.holding.findUnique({
     where: { accountId_symbol: { accountId: id, symbol: parsed.data.symbol } },
@@ -87,21 +90,21 @@ export const PATCH = withAuth<IdCtx>(async (request, _ctx, userId) => {
 
   const { id, ...data } = parsed.data;
 
+  const existingHolding = await prisma.holding.findUnique({ where: { id }, include: { account: true } });
+  if (!existingHolding || existingHolding.account.userId !== userId) return failure("Holding not found", 404);
+
   // Log quantity change as EDIT transaction
   if (data.quantity !== undefined) {
-    const existing = await prisma.holding.findUnique({ where: { id } });
-    if (existing) {
-      const diff = data.quantity - Number(existing.quantity);
-      if (diff !== 0) {
-        await prisma.holdingTransaction.create({
-          data: {
-            holdingId: id,
-            type: "EDIT",
-            quantity: diff,
-            note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
-          },
-        });
-      }
+    const diff = data.quantity - Number(existingHolding.quantity);
+    if (diff !== 0) {
+      await prisma.holdingTransaction.create({
+        data: {
+          holdingId: id,
+          type: "EDIT",
+          quantity: diff,
+          note: `Quantity changed from ${Number(existingHolding.quantity)} to ${data.quantity}`,
+        },
+      });
     }
   }
 
@@ -114,6 +117,9 @@ export const DELETE = withAuth<IdCtx>(async (request, _ctx, userId) => {
   const body = await request.json();
   const { id } = body;
   if (!id) return failure("Holding ID required");
+
+  const existing = await prisma.holding.findUnique({ where: { id }, include: { account: true } });
+  if (!existing || existing.account.userId !== userId) return failure("Holding not found", 404);
 
   await prisma.holding.delete({ where: { id } });
   invalidateUserCaches(userId);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -2,13 +2,16 @@ import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string; transactionId: string }> }
-) {
+type TxCtx = { params: Promise<{ id: string; transactionId: string }> };
+
+export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
   const body = await request.json();
+
+  const account = await prisma.account.findUnique({ where: { id: accountId, userId } });
+  if (!account) return failure("Account not found", 404);
 
   // Determine if it's a HoldingTransaction or CashTransaction
   const holdingTx = await prisma.holdingTransaction.findUnique({
@@ -100,13 +103,13 @@ export async function PATCH(
   }
 
   return failure("Transaction not found", 404);
-}
+});
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: Promise<{ id: string; transactionId: string }> }
-) {
+export const DELETE = withAuth<TxCtx>(async (request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
+
+  const account = await prisma.account.findUnique({ where: { id: accountId, userId } });
+  if (!account) return failure("Account not found", 404);
 
   const holdingTx = await prisma.holdingTransaction.findUnique({
     where: { id: transactionId },
@@ -149,4 +152,4 @@ export async function DELETE(
   }
 
   return failure("Transaction not found", 404);
-}
+});

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
-import { ok } from "@/lib/api-responses";
+import { ok, failure } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
 
 interface UnifiedRow {
   id: string;
@@ -11,11 +12,14 @@ interface UnifiedRow {
   holdingId: string | null;
 }
 
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+type IdCtx = { params: Promise<{ id: string }> };
+
+export const GET = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
+  
+  const account = await prisma.account.findUnique({ where: { id, userId } });
+  if (!account) return failure("Account not found", 404);
+
   const { searchParams } = new URL(request.url);
 
   const page = Math.max(1, Number(searchParams.get("page") || "1"));
@@ -64,4 +68,4 @@ export async function GET(
   }));
 
   return ok(result);
-}
+});


### PR DESCRIPTION
This PR fixes R5: Enforce account/holding ownership on every mutation route. Added withAuth wrappers to transactions and cash-transactions endpoints, and ensured that holdings and transactions are verified against the session user's account before modification.