### PR TITLE
fix: enable Safari homescreen standalone mode (PWA)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,11 @@ export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://assets-tracker-ct.vercel.app"),
   title: "Assets Tracker",
   description: "Track your net worth, assets, and investments",
+  appleWebApp: {
+    capable: true,
+    title: "Assets Tracker",
+    statusBarStyle: "default",
+  },
   openGraph: {
     title: "Assets Tracker",
     description: "Track your net worth, assets, and investments",
@@ -48,6 +53,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  viewportFit: "cover",
 };
 
 /**

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Assets Tracker",
+    short_name: "Assets",
+    description: "Track your net worth, assets, and investments",
+    start_url: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: "#0d1f1e",
+    theme_color: "#0d1f1e",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -14,7 +14,7 @@ export function MobileHeader() {
 
   return (
     <header className={cn(
-      "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 py-3 flex items-center justify-between transition-transform duration-300 ease-in-out",
+      "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))] flex items-center justify-between transition-transform duration-300 ease-in-out",
       hidden && "-translate-y-full"
     )}>
       <div className="flex items-center gap-2 min-w-0">

--- a/src/components/layout/mobile-main-shell.tsx
+++ b/src/components/layout/mobile-main-shell.tsx
@@ -12,7 +12,7 @@ export function MobileMainShell({ children }: { children: React.ReactNode }) {
   return (
     <main
       className={cn(
-        "flex-1 overflow-y-auto overflow-x-hidden pb-16 md:pb-0 relative w-full",
+        "flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0 relative w-full",
         isPulling ? "transition-none" : "transition-transform duration-300"
       )}
       style={offset > 0 ? { transform: `translateY(${offset}px)` } : undefined}


### PR DESCRIPTION
Add apple-mobile-web-app-capable, Web App Manifest with display:standalone,
and viewport-fit:cover with safe-area-inset padding on the mobile header and
main shell so the app launches without Safari chrome on all iOS devices.

https://claude.ai/code/session_01DSJkXRAbaZbtbj9ybfCSpc