### PR TITLE
Add desktop command palette + keyboard shortcuts, price-refresh hook, and sticky history headers

### DIFF
--- a/docs/UI_UX_SUGGESTIONS.md
+++ b/docs/UI_UX_SUGGESTIONS.md
@@ -87,9 +87,9 @@ When tapping an account in the list to open `/accounts/[id]`, do a slide-from-ri
 
 ## Desktop (smaller, but high leverage)
 
-- **Command palette (⌘K)** — ⚠️ Partial: `cmdk` is installed and `src/components/ui/command.tsx` exists, but no palette UI is wired up. Jump-to-account, privacy toggle, refresh prices, base-currency switch still need implementing.
-- **Keyboard shortcuts** — ❌ Not Done: `g d`, `g a`, `g h` Vim-style (or `1–5` for tab indices) for nav.
-- **Sticky table headers** — ❌ Not Done: needed in `accounts-summary` and transaction history when the list grows past ~10 rows.
+- **Command palette (⌘K)** — ✅ Done: global palette now mounted in `(main)/layout.tsx` via `src/components/layout/desktop-command-palette.tsx` with navigation, privacy toggle, and price refresh actions. Base-currency switch remains out of scope for now.
+- **Keyboard shortcuts** — ✅ Done: supports `1–5` route shortcuts plus Vim-style `g d`, `g a`, `g h`; also `⌘/Ctrl+K` palette open, `⌘/Ctrl+⇧P` privacy toggle, and `⌘/Ctrl+⇧R` refresh prices.
+- **Sticky table headers** — ⚠️ Partial: month headers are now sticky in `src/components/history/history-table.tsx`; `accounts-summary`/transaction history still need full sticky header treatment.
 - **Density toggle** — ❌ Not Done: (Comfortable / Compact) — the current 2xl rounded glass cards eat a lot of vertical space at desktop widths; power users want more density.
 - **Hover sparklines** — ❌ Not Done: on holding rows (last-30-day mini chart on hover) — pulls from `PriceCache` history if you start storing it.
 - **Sidebar collapse to icons-only** — ❌ Not Done: current sidebar at `src/components/layout/sidebar.tsx:28` is fixed `w-64`; a 60px collapsed mode reclaims meaningful canvas on 13" laptops.

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -6,6 +6,7 @@ import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indi
 import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
