### PR TITLE
style: iOS-style rounded pill buttons for swipe actions

### DIFF
--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -122,12 +122,12 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
     <div className="relative overflow-hidden bg-card select-none">
       {/* Action buttons revealed on left swipe */}
       <motion.div
-        className="absolute inset-y-0 right-0 flex"
+        className="absolute inset-y-0 right-0 flex gap-2 px-2"
         style={{ opacity: actionsOpacity, width: REVEAL_WIDTH }}
         aria-hidden="true"
       >
         <motion.button
-          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden active:brightness-90 transition-[filter]"
+          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           style={{ opacity: editOpacity, width: editWidth, minWidth: 0 }}
           onClick={() => { snapClose(); onEdit(h); }}
           aria-label={t("common.edit")}
@@ -138,7 +138,7 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
           </motion.div>
         </motion.button>
         <button
-          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium active:brightness-90 transition-[filter]"
+          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           onClick={() => { snapClose(); onDelete(h.id); }}
           aria-label={t("common.delete")}
         >

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -19,8 +19,8 @@ import { registerSwipeRow, closeOtherSwipeRows } from "@/lib/swipe-row-registry"
 import type { SerializedHolding } from "@/lib/types";
 
 const HIDDEN = "***";
-const ACTION_WIDTH = 72;
-const REVEAL_WIDTH = ACTION_WIDTH * 2;
+const ACTION_WIDTH = 60;
+const REVEAL_WIDTH = 144; // fixed: accommodates gap-2 + px-2 while keeping both action buttons equal width
 const SNAP_THRESHOLD = REVEAL_WIDTH * 0.4;
 const FULL_SWIPE = REVEAL_WIDTH + 80; // past this → delete on release
 
@@ -138,7 +138,7 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
           </motion.div>
         </motion.button>
         <button
-          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
+          className="flex-1 flex items-center justify-center bg-destructive text-white text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           onClick={() => { snapClose(); onDelete(h.id); }}
           aria-label={t("common.delete")}
         >

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -135,12 +135,12 @@ function SwipeableTxRow({ tx, typeLabel, typeVariant, symbol, qty, time, onEdit,
     <div className="relative overflow-hidden bg-card select-none">
       {/* Action buttons revealed on left swipe */}
       <motion.div
-        className="absolute inset-y-0 right-0 flex"
+        className="absolute inset-y-0 right-0 flex gap-2 px-2"
         style={{ opacity: actionsOpacity, width: REVEAL_WIDTH }}
         aria-hidden="true"
       >
         <motion.button
-          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden active:brightness-90 transition-[filter]"
+          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           style={{ opacity: editOpacity, width: editWidth, minWidth: 0 }}
           onClick={() => { snapClose(); onEdit(); }}
           aria-label={tCommon("edit")}
@@ -151,7 +151,7 @@ function SwipeableTxRow({ tx, typeLabel, typeVariant, symbol, qty, time, onEdit,
           </motion.div>
         </motion.button>
         <button
-          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium active:brightness-90 transition-[filter]"
+          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           onClick={() => { snapClose(); onDelete(); }}
           aria-label={tCommon("delete")}
         >

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -45,8 +45,8 @@ const TYPE_VARIANTS: Record<string, "default" | "secondary" | "destructive"> = {
   EDIT: "secondary",
 };
 
-const ACTION_WIDTH = 72;
-const REVEAL_WIDTH = ACTION_WIDTH * 2;
+const ACTION_WIDTH = 60;
+const REVEAL_WIDTH = 144; // fixed: accommodates gap-2 + px-2 while keeping both action buttons equal width
 const SNAP_THRESHOLD = REVEAL_WIDTH * 0.4;
 const FULL_SWIPE = REVEAL_WIDTH + 80; // past this → trigger delete on release
 
@@ -151,7 +151,7 @@ function SwipeableTxRow({ tx, typeLabel, typeVariant, symbol, qty, time, onEdit,
           </motion.div>
         </motion.button>
         <button
-          className="flex-1 flex items-center justify-center bg-destructive text-destructive-foreground text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
+          className="flex-1 flex items-center justify-center bg-destructive text-white text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
           onClick={() => { snapClose(); onDelete(); }}
           aria-label={tCommon("delete")}
         >


### PR DESCRIPTION
Replace full-height rectangular action buttons with rounded-2xl pill
buttons that float inside the row (my-1.5 vertical inset, gap-2 + px-2
horizontal spacing) — matching the iOS Mail/Reminders swipe aesthetic.

https://claude.ai/code/session_01ASxEFhpm3Lok9Jas5NcRAT