### PR TITLE
fix(db): use DIRECT_URL for prisma migrations to avoid pooler timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
-# PostgreSQL connection string
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?sslmode=require"
+# PostgreSQL connection string — pooled connection (PgBouncer / Neon pooler).
+# Used by the app at runtime via the Neon WebSocket adapter.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST-pooler.HOST:5432/DATABASE?sslmode=require"
+
+# Direct (non-pooled) connection — used only by `prisma migrate` / `prisma db push`.
+# For Neon, this is the same URL with the "-pooler" suffix removed from the host.
+# Optional: when unset, migrations fall back to DATABASE_URL.
+# DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?sslmode=require"
 
 # NextAuth/App auth secret (generate a long random value)
 AUTH_SECRET="replace-with-long-random-secret"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: process.env["DATABASE_URL"],
+    // Migrations use the direct (non-pooled) connection to avoid
+    // pooler-mediated timeouts and advisory-lock issues in CI / Vercel builds.
+    // Falls back to DATABASE_URL when DIRECT_URL is unset (local dev convenience).
+    url: process.env["DIRECT_URL"] ?? process.env["DATABASE_URL"],
   },
 });


### PR DESCRIPTION
prisma migrate deploy was running through the Neon pooler (DATABASE_URL),
which causes session-state and advisory-lock issues plus connection
timeouts during CI / Vercel builds. Point prisma.config.ts at DIRECT_URL
(non-pooled) with a fallback to DATABASE_URL so local dev still works
when only one URL is set. Runtime queries continue to use DATABASE_URL
via the Neon adapter, unchanged.

https://claude.ai/code/session_01Rc3ASpQTAuKYi459woPzDt