+import { DesktopCommandPalette } from "@/components/layout/desktop-command-palette";
 import { getSession } from "@/lib/auth-session";
 
 async function SidebarWithSession() {
@@ -36,6 +37,7 @@ export default function MainLayout({
             <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
           </MobileMainShell>
           <MobileNav />
+          <DesktopCommandPalette />
         </PullToRefreshProvider>
       </LargeTitleProvider>
     </PrivacyModeProvider>

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { RefreshCw, Camera, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -55,6 +55,13 @@ export function DashboardActions({
       setRefreshing(false);
     }
   }
+
+  useEffect(() => {
+    const handler = () => { void handleRefreshPrices(); };
+    window.addEventListener("prices:refresh", handler);
+    return () => window.removeEventListener("prices:refresh", handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const priceAge = lastPriceUpdate
     ? getRelativeTime(lastPriceUpdate, locale)

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { RefreshCw, Camera, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -38,7 +38,7 @@ export function DashboardActions({
   const locale = useLocale();
   const [refreshing, setRefreshing] = useState(false);
 
-  async function handleRefreshPrices() {
+  const handleRefreshPrices = useCallback(async () => {
     hapticTick();
     setRefreshing(true);
     try {
@@ -54,14 +54,13 @@ export function DashboardActions({
     } finally {
       setRefreshing(false);
     }
-  }
+  }, [router, t]);
 
   useEffect(() => {
     const handler = () => { void handleRefreshPrices(); };
     window.addEventListener("prices:refresh", handler);
     return () => window.removeEventListener("prices:refresh", handler);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [handleRefreshPrices]);
 
   const priceAge = lastPriceUpdate
     ? getRelativeTime(lastPriceUpdate, locale)

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -59,7 +59,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
           <div className="max-h-[480px] overflow-y-auto space-y-4 pr-1">
             {monthGroups.map(({ monthKey, label, items }) => (
               <div key={monthKey}>
-                <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2 px-1">
+                <p className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm text-xs font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2 px-1 py-1">
                   {label}
                 </p>
                 <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">

--- a/src/components/layout/desktop-command-palette.tsx
+++ b/src/components/layout/desktop-command-palette.tsx
@@ -21,6 +21,7 @@ export function DesktopCommandPalette() {
   const t = useTranslations();
   const { togglePrivacyMode } = usePrivacyMode();
   const pendingGoTo = useRef(false);
+  const goToTimeoutRef = useRef<number | null>(null);
 
   const navItems = useMemo(
     () => [
@@ -39,6 +40,8 @@ export function DesktopCommandPalette() {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (!window.matchMedia("(min-width: 768px)").matches) return;
+
       const target = e.target as HTMLElement | null;
       if (target?.closest("input,textarea,[contenteditable=true]")) return;
 
@@ -62,7 +65,10 @@ export function DesktopCommandPalette() {
 
       if (/^[1-5]$/.test(e.key)) {
         const item = navItems[Number(e.key) - 1];
-        if (item) router.push(item.href);
+        if (item) {
+          router.push(item.href);
+          setOpen(false);
+        }
         return;
       }
 
@@ -71,19 +77,25 @@ export function DesktopCommandPalette() {
         if (e.key.toLowerCase() === "d") router.push("/");
         if (e.key.toLowerCase() === "a") router.push("/accounts");
         if (e.key.toLowerCase() === "h") router.push("/history");
+        setOpen(false);
         return;
       }
 
       if (e.key.toLowerCase() === "g") {
         pendingGoTo.current = true;
-        window.setTimeout(() => {
+        if (goToTimeoutRef.current !== null) window.clearTimeout(goToTimeoutRef.current);
+        goToTimeoutRef.current = window.setTimeout(() => {
           pendingGoTo.current = false;
+          goToTimeoutRef.current = null;
         }, 900);
       }
     };
 
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      if (goToTimeoutRef.current !== null) window.clearTimeout(goToTimeoutRef.current);
+    };
   }, [navItems, router, togglePrivacyMode, triggerRefresh]);
 
   return (

--- a/src/components/layout/desktop-command-palette.tsx
+++ b/src/components/layout/desktop-command-palette.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { BarChart3, Copy, History, LayoutDashboard, RefreshCw, Settings, Shield } from "lucide-react";
+import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandShortcut } from "@/components/ui/command";
+import { usePrivacyMode } from "./privacy-mode-context";
+
+export function DesktopCommandPalette() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+    const t = useTranslations();
+  const { togglePrivacyMode } = usePrivacyMode();
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+      if ((e.target as HTMLElement | null)?.closest("input,textarea,[contenteditable=true]")) return;
+      if (e.key === "1") router.push("/");
+      if (e.key === "2") router.push("/accounts");
+      if (e.key === "3") router.push("/analysis");
+      if (e.key === "4") router.push("/history");
+      if (e.key === "5") router.push("/settings");
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [router]);
+
+
+  const navItems = useMemo(() => ([
+    { href: "/", label: t("nav.dashboard"), icon: LayoutDashboard, kbd: "1" },
+    { href: "/accounts", label: t("nav.accounts"), icon: Copy, kbd: "2" },
+    { href: "/analysis", label: t("nav.analysis"), icon: BarChart3, kbd: "3" },
+    { href: "/history", label: t("nav.history"), icon: History, kbd: "4" },
+    { href: "/settings", label: t("nav.settings"), icon: Settings, kbd: "5" },
+  ]), [t]);
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Type a command or search…" />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Navigation">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <CommandItem key={item.href} onSelect={() => router.push(item.href)}>
+                <Icon className="mr-2 h-4 w-4" />
+                {item.label}
+                <CommandShortcut>{item.kbd}</CommandShortcut>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+        <CommandGroup heading="Actions">
+          <CommandItem onSelect={() => { togglePrivacyMode(); setOpen(false); }}>
+            <Shield className="mr-2 h-4 w-4" />
+            Toggle privacy mode
+            <CommandShortcut>⌘⇧P</CommandShortcut>
+          </CommandItem>
+          <CommandItem onSelect={() => { window.dispatchEvent(new CustomEvent("prices:refresh")); setOpen(false); }}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh prices
+            <CommandShortcut>⌘R</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/layout/desktop-command-palette.tsx
+++ b/src/components/layout/desktop-command-palette.tsx
@@ -1,44 +1,90 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { BarChart3, Copy, History, LayoutDashboard, RefreshCw, Settings, Shield } from "lucide-react";
-import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandShortcut } from "@/components/ui/command";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command";
 import { usePrivacyMode } from "./privacy-mode-context";
 
 export function DesktopCommandPalette() {
   const [open, setOpen] = useState(false);
   const router = useRouter();
-    const t = useTranslations();
+  const t = useTranslations();
   const { togglePrivacyMode } = usePrivacyMode();
+  const pendingGoTo = useRef(false);
+
+  const navItems = useMemo(
+    () => [
+      { href: "/", label: t("nav.dashboard"), icon: LayoutDashboard, kbd: "1" },
+      { href: "/accounts", label: t("nav.accounts"), icon: Copy, kbd: "2" },
+      { href: "/analysis", label: t("nav.analysis"), icon: BarChart3, kbd: "3" },
+      { href: "/history", label: t("nav.history"), icon: History, kbd: "4" },
+      { href: "/settings", label: t("nav.settings"), icon: Settings, kbd: "5" },
+    ],
+    [t],
+  );
+
+  const triggerRefresh = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("prices:refresh"));
+  }, []);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest("input,textarea,[contenteditable=true]")) return;
+
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((v) => !v);
+        return;
       }
-      if ((e.target as HTMLElement | null)?.closest("input,textarea,[contenteditable=true]")) return;
-      if (e.key === "1") router.push("/");
-      if (e.key === "2") router.push("/accounts");
-      if (e.key === "3") router.push("/analysis");
-      if (e.key === "4") router.push("/history");
-      if (e.key === "5") router.push("/settings");
+
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        togglePrivacyMode();
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "r") {
+        e.preventDefault();
+        triggerRefresh();
+        return;
+      }
+
+      if (/^[1-5]$/.test(e.key)) {
+        const item = navItems[Number(e.key) - 1];
+        if (item) router.push(item.href);
+        return;
+      }
+
+      if (pendingGoTo.current) {
+        pendingGoTo.current = false;
+        if (e.key.toLowerCase() === "d") router.push("/");
+        if (e.key.toLowerCase() === "a") router.push("/accounts");
+        if (e.key.toLowerCase() === "h") router.push("/history");
+        return;
+      }
+
+      if (e.key.toLowerCase() === "g") {
+        pendingGoTo.current = true;
+        window.setTimeout(() => {
+          pendingGoTo.current = false;
+        }, 900);
+      }
     };
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [router]);
-
-
-  const navItems = useMemo(() => ([
-    { href: "/", label: t("nav.dashboard"), icon: LayoutDashboard, kbd: "1" },
-    { href: "/accounts", label: t("nav.accounts"), icon: Copy, kbd: "2" },
-    { href: "/analysis", label: t("nav.analysis"), icon: BarChart3, kbd: "3" },
-    { href: "/history", label: t("nav.history"), icon: History, kbd: "4" },
-    { href: "/settings", label: t("nav.settings"), icon: Settings, kbd: "5" },
-  ]), [t]);
+  }, [navItems, router, togglePrivacyMode, triggerRefresh]);
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
@@ -58,15 +104,25 @@ export function DesktopCommandPalette() {
           })}
         </CommandGroup>
         <CommandGroup heading="Actions">
-          <CommandItem onSelect={() => { togglePrivacyMode(); setOpen(false); }}>
+          <CommandItem
+            onSelect={() => {
+              togglePrivacyMode();
+              setOpen(false);
+            }}
+          >
             <Shield className="mr-2 h-4 w-4" />
             Toggle privacy mode
             <CommandShortcut>⌘⇧P</CommandShortcut>
           </CommandItem>
-          <CommandItem onSelect={() => { window.dispatchEvent(new CustomEvent("prices:refresh")); setOpen(false); }}>
+          <CommandItem
+            onSelect={() => {
+              triggerRefresh();
+              setOpen(false);
+            }}
+          >
             <RefreshCw className="mr-2 h-4 w-4" />
             Refresh prices
-            <CommandShortcut>⌘R</CommandShortcut>
+            <CommandShortcut>⌘⇧R</CommandShortcut>
           </CommandItem>
         </CommandGroup>
       </CommandList>


### PR DESCRIPTION
### Motivation
- Improve desktop productivity and parity with UI_UX_SUGGESTIONS by providing a system-wide command palette and quick keyboard navigation. 
- Provide a desktop-accessible way to trigger common actions like toggling privacy and refreshing prices without hunting through the UI. 
- Improve readability of long history lists on desktop by keeping month headers visible while scrolling.

### Description
- Added a new command-palette component `src/components/layout/desktop-command-palette.tsx` using existing `cmdk` primitives and `usePrivacyMode()` for the privacy toggle. 
- Wired the palette into the global app shell by mounting `DesktopCommandPalette` in `src/app/(main)/layout.tsx` so it is available across pages. 
- Implemented global keyboard handlers for `⌘/Ctrl + K` to open the palette and `1`–`5` shortcuts to navigate top-level routes, and added palette actions for privacy toggle and dispatching a `prices:refresh` event. 
- Connected the `prices:refresh` event to the existing refresh flow by adding a window listener in `src/components/dashboard/dashboard-actions.tsx` that invokes the existing `handleRefreshPrices` routine, and made month headers sticky in `src/components/history/history-table.tsx` for better desktop scrolling UX.

### Testing
- Ran the project linter with `npm run -s lint`, which completed successfully with only pre-existing warnings in unrelated files. 
- No new automated unit or e2e tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7822188c08321ad04a32fdc84b0c6)