### PR TITLE
docs: refresh CLAUDE.md and README.md to match current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,14 @@ ANALYZE=true npm run build  # Build with @next/bundle-analyzer HTML reports
 npm run lint         # Run ESLint
 
 # Database
-npx prisma generate  # Regenerate Prisma client after schema changes
+npx prisma generate  # Regenerate Prisma client after schema changes (also runs automatically via `postinstall` after `npm install`)
 npx prisma db push   # Push schema to database (dev)
 npx prisma studio    # Open Prisma Studio GUI
+
+# E2E tests (Playwright)
+npm run test:e2e         # Run Playwright suite headless
+npm run test:e2e:ui      # Open the Playwright UI runner
+npm run test:e2e:report  # Open the last HTML report
 ```
 
 ## Architecture
@@ -50,33 +55,39 @@ npx prisma studio    # Open Prisma Studio GUI
 ### Route Structure
 
 ```
-src/app/
-├── layout.tsx              # Root layout (fonts, global CSS)
-├── login/page.tsx          # Public login page
-├── (main)/                 # Auth-gated route group
-│   ├── layout.tsx          # Sidebar + mobile header shell
-│   ├── page.tsx            # Dashboard
-│   ├── accounts/page.tsx   # Accounts list
-│   ├── accounts/[id]/      # Account detail page
-│   └── settings/           # User settings
-└── api/
-    ├── auth/[...nextauth]/ # NextAuth handlers
-    ├── accounts/           # CRUD for accounts
-    ├── accounts/[id]/holdings/          # Holdings CRUD
-    ├── accounts/[id]/transactions/      # HoldingTransaction CRUD
-    ├── accounts/[id]/cash-transactions/ # CashTransaction CRUD
-    ├── exchange-rates/     # Fetch + refresh exchange rates
-    ├── prices/refresh/     # Manual price refresh trigger
-    ├── snapshots/          # Net worth snapshot history
-    ├── search/             # Holding symbol search (Yahoo Finance)
-    ├── settings/           # User settings API
-    └── cron/snapshot/      # Daily cron job (requires CRON_SECRET bearer token)
+src/
+├── app/
+│   ├── layout.tsx              # Root layout (fonts, global CSS)
+│   ├── login/page.tsx          # Public login page
+│   ├── privacy/, terms/        # Public legal pages
+│   ├── (main)/                 # Auth-gated route group
+│   │   ├── layout.tsx          # Sidebar + mobile header shell
+│   │   ├── page.tsx            # Dashboard
+│   │   ├── accounts/           # Accounts list + [id] detail
+│   │   ├── analysis/           # /analysis tab (see docs/ANALYSIS_ROADMAP.md)
+│   │   ├── history/            # Net worth history view
+│   │   └── settings/           # User settings
+│   └── api/
+│       ├── auth/[...nextauth]/ # NextAuth handlers
+│       ├── accounts/           # CRUD for accounts
+│       ├── accounts/[id]/holdings/          # Holdings CRUD
+│       ├── accounts/[id]/transactions/      # HoldingTransaction CRUD
+│       ├── accounts/[id]/cash-transactions/ # CashTransaction CRUD
+│       ├── exchange-rates/     # Fetch + refresh exchange rates
+│       ├── prices/refresh/     # Manual price refresh trigger
+│       ├── snapshots/          # Net worth snapshot history
+│       ├── search/             # Holding symbol search (Yahoo Finance)
+│       ├── settings/           # User settings API
+│       └── cron/snapshot/      # Daily cron job (requires CRON_SECRET bearer token)
+├── hooks/                      # Client hooks (use-chart-animation, use-count-up)
+└── proxy.ts                    # Server-side proxy module (used by service layer)
 ```
 
 ### Next.js 16 Breaking Changes
 
+> ⚠️ This is **not** the Next.js most training data describes. APIs, conventions, and file structure have shifted. Before writing code that touches a Next.js API, read the relevant page in `node_modules/next/dist/docs/` and heed deprecation notices — guessing from memory will produce broken code.
+
 - **`params` is a `Promise`** — page components receive `params: Promise<{ id: string }>` and must `await params` before accessing fields.
-- Read `node_modules/next/dist/docs/` for any Next.js APIs before using them — many APIs changed from earlier versions.
 
 ### Cache model (`cacheComponents: true`)
 
@@ -146,9 +157,29 @@ Config entry point: `src/i18n/request.ts` (loaded by `next.config.ts` via `creat
 - Two-pass algorithm: first pass collects missing rate pairs, second pass computes values after batch-fetching missing rates
 - `getNetWorthSummary(userId, baseCurrency)` returns fully computed `NetWorthSummary`
 
+**Other services in `src/lib/services/`:**
+- `snapshot-service.ts` — creates `NetWorthSnapshot` rows with the lossless per-account breakdown
+- `history-service.ts` — reads snapshots and renormalizes them on the fly into the user's current base currency
+- `analysis-service.ts` — backs the `/analysis` tab
+- `settings-service.ts` — user settings reads/writes
+- `balance.ts` — shared balance/value computation helpers
+
+### API utilities
+
+- `src/lib/api-handler.ts` + `src/lib/api-responses.ts` — standardized request handling and JSON response shapes for route handlers.
+- `src/lib/rate-limit.ts` — in-process rate limiter; wrap any new public-facing or cron-adjacent API route with it.
+- `src/lib/validators.ts` — Zod 4 schemas for all API input validation.
+
 ### Daily Snapshot Cron
 
