### PR TITLE
fix: restore dialog position on mobile for swipe-to-edit sheet

### DIFF
--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -117,9 +117,8 @@ export function EditHoldingDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpen}>
-      <DialogContent className="fixed inset-x-0 bottom-0 top-auto translate-x-0 translate-y-0 rounded-t-2xl rounded-b-none border-t pb-[calc(env(safe-area-inset-bottom)+1rem)] data-[ending-style]:translate-y-full sm:left-1/2 sm:top-1/2 sm:bottom-auto sm:max-w-md sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl sm:pb-6">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-muted" aria-hidden="true" />
           <DialogTitle>Edit Holding</DialogTitle>
         </DialogHeader>
 

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -117,7 +117,7 @@ export function EditHoldingDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpen}>
-      <DialogContent className="fixed inset-x-0 bottom-0 top-auto translate-y-0 rounded-t-2xl rounded-b-none border-t pb-[calc(env(safe-area-inset-bottom)+1rem)] data-[ending-style]:translate-y-full sm:top-1/2 sm:bottom-auto sm:max-w-md sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl sm:pb-6">
+      <DialogContent className="fixed inset-x-0 bottom-0 top-auto translate-x-0 translate-y-0 rounded-t-2xl rounded-b-none border-t pb-[calc(env(safe-area-inset-bottom)+1rem)] data-[ending-style]:translate-y-full sm:left-1/2 sm:top-1/2 sm:bottom-auto sm:max-w-md sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl sm:pb-6">
         <DialogHeader>
           <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-muted" aria-hidden="true" />
           <DialogTitle>Edit Holding</DialogTitle>


### PR DESCRIPTION
The base DialogContent applies `-translate-x-1/2` by default. tailwind-merge
also removed `left-1/2` (base) when `inset-x-0` (prop) was merged, since both
conflict on the CSS `left` property. This left the mobile bottom sheet shifted
50% off-screen to the left and the desktop modal without `left: 50%` for
centering.

Adds `translate-x-0` to reset the horizontal transform on mobile, and
`sm:left-1/2` to explicitly restore centered positioning on desktop.

https://claude.ai/code/session_01F1WbqeHa3FJv6pUPV2z1vU