### PR TITLE
feat: replace tables with iOS-style inset grouped lists

### DIFF
--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -233,34 +233,9 @@ export function AccountDetail({
       {!isBank && (
         <Card>
           <CardHeader className="pb-3">
-            <div className="flex items-center gap-3 flex-wrap">
-              <CardTitle className="text-base font-medium shrink-0">{t("accountDetail.holdingsCount")}</CardTitle>
-              {holdingsWithValue.length > 1 && (
-                <div className="flex items-center gap-1 flex-1">
-                  <span className="text-xs text-muted-foreground mr-1 shrink-0">Sort:</span>
-                  {(
-                    [
-                      { field: "marketValue" as HoldingSortField, label: t("accountDetail.colValue") },
-                      { field: "symbol" as HoldingSortField, label: t("accountDetail.colSymbol") },
-                      { field: "percentage" as HoldingSortField, label: t("accountDetail.colPercentage") },
-                      { field: "quantity" as HoldingSortField, label: t("accountDetail.colQty") },
-                    ] as { field: HoldingSortField; label: string }[]
-                  ).map(({ field, label }) => (
-                    <button
-                      key={field}
-                      onClick={() => handleSort(field)}
-                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
-                        sortField === field
-                          ? "border-primary/40 bg-primary/10 text-primary font-medium"
-                          : "border-border/50 text-muted-foreground hover:text-foreground hover:border-border hover:bg-muted/40"
-                      }`}
-                    >
-                      {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-                    </button>
-                  ))}
-                </div>
-              )}
-              <Button size="sm" className="ml-auto shrink-0" onClick={() => setShowHoldingForm(true)}>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base font-medium">{t("accountDetail.holdingsCount")}</CardTitle>
+              <Button size="sm" onClick={() => setShowHoldingForm(true)}>
                 {t("accountDetail.addHolding")}
               </Button>
             </div>
@@ -271,7 +246,33 @@ export function AccountDetail({
                 {t("accountDetail.noHoldings")}
               </p>
             ) : (
-              <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+              <>
+                {holdingsWithValue.length > 1 && (
+                  <div className="flex items-center gap-1.5 mb-2 flex-wrap">
+                    <span className="text-xs text-muted-foreground shrink-0">Sort:</span>
+                    {(
+                      [
+                        { field: "marketValue" as HoldingSortField, label: t("accountDetail.colValue") },
+                        { field: "symbol" as HoldingSortField, label: t("accountDetail.colSymbol") },
+                        { field: "percentage" as HoldingSortField, label: t("accountDetail.colPercentage") },
+                        { field: "quantity" as HoldingSortField, label: t("accountDetail.colQty") },
+                      ] as { field: HoldingSortField; label: string }[]
+                    ).map(({ field, label }) => (
+                      <button
+                        key={field}
+                        onClick={() => handleSort(field)}
+                        className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                          sortField === field
+                            ? "border-primary/40 bg-primary/10 text-primary font-medium"
+                            : "border-border/50 text-muted-foreground hover:text-foreground hover:border-border hover:bg-muted/40"
+                        }`}
+                      >
+                        {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
                 {sortedHoldings.map((h, index) => (
                   <div key={h.id}>
                     {index > 0 && <div className="h-px bg-border/60 mx-4" />}
@@ -285,6 +286,7 @@ export function AccountDetail({
                   </div>
                 ))}
               </div>
+              </>
             )}
           </CardContent>
         </Card>

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -233,37 +233,36 @@ export function AccountDetail({
       {!isBank && (
         <Card>
           <CardHeader className="pb-3">
-            <div className="flex items-center justify-between gap-3 flex-wrap">
-              <CardTitle className="text-base font-medium">{t("accountDetail.holdingsCount")}</CardTitle>
-              <div className="flex items-center gap-2">
-                {holdingsWithValue.length > 1 && (
-                  <div className="flex items-center gap-1">
-                    {(
-                      [
-                        { field: "marketValue" as HoldingSortField, label: t("accountDetail.colValue") },
-                        { field: "symbol" as HoldingSortField, label: t("accountDetail.colSymbol") },
-                        { field: "percentage" as HoldingSortField, label: t("accountDetail.colPercentage") },
-                        { field: "quantity" as HoldingSortField, label: t("accountDetail.colQty") },
-                      ] as { field: HoldingSortField; label: string }[]
-                    ).map(({ field, label }) => (
-                      <button
-                        key={field}
-                        onClick={() => handleSort(field)}
-                        className={`text-[10px] px-2 py-1 rounded-md transition-colors ${
-                          sortField === field
-                            ? "bg-primary/10 text-primary font-semibold"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                        }`}
-                      >
-                        {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-                      </button>
-                    ))}
-                  </div>
-                )}
-                <Button size="sm" onClick={() => setShowHoldingForm(true)}>
-                  {t("accountDetail.addHolding")}
-                </Button>
-              </div>
+            <div className="flex items-center gap-3 flex-wrap">
+              <CardTitle className="text-base font-medium shrink-0">{t("accountDetail.holdingsCount")}</CardTitle>
+              {holdingsWithValue.length > 1 && (
+                <div className="flex items-center gap-1 flex-1">
+                  <span className="text-xs text-muted-foreground mr-1 shrink-0">Sort:</span>
+                  {(
+                    [
+                      { field: "marketValue" as HoldingSortField, label: t("accountDetail.colValue") },
+                      { field: "symbol" as HoldingSortField, label: t("accountDetail.colSymbol") },
+                      { field: "percentage" as HoldingSortField, label: t("accountDetail.colPercentage") },
+                      { field: "quantity" as HoldingSortField, label: t("accountDetail.colQty") },
+                    ] as { field: HoldingSortField; label: string }[]
+                  ).map(({ field, label }) => (
+                    <button
+                      key={field}
+                      onClick={() => handleSort(field)}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        sortField === field
+                          ? "border-primary/40 bg-primary/10 text-primary font-medium"
+                          : "border-border/50 text-muted-foreground hover:text-foreground hover:border-border hover:bg-muted/40"
+                      }`}
+                    >
+                      {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <Button size="sm" className="ml-auto shrink-0" onClick={() => setShowHoldingForm(true)}>
+                {t("accountDetail.addHolding")}
+              </Button>
             </div>
           </CardHeader>
           <CardContent className="pt-0">

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -3,18 +3,10 @@
 import { useState, useMemo, startTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 
 import { HoldingForm } from "./holding-form";
 import { EditHoldingDialog } from "./edit-holding-dialog";
@@ -28,19 +20,6 @@ import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/typ
 
 type HoldingSortField = "symbol" | "name" | "assetType" | "currency" | "quantity" | "currentPrice" | "marketValue" | "percentage";
 type SortOrder = "asc" | "desc";
-
-function SortIcon({
-  field,
-  sortField,
-  sortDirection,
-}: {
-  field: HoldingSortField;
-  sortField: HoldingSortField;
-  sortDirection: SortOrder;
-}) {
-  if (sortField !== field) return <ArrowUpDown className="ml-1 h-3.5 w-3.5 text-muted-foreground opacity-50" />;
-  return sortDirection === "asc" ? <ArrowUp className="ml-1 h-3.5 w-3.5" /> : <ArrowDown className="ml-1 h-3.5 w-3.5" />;
-}
 
 export function AccountDetail({
   account,
@@ -253,85 +232,60 @@ export function AccountDetail({
 
       {!isBank && (
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="text-base font-medium">{t("accountDetail.holdingsCount")}</CardTitle>
-            <Button size="sm" onClick={() => setShowHoldingForm(true)}>
-              {t("accountDetail.addHolding")}
-            </Button>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <CardTitle className="text-base font-medium">{t("accountDetail.holdingsCount")}</CardTitle>
+              <div className="flex items-center gap-2">
+                {holdingsWithValue.length > 1 && (
+                  <div className="flex items-center gap-1">
+                    {(
+                      [
+                        { field: "marketValue" as HoldingSortField, label: t("accountDetail.colValue") },
+                        { field: "symbol" as HoldingSortField, label: t("accountDetail.colSymbol") },
+                        { field: "percentage" as HoldingSortField, label: t("accountDetail.colPercentage") },
+                        { field: "quantity" as HoldingSortField, label: t("accountDetail.colQty") },
+                      ] as { field: HoldingSortField; label: string }[]
+                    ).map(({ field, label }) => (
+                      <button
+                        key={field}
+                        onClick={() => handleSort(field)}
+                        className={`text-[10px] px-2 py-1 rounded-md transition-colors ${
+                          sortField === field
+                            ? "bg-primary/10 text-primary font-semibold"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                        }`}
+                      >
+                        {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                <Button size="sm" onClick={() => setShowHoldingForm(true)}>
+                  {t("accountDetail.addHolding")}
+                </Button>
+              </div>
+            </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-0">
             {holdingsWithValue.length === 0 ? (
               <p className="text-muted-foreground text-center py-8">
                 {t("accountDetail.noHoldings")}
               </p>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead
-                      className="cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("symbol")}
-                    >
-                      <div className="flex items-center">{t("accountDetail.colSymbol")} <SortIcon field="symbol" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("name")}
-                    >
-                      <div className="flex items-center">{t("accountDetail.colName")} <SortIcon field="name" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("assetType")}
-                    >
-                      <div className="flex items-center">{t("accountDetail.colType")} <SortIcon field="assetType" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("currency")}
-                    >
-                      <div className="flex items-center">{t("accountDetail.colCurrency")} <SortIcon field="currency" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="text-right cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("quantity")}
-                    >
-                      <div className="flex items-center justify-end">{t("accountDetail.colQty")} <SortIcon field="quantity" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="text-right cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("currentPrice")}
-                    >
-                      <div className="flex items-center justify-end">{t("accountDetail.colPrice")} <SortIcon field="currentPrice" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="text-right cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("marketValue")}
-                    >
-                      <div className="flex items-center justify-end">{t("accountDetail.colValue")} <SortIcon field="marketValue" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead
-                      className="text-right cursor-pointer select-none hover:bg-accent/50"
-                      onClick={() => handleSort("percentage")}
-                    >
-                      <div className="flex items-center justify-end">{t("accountDetail.colPercentage")} <SortIcon field="percentage" sortField={sortField} sortDirection={sortDirection} /></div>
-                    </TableHead>
-                    <TableHead />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sortedHoldings.map((h) => (
+              <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+                {sortedHoldings.map((h, index) => (
+                  <div key={h.id}>
+                    {index > 0 && <div className="h-px bg-border/60 mx-4" />}
                     <HoldingRow
-                      key={h.id}
                       holding={h}
                       totalValue={totalHoldingsValue}
                       accountCurrency={account.currency}
                       onEdit={setEditingHolding}
                       onDelete={deleteHolding}
                     />
-                  ))}
-                </TableBody>
-              </Table>
+                  </div>
+                ))}
+              </div>
             )}
           </CardContent>
         </Card>

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TableCell, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -8,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { MoreHorizontal } from "lucide-react";
 import { formatCurrency, formatQuantity } from "@/lib/currencies";
 import { getOptionDisplay } from "@/lib/options";
 import { useTranslations } from "next-intl";
@@ -36,55 +36,65 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
   const symbolLabel = optionDisplay ? optionDisplay.short : h.symbol;
   const nameLabel = optionDisplay ? optionDisplay.long : h.name;
   const isOption = h.assetType === "OPTION";
+
   return (
-    <TableRow key={h.id}>
-      <TableCell className="font-mono font-medium" title={isOption ? optionDisplay?.occ : undefined}>
-        {symbolLabel}
-      </TableCell>
-      <TableCell>{nameLabel}</TableCell>
-      <TableCell>
-        <Badge variant="secondary">{h.assetType}</Badge>
-      </TableCell>
-      <TableCell>
-        <Badge variant="outline">{h.currency || "USD"}</Badge>
-      </TableCell>
-      <TableCell className="text-right">
-        {formatQuantity(h.quantity, h.assetType)}
-        {isOption && <span className="ml-1 text-muted-foreground text-xs">contracts</span>}
-      </TableCell>
-      <TableCell className="text-right">
-        {privacyMode ? HIDDEN : h.currentPrice !== null
-          ? <>{formatCurrency(h.currentPrice, h.currency || "USD")}{isOption && <span className="ml-1 text-muted-foreground text-xs">/share</span>}</>
-          : "—"}
-      </TableCell>
-      <TableCell className="text-right font-medium">
-        {privacyMode ? HIDDEN : h.marketValue !== null
-          ? formatCurrency(h.marketValue, accountCurrency)
-          : "—"}
-      </TableCell>
-      <TableCell className="text-right text-muted-foreground">
-        {privacyMode ? "—" : h.marketValue !== null && totalValue > 0
-          ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
-          : "—"}
-      </TableCell>
-      <TableCell>
-        <DropdownMenu>
-          <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 hover:bg-accent hover:text-accent-foreground">
-            ...
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onEdit(h)}>
-              {t("common.edit")}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-destructive"
-              onClick={() => onDelete(h.id)}
-            >
-              {t("common.delete")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </TableCell>
-    </TableRow>
+    <div className="flex items-center gap-3 px-4 py-3.5">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span
+            className="font-mono font-semibold text-sm"
+            title={isOption ? optionDisplay?.occ : undefined}
+          >
+            {symbolLabel}
+          </span>
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
+            {h.assetType}
+          </Badge>
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
+            {h.currency || "USD"}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">{nameLabel}</p>
+        <p className="text-xs text-muted-foreground/70 mt-0.5 tabular-nums">
+          {formatQuantity(h.quantity, h.assetType)}
+          {isOption && <span className="ml-1">contracts</span>}
+          {!privacyMode && h.currentPrice !== null && (
+            <span className="ml-2">
+              @ {formatCurrency(h.currentPrice, h.currency || "USD")}
+              {isOption && <span>/share</span>}
+            </span>
+          )}
+        </p>
+      </div>
+      <div className="text-right shrink-0">
+        <p className="text-sm font-medium tabular-nums">
+          {privacyMode
+            ? HIDDEN
+            : h.marketValue !== null
+              ? formatCurrency(h.marketValue, accountCurrency)
+              : "—"}
+        </p>
+        <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
+          {privacyMode
+            ? "—"
+            : h.marketValue !== null && totalValue > 0
+              ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
+              : "—"}
+        </p>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0">
+          <MoreHorizontal className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onEdit(h)}>
+            {t("common.edit")}
+          </DropdownMenuItem>
+          <DropdownMenuItem className="text-destructive" onClick={() => onDelete(h.id)}>
+            {t("common.delete")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -2,17 +2,8 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
@@ -22,19 +13,6 @@ const HIDDEN = "***";
 
 type SortField = "name" | "category" | "value" | "percentage";
 type SortOrder = "asc" | "desc";
-
-function SortIcon({
-  field,
-  sortField,
-  sortDirection,
-}: {
-  field: SortField;
-  sortField: SortField;
-  sortDirection: SortOrder;
-}) {
-  if (sortField !== field) return <ArrowUpDown className="ml-2 h-4 w-4 text-muted-foreground opacity-50" />;
-  return sortDirection === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />;
-}
 
 export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   const [sortField, setSortField] = useState<SortField>("value");
@@ -50,7 +28,6 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
       setSortDirection(field === "value" || field === "percentage" ? "desc" : "asc");
     }
   };
-
 
   const getPercentage = (account: (typeof summary.accounts)[number]) => {
     if (account.type === "ASSET") {
@@ -87,7 +64,6 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
     };
   }, [summary, sortField, sortDirection, t]);
 
-
   if (summary.accounts.length === 0) {
     return (
       <Card>
@@ -103,111 +79,93 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
     );
   }
 
-  const colGroup = (
-    <colgroup>
-      <col className="w-[32%]" />
-      <col className="w-[23%]" />
-      <col className="w-[15%]" />
-      <col className="w-[30%]" />
-    </colgroup>
-  );
+  const sortOptions: { field: SortField; label: string }[] = [
+    { field: "value", label: t("accountsSummary.colValue", { currency: summary.baseCurrency }) },
+    { field: "name", label: t("accountsSummary.colAccount") },
+    { field: "percentage", label: t("accountsSummary.colPercentage") },
+    { field: "category", label: t("accountsSummary.colCategory") },
+  ];
 
-  const tableHeader = (
-    <TableHeader>
-      <TableRow>
-        <TableHead onClick={() => handleSort("name")} className="whitespace-normal cursor-pointer select-none hover:bg-muted/50">
-          <div className="flex items-center">{t("accountsSummary.colAccount")} <SortIcon field="name" sortField={sortField} sortDirection={sortDirection} /></div>
-        </TableHead>
-        <TableHead onClick={() => handleSort("category")} className="whitespace-normal cursor-pointer select-none hover:bg-muted/50">
-          <div className="flex items-center">{t("accountsSummary.colCategory")} <SortIcon field="category" sortField={sortField} sortDirection={sortDirection} /></div>
-        </TableHead>
-        <TableHead onClick={() => handleSort("percentage")} className="cursor-pointer select-none hover:bg-muted/50 text-right">
-          <div className="flex items-center justify-end">{t("accountsSummary.colPercentage")} <SortIcon field="percentage" sortField={sortField} sortDirection={sortDirection} /></div>
-        </TableHead>
-        <TableHead onClick={() => handleSort("value")} className="cursor-pointer select-none hover:bg-muted/50 text-right">
-          <div className="flex items-center justify-end">{t("accountsSummary.colValue", { currency: summary.baseCurrency })} <SortIcon field="value" sortField={sortField} sortDirection={sortDirection} /></div>
-        </TableHead>
-      </TableRow>
-    </TableHeader>
-  );
+  const renderGroup = (accounts: typeof summary.accounts, isAsset: boolean) => {
+    const totalDisplay = isAsset ? summary.totalAssets : summary.totalLiabilities;
+    const label = isAsset ? t("common.asset").toUpperCase() : t("common.liability").toUpperCase();
+    const accentClass = isAsset ? "text-primary" : "text-destructive";
+    const dotClass = isAsset ? "bg-primary" : "bg-destructive";
+    const totalAccentClass = isAsset ? "text-primary" : "text-destructive";
 
-  const renderRows = (accounts: typeof summary.accounts) =>
-    accounts.map((account) => (
-      <TableRow key={account.id} className="group hover:bg-muted/30 transition-colors duration-200 border-border/50">
-        <TableCell className="whitespace-normal break-words py-3">
-          <Link href={`/accounts/${account.id}`} className="font-medium group-hover:text-primary transition-colors">
-            {account.name}
-          </Link>
-        </TableCell>
-        <TableCell className="whitespace-normal text-muted-foreground py-3">
-          {t(`categories.${account.category}`, { defaultValue: account.category })}
-        </TableCell>
-        <TableCell className="text-right text-muted-foreground tabular-nums py-3">
-          {privacyMode ? "—" : `${getPercentage(account).toFixed(1)}%`}
-        </TableCell>
-        <TableCell className="text-right font-medium tabular-nums py-3">
-          {privacyMode ? HIDDEN : formatCurrency(account.totalValueInBaseCurrency, summary.baseCurrency)}
-        </TableCell>
-      </TableRow>
-    ));
+    return (
+      <div>
+        <p className={`text-xs font-semibold uppercase tracking-widest mb-2 px-1 flex items-center gap-1.5 opacity-70 ${accentClass}`}>
+          <span className={`w-1.5 h-1.5 rounded-full ${dotClass}`} />
+          {label}
+        </p>
+        <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+          {accounts.map((account, index) => (
+            <div key={account.id}>
+              {index > 0 && <div className="h-px bg-border/60 mx-4" />}
+              <Link
+                href={`/accounts/${account.id}`}
+                className="flex items-center gap-3 px-4 py-3.5 hover:bg-muted/40 active:bg-muted/60 transition-colors group"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm truncate group-hover:text-primary transition-colors">
+                    {account.name}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {t(`categories.${account.category}`, { defaultValue: account.category })}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="text-right">
+                    <p className="text-sm font-medium tabular-nums">
+                      {privacyMode ? HIDDEN : formatCurrency(account.totalValueInBaseCurrency, summary.baseCurrency)}
+                    </p>
+                    <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
+                      {privacyMode ? "—" : `${getPercentage(account).toFixed(1)}%`}
+                    </p>
+                  </div>
+                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+                </div>
+              </Link>
+            </div>
+          ))}
+          <div className="h-px bg-border/60" />
+          <div className="flex items-center justify-between px-4 py-3 bg-muted/20">
+            <span className="text-xs font-medium text-muted-foreground">{t("accountsSummary.total")}</span>
+            <span className={`text-sm font-semibold tabular-nums ${totalAccentClass}`}>
+              {privacyMode ? HIDDEN : formatCurrency(totalDisplay, summary.baseCurrency)}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <Card className="border-0 shadow-none bg-transparent">
-      <CardHeader className="pb-4">
-        <CardTitle className="text-lg font-semibold tracking-tight">{t("accountsSummary.title")}</CardTitle>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-4">
+          <CardTitle className="text-lg font-semibold tracking-tight">{t("accountsSummary.title")}</CardTitle>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {sortOptions.map(({ field, label }) => (
+              <button
+                key={field}
+                onClick={() => handleSort(field)}
+                className={`text-[10px] px-2 py-1 rounded-md transition-colors ${
+                  sortField === field
+                    ? "bg-primary/10 text-primary font-semibold"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                }`}
+              >
+                {label}{sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+              </button>
+            ))}
+          </div>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-6">
-        {assets.length > 0 && (
-          <div>
-            <p className="text-xs font-semibold text-primary uppercase tracking-wider mb-2 px-1 flex items-center gap-1.5 opacity-80">
-              <span className="w-2 h-2 rounded-full bg-primary" /> {t("common.asset")}
-            </p>
-            <div className="overflow-x-auto rounded-lg border border-border/40 bg-background/30 backdrop-blur-sm">
-              <Table className="table-fixed [&_th]:px-3 sm:[&_th]:px-4 [&_td]:px-3 sm:[&_td]:px-4">
-                {colGroup}
-                {tableHeader}
-                <TableBody>{renderRows(assets)}</TableBody>
-                <tfoot>
-                  <tr className="border-t-[2px] border-border/50 font-semibold bg-muted/10">
-                    <td colSpan={2} className="px-3 sm:px-4 py-3 text-sm text-muted-foreground">
-                      {t("accountsSummary.total")}
-                    </td>
-                    <td />
-                    <td className="px-3 sm:px-4 py-3 text-right text-base tabular-nums text-primary">
-                      {privacyMode ? HIDDEN : formatCurrency(summary.totalAssets, summary.baseCurrency)}
-                    </td>
-                  </tr>
-                </tfoot>
-              </Table>
-            </div>
-          </div>
-        )}
-
-        {liabilities.length > 0 && (
-          <div>
-            <p className="text-xs font-semibold text-destructive uppercase tracking-wider mb-2 px-1 flex items-center gap-1.5 opacity-80 mt-6">
-              <span className="w-2 h-2 rounded-full bg-destructive" /> {t("common.liability")}
-            </p>
-            <div className="overflow-x-auto rounded-lg border border-border/40 bg-background/30 backdrop-blur-sm">
-              <Table className="table-fixed [&_th]:px-3 sm:[&_th]:px-4 [&_td]:px-3 sm:[&_td]:px-4">
-                {colGroup}
-                {tableHeader}
-                <TableBody>{renderRows(liabilities)}</TableBody>
-                <tfoot>
-                  <tr className="border-t-[2px] border-border/50 font-semibold bg-muted/10">
-                    <td colSpan={2} className="px-3 sm:px-4 py-3 text-sm text-muted-foreground">
-                      {t("accountsSummary.total")}
-                    </td>
-                    <td />
-                    <td className="px-3 sm:px-4 py-3 text-right text-base tabular-nums text-destructive">
-                      {privacyMode ? HIDDEN : formatCurrency(summary.totalLiabilities, summary.baseCurrency)}
-                    </td>
-                  </tr>
-                </tfoot>
-              </Table>
-            </div>
-          </div>
-        )}
+      <CardContent className="space-y-6 pt-4">
+        {assets.length > 0 && renderGroup(assets, true)}
+        {liabilities.length > 0 && renderGroup(liabilities, false)}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Converts accounts-summary and holding-row from HTML tables to
rounded inset grouped list cards with hairline dividers, uppercase
section headers, disclosure chevrons, and compact sort pill controls.

https://claude.ai/code/session_01LTgkDCzTPX8QjmAT5hV7we