### PR TITLE
fix(e2e): skip smoke tests on Production deployments; improve timeout and error messaging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,11 @@ on:
 jobs:
   e2e:
     name: Playwright smoke tests
-    # Vercel sets state=success when the preview is live and ready
-    if: github.event.deployment_status.state == 'success'
+    # Run only on preview deployments — production uses VERCEL_ENV=production
+    # which never renders the preview-credentials password form.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment != 'Production'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -34,8 +34,16 @@ async function globalSetup() {
 
   await page.goto(`${baseURL}/login`)
 
-  // Preview-mode password form (only shown when VERCEL_ENV=preview)
-  await page.waitForSelector('input[name="password"]', { timeout: 30_000 })
+  // Preview-mode password form (only rendered when VERCEL_ENV=preview)
+  // Allow 60 s to survive Vercel cold-start + PPR streaming latency.
+  const passwordInput = await page.waitForSelector('input[name="password"]', { timeout: 60_000 }).catch(() => null)
+  if (!passwordInput) {
+    throw new Error(
+      `Preview password form not found on ${baseURL}/login after 60 s. ` +
+      "Ensure the deployment has VERCEL_ENV=preview and PREVIEW_AUTH_PASSWORD set. " +
+      "Production deployments (VERCEL_ENV=production) never render this form.",
+    )
+  }
   await page.fill('input[name="password"]', password)
   await page.getByRole("button", { name: "Preview Login" }).click()
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -36,6 +36,7 @@ test("1. unauthenticated visitor is redirected to /login and can sign in", async
   ).toBeVisible()
 
   // Sign in via preview-credentials (the OAuth stub for CI)
+  await page.waitForSelector('input[name="password"]', { timeout: 60_000 })
   await page.fill('input[name="password"]', process.env.E2E_PASSWORD ?? "e2e-smoke-test")
   await page.getByRole("button", { name: "Preview Login" }).click()
 


### PR DESCRIPTION
The e2e.yml job fired on every successful Vercel deployment — including
production — but the preview-credentials password form is only rendered
when VERCEL_ENV=preview. On production the selector never appeared,
causing a cryptic 30 s timeout in global-setup.ts.

- e2e.yml: add `github.event.deployment.environment != 'Production'`
  guard so the job is silently skipped for production deployments.
- global-setup.ts: raise waitForSelector timeout to 60 s (handles
  Vercel cold-start + PPR streaming latency) and throw a descriptive
  error if the form still doesn't appear.
- smoke.spec.ts test 1: add waitForSelector before page.fill for
  consistency with global-setup and to avoid PPR streaming races.

https://claude.ai/code/session_01RUDY1TmJUhVEKVmHfzsHCt