### PR TITLE
ci: skip CI and Vercel deployments for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   push:
     branches: [master, main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   ci:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ npx prisma migrate resolve --applied <migration>   # One-shot baseline: mark a m
 npx prisma db push                                 # Quick prototype-only schema sync — bypasses migration history; commit a migrate dev before merging
 npx prisma studio                                  # Open Prisma Studio GUI
 
+# Skip CI/Vercel for a one-off commit: add [skip ci] or [skip actions] to the commit message
+
 # E2E tests (Playwright)
 npm run test:e2e         # Run Playwright suite headless
 npm run test:e2e:ui      # Open the Playwright UI runner

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff HEAD^ HEAD --name-only | grep -qvE '(\\.md$|^docs/)'",
   "buildCommand": "npm run build:vercel",
   "regions": ["sin1"],
   "crons": [


### PR DESCRIPTION
## Summary
- `paths-ignore` added to `ci.yml` — lint/type-check/build are skipped entirely when only `.md` files or `docs/**` change. GitHub marks skipped checks as neutral, which satisfies branch-protection required checks without any rule changes.
- `ignoreCommand` added to `vercel.json` — Vercel runs `git diff HEAD^ HEAD --name-only | grep -qvE '(\.md$|^docs/)'` before each build; exits 1 (skip deployment) when all changed files are doc-only, exits 0 (build) otherwise. Since `e2e.yml` triggers on `deployment_status` events, skipping Vercel automatically skips E2E too.
- `[skip ci]` / `[skip actions]` escape hatch noted in `CLAUDE.md` for one-off manual overrides.

## Test plan
- [ ] Open a doc-only PR (only `.md` / `docs/` changes) → CI job shows "skipped", Vercel shows no deployment
- [ ] Open a PR with `.ts`/`.tsx` changes (even mixed with docs) → CI and Vercel run normally
- [ ] Merge a doc-only commit to `master` → no production Vercel redeploy triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)