### PR TITLE
feat: iOS large-title nav bar, theme-color meta, and safe-area support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7265,6 +7265,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9509,8 +9510,9 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "extraneous": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { AccountsList } from "@/components/accounts/accounts-list";
+import { MobileLargeTitle } from "@/components/layout/mobile-large-title";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
@@ -75,7 +76,7 @@ async function AccountsContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 animate-in fade-in duration-500">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground">{t("title")}</h2>
+        <MobileLargeTitle title={t("title")} />
         <AccountsList accounts={accounts} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
       </div>
     </NextIntlClientProvider>

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/services/history-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { AnalysisView } from "@/components/analysis/analysis-view";
+import { MobileLargeTitle } from "@/components/layout/mobile-large-title";
 import AnalysisLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["analysis", "categories"];
@@ -32,9 +33,7 @@ async function AnalysisContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 animate-in fade-in duration-500">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground">
-          {t("title")}
-        </h2>
+        <MobileLargeTitle title={t("title")} />
 
         <AnalysisView
           snapshots={snapshots}

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -7,6 +7,7 @@ import { pickMessages } from "@/lib/i18n-utils";
 import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
 import { HistoryTable } from "@/components/history/history-table";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
+import { MobileLargeTitle } from "@/components/layout/mobile-large-title";
 import { getNormalizedHistory } from "@/lib/services/history-service";
 import HistoryLoading from "./loading";
 
