### PR TITLE
Add Comfortable/Compact density toggle (UI/UX desktop item)

### DIFF
--- a/docs/UI_UX_SUGGESTIONS.md
+++ b/docs/UI_UX_SUGGESTIONS.md
@@ -90,9 +90,11 @@ When tapping an account in the list to open `/accounts/[id]`, do a slide-from-ri
 - **Command palette (⌘K)** — ✅ Done: global palette now mounted in `(main)/layout.tsx` via `src/components/layout/desktop-command-palette.tsx` with navigation, privacy toggle, and price refresh actions. Base-currency switch remains out of scope for now.
 - **Keyboard shortcuts** — ✅ Done: supports `1–5` route shortcuts plus Vim-style `g d`, `g a`, `g h`; also `⌘/Ctrl+K` palette open, `⌘/Ctrl+⇧P` privacy toggle, and `⌘/Ctrl+⇧R` refresh prices.
 - **Sticky table headers** — ⚠️ Partial: month headers are now sticky in `src/components/history/history-table.tsx`; `accounts-summary`/transaction history still need full sticky header treatment.
-- **Density toggle** — ❌ Not Done: (Comfortable / Compact) — the current 2xl rounded glass cards eat a lot of vertical space at desktop widths; power users want more density.
+- **Density toggle** — ✅ Done: (Comfortable / Compact) — the current 2xl rounded glass cards eat a lot of vertical space at desktop widths; power users want more density.
 - **Hover sparklines** — ❌ Not Done: on holding rows (last-30-day mini chart on hover) — pulls from `PriceCache` history if you start storing it.
 - **Sidebar collapse to icons-only** — ✅ Done: desktop sidebar now supports a persisted icons-only mode (`w-[72px]`) with a footer toggle control and localStorage preference (`asset-tracker:sidebar-collapsed`) in `src/components/layout/sidebar.tsx`.
+
+> **Density toggle implementation**: `DensityProvider` (mirroring `PrivacyModeProvider`) wraps the `(main)` layout in `src/components/layout/density-context.tsx`. Preference is persisted to localStorage key `asset-tracker:density` (default `"comfortable"`). The Settings → Preferences section exposes a segmented control (Comfortable / Compact) in `src/components/settings/settings-form.tsx`. Density-aware spacing applied to: `net-worth-card.tsx` (card padding + grid gap), `accounts-summary.tsx` (row padding + section spacing), `holding-row.tsx` (draggable row padding). No DB migration needed — pure client preference.
 
 ## Cross-cutting
 
@@ -108,7 +110,7 @@ When tapping an account in the list to open `/accounts/[id]`, do a slide-from-ri
 4. Tab-bar pill background + filled-icon pattern.
 5. Swipe actions on holding rows.
 6. Command palette (desktop).
-7. ✅ Sidebar collapse + density toggle (desktop).
+7. ✅ Sidebar collapse (desktop) + ✅ density toggle (desktop).
 
 ## Additional suggestions (Codex review)
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -57,6 +57,10 @@
     "refreshExchangeRates": "Refresh Exchange Rates",
     "takeSnapshot": "Take Net Worth Snapshot",
     "creating": "Creating...",
+    "density": "Display Density",
+    "densityDescription": "Control the spacing of cards and rows",
+    "densityComfortable": "Comfortable",
+    "densityCompact": "Compact",
     "signOut": "Sign Out",
     "signOutDesc": "Securely log out of your account on this device.",
     "dangerZone": "Danger Zone"

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -57,6 +57,10 @@
     "refreshExchangeRates": "更新匯率",
     "takeSnapshot": "建立淨資產快照",
     "creating": "建立中...",
+    "density": "顯示密度",
+    "densityDescription": "調整卡片與列的間距",
+    "densityComfortable": "舒適",
+    "densityCompact": "緊湊",
     "signOut": "登出",
     "signOutDesc": "安全地登出此裝置上的帳戶。",
     "dangerZone": "危險區域"

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { MobileHeader } from "@/components/layout/mobile-header";
 import { MobileMainShell } from "@/components/layout/mobile-main-shell";
 import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indicator";
 import { PrivacyModeProvider } from "@/components/layout/privacy-mode-context";