-`GET /api/cron/snapshot` — requires `Authorization: Bearer <CRON_SECRET>` header. Refreshes all prices, then creates `NetWorthSnapshot` records for every user. Scheduled in `vercel.json` at `30 21 * * *` (21:30 UTC daily); `maxDuration` is 60s and the function region is pinned to `sin1` to match the Neon database region.
+`GET /api/cron/snapshot` — requires `Authorization: Bearer <CRON_SECRET>` header. Refreshes all prices, then creates `NetWorthSnapshot` records for every user. Scheduled in `vercel.json` at `30 21 * * *` (21:30 UTC daily); `maxDuration` is 60s and the function region is pinned to `sin1` to match the Neon database region. (Note: `README.md` still says "00:00 UTC" — `vercel.json` and this file are the source of truth.)
+
+### E2E Testing (Playwright)
+
+- Specs live in `tests/e2e/` (`smoke.spec.ts` is the entry; `global-setup.ts` / `global-teardown.ts` provision and tear down a dedicated test user so runs don't pollute real user data — see commit `3289e91`).
+- Stored auth state: `tests/e2e/.auth/user.json` (loaded by the `chromium` project).
+- The config auto-starts `npm run dev` with `VERCEL_ENV=preview` and `PREVIEW_AUTH_PASSWORD=<E2E_PASSWORD>` unless `PLAYWRIGHT_TEST_BASE_URL` is set; CI sets that var to skip the bootstrap and run against an existing deployment.
+- `fullyParallel: false` and `workers: 1` — the suite is intentionally serial; do not parallelize without revisiting the global setup.
 
 ### Component Organization
 
@@ -193,3 +224,4 @@ Before proposing changes, check whether the work is already tracked in one of th
 - `docs/ANALYSIS_ROADMAP.md` — `/analysis` tab feature roadmap
 - `docs/RELEASE_READINESS.md` — pre-market-launch blockers (R1–R26)
 - `docs/DOCS_REVIEW_SUGGESTIONS.md` — consolidated cross-doc recommendations
+- `docs/LOG.md` — running engineering log / decision journal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern, high-performance net worth and investment tracker. Built with **Next.js 16**, **Prisma**, and **Tailwind CSS**.
 
-![Dashboard Mockup](https://images.unsplash.com/photo-1611974714013-3c8c0d088bd3?auto=format&fit=crop&q=80&w=1200&h=400)
+![Assets Tracker](./public/opengraph-image.png)
 
 ## ✨ Features
 
@@ -32,7 +32,7 @@ A modern, high-performance net worth and investment tracker. Built with **Next.j
 
 ### 1. Prerequisites
 
-- Node.js 18+
+- Node.js 20.9+ (required by Next.js 16)
 - A [Neon](https://neon.tech) PostgreSQL database (or any PostgreSQL with a Neon-compatible connection string)
 - A Google OAuth app (for authentication)
 
@@ -67,13 +67,24 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) to see your dashboard.
 
+### 5. End-to-End Tests
+
+A Playwright suite lives in `tests/e2e/`. The global setup provisions a dedicated test user so runs don't pollute real data.
+
+```bash
+npm run test:e2e         # Run headless
+npm run test:e2e:ui      # Open the Playwright UI runner
+npm run test:e2e:report  # Open the last HTML report
+```
+
 ## 🤖 Automated Snapshots (Cron Jobs)
 
 This project is optimized for **Vercel** and includes native Cron Job support via `vercel.json`.
 
 - **Endpoint**: `/api/cron/snapshot`
-- **Schedule**: Every day at 00:00 UTC.
+- **Schedule**: Every day at 21:30 UTC (`30 21 * * *`).
 - **Security**: Protected via `CRON_SECRET` header verification.
+- **Region**: Functions are pinned to `sin1` to colocate with the Neon database. If your Neon project lives in a different region, update `regions` in `vercel.json` to match.
 
 To enable automation, deploy to Vercel and set all environment variables in your project settings.
 


### PR DESCRIPTION
## Summary
- Bring `CLAUDE.md` in sync with the current codebase: Playwright E2E commands & section, expanded route tree, full service inventory, API utilities, promoted Next.js 16 warning, and `docs/LOG.md` reference.
- Fix factual bugs in `README.md`: cron schedule was `00:00 UTC` but `vercel.json` runs `30 21 * * *` (21:30 UTC), and Node prerequisite was `18+` but Next.js 16 requires `20.9+`.
- Add a Playwright E2E section to the README and a note about the `sin1` region pin.
- Swap the Unsplash placeholder header image for the local `public/opengraph-image.png`.

## Test plan
- [ ] `CLAUDE.md` renders correctly on GitHub
- [ ] `README.md` renders correctly on GitHub and the opengraph image displays
- [ ] No code changes — no build/test impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)