### PR TITLE
fix(e2e): isolate tests to dedicated user, add global teardown

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ const E2E_PASSWORD = process.env.E2E_PASSWORD ?? "e2e-smoke-test"
 
 export default defineConfig({
   globalSetup: "./tests/e2e/global-setup",
+  globalTeardown: "./tests/e2e/global-teardown",
   testDir: "./tests/e2e",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,7 +18,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         if (VERCEL_ENV !== "preview") return null
         const expected = PREVIEW_AUTH_PASSWORD
         if (!expected || credentials?.password !== expected) return null
-        const user = await prisma.user.findFirst()
+        const E2E_TEST_EMAIL = "e2e-test@preview.local"
+        const user = await prisma.user.upsert({
+          where: { email: E2E_TEST_EMAIL },
+          update: {},
+          create: { email: E2E_TEST_EMAIL, name: "E2E Test User" },
+        })
         if (!user) return null
         return { id: user.id, name: user.name, email: user.email, image: user.image }
       },

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -14,7 +14,7 @@ async function globalTeardown() {
   try {
     const res = await context.request.get(`${baseURL}/api/accounts`)
     if (res.ok()) {
-      const accounts: { id: string; name: string }[] = await res.json()
+      const { data: accounts }: { data: { id: string; name: string }[] } = await res.json()
       const e2eIds = accounts
         .filter((a) => a.name.startsWith("E2E "))
         .map((a) => a.id)

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,32 @@
+import { chromium } from "@playwright/test"
+import path from "path"
+import fs from "fs"
+
+const authFile = path.join(__dirname, ".auth/user.json")
+
+async function globalTeardown() {
+  if (!fs.existsSync(authFile)) return
+
+  const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000"
+  const browser = await chromium.launch()
+  const context = await browser.newContext({ storageState: authFile })
+
+  try {
+    const res = await context.request.get(`${baseURL}/api/accounts`)
+    if (res.ok()) {
+      const accounts: { id: string; name: string }[] = await res.json()
+      const e2eIds = accounts
+        .filter((a) => a.name.startsWith("E2E "))
+        .map((a) => a.id)
+      if (e2eIds.length > 0) {
+        await context.request.delete(`${baseURL}/api/accounts`, {
+          data: { ids: e2eIds },
+        })
+      }
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+export default globalTeardown

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -113,6 +113,9 @@ test("2. create an account, add a holding manually, and see it in the list", asy
   // Holding symbol must appear somewhere on the page
   await expect(page.getByText(symbol)).toBeVisible({ timeout: 15_000 })
 
+  // Wait for the "Add Holding" dialog to fully close before hovering
+  await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10_000 })
+
   // ── Cleanup: delete the test account ────────────────────────────────────
   // Select the account checkbox and delete it so test runs stay idempotent
   const accountCard = page.locator("a", { hasText: accountName })


### PR DESCRIPTION
## Summary

- **Root cause**: `src/auth.ts` preview credentials used `prisma.user.findFirst()`, which logged CI tests in as the first real user — all test-created accounts accumulated in that user's account when cleanup failed
- **Fix 1**: Replace `findFirst()` with `upsert` of a fixed `e2e-test@preview.local` user so test data is always isolated from real accounts
- **Fix 2**: Add `tests/e2e/global-teardown.ts` — after every test run, batch-deletes all accounts starting with `"E2E "` via the REST API using the saved auth state
- **Fix 3**: Register `globalTeardown` in `playwright.config.ts`

## Test plan

- [ ] Verify `e2e-test@preview.local` user is upserted on preview login (Prisma Studio)
- [ ] Confirm real user's account list is unaffected after a test run
- [ ] Confirm no `E2E Brokerage ...` accounts remain after teardown
- [ ] Run tests twice to confirm idempotency

## Notes for reviewer

The `e2e-test@preview.local` user is created automatically on first preview login — no manual DB setup needed. The credentials provider only runs when `VERCEL_ENV=preview`, so production is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)