### PR TITLE
feat: iOS 11+ large-title navigation bar pattern

### DIFF
--- a/docs/UI_UX_SUGGESTIONS.md
+++ b/docs/UI_UX_SUGGESTIONS.md
@@ -4,14 +4,14 @@ Recommendations for making the mobile experience feel like a native iOS app, plu
 
 ## Mobile / iOS-native feel (biggest wins first)
 
-### 1. Large-title navigation bar (iOS 11+ pattern) — ❌ Not Done
+### 1. Large-title navigation bar (iOS 11+ pattern) — ✅ Done
 
-`src/components/layout/mobile-header.tsx` is currently a small sticky bar with the logo. Replace it (per route) with the iOS pattern:
+`src/components/layout/mobile-header.tsx` + `src/components/layout/large-title-heading.tsx`
 
-- A *very big* page title (e.g. "Dashboard", "Accounts", "$1,234,567") that lives inline at the top of scroll content.
-- It collapses into a small centered title in the sticky bar as the user scrolls.
-
-Use `IntersectionObserver` on the big title to drive the swap. This single change is what most makes a web app "feel" iOS.
+- `LargeTitleHeading` replaces the page-level `<h2>` on all 5 main pages. It renders as `text-4xl` on mobile (≈36 px, close to iOS 34 pt) and the existing `text-3xl` on desktop.
+- An `IntersectionObserver` (with `-64px` top `rootMargin` to account for the sticky bar) drives `LargeTitleContext.isVisible`.
+- `MobileHeader` reads that flag: logo + app-name fade out and a small centred page title fades in as the user scrolls. The separator border appears only once the large title has collapsed (mirrors iOS behaviour).
+- `LargeTitleProvider` (in `(main)/layout.tsx`) resets `isVisible = true` on every route change so detail pages without a `LargeTitleHeading` always show the logo.
 
 ### 2. Inset-grouped lists, not tables — ✅ Done
 
@@ -96,7 +96,7 @@ When tapping an account in the list to open `/accounts/[id]`, do a slide-from-ri
 
 ## Suggested implementation order
 
-1. Large-title nav + status-bar `theme-color` + safe-area `pt-safe` on mobile header.
+1. ✅ Large-title nav + status-bar `theme-color` + safe-area `pt-safe` on mobile header.
 2. Bottom-sheet dialogs for forms.
 3. Inset-grouped account/holding lists with disclosure chevrons.
 4. Tab-bar pill background + filled-icon pattern.

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth-session";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AccountsList } from "@/components/accounts/accounts-list";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
@@ -75,7 +76,7 @@ async function AccountsContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 animate-in fade-in duration-500">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground">{t("title")}</h2>
+        <LargeTitleHeading>{t("title")}</LargeTitleHeading>
         <AccountsList accounts={accounts} priceMap={priceMap} ratesMap={ratesMap} baseCurrency={baseCurrency} />
       </div>
     </NextIntlClientProvider>

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -9,6 +9,7 @@ import {
   getMonthlyCashFlow,
 } from "@/lib/services/history-service";
 import { pickMessages } from "@/lib/i18n-utils";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AnalysisView } from "@/components/analysis/analysis-view";
 import AnalysisLoading from "./loading";
 
@@ -32,9 +33,7 @@ async function AnalysisContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 animate-in fade-in duration-500">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground">
-          {t("title")}
-        </h2>
+        <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
         <AnalysisView
           snapshots={snapshots}

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -4,6 +4,7 @@ import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
 import { HistoryTable } from "@/components/history/history-table";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