+import { DensityProvider } from "@/components/layout/density-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { DesktopCommandPalette } from "@/components/layout/desktop-command-palette";
@@ -25,21 +26,23 @@ export default function MainLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <PrivacyModeProvider>
-      <LargeTitleProvider>
-        <PullToRefreshProvider>
-          <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
-            <SidebarWithSession />
-          </Suspense>
-          <PullToRefreshIndicator />
-          <MobileMainShell>
-            <MobileHeader />
-            <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
-          </MobileMainShell>
-          <MobileNav />
-          <DesktopCommandPalette />
-        </PullToRefreshProvider>
-      </LargeTitleProvider>
-    </PrivacyModeProvider>
+    <DensityProvider>
+      <PrivacyModeProvider>
+        <LargeTitleProvider>
+          <PullToRefreshProvider>
+            <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+              <SidebarWithSession />
+            </Suspense>
+            <PullToRefreshIndicator />
+            <MobileMainShell>
+              <MobileHeader />
+              <div className="mx-auto w-full max-w-6xl p-4 md:p-6">{children}</div>
+            </MobileMainShell>
+            <MobileNav />
+            <DesktopCommandPalette />
+          </PullToRefreshProvider>
+        </LargeTitleProvider>
+      </PrivacyModeProvider>
+    </DensityProvider>
   );
 }

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -12,6 +12,7 @@ import { formatCurrency, formatQuantity } from "@/lib/currencies";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 
 const AccountForm = dynamic(
@@ -296,6 +297,8 @@ function CategorySection({
 }) {
   const t = useTranslations();
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const colors = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.OTHER;
   const icon = CATEGORY_ICONS[category] ?? "📁";
   const label = t(`categories.${category}`, { defaultValue: category });
@@ -316,7 +319,7 @@ function CategorySection({
     <div className={`rounded-xl border overflow-hidden transition-all duration-300 ${colors.border} ${isExpanded ? "shadow-md" : "shadow-sm hover:shadow-md"}`}>
       <button
         onClick={onToggleExpand}
-        className={`w-full text-left px-5 py-4 flex items-center justify-between transition-colors ${colors.bg} hover:brightness-95 dark:hover:brightness-110`}
+        className={`w-full text-left ${isCompact ? "px-4 py-2.5" : "px-5 py-4"} flex items-center justify-between transition-colors ${colors.bg} hover:brightness-95 dark:hover:brightness-110`}
       >
         <div className="flex items-center gap-3 min-w-0">
           <span className="text-2xl flex-shrink-0">{icon}</span>
@@ -350,7 +353,7 @@ function CategorySection({
 
       <div className={`grid transition-all duration-300 ease-in-out ${isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}>
         <div className="overflow-hidden">
-          <div className="px-4 py-4 space-y-3 bg-background/50">
+          <div className={`${isCompact ? "px-3 py-2.5 space-y-2" : "px-4 py-4 space-y-3"} bg-background/50`}>
             {accounts.map((account) => (
               <AccountCardWithHoldings
                 key={account.id}
@@ -388,6 +391,8 @@ function AccountCardWithHoldings({
   isSelecting: boolean;
 }) {
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const displayValue = getAccountValue(account, priceMap, ratesMap);
   const displayCurrency = account.currency;
   const rate = displayCurrency === baseCurrency ? 1 : (ratesMap[`${displayCurrency}_${baseCurrency}`] ?? 1);
@@ -412,7 +417,7 @@ function AccountCardWithHoldings({
       </div>
       <Link href={`/accounts/${account.id}`} transitionTypes={["nav-forward"]}>
         <Card className={`hover:shadow-md transition-all cursor-pointer ${isSelected ? "ring-2 ring-primary" : ""}`}>
-          <CardContent className="pt-5 pb-4">
+          <CardContent className={isCompact ? "pt-3 pb-2" : "pt-5 pb-4"}>
             <div className="flex items-start justify-between">
               <div className={isSelecting ? "pl-6" : "group-hover:pl-6 transition-all"}>
                 <p className="font-semibold">{account.name}</p>

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -14,6 +14,7 @@ import { formatCurrency, formatQuantity } from "@/lib/currencies";
 import { getOptionDisplay } from "@/lib/options";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { hapticTick } from "@/lib/haptics";
 import { registerSwipeRow, closeOtherSwipeRows } from "@/lib/swipe-row-registry";
 import type { SerializedHolding } from "@/lib/types";
@@ -40,6 +41,8 @@ interface HoldingRowProps {
 export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, onDelete }: HoldingRowProps) {
   const t = useTranslations();
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const optionDisplay = getOptionDisplay(h);
   const symbolLabel = optionDisplay ? optionDisplay.short : h.symbol;
   const nameLabel = optionDisplay ? optionDisplay.long : h.name;
@@ -151,7 +154,7 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
 
       {/* Draggable row */}
       <motion.div
-        className="flex items-center gap-3 px-4 py-3.5 bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10"
+        className={`flex items-center gap-3 px-4 ${isCompact ? "py-2.5" : "py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10`}
         style={{ x }}
         drag="x"
         dragDirectionLock

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -154,7 +154,7 @@ export function HoldingRow({ holding: h, totalValue, accountCurrency, onEdit, on
 
       {/* Draggable row */}
       <motion.div
-        className={`flex items-center gap-3 px-4 ${isCompact ? "py-2.5" : "py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10`}
+        className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10`}
         style={{ x }}
         drag="x"
         dragDirectionLock

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useDensity } from "@/components/layout/density-context";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
 import type { RawHistoryData, SnapshotBreakdown } from "@/lib/services/history-service";
 import {
@@ -48,6 +49,8 @@ function rangeCutoff(months: number): Date {
 
 export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const [range, setRange] = useState<RangeLabel>("YTD");
 
   const rangeLabelKey: Record<RangeLabel, string> = {
@@ -170,7 +173,7 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
           {t("noData")}
         </div>
       ) : (
-        <div className="space-y-6">
+        <div className={isCompact ? "space-y-3" : "space-y-6"}>
           <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
           <div className="premium-card">
             <MonthlyChangeChart buckets={buckets} baseCurrency={baseCurrency} locale={locale} />

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { AnalysisKpis } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 
@@ -59,6 +60,8 @@ function signed(n: number, currency: string): string {
 export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const dash = "—";
   const hidden = "***";
 
@@ -72,7 +75,7 @@ export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
     : kpis.ytdPct === null ? undefined : `${kpis.ytdPct >= 0 ? "+" : ""}${kpis.ytdPct.toFixed(1)}%`;
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className={`grid ${isCompact ? "gap-2" : "gap-4"} sm:grid-cols-2 lg:grid-cols-4`}>
       <Tile
         title={t("bestMonth")}
         value={bestValue}

--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { TopMover } from "@/lib/services/analysis-service";
 
 interface Props {
@@ -15,6 +16,8 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
   const t = useTranslations("analysis");
   const tCat = useTranslations("categories");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
 
   return (
     <Card>
@@ -61,7 +64,7 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
                       key={m.accountId}
                       className="border-b border-border/40 last:border-0 hover:bg-muted/30 transition-colors"
                     >
-                      <td className="py-2.5 pr-4">
+                      <td className={`${isCompact ? "py-1.5" : "py-2.5"} pr-4`}>
                         <div className="font-medium leading-tight">{m.accountName}</div>
                         <div className="text-xs text-muted-foreground">
                           {tCat(m.category as Parameters<typeof tCat>[0], {
@@ -69,13 +72,13 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
                           })}
                         </div>
                       </td>
-                      <td className="py-2.5 text-right tabular-nums text-muted-foreground">
+                      <td className={`${isCompact ? "py-1.5" : "py-2.5"} text-right tabular-nums text-muted-foreground`}>
                         {privacyMode ? "***" : formatCurrency(m.startValue, baseCurrency)}
                       </td>
-                      <td className="py-2.5 text-right tabular-nums">
+                      <td className={`${isCompact ? "py-1.5" : "py-2.5"} text-right tabular-nums`}>
                         {privacyMode ? "***" : formatCurrency(m.endValue, baseCurrency)}
                       </td>
-                      <td className={`py-2.5 text-right tabular-nums font-medium ${changeColor}`}>
+                      <td className={`${isCompact ? "py-1.5" : "py-2.5"} text-right tabular-nums font-medium ${changeColor}`}>
                         <div>
                           {privacyMode ? "***" : (
                             <>

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -108,7 +108,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
               {index > 0 && <div className="h-px bg-border/60 mx-4" />}
               <Link
                 href={`/accounts/${account.id}`}
-                className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"} hover:bg-muted/40 active:bg-muted/60 transition-colors group`}
+                className={`flex items-center gap-3 px-4 ${isCompact ? "py-1.5" : "py-3.5"} hover:bg-muted/40 active:bg-muted/60 transition-colors group`}
                 transitionTypes={["nav-forward"]}
               >
                 <div className="flex-1 min-w-0">
@@ -167,7 +167,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
           </div>
         </div>
       </CardHeader>
-      <CardContent className={`${isCompact ? "space-y-3" : "space-y-6"} pt-4`}>
+      <CardContent className={`${isCompact ? "space-y-2" : "space-y-6"} pt-4`}>
         {assets.length > 0 && renderGroup(assets, true)}
         {liabilities.length > 0 && renderGroup(liabilities, false)}
       </CardContent>

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { NetWorthSummary } from "@/lib/types";
 
 const HIDDEN = "***";
@@ -19,6 +20,8 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   const [sortDirection, setSortDirection] = useState<SortOrder>("desc");
   const t = useTranslations();
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -105,7 +108,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
               {index > 0 && <div className="h-px bg-border/60 mx-4" />}
               <Link
                 href={`/accounts/${account.id}`}
-                className="flex items-center gap-3 px-4 py-3.5 hover:bg-muted/40 active:bg-muted/60 transition-colors group"
+                className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"} hover:bg-muted/40 active:bg-muted/60 transition-colors group`}
                 transitionTypes={["nav-forward"]}
               >
                 <div className="flex-1 min-w-0">
@@ -164,7 +167,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-6 pt-4">
+      <CardContent className={`${isCompact ? "space-y-3" : "space-y-6"} pt-4`}>
         {assets.length > 0 && renderGroup(assets, true)}
         {liabilities.length > 0 && renderGroup(liabilities, false)}
       </CardContent>

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Sector, Label } from "recharts";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { formatCurrency } from "@/lib/currencies";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { NetWorthSummary } from "@/lib/types";
@@ -27,6 +28,8 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   const t = useTranslations();
   const { privacyMode } = usePrivacyMode();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   useEffect(() => startTransition(() => setMounted(true)), []);
 
   const data = useMemo(() => {
@@ -170,7 +173,7 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                   return (
                     <div
                       key={item.name}
-                      className={`group flex items-center gap-2 px-2.5 py-1.5 rounded-lg cursor-pointer transition-all duration-200 ${
+                      className={`group flex items-center gap-2 ${isCompact ? "px-2 py-1" : "px-2.5 py-1.5"} rounded-lg cursor-pointer transition-all duration-200 ${
                         isActive
                           ? "bg-accent/80 shadow-sm scale-[1.01]"
                           : "hover:bg-accent/50"

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -46,7 +46,7 @@ export function NetWorthCard({
       <Card className="col-span-2 lg:col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 relative group min-w-0">
         {meshClass && <div className={meshClass} />}
         <div className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-primary to-primary/50 opacity-100 transition-opacity" />
-        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0 relative z-10`}>
+        <CardContent className={`${isCompact ? "p-2.5 sm:p-3" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0 relative z-10`}>
           <div className="flex items-center gap-2.5 mb-1.5 whitespace-nowrap overflow-hidden">
             <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
               <Layers className="h-4 w-4" />
@@ -75,7 +75,7 @@ export function NetWorthCard({
 
       {/* Secondary Metrics: Assets */}
       <Card className="col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 min-w-0">
-        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
+        <CardContent className={`${isCompact ? "p-2.5 sm:p-3" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
             <Wallet className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-primary shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">
@@ -92,7 +92,7 @@ export function NetWorthCard({
       
       {/* Secondary Metrics: Liabilities */}
       <Card className="col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 min-w-0">
-        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
+        <CardContent className={`${isCompact ? "p-2.5 sm:p-3" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
             <TrendingDown className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-destructive shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { useCountUp } from "@/hooks/use-count-up";
 import type { NetWorthSummary } from "@/lib/types";
 import { TrendingUp, TrendingDown, Layers, Wallet } from "lucide-react";
@@ -20,6 +21,8 @@ export function NetWorthCard({
   const { totalAssets, totalLiabilities, netWorth, baseCurrency } = summary;
   const t = useTranslations("netWorthCard");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
 
   const animatedNetWorth = useCountUp(netWorth, 1200);
   const animatedAssets = useCountUp(totalAssets, 1000);
@@ -38,12 +41,12 @@ export function NetWorthCard({
   const meshClass = delta === null ? "" : isPositive ? "hero-mesh-positive" : "hero-mesh-negative";
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-both">
+    <div className={`grid grid-cols-2 lg:grid-cols-3 ${isCompact ? "gap-2 sm:gap-3" : "gap-3 sm:gap-6"} animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-both`}>
       {/* Primary Hero Metric: Net Worth */}
       <Card className="col-span-2 lg:col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 relative group min-w-0">
         {meshClass && <div className={meshClass} />}
         <div className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-primary to-primary/50 opacity-100 transition-opacity" />
-        <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center min-w-0 relative z-10">
+        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0 relative z-10`}>
           <div className="flex items-center gap-2.5 mb-1.5 whitespace-nowrap overflow-hidden">
             <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
               <Layers className="h-4 w-4" />
@@ -72,7 +75,7 @@ export function NetWorthCard({
 
       {/* Secondary Metrics: Assets */}
       <Card className="col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 min-w-0">
-        <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center min-w-0">
+        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
             <Wallet className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-primary shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">
@@ -89,7 +92,7 @@ export function NetWorthCard({
       
       {/* Secondary Metrics: Liabilities */}
       <Card className="col-span-1 glass card-gradient rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1 min-w-0">
-        <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center min-w-0">
+        <CardContent className={`${isCompact ? "p-3 sm:p-4" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}>
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
             <TrendingDown className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-destructive shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 
 type SnapshotRow = {
   id: string;
@@ -23,6 +24,8 @@ type Props = {
 export function HistoryTable({ snapshots, baseCurrency }: Props) {
   const t = useTranslations("history");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
 
   const monthGroups = useMemo(() => {
     const rows = [...snapshots].reverse().map((snap, idx, arr) => ({
@@ -72,7 +75,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                     return (
                       <div key={row.id}>
                         {index > 0 && <div className="h-px bg-border/60 mx-4" />}
-                        <div className="flex items-center gap-3 px-4 py-3.5">
+                        <div className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"}`}>
                           <div className="w-16 shrink-0">
                             <p className="text-sm font-medium">{dayLabel}</p>
                           </div>

--- a/src/components/layout/density-context.tsx
+++ b/src/components/layout/density-context.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+} from "react";
+
+export type Density = "comfortable" | "compact";
+
+interface DensityContextType {
+  density: Density;
+  setDensity: (density: Density) => void;
+}
+
+const DensityContext = createContext<DensityContextType>({
+  density: "comfortable",
+  setDensity: () => {},
+});
+
+const STORAGE_KEY = "asset-tracker:density";
+
+export function DensityProvider({ children }: { children: React.ReactNode }) {
+  const [density, setDensityState] = useState<Density>("comfortable");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    startTransition(() => {
+      setMounted(true);
+      if (stored === "compact") setDensityState("compact");
+    });
+  }, []);
+
+  const setDensity = useCallback((next: Density) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    startTransition(() => setDensityState(next));
+  }, []);
+
+  const value = useMemo(
+    () => ({ density: mounted ? density : "comfortable", setDensity }),
+    [mounted, density, setDensity],
+  );
+
+  return (
+    <DensityContext.Provider value={value}>
+      {children}
+    </DensityContext.Provider>
+  );
+}
+
+export function useDensity() {
+  return useContext(DensityContext);
+}

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -15,6 +15,7 @@ import { CURRENCIES } from "@/lib/currencies";
 import { toast } from "sonner";
 import { useLocale, useTranslations } from "next-intl";
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, type Locale } from "@/i18n/config";
+import { useDensity, type Density } from "@/components/layout/density-context";
 
 export function SettingsForm({
   currentCurrency,
@@ -33,6 +34,7 @@ export function SettingsForm({
       : DEFAULT_LOCALE;
   const [currency, setCurrency] = useState(currentCurrency);
   const [locale, setLocale] = useState<Locale>(resolvedActiveLocale);
+  const { density, setDensity } = useDensity();
   const [saving, setSaving] = useState(false);
   const [savingLocale, setSavingLocale] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -127,7 +129,7 @@ export function SettingsForm({
             </div>
 
             {/* Language Row */}
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
               <div className="space-y-1">
                 <p className="text-sm font-medium">{t("settings.language")}</p>
                 <p className="text-sm text-muted-foreground">{t("settings.languageDescription")}</p>
@@ -151,6 +153,29 @@ export function SettingsForm({
                 >
                   {savingLocale ? t("settings.saving") : t("settings.save")}
                 </Button>
+              </div>
+            </div>
+
+            {/* Density Row */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">{t("settings.density")}</p>
+                <p className="text-sm text-muted-foreground">{t("settings.densityDescription")}</p>
+              </div>
+              <div className="flex items-center gap-1 rounded-lg border p-1 bg-muted/30">
+                {(["comfortable", "compact"] as Density[]).map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => setDensity(d)}
+                    className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                      density === d
+                        ? "bg-background shadow-sm text-foreground"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {d === "comfortable" ? t("settings.densityComfortable") : t("settings.densityCompact")}
+                  </button>
+                ))}
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary

- Adds a `DensityProvider` context (`src/components/layout/density-context.tsx`) that persists the user's spacing preference to `localStorage` (`asset-tracker:density`) — no DB migration needed
- Wires the provider into `(main)/layout.tsx` wrapping all existing providers
- Exposes a segmented **Comfortable / Compact** control in Settings → Preferences (instant, no Save button required)
- Density-aware spacing applied to:
  - `net-worth-card.tsx` — card padding and grid gap
  - `accounts-summary.tsx` — account row padding and section spacing
  - `holding-row.tsx` — draggable row padding
- i18n strings added for `en-US` and `zh-TW`
- `docs/UI_UX_SUGGESTIONS.md` updated: density toggle marked ✅ Done

Closes the "Density toggle — ❌ Not Done" item in the Desktop section of `UI_UX_SUGGESTIONS.md`.

## Test plan

- [x] Navigate to `/settings` → Preferences — "Display Density" row should appear with Comfortable / Compact buttons
- [x] Click **Compact** — net-worth cards shrink padding, account rows tighten, holding rows tighten (no reload)
- [x] Navigate away and back — density preference persists
- [x] Refresh page — preference still persists (localStorage)
- [x] DevTools → Application → Local Storage → confirm `asset-tracker:density = compact`
- [x] Switch back to **Comfortable** — spacing restores
- [x] Switch locale to 繁體中文 — density labels appear as 舒適 / 緊湊

🤖 Generated with [Claude Code](https://claude.com/claude-code)