### PR TITLE
fix(settings): swap export/import icons and align export button style

### DIFF
--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -126,14 +126,15 @@ export function DataManagement() {
               <p className="text-sm text-muted-foreground">{t("exportDescription")}</p>
             </div>
             <Button
+              variant="outline"
               onClick={handleExport}
               disabled={isExporting}
-              className="w-full sm:w-auto min-w-[200px]"
+              className="w-full min-w-[200px]"
             >
               {isExporting ? (
                 <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
               ) : (
-                <DownloadIcon className="mr-2 h-4 w-4" />
+                <UploadIcon className="mr-2 h-4 w-4" />
               )}
               {t("export")}
             </Button>
@@ -163,7 +164,7 @@ export function DataManagement() {
                 {isImporting ? (
                   <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
-                  <UploadIcon className="mr-2 h-4 w-4" />
+                  <DownloadIcon className="mr-2 h-4 w-4" />
                 )}
                 {t("importButton")}
               </Button>


### PR DESCRIPTION
## Summary
- Swapped icons: Export button now shows `UploadIcon`, Import button now shows `DownloadIcon`
- Aligned Export button style to match Import button: added `variant="outline"` and removed `sm:w-auto` for consistent sizing

## Test plan
- [ ] Navigate to Settings tab
- [ ] Verify Export button has the upload icon and outline style
- [ ] Verify Import button has the download icon (outline style unchanged)
- [ ] Confirm both buttons function correctly (export downloads JSON, import opens file picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)