### PR TITLE
ui: mobile navbar auto-hide and pull-to-refresh

### DIFF
--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -6,6 +6,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
 import { HistoryTable } from "@/components/history/history-table";
+import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { getNormalizedHistory } from "@/lib/services/history-service";
 import HistoryLoading from "./loading";
 
@@ -24,19 +25,21 @@ async function HistoryContent() {
 
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
-      <div className="space-y-8 animate-in fade-in duration-500">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground">
-          {t("title")}
-        </h2>
+      <HistoryPullRefresh>
+        <div className="space-y-8 animate-in fade-in duration-500">
+          <h2 className="text-3xl font-bold tracking-tight text-foreground">
+            {t("title")}
+          </h2>
 
-        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
-          <LazyTrendChart baseCurrency={settings.baseCurrency} snapshots={snapshots} hideRangeFilter />
-        </div>
+          <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+            <LazyTrendChart baseCurrency={settings.baseCurrency} snapshots={snapshots} hideRangeFilter />
+          </div>
 
-        <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
-          <HistoryTable snapshots={snapshots} baseCurrency={settings.baseCurrency} />
+          <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+            <HistoryTable snapshots={snapshots} baseCurrency={settings.baseCurrency} />
+          </div>
         </div>
-      </div>
+      </HistoryPullRefresh>
     </NextIntlClientProvider>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
+import { DashboardPullRefresh } from "@/components/dashboard/dashboard-pull-refresh";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
@@ -28,15 +29,17 @@ async function DashboardPageContent() {
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
-      <div className="space-y-8 animate-in fade-in duration-500">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground">
-            {t("title")}
-          </h2>
-        </div>
+      <DashboardPullRefresh>
+        <div className="space-y-8 animate-in fade-in duration-500">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground">
+              {t("title")}
+            </h2>
+          </div>
 
-        <DashboardContent userId={userId} />
-      </div>
+          <DashboardContent userId={userId} />
+        </div>
+      </DashboardPullRefresh>
     </NextIntlClientProvider>
   );
 }

--- a/src/components/accounts/option-builder.tsx
+++ b/src/components/accounts/option-builder.tsx
@@ -68,7 +68,7 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
   const [chain, setChain] = useState<ChainResponse | null>(null);
   const [chainLoading, setChainLoading] = useState(false);
   const [chainError, setChainError] = useState<string | null>(null);
-  const [expChainLoading, setExpChainLoading] = useState(false);
+  const [failedExpirations, setFailedExpirations] = useState<Set<string>>(new Set());
 
   const [expiration, setExpiration] = useState("");
   const [side, setSide] = useState<OptionSide>("CALL");
@@ -105,28 +105,42 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
   }, []);
 
   // Lazy-load chain data when user picks an expiration not yet fetched.
-  const underlyingRef = useRef(underlying);
-  underlyingRef.current = underlying;
   useEffect(() => {
-    if (!chain || !expiration || chain.chains[expiration]) return;
-    setExpChainLoading(true);
-    const sym = underlyingRef.current;
-    fetch(`/api/options/chain?symbol=${encodeURIComponent(sym)}&date=${expiration}`)
+    if (!chain || !expiration) return;
+    if (chain.chains[expiration]) return;
+    if (failedExpirations.has(expiration)) return;
+    const sym = chain.underlying;
+    const exp = expiration;
+    fetch(`/api/options/chain?symbol=${encodeURIComponent(sym)}&date=${exp}`)
       .then((r) => r.json())
       .then(({ data }: { data: ChainResponse }) => {
-        if (data.chains[expiration]) {
+        if (data.chains[exp]) {
           setChain((prev) =>
             prev ? { ...prev, chains: { ...prev.chains, ...data.chains } } : null,
           );
+        } else {
+          setFailedExpirations((prev) => new Set(prev).add(exp));
         }
       })
-      .catch((err) => console.error("Chain fetch error:", err))
-      .finally(() => setExpChainLoading(false));
-  }, [chain, expiration]);
+      .catch((err) => {
+        console.error("Chain fetch error:", err);
+        setFailedExpirations((prev) => new Set(prev).add(exp));
+      });
+  }, [chain, expiration, failedExpirations]);
+
+  const expChainLoading =
+    !!chain &&
+    !!expiration &&
+    !chain.chains[expiration] &&
+    !failedExpirations.has(expiration);
+
+  // Read latest strike via a ref so the validation effect below doesn't re-run on every keystroke.
+  const strikeRef = useRef(strike);
+  useEffect(() => {
+    strikeRef.current = strike;
+  });
 
   // When expiration or side changes, reset strike if the current one is no longer valid.
-  const strikeRef = useRef(strike);
-  strikeRef.current = strike;
   useEffect(() => {
     if (!chain || !expiration) return;
     const block = chain.chains[expiration];

--- a/src/components/dashboard/dashboard-pull-refresh.tsx
+++ b/src/components/dashboard/dashboard-pull-refresh.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { PullToRefresh } from "@/components/layout/pull-to-refresh";
+
+export function DashboardPullRefresh({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const t = useTranslations("dashboardActions");
+
+  const onRefresh = useCallback(async () => {
+    try {
+      const [priceRes] = await Promise.all([
+        fetch("/api/prices/refresh", { method: "POST" }),
+        fetch("/api/exchange-rates/refresh", { method: "POST" }),
+      ]);
+      const { data: priceData } = await priceRes.json();
+      toast.success(t("refreshSuccess", { count: priceData.updated }));
+      router.refresh();
+    } catch {
+      toast.error(t("refreshFailed"));
+    }
+  }, [router, t]);
+
+  return <PullToRefresh onRefresh={onRefresh}>{children}</PullToRefresh>;
+}

--- a/src/components/history/history-pull-refresh.tsx
+++ b/src/components/history/history-pull-refresh.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { PullToRefresh } from "@/components/layout/pull-to-refresh";
+
+export function HistoryPullRefresh({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+
+  const onRefresh = useCallback(async () => {
+    router.refresh();
+  }, [router]);
+
+  return <PullToRefresh onRefresh={onRefresh}>{children}</PullToRefresh>;
+}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -4,13 +4,19 @@ import { Eye, EyeOff } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
 
 export function MobileHeader() {
   const t = useTranslations("app");
   const { privacyMode, togglePrivacyMode } = usePrivacyMode();
+  const hidden = useHideOnScroll();
 
   return (
-    <header className="md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between">
+    <header className={cn(
+      "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between transition-transform duration-300 ease-in-out",
+      hidden && "-translate-y-full"
+    )}>
       <div className="flex items-center gap-2 min-w-0">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" className="h-6 w-6 shrink-0 drop-shadow-lg dark:drop-shadow-[0_3px_10px_rgba(52,211,153,0.25)]">
           <defs>

--- a/src/components/layout/pull-to-refresh.tsx
+++ b/src/components/layout/pull-to-refresh.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const THRESHOLD = 70;
+const MAX_PULL = 120;
+
+interface Props {
+  onRefresh: () => Promise<void> | void;
+  children: React.ReactNode;
+}
+
+export function PullToRefresh({ onRefresh, children }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const isMobile = window.matchMedia("(max-width: 767px)").matches;
+    if (!isMobile) return;
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const main = document.querySelector("main");
+    let startY = 0;
+    let active = false;
+    let currentPull = 0;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (refreshing) return;
+      const scrollTop = main?.scrollTop ?? window.scrollY;
+      if (scrollTop > 0) {
+        active = false;
+        return;
+      }
+      startY = e.touches[0].clientY;
+      active = true;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!active || refreshing) return;
+      const delta = e.touches[0].clientY - startY;
+      if (delta <= 0) {
+        currentPull = 0;
+        setPull(0);
+        return;
+      }
+      const damped = Math.min(delta * 0.5, MAX_PULL);
+      currentPull = damped;
+      if (!reduceMotion) setPull(damped);
+    };
+
+    const onTouchEnd = async () => {
+      if (!active || refreshing) {
+        active = false;
+        return;
+      }
+      active = false;
+      if (currentPull >= THRESHOLD) {
+        setRefreshing(true);
+        setPull(THRESHOLD);
+        try {
+          await onRefresh();
+        } finally {
+          setRefreshing(false);
+          setPull(0);
+          currentPull = 0;
+        }
+      } else {
+        setPull(0);
+        currentPull = 0;
+      }
+    };
+
+    wrapper.addEventListener("touchstart", onTouchStart, { passive: true });
+    wrapper.addEventListener("touchmove", onTouchMove, { passive: true });
+    wrapper.addEventListener("touchend", onTouchEnd, { passive: true });
+    wrapper.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+    return () => {
+      wrapper.removeEventListener("touchstart", onTouchStart);
+      wrapper.removeEventListener("touchmove", onTouchMove);
+      wrapper.removeEventListener("touchend", onTouchEnd);
+      wrapper.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [onRefresh, refreshing]);
+
+  const progress = Math.min(pull / THRESHOLD, 1);
+  const armed = pull >= THRESHOLD;
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div
+        className={cn(
+          "md:hidden pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 flex items-center justify-center",
+          "h-9 w-9 rounded-full bg-background/90 border border-border/50 shadow-md backdrop-blur-md",
+          !refreshing && pull === 0 && "opacity-0",
+          refreshing ? "transition-transform duration-300" : "transition-none"
+        )}
+        style={{
+          top: 8,
+          transform: `translate(-50%, ${pull - 36}px)`,
+          opacity: refreshing ? 1 : progress,
+        }}
+        aria-hidden
+      >
+        <RefreshCw
+          className={cn(
+            "h-4 w-4 text-primary",
+            refreshing && "animate-spin",
+            !refreshing && armed && "text-primary",
+            !refreshing && !armed && "text-muted-foreground"
+          )}
+          style={!refreshing ? { transform: `rotate(${progress * 270}deg)` } : undefined}
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,13 +3,12 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { BarChart3, Copy, Eye, EyeOff, History, LayoutDashboard, Settings } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
 
 export function Sidebar({ userImage, userName }: { userImage?: string | null; userName?: string | null }) {
   const pathname = usePathname();
@@ -117,7 +116,7 @@ export function Sidebar({ userImage, userName }: { userImage?: string | null; us
 export function MobileNav() {
   const pathname = usePathname();
   const t = useTranslations();
-  const [hidden, setHidden] = useState(false);
+  const hidden = useHideOnScroll();
 
   const navItems = [
     { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
@@ -126,41 +125,6 @@ export function MobileNav() {
     { label: t("nav.history"), href: "/history", icon: History },
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
-
-  useEffect(() => {
-    const main = document.querySelector("main");
-    let lastY = 0;
-    let touchStartY = 0;
-
-    const getScrollY = () => Math.max(main?.scrollTop ?? 0, window.scrollY);
-
-    const onScroll = () => {
-      const y = getScrollY();
-      if (y > lastY && y > 64) setHidden(true);
-      else if (y < lastY) setHidden(false);
-      lastY = y;
-    };
-
-    const onTouchStart = (e: TouchEvent) => {
-      touchStartY = e.touches[0].clientY;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      const delta = touchStartY - e.touches[0].clientY;
-      if (delta > 10) setHidden(true);
-      else if (delta < -10) setHidden(false);
-    };
-
-    main?.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("touchstart", onTouchStart, { passive: true });
-    window.addEventListener("touchmove", onTouchMove, { passive: true });
-    return () => {
-      main?.removeEventListener("scroll", onScroll);
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("touchstart", onTouchStart);
-      window.removeEventListener("touchmove", onTouchMove);
-    };
-  }, []);
 
   return (
     <nav className={cn(

--- a/src/hooks/use-hide-on-scroll.ts
+++ b/src/hooks/use-hide-on-scroll.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Options {
+  threshold?: number;
+}
+
+export function useHideOnScroll({ threshold = 64 }: Options = {}): boolean {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) return;
+
+    const main = document.querySelector("main");
+    let lastY = 0;
+    let touchStartY = 0;
+    let frame = 0;
+    let pending = false;
+
+    const getScrollY = () => Math.max(main?.scrollTop ?? 0, window.scrollY);
+
+    const flush = () => {
+      pending = false;
+      const y = getScrollY();
+      if (y <= threshold) {
+        setHidden(false);
+      } else if (y > lastY) {
+        setHidden(true);
+      } else if (y < lastY) {
+        setHidden(false);
+      }
+      lastY = y;
+    };
+
+    const schedule = () => {
+      if (pending) return;
+      pending = true;
+      frame = requestAnimationFrame(flush);
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      touchStartY = e.touches[0].clientY;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      const delta = touchStartY - e.touches[0].clientY;
+      if (getScrollY() <= threshold) return;
+      if (delta > 10) setHidden(true);
+      else if (delta < -10) setHidden(false);
+    };
+
+    main?.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      main?.removeEventListener("scroll", schedule);
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [threshold]);
+
+  return hidden;
+}


### PR DESCRIPTION
Reclaim screen space on mobile by auto-hiding the top header on scroll
(previously only the bottom nav hid). The shared useHideOnScroll hook
adds rAF throttling and respects prefers-reduced-motion. Adds a
pull-to-refresh gesture on Dashboard and History for a native feel.

https://claude.ai/code/session_01NSfa1gJcQUDTqmDm9DF5dQ