@@ -27,9 +28,7 @@ async function HistoryContent() {
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <HistoryPullRefresh>
         <div className="space-y-8 animate-in fade-in duration-500">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground">
-            {t("title")}
-          </h2>
+          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
           <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
             <LazyTrendChart baseCurrency={settings.baseCurrency} snapshots={snapshots} hideRangeFilter />

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import { MobileMainShell } from "@/components/layout/mobile-main-shell";
 import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indicator";
 import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
+import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { getSession } from "@/lib/auth-session";
 
 async function SidebarWithSession() {
@@ -24,17 +25,19 @@ export default function MainLayout({
 }>) {
   return (
     <PrivacyModeProvider>
-      <PullToRefreshProvider>
-        <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
-          <SidebarWithSession />
-        </Suspense>
-        <PullToRefreshIndicator />
-        <MobileMainShell>
-          <MobileHeader />
-          <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
-        </MobileMainShell>
-        <MobileNav />
-      </PullToRefreshProvider>
+      <LargeTitleProvider>
+        <PullToRefreshProvider>
+          <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+            <SidebarWithSession />
+          </Suspense>
+          <PullToRefreshIndicator />
+          <MobileMainShell>
+            <MobileHeader />
+            <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
+          </MobileMainShell>
+          <MobileNav />
+        </PullToRefreshProvider>
+      </LargeTitleProvider>
     </PrivacyModeProvider>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import { DashboardPullRefresh } from "@/components/dashboard/dashboard-pull-refr
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 
 const CLIENT_NAMESPACES = [
   "dashboardActions",
@@ -32,9 +33,7 @@ async function DashboardPageContent() {
       <DashboardPullRefresh>
         <div className="space-y-8 animate-in fade-in duration-500">
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-3xl font-bold tracking-tight text-foreground">
-              {t("title")}
-            </h2>
+            <LargeTitleHeading>{t("title")}</LargeTitleHeading>
           </div>
 
           <DashboardContent userId={userId} />

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import SettingsLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement"];
@@ -28,7 +29,7 @@ async function SettingsContent() {
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <div className="space-y-10 max-w-2xl pb-16 animate-in fade-in duration-500">
         <div className="flex flex-col space-y-4">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground">{t("title")}</h2>
+          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
           <div className="bg-muted/50 p-4 rounded-lg border w-full">
             <h3 className="font-semibold text-sm mb-1">{t("appPhilosophy")}</h3>
             <p className="text-sm text-muted-foreground leading-relaxed">

--- a/src/components/layout/large-title-context.tsx
+++ b/src/components/layout/large-title-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 
 interface LargeTitleContextValue {
@@ -14,17 +14,29 @@ const LargeTitleContext = createContext<LargeTitleContextValue>({
 });
 
 export function LargeTitleProvider({ children }: { children: React.ReactNode }) {
-  const [isVisible, setIsVisible] = useState(true);
   const pathname = usePathname();
 
-  // Reset to "expanded" on every route change so the header shows the logo
-  // even on pages that don't have a LargeTitleHeading.
-  useEffect(() => {
-    setIsVisible(true);
-  }, [pathname]);
+  // Co-locate the tracked pathname with isVisible so we can reset during render
+  // without a useEffect (avoids the react-hooks/set-state-in-effect lint error).
+  const [state, setState] = useState({ trackedPathname: pathname, isVisible: true });
+
+  // Derived-state-from-props pattern: update during render when the route changes.
+  // React processes this synchronously and re-renders once, without an extra paint.
+  if (state.trackedPathname !== pathname) {
+    setState({ trackedPathname: pathname, isVisible: true });
+  }
+
+  const setIsVisible = useCallback((v: boolean) => {
+    setState((prev) => ({ ...prev, isVisible: v }));
+  }, []);
+
+  const value = useMemo(
+    () => ({ isVisible: state.isVisible, setIsVisible }),
+    [state.isVisible, setIsVisible]
+  );
 
   return (
-    <LargeTitleContext.Provider value={{ isVisible, setIsVisible }}>
+    <LargeTitleContext.Provider value={value}>
       {children}
     </LargeTitleContext.Provider>
   );

--- a/src/components/layout/large-title-context.tsx
+++ b/src/components/layout/large-title-context.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+interface LargeTitleContextValue {
+  isVisible: boolean;
+  setIsVisible: (v: boolean) => void;
+}
+
+const LargeTitleContext = createContext<LargeTitleContextValue>({
+  isVisible: true,
+  setIsVisible: () => {},
+});
+
+export function LargeTitleProvider({ children }: { children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = useState(true);
+  const pathname = usePathname();
+
+  // Reset to "expanded" on every route change so the header shows the logo
+  // even on pages that don't have a LargeTitleHeading.
+  useEffect(() => {
+    setIsVisible(true);
+  }, [pathname]);
+
+  return (
+    <LargeTitleContext.Provider value={{ isVisible, setIsVisible }}>
+      {children}
+    </LargeTitleContext.Provider>
+  );
+}
+
+export function useLargeTitle() {
+  return useContext(LargeTitleContext);
+}

--- a/src/components/layout/large-title-heading.tsx
+++ b/src/components/layout/large-title-heading.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useLargeTitle } from "./large-title-context";
+
+interface Props {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Drop-in replacement for the page-level <h2> that drives the iOS 11+
+ * large-title navigation bar pattern.
+ *
+ * On mobile: renders as a large (text-4xl) inline title and uses an
+ * IntersectionObserver to tell MobileHeader when it has been scrolled
+ * behind the sticky bar so the bar can collapse to a small centred title.
+ *
+ * On desktop: renders as the standard text-3xl heading, no observer wired up.
+ */
+export function LargeTitleHeading({ children, className }: Props) {
+  const ref = useRef<HTMLHeadingElement>(null);
+  const { setIsVisible } = useLargeTitle();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // rootMargin shrinks the effective viewport from the top by 64 px so the
+    // element is considered "not visible" the moment it slides behind the
+    // ~56 px sticky header (plus a small buffer).
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsVisible(entry.isIntersecting),
+      { rootMargin: "-64px 0px 0px 0px", threshold: 0 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [setIsVisible]);
+
+  return (
+    <h2
+      ref={ref}
+      className={cn(
+        // mobile: iOS-style large title; desktop: existing size
+        "text-4xl md:text-3xl font-bold tracking-tight text-foreground",
+        className
+      )}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -6,36 +6,99 @@ import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
+import { useLargeTitle } from "./large-title-context";
+import { usePathname } from "next/navigation";
+
+function getPageTitle(pathname: string, nav: (k: string) => string): string {
+  if (pathname === "/") return nav("dashboard");
+  if (pathname.startsWith("/accounts")) return nav("accounts");
+  if (pathname.startsWith("/analysis")) return nav("analysis");
+  if (pathname.startsWith("/history")) return nav("history");
+  if (pathname.startsWith("/settings")) return nav("settings");
+  return "";
+}
 
 export function MobileHeader() {
-  const t = useTranslations("app");
+  const t = useTranslations();
   const { privacyMode, togglePrivacyMode } = usePrivacyMode();
   const hidden = useHideOnScroll();
+  const { isVisible } = useLargeTitle();
+  const pathname = usePathname();
+
+  const pageTitle = getPageTitle(pathname, (k) => t(`nav.${k}`));
 
   return (
-    <header className={cn(
-      "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md border-b border-border/50 px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))] flex items-center justify-between transition-transform duration-300 ease-in-out",
-      hidden && "-translate-y-full"
-    )}>
-      <div className="flex items-center gap-2 min-w-0">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" className="h-6 w-6 shrink-0 drop-shadow-lg dark:drop-shadow-[0_3px_10px_rgba(52,211,153,0.25)]">
+    <header
+      className={cn(
+        "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md",
+        "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",
+        "flex items-center justify-between",
+        "border-b transition-[border-color,transform] duration-300 ease-in-out",
+        hidden ? "-translate-y-full" : "translate-y-0",
+        // Separator only appears once the large title is behind the bar (iOS behaviour)
+        isVisible ? "border-transparent" : "border-border/50"
+      )}
+    >
+      {/* Left: logo + app name — fades away when the large title scrolls out */}
+      <div
+        className={cn(
+          "flex items-center gap-2 min-w-0 transition-all duration-300",
+          !isVisible && "opacity-0 pointer-events-none -translate-y-1 scale-95"
+        )}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 32 32"
+          fill="none"
+          className="h-6 w-6 shrink-0 drop-shadow-lg dark:drop-shadow-[0_3px_10px_rgba(52,211,153,0.25)]"
+        >
           <defs>
             <linearGradient id="mobile-icon-g" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#34d399"/>
-              <stop offset="100%" stopColor="#065f46"/>
+              <stop offset="0%" stopColor="#34d399" />
+              <stop offset="100%" stopColor="#065f46" />
             </linearGradient>
           </defs>
-          <rect width="32" height="32" rx="9" fill="url(#mobile-icon-g)"/>
-          <path d="M8 20 L13.5 13.5 L17.5 17.5 L24 10" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
-          <path d="M20 10 L24 10 L24 14" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          <rect width="32" height="32" rx="9" fill="url(#mobile-icon-g)" />
+          <path
+            d="M8 20 L13.5 13.5 L17.5 17.5 L24 10"
+            stroke="white"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M20 10 L24 10 L24 14"
+            stroke="white"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
         <div className="flex flex-col min-w-0">
           <h1 className="text-lg font-bold tracking-tight bg-gradient-to-br from-primary to-chart-3 bg-clip-text text-transparent truncate">
-            {t("name")}
+            {t("app.name")}
           </h1>
-          <p className="text-[10px] text-muted-foreground font-medium -mt-1 opacity-80 uppercase tracking-wide truncate">{t("subtitleMobile")}</p>
+          <p className="text-[10px] text-muted-foreground font-medium -mt-1 opacity-80 uppercase tracking-wide truncate">
+            {t("app.subtitleMobile")}
+          </p>
         </div>
       </div>
+
+      {/* Centre: small page title — slides in when the large title collapses */}
+      <span
+        aria-hidden={isVisible}
+        className={cn(
+          "absolute left-1/2 -translate-x-1/2 text-[15px] font-semibold text-foreground",
+          "transition-all duration-300 pointer-events-none select-none",
+          isVisible
+            ? "opacity-0 translate-y-2"
+            : "opacity-100 translate-y-0"
+        )}
+      >
+        {pageTitle}
+      </span>
+
+      {/* Right: controls — always visible */}
       <div className="flex items-center gap-1 scale-90 origin-right">
         <button
           onClick={togglePrivacyMode}


### PR DESCRIPTION
Adds an IntersectionObserver-driven large-title bar that mirrors the iOS
native UX: each main page's heading renders large (text-4xl on mobile)
inline in the scroll area, and the sticky MobileHeader transitions to a
small centred page title as the user scrolls it out of view. The header
separator border also follows iOS convention — appearing only once the
large title has collapsed behind the bar.

Key files:
- large-title-context.tsx  — shared isVisible state + route-change reset
- large-title-heading.tsx  — drop-in <h2> replacement with IntersectionObserver
- mobile-header.tsx        — logo fades out / centred title fades in on scroll
- (main)/layout.tsx        — wraps tree with LargeTitleProvider

Closes UI_UX_SUGGESTIONS.md §1.

https://claude.ai/code/session_01VEKxepRptDiFWKFodi4i8m