@@ -27,9 +28,7 @@ async function HistoryContent() {
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <HistoryPullRefresh>
         <div className="space-y-8 animate-in fade-in duration-500">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground">
-            {t("title")}
-          </h2>
+          <MobileLargeTitle title={t("title")} />
 
           <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
             <LazyTrendChart baseCurrency={settings.baseCurrency} snapshots={snapshots} hideRangeFilter />

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import { MobileMainShell } from "@/components/layout/mobile-main-shell";
 import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indicator";
 import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
+import { PageTitleProvider } from "@/contexts/page-title-context";
 import { getSession } from "@/lib/auth-session";
 
 async function SidebarWithSession() {
@@ -25,15 +26,17 @@ export default function MainLayout({
   return (
     <PrivacyModeProvider>
       <PullToRefreshProvider>
-        <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
-          <SidebarWithSession />
-        </Suspense>
-        <PullToRefreshIndicator />
-        <MobileMainShell>
-          <MobileHeader />
-          <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
-        </MobileMainShell>
-        <MobileNav />
+        <PageTitleProvider>
+          <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+            <SidebarWithSession />
+          </Suspense>
+          <PullToRefreshIndicator />
+          <MobileMainShell>
+            <MobileHeader />
+            <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
+          </MobileMainShell>
+          <MobileNav />
+        </PageTitleProvider>
       </PullToRefreshProvider>
     </PrivacyModeProvider>
   );

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth-session";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
 import { DashboardPullRefresh } from "@/components/dashboard/dashboard-pull-refresh";
+import { MobileLargeTitle } from "@/components/layout/mobile-large-title";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
@@ -31,11 +32,7 @@ async function DashboardPageContent() {
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <DashboardPullRefresh>
         <div className="space-y-8 animate-in fade-in duration-500">
-          <div className="flex items-center justify-between mb-2">
-            <h2 className="text-3xl font-bold tracking-tight text-foreground">
-              {t("title")}
-            </h2>
-          </div>
+          <MobileLargeTitle title={t("title")} />
 
           <DashboardContent userId={userId} />
         </div>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
+import { MobileLargeTitle } from "@/components/layout/mobile-large-title";
 import SettingsLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement"];
@@ -28,7 +29,7 @@ async function SettingsContent() {
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <div className="space-y-10 max-w-2xl pb-16 animate-in fade-in duration-500">
         <div className="flex flex-col space-y-4">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground">{t("title")}</h2>
+          <MobileLargeTitle title={t("title")} />
           <div className="bg-muted/50 p-4 rounded-lg border w-full">
             <h3 className="font-semibold text-sm mb-1">{t("appPhilosophy")}</h3>
             <p className="text-sm text-muted-foreground leading-relaxed">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,10 @@
 }
 
 :root {
+  /* Expose safe-area-inset-top as a CSS custom property so JS can read it
+     via getComputedStyle without needing a dummy DOM element. */
+  --sat: env(safe-area-inset-top, 0px);
+
   --background: oklch(0.99 0.003 260);
   --foreground: oklch(0.15 0.02 260);
   --card: oklch(1 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,6 +154,19 @@
 
 /* Premium utilities */
 @layer utilities {
+  /* Safe-area padding utilities for notched iOS devices (requires viewport-fit=cover). */
+  .pt-safe {
+    /* On notched devices this is the status-bar/notch height (44px+); 0 on flat devices. */
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  /* Combines a base rem padding with the safe-area inset so content clears the notch. */
+  .pt-3-safe {
+    padding-top: calc(0.75rem + env(safe-area-inset-top, 0px));
+  }
+
   /* .glass is intentionally blur-free for static layout elements.
      Fixed/sticky overlays (sidebar, mobile header, mobile nav) apply backdrop-blur inline. */
   .glass {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import localFont from "next/font/local";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/layout/theme-provider";
+import { ThemeColorSync } from "@/components/layout/theme-color-sync";
 import { CustomSpeedInsights } from "@/components/layout/speed-insights";
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
@@ -41,6 +42,13 @@ export const metadata: Metadata = {
     description: "Track your net worth, assets, and investments",
     images: ["/twitter-image.png"],
   },
+  appleWebApp: {
+    capable: true,
+    title: "Assets Tracker",
+    // "black-translucent" lets the status bar overlay content; safe-area
+    // insets push content below it. Required for viewport-fit=cover PWA mode.
+    statusBarStyle: "black-translucent",
+  },
 };
 
 export const viewport: Viewport = {
@@ -48,6 +56,14 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // viewport-fit=cover lets content extend behind the iPhone notch/Dynamic Island.
+  // pt-safe / pb-safe utilities then push content clear of those insets.
+  viewportFit: "cover",
+  themeColor: [
+    // Approximations of the CSS oklch() background colors (light / dark).
+    { media: "(prefers-color-scheme: light)", color: "#f8f9ff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0e1f24" },
+  ],
 };
 
 /**
@@ -101,6 +117,7 @@ export default function RootLayout({
           <Suspense fallback={<span />}>
             <LocaleProviders>{children}</LocaleProviders>
           </Suspense>
+          <ThemeColorSync />
           <Toaster />
           <Analytics />
           <CustomSpeedInsights />

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -3,6 +3,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { usePrivacyMode } from "./privacy-mode-context";
+import { usePageTitle } from "@/contexts/page-title-context";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
@@ -10,39 +11,92 @@ import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
 export function MobileHeader() {
   const t = useTranslations("app");
   const { privacyMode, togglePrivacyMode } = usePrivacyMode();
+  const { title, isLargeTitleVisible } = usePageTitle();
   const hidden = useHideOnScroll();
 
+  // Show the collapsed page title once the inline large title has scrolled away.
+  const showCollapsedTitle = !isLargeTitleVisible && Boolean(title);
+
   return (
-    <header className={cn(
-      "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between transition-transform duration-300 ease-in-out",
-      hidden && "-translate-y-full"
-    )}>
-      <div className="flex items-center gap-2 min-w-0">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" className="h-6 w-6 shrink-0 drop-shadow-lg dark:drop-shadow-[0_3px_10px_rgba(52,211,153,0.25)]">
+    <header
+      className={cn(
+        // pt-3-safe = 0.75rem base + env(safe-area-inset-top) so content clears
+        // the iPhone notch / Dynamic Island when viewport-fit=cover is active.
+        "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 pt-3-safe pb-3 flex items-center justify-between transition-transform duration-300 ease-in-out",
+        hidden && "-translate-y-full"
+      )}
+    >
+      {/* App logo + name — fades out when the page's large title is visible */}
+      <div
+        className={cn(
+          "flex items-center gap-2 min-w-0 transition-opacity duration-200",
+          showCollapsedTitle && "opacity-0 pointer-events-none"
+        )}
+        aria-hidden={showCollapsedTitle}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 32 32"
+          fill="none"
+          className="h-6 w-6 shrink-0 drop-shadow-lg dark:drop-shadow-[0_3px_10px_rgba(52,211,153,0.25)]"
+        >
           <defs>
             <linearGradient id="mobile-icon-g" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#34d399"/>
-              <stop offset="100%" stopColor="#065f46"/>
+              <stop offset="0%" stopColor="#34d399" />
+              <stop offset="100%" stopColor="#065f46" />
             </linearGradient>
           </defs>
-          <rect width="32" height="32" rx="9" fill="url(#mobile-icon-g)"/>
-          <path d="M8 20 L13.5 13.5 L17.5 17.5 L24 10" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
-          <path d="M20 10 L24 10 L24 14" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          <rect width="32" height="32" rx="9" fill="url(#mobile-icon-g)" />
+          <path
+            d="M8 20 L13.5 13.5 L17.5 17.5 L24 10"
+            stroke="white"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M20 10 L24 10 L24 14"
+            stroke="white"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
         <div className="flex flex-col min-w-0">
           <h1 className="text-lg font-bold tracking-tight bg-gradient-to-br from-primary to-chart-3 bg-clip-text text-transparent truncate">
             {t("name")}
           </h1>
-          <p className="text-[10px] text-muted-foreground font-medium -mt-1 opacity-80 uppercase tracking-wide truncate">{t("subtitleMobile")}</p>
+          <p className="text-[10px] text-muted-foreground font-medium -mt-1 opacity-80 uppercase tracking-wide truncate">
+            {t("subtitleMobile")}
+          </p>
         </div>
       </div>
+
+      {/* Collapsed page title — slides in once the inline large title scrolls away */}
+      <div
+        className={cn(
+          "absolute inset-x-0 flex justify-center items-center pointer-events-none transition-opacity duration-200",
+          showCollapsedTitle ? "opacity-100" : "opacity-0"
+        )}
+        aria-hidden={!showCollapsedTitle}
+      >
+        <span className="text-base font-semibold tracking-tight text-foreground">
+          {title}
+        </span>
+      </div>
+
+      {/* Action buttons (always visible) */}
       <div className="flex items-center gap-1 scale-90 origin-right">
         <button
           onClick={togglePrivacyMode}
           title={privacyMode ? "Show values" : "Hide values"}
           className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:text-foreground transition-colors"
         >
-          {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          {privacyMode ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
         </button>
         <ThemeToggle />
       </div>

--- a/src/components/layout/mobile-large-title.tsx
+++ b/src/components/layout/mobile-large-title.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePageTitle } from "@/contexts/page-title-context";
+
+interface MobileLargeTitleProps {
+  title: string;
+}
+
+// Approximately the height of the sticky mobile header (px-4 py-3 + icon).
+// The negative rootMargin shrinks the observed root from the top so the
+// observer fires "not intersecting" as soon as the heading scrolls behind
+// the header — triggering the collapsed title in the nav bar.
+const HEADER_HEIGHT_PX = 56;
+
+export function MobileLargeTitle({ title }: MobileLargeTitleProps) {
+  const { setTitle, setIsLargeTitleVisible } = usePageTitle();
+  const ref = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    setTitle(title);
+    setIsLargeTitleVisible(true);
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsLargeTitleVisible(entry.isIntersecting),
+      {
+        threshold: 0,
+        rootMargin: `-${HEADER_HEIGHT_PX}px 0px 0px 0px`,
+      }
+    );
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      setIsLargeTitleVisible(true);
+    };
+  }, [title, setTitle, setIsLargeTitleVisible]);
+
+  return (
+    <h2
+      ref={ref}
+      className="text-3xl font-bold tracking-tight text-foreground"
+    >
+      {title}
+    </h2>
+  );
+}

--- a/src/components/layout/mobile-main-shell.tsx
+++ b/src/components/layout/mobile-main-shell.tsx
@@ -13,6 +13,10 @@ export function MobileMainShell({ children }: { children: React.ReactNode }) {
     <main
       className={cn(
         "flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full",
+        // Prevent the browser's native pull-to-refresh / overscroll glow from
+        // interfering with our custom indicator. Also enables the rubber-band
+        // transform below to feel elastic rather than fighting the UA.
+        "overscroll-y-contain",
         isPulling ? "transition-none" : "transition-transform duration-300"
       )}
       style={offset > 0 ? { transform: `translateY(${offset}px)` } : undefined}

--- a/src/components/layout/mobile-main-shell.tsx
+++ b/src/components/layout/mobile-main-shell.tsx
@@ -1,21 +1,17 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { usePullToRefreshContext, HANG_OFFSET } from "./pull-to-refresh-context";
+import { usePullToRefreshContext } from "./pull-to-refresh-context";
 
 export function MobileMainShell({ children }: { children: React.ReactNode }) {
-  const { pull, refreshing } = usePullToRefreshContext();
-  // true only while finger is actively dragging — follow without transition lag
+  const { pull, refreshing, hangOffset } = usePullToRefreshContext();
   const isPulling = pull > 0 && !refreshing;
-  const offset = refreshing ? HANG_OFFSET : Math.min(pull, HANG_OFFSET);
+  const offset = refreshing ? hangOffset : Math.min(pull, hangOffset);
 
   return (
     <main
       className={cn(
         "flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full",
-        // Prevent the browser's native pull-to-refresh / overscroll glow from
-        // interfering with our custom indicator. Also enables the rubber-band
-        // transform below to feel elastic rather than fighting the UA.
         "overscroll-y-contain",
         isPulling ? "transition-none" : "transition-transform duration-300"
       )}

--- a/src/components/layout/pull-to-refresh-context.tsx
+++ b/src/components/layout/pull-to-refresh-context.tsx
@@ -1,15 +1,33 @@
 "use client";
 
-import { createContext, useContext, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useLayoutEffect,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
-// Space opened above the header for the refresh indicator (8px margin + h-9 indicator + 8px margin)
-export const HANG_OFFSET = 52;
+// Base hang space on devices without a notch:
+//   MARGIN(8) + indicator(h-9 = 36px) + MARGIN(8) = 52 px
+const BASE_HANG = 52;
+
 // Damped pull distance (px) that triggers a refresh when the finger lifts.
 export const THRESHOLD = 70;
+
+function readSafeAreaTop(): number {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue("--sat");
+  return parseFloat(raw) || 0;
+}
 
 interface PullToRefreshContextValue {
   pull: number;
   refreshing: boolean;
+  /** Total px the main shell shifts down to reveal the indicator. */
+  hangOffset: number;
+  /** env(safe-area-inset-top) in px — 0 on flat-screen devices. */
+  safeAreaTop: number;
   setPull: Dispatch<SetStateAction<number>>;
   setRefreshing: Dispatch<SetStateAction<boolean>>;
 }
@@ -17,6 +35,8 @@ interface PullToRefreshContextValue {
 const PullToRefreshContext = createContext<PullToRefreshContextValue>({
   pull: 0,
   refreshing: false,
+  hangOffset: BASE_HANG,
+  safeAreaTop: 0,
   setPull: () => {},
   setRefreshing: () => {},
 });
@@ -26,9 +46,28 @@ export const usePullToRefreshContext = () => useContext(PullToRefreshContext);
 export function PullToRefreshProvider({ children }: { children: React.ReactNode }) {
   const [pull, setPull] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const [safeAreaTop, setSafeAreaTop] = useState(0);
+
+  // Read the CSS --sat variable synchronously before first paint, and again
+  // on orientation change / resize (safe-area insets can change on rotation).
+  useLayoutEffect(() => {
+    function update() {
+      setSafeAreaTop(readSafeAreaTop());
+    }
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  // hangOffset = safe-area height + fixed base space (indicator + margins).
+  // On a flat-screen device: 0 + 52 = 52 px (same as before).
+  // On iPhone with 44 px notch: 44 + 52 = 96 px.
+  const hangOffset = safeAreaTop + BASE_HANG;
 
   return (
-    <PullToRefreshContext.Provider value={{ pull, refreshing, setPull, setRefreshing }}>
+    <PullToRefreshContext.Provider
+      value={{ pull, refreshing, hangOffset, safeAreaTop, setPull, setRefreshing }}
+    >
       {children}
     </PullToRefreshContext.Provider>
   );

--- a/src/components/layout/pull-to-refresh-context.tsx
+++ b/src/components/layout/pull-to-refresh-context.tsx
@@ -4,6 +4,8 @@ import { createContext, useContext, useState, type Dispatch, type SetStateAction
 
 // Space opened above the header for the refresh indicator (8px margin + h-9 indicator + 8px margin)
 export const HANG_OFFSET = 52;
+// Damped pull distance (px) that triggers a refresh when the finger lifts.
+export const THRESHOLD = 70;
 
 interface PullToRefreshContextValue {
   pull: number;

--- a/src/components/layout/pull-to-refresh-indicator.tsx
+++ b/src/components/layout/pull-to-refresh-indicator.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { usePullToRefreshContext, HANG_OFFSET, THRESHOLD } from "./pull-to-refresh-context";
+import { usePullToRefreshContext, THRESHOLD } from "./pull-to-refresh-context";
 
-// Indicator pill: 36 × 36 px (h-9 w-9)
+// Indicator pill matches h-9 w-9 = 36 px
 const INDICATOR_SIZE = 36;
-// Vertical centre of the gap that the main shell opens above itself.
-const INDICATOR_REST_Y = (HANG_OFFSET - INDICATOR_SIZE) / 2; // 8 px
+// Gap between the bottom of the safe-area (notch) and the top of the pill.
+const INDICATOR_MARGIN = 8;
 
 // SVG arc geometry
 const VIEWBOX = 28;
@@ -14,31 +14,34 @@ const CENTER = VIEWBOX / 2; // 14
 const RADIUS = 11;
 const STROKE = 2.5;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS; // ≈ 69.1 px
-
-// The arc drawn while refreshing: a 270° (¾-circle) gap-less stroke that spins.
 const REFRESH_ARC = CIRCUMFERENCE * 0.75;
 const REFRESH_GAP = CIRCUMFERENCE * 0.25;
 
 export function PullToRefreshIndicator() {
-  const { pull, refreshing } = usePullToRefreshContext();
+  const { pull, refreshing, hangOffset, safeAreaTop } = usePullToRefreshContext();
   const progress = Math.min(pull / THRESHOLD, 1);
   const armed = pull >= THRESHOLD;
   const isPulling = pull > 0 && !refreshing;
 
-  // Stroke-dashoffset for the filling arc:
-  //   offset = CIRCUMFERENCE → nothing visible (progress 0)
-  //   offset = 0             → full circle   (progress 1)
   const dashOffset = CIRCUMFERENCE * (1 - progress);
 
-  // The main shell opens a gap of min(pull, HANG_OFFSET) px above itself.
-  // Centre the indicator inside that gap so it never overlaps the content.
-  const gap = Math.min(pull, HANG_OFFSET);
-  const translateY = refreshing
-    ? INDICATOR_REST_Y           // = (HANG_OFFSET - INDICATOR_SIZE) / 2 = 8 px
-    : gap / 2 - INDICATOR_SIZE / 2; // same formula → 8 px when gap=HANG_OFFSET ✓
+  // The pill should sit just below the safe-area (notch/status-bar).
+  // On flat devices: safeAreaTop=0, so restY = 0 + 8 = 8 px (unchanged).
+  // On notched iPhone (44 px): restY = 44 + 8 = 52 px — below the notch. ✓
+  const restY = safeAreaTop + INDICATOR_MARGIN;
 
-  // Scale reaches 1.0 once the gap is fully open (pull ≥ HANG_OFFSET).
-  const scale = refreshing ? 1 : 0.75 + 0.25 * (gap / HANG_OFFSET);
+  // Interpolate position as the gap opens:
+  //   gap=0          → fully hidden above viewport (−INDICATOR_SIZE)
+  //   gap=hangOffset → at restY
+  // This keeps the pill inside the visible gap at all pull distances.
+  const gap = Math.min(pull, hangOffset);
+  const t = hangOffset > 0 ? gap / hangOffset : 0;
+  const translateY = refreshing
+    ? restY
+    : -INDICATOR_SIZE + t * (restY + INDICATOR_SIZE);
+
+  // Scale reaches 1 once the gap is fully open.
+  const scale = refreshing ? 1 : 0.75 + 0.25 * t;
 
   return (
     <div
@@ -47,9 +50,7 @@ export function PullToRefreshIndicator() {
         "flex items-center justify-center",
         "h-9 w-9 rounded-full",
         "bg-background/90 border border-border/50 shadow-lg backdrop-blur-md",
-        // Only animate transform/opacity on release; follow finger with no lag.
         isPulling ? "transition-none" : "transition-[transform,opacity] duration-300 ease-out",
-        // Hide entirely when idle so it never blocks taps.
         !refreshing && pull === 0 && "opacity-0"
       )}
       style={{
@@ -59,20 +60,13 @@ export function PullToRefreshIndicator() {
       }}
       aria-hidden
     >
-      {/*
-       * Spinning wrapper: rotate the whole SVG continuously while the network
-       * request is in flight. A plain CSS `animate-spin` is used so the arc
-       * colour and position remain under our control.
-       */}
       <div className={refreshing ? "animate-spin" : undefined}>
         <svg
           viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
           width={VIEWBOX}
           height={VIEWBOX}
-          // Rotate -90° so the arc path starts at 12 o'clock instead of 3 o'clock.
           style={{ transform: "rotate(-90deg)" }}
         >
-          {/* Faint track ring — only shown while pulling to give context */}
           {!refreshing && (
             <circle
               cx={CENTER}
@@ -84,8 +78,6 @@ export function PullToRefreshIndicator() {
               className="text-border/50"
             />
           )}
-
-          {/* Main arc — fills progressively while pulling; spins while refreshing */}
           <circle
             cx={CENTER}
             cy={CENTER}
@@ -95,9 +87,7 @@ export function PullToRefreshIndicator() {
             strokeWidth={STROKE}
             strokeLinecap="round"
             strokeDasharray={
-              refreshing
-                ? `${REFRESH_ARC} ${REFRESH_GAP}`
-                : `${CIRCUMFERENCE}`
+              refreshing ? `${REFRESH_ARC} ${REFRESH_GAP}` : `${CIRCUMFERENCE}`
             }
             strokeDashoffset={refreshing ? 0 : dashOffset}
             className={cn(

--- a/src/components/layout/pull-to-refresh-indicator.tsx
+++ b/src/components/layout/pull-to-refresh-indicator.tsx
@@ -1,12 +1,23 @@
 "use client";
 
-import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { usePullToRefreshContext, HANG_OFFSET } from "./pull-to-refresh-context";
+import { usePullToRefreshContext, HANG_OFFSET, THRESHOLD } from "./pull-to-refresh-context";
 
-const THRESHOLD = 70;
-// Vertical centre of the gap opened above the page (h-9 = 36px indicator)
-const INDICATOR_REST_Y = (HANG_OFFSET - 36) / 2; // 8px
+// Indicator pill: 36 × 36 px (h-9 w-9)
+const INDICATOR_SIZE = 36;
+// Vertical centre of the gap that the main shell opens above itself.
+const INDICATOR_REST_Y = (HANG_OFFSET - INDICATOR_SIZE) / 2; // 8 px
+
+// SVG arc geometry
+const VIEWBOX = 28;
+const CENTER = VIEWBOX / 2; // 14
+const RADIUS = 11;
+const STROKE = 2.5;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS; // ≈ 69.1 px
+
+// The arc drawn while refreshing: a 270° (¾-circle) gap-less stroke that spins.
+const REFRESH_ARC = CIRCUMFERENCE * 0.75;
+const REFRESH_GAP = CIRCUMFERENCE * 0.25;
 
 export function PullToRefreshIndicator() {
   const { pull, refreshing } = usePullToRefreshContext();
@@ -14,32 +25,85 @@ export function PullToRefreshIndicator() {
   const armed = pull >= THRESHOLD;
   const isPulling = pull > 0 && !refreshing;
 
+  // Stroke-dashoffset for the filling arc:
+  //   offset = CIRCUMFERENCE → nothing visible (progress 0)
+  //   offset = 0             → full circle   (progress 1)
+  const dashOffset = CIRCUMFERENCE * (1 - progress);
+
+  // Pill follows the finger while dragging; springs back/out with a transition.
+  const translateY = refreshing
+    ? INDICATOR_REST_Y
+    : pull - INDICATOR_SIZE - 8; // enters the viewport from above
+
+  // Subtle scale-up as the user pulls — "materialises" the pill.
+  const scale = refreshing ? 1 : 0.75 + 0.25 * progress;
+
   return (
     <div
       className={cn(
-        "md:hidden pointer-events-none fixed left-1/2 z-[60] flex items-center justify-center",
-        "h-9 w-9 rounded-full bg-background/90 border border-border/50 shadow-md backdrop-blur-md",
-        !refreshing && pull === 0 && "opacity-0",
-        isPulling ? "transition-none" : "transition-[transform,opacity] duration-300"
+        "md:hidden pointer-events-none fixed left-1/2 z-[60]",
+        "flex items-center justify-center",
+        "h-9 w-9 rounded-full",
+        "bg-background/90 border border-border/50 shadow-lg backdrop-blur-md",
+        // Only animate transform/opacity on release; follow finger with no lag.
+        isPulling ? "transition-none" : "transition-[transform,opacity] duration-300 ease-out",
+        // Hide entirely when idle so it never blocks taps.
+        !refreshing && pull === 0 && "opacity-0"
       )}
       style={{
         top: 0,
-        transform: refreshing
-          ? `translate(-50%, ${INDICATOR_REST_Y}px)`
-          : `translate(-50%, ${pull - 44}px)`,
+        transform: `translate(-50%, ${translateY}px) scale(${scale})`,
         opacity: refreshing ? 1 : progress,
       }}
       aria-hidden
     >
-      <RefreshCw
-        className={cn(
-          "h-4 w-4",
-          refreshing && "animate-spin text-primary",
-          !refreshing && armed && "text-primary",
-          !refreshing && !armed && "text-muted-foreground"
-        )}
-        style={!refreshing ? { transform: `rotate(${progress * 270}deg)` } : undefined}
-      />
+      {/*
+       * Spinning wrapper: rotate the whole SVG continuously while the network
+       * request is in flight. A plain CSS `animate-spin` is used so the arc
+       * colour and position remain under our control.
+       */}
+      <div className={refreshing ? "animate-spin" : undefined}>
+        <svg
+          viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+          width={VIEWBOX}
+          height={VIEWBOX}
+          // Rotate -90° so the arc path starts at 12 o'clock instead of 3 o'clock.
+          style={{ transform: "rotate(-90deg)" }}
+        >
+          {/* Faint track ring — only shown while pulling to give context */}
+          {!refreshing && (
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={RADIUS}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={STROKE - 0.5}
+              className="text-border/50"
+            />
+          )}
+
+          {/* Main arc — fills progressively while pulling; spins while refreshing */}
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeDasharray={
+              refreshing
+                ? `${REFRESH_ARC} ${REFRESH_GAP}`
+                : `${CIRCUMFERENCE}`
+            }
+            strokeDashoffset={refreshing ? 0 : dashOffset}
+            className={cn(
+              armed || refreshing ? "text-primary" : "text-muted-foreground/80"
+            )}
+          />
+        </svg>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/pull-to-refresh-indicator.tsx
+++ b/src/components/layout/pull-to-refresh-indicator.tsx
@@ -30,13 +30,15 @@ export function PullToRefreshIndicator() {
   //   offset = 0             → full circle   (progress 1)
   const dashOffset = CIRCUMFERENCE * (1 - progress);
 
-  // Pill follows the finger while dragging; springs back/out with a transition.
+  // The main shell opens a gap of min(pull, HANG_OFFSET) px above itself.
+  // Centre the indicator inside that gap so it never overlaps the content.
+  const gap = Math.min(pull, HANG_OFFSET);
   const translateY = refreshing
-    ? INDICATOR_REST_Y
-    : pull - INDICATOR_SIZE - 8; // enters the viewport from above
+    ? INDICATOR_REST_Y           // = (HANG_OFFSET - INDICATOR_SIZE) / 2 = 8 px
+    : gap / 2 - INDICATOR_SIZE / 2; // same formula → 8 px when gap=HANG_OFFSET ✓
 
-  // Subtle scale-up as the user pulls — "materialises" the pill.
-  const scale = refreshing ? 1 : 0.75 + 0.25 * progress;
+  // Scale reaches 1.0 once the gap is fully open (pull ≥ HANG_OFFSET).
+  const scale = refreshing ? 1 : 0.75 + 0.25 * (gap / HANG_OFFSET);
 
   return (
     <div

--- a/src/components/layout/pull-to-refresh.tsx
+++ b/src/components/layout/pull-to-refresh.tsx
@@ -20,7 +20,12 @@ interface Props {
 
 export function PullToRefresh({ onRefresh, children }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const { refreshing, setPull, setRefreshing } = usePullToRefreshContext();
+  const { refreshing, hangOffset, setPull, setRefreshing } = usePullToRefreshContext();
+
+  // Keep hangOffset in a ref so the touchEnd closure always sees the latest
+  // value without it appearing in the effect dependency array.
+  const hangOffsetRef = useRef(hangOffset);
+  useEffect(() => { hangOffsetRef.current = hangOffset; }, [hangOffset]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -79,7 +84,10 @@ export function PullToRefresh({ onRefresh, children }: Props) {
       active = false;
       if (currentPull >= THRESHOLD) {
         setRefreshing(true);
-        setPull(THRESHOLD);
+        // Set pull to hangOffset (not just THRESHOLD) so the indicator
+        // lands exactly at its resting position — especially important on
+        // notched devices where hangOffset > THRESHOLD.
+        setPull(hangOffsetRef.current);
         try {
           await onRefresh();
         } finally {

--- a/src/components/layout/pull-to-refresh.tsx
+++ b/src/components/layout/pull-to-refresh.tsx
@@ -1,10 +1,17 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { usePullToRefreshContext } from "./pull-to-refresh-context";
+import { usePullToRefreshContext, THRESHOLD } from "./pull-to-refresh-context";
 
-const THRESHOLD = 70;
+// Maximum px the page visually shifts down while dragging.
 const MAX_PULL = 120;
+
+// Hyperbolic-tangent damping — gives a rubber-band feel that gets
+// progressively harder to pull rather than a hard linear cap.
+// At delta=0 → 0px, at delta≈140 → ~70px (threshold), asymptotes at MAX_PULL.
+function dampPull(delta: number): number {
+  return MAX_PULL * Math.tanh(delta / (MAX_PULL * 1.4));
+}
 
 interface Props {
   onRefresh: () => Promise<void> | void;
@@ -13,7 +20,7 @@ interface Props {
 
 export function PullToRefresh({ onRefresh, children }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const { pull, refreshing, setPull, setRefreshing } = usePullToRefreshContext();
+  const { refreshing, setPull, setRefreshing } = usePullToRefreshContext();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -29,6 +36,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
     let startY = 0;
     let active = false;
     let currentPull = 0;
+    let wasArmed = false; // tracks threshold crossing for one-shot haptic
 
     const onTouchStart = (e: TouchEvent) => {
       if (refreshing) return;
@@ -39,6 +47,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
       }
       startY = e.touches[0].clientY;
       active = true;
+      wasArmed = false;
     };
 
     const onTouchMove = (e: TouchEvent) => {
@@ -49,9 +58,17 @@ export function PullToRefresh({ onRefresh, children }: Props) {
         setPull(0);
         return;
       }
-      const damped = Math.min(delta * 0.5, MAX_PULL);
+      const damped = dampPull(delta);
       currentPull = damped;
+
       if (!reduceMotion) setPull(damped);
+
+      // One-shot haptic tick the moment the pull crosses the trigger threshold.
+      const isArmed = damped >= THRESHOLD;
+      if (isArmed && !wasArmed) {
+        navigator.vibrate?.(10);
+      }
+      wasArmed = isArmed;
     };
 
     const onTouchEnd = async () => {
@@ -74,6 +91,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
         setPull(0);
         currentPull = 0;
       }
+      wasArmed = false;
     };
 
     wrapper.addEventListener("touchstart", onTouchStart, { passive: true });

--- a/src/components/layout/theme-color-sync.tsx
+++ b/src/components/layout/theme-color-sync.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTheme } from "next-themes";
+
+// Approximate hex equivalents of the CSS oklch() background tokens.
+const LIGHT_COLOR = "#f8f9ff"; // oklch(0.99 0.003 260)
+const DARK_COLOR = "#0e1f24"; // oklch(0.14 0.030 200)
+
+// Updates the first <meta name="theme-color"> tag whenever the user explicitly
+// toggles the in-app theme (light / dark / system). The Next.js viewport export
+// already seeds two media-query tags for SSR / system-preference; this component
+// corrects whichever tag is active after client-side hydration.
+export function ThemeColorSync() {
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    if (!resolvedTheme) return;
+    const color = resolvedTheme === "dark" ? DARK_COLOR : LIGHT_COLOR;
+    // Update all theme-color meta tags so both light/dark media variants reflect
+    // the user's explicit preference.
+    document
+      .querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')
+      .forEach((el) => {
+        el.content = color;
+      });
+  }, [resolvedTheme]);
+
+  return null;
+}

--- a/src/contexts/page-title-context.tsx
+++ b/src/contexts/page-title-context.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+interface PageTitleContextValue {
+  title: string;
+  isLargeTitleVisible: boolean;
+  setTitle: (title: string) => void;
+  setIsLargeTitleVisible: (visible: boolean) => void;
+}
+
+const PageTitleContext = createContext<PageTitleContextValue>({
+  title: "",
+  isLargeTitleVisible: true,
+  setTitle: () => {},
+  setIsLargeTitleVisible: () => {},
+});
+
+export function PageTitleProvider({ children }: { children: React.ReactNode }) {
+  const [title, setTitle] = useState("");
+  const [isLargeTitleVisible, setIsLargeTitleVisible] = useState(true);
+
+  return (
+    <PageTitleContext.Provider
+      value={{ title, isLargeTitleVisible, setTitle, setIsLargeTitleVisible }}
+    >
+      {children}
+    </PageTitleContext.Provider>
+  );
+}
+
+export function usePageTitle() {
+  return useContext(PageTitleContext);
+}


### PR DESCRIPTION
Implements UI/UX suggestion #1 from docs/UI_UX_SUGGESTIONS.md
(first item in Suggested implementation order).

- PageTitleContext: shared client context that lets each page register
  its title and IntersectionObserver visibility state so the mobile
  header can react without prop-drilling through RSC boundaries.

- MobileLargeTitle component: replaces the bare <h2> on all five main
  pages (Dashboard, Accounts, Analysis, History, Settings). Uses
  IntersectionObserver with a -56 px rootMargin to fire "not visible"
  the moment the heading scrolls behind the sticky nav bar.

- MobileHeader: reads PageTitleContext and cross-fades between the app
  logo+name (when the large title is in view) and a centred collapsed
  page title (once it scrolls away). Switched from py-3 to pt-3-safe +
  pb-3 so the header clears the iPhone notch / Dynamic Island.

- Safe-area utilities added to globals.css: .pt-safe, .pb-safe (bare
  env() insets) and .pt-3-safe (0.75 rem + inset) — also backfills the
  existing .pb-safe usage on MobileNav which had no CSS definition.

- Root layout: viewport export gains viewportFit="cover" (required for
  safe-area insets to apply under the notch) plus themeColor with light
  and dark media-query variants for the iOS status-bar tint.

- ThemeColorSync: tiny client component that listens to next-themes
  resolvedTheme and patches the <meta name="theme-color"> content when
  the user explicitly toggles the in-app theme, ensuring the status-bar
  colour tracks the user's choice rather than only the system preference.

- appleWebApp metadata added: capable=true + statusBarStyle=
  "black-translucent" so installed PWA mode uses the full screen canvas.

https://claude.ai/code/session_01VDqh6YJSzBhcFo8mymS1hA