### PR TITLE
feat: iOS typography — system font stack + net-worth letter-spacing (#8)

### DIFF
--- a/docs/UI_UX_SUGGESTIONS.md
+++ b/docs/UI_UX_SUGGESTIONS.md
@@ -68,10 +68,12 @@ The bottom nav at `src/components/layout/sidebar.tsx:129` is close. Two tweaks:
 
 > `apple-mobile-web-app-capable` (`appleWebApp: { capable: true }`) and `viewport-fit: "cover"` are set in `layout.tsx`. Safe-area env vars applied on mobile header. Missing: `theme-color` meta tag and iOS splash screen configuration.
 
-### 8. iOS typography — ❌ Not Done
+### 8. iOS typography — ✅ Done
 
 - Add `-apple-system, "SF Pro Text", "SF Pro Display"` *before* Geist in the body font stack so when run as PWA on iOS it picks up SF and Dynamic Type.
 - Tighten letter-spacing (`-0.02em`) on the big net-worth number — that's the single most "Stocks-app" detail.
+
+> `src/app/globals.css`: `body` rule now sets an explicit `font-family` that begins with `-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display"` and falls through to `var(--font-sans)` (Geist) on non-Apple platforms. `src/components/dashboard/net-worth-card.tsx`: net-worth number changed from `tracking-tight` (−0.025 em) to `tracking-[-0.02em]` matching the iOS Stocks app detail.
 
 ### 9. Swipe actions — ✅ Done
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,6 +135,8 @@
   }
   body {
     @apply bg-background text-foreground min-h-screen text-base;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display",
+      var(--font-sans), ui-sans-serif, system-ui, sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
   }
   /* Static ambient gradients — no runtime color computation */

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -56,7 +56,7 @@ export function NetWorthCard({
             </p>
           </div>
           <div className="overflow-x-auto scrollbar-none">
-            <p className="text-2xl sm:text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent mt-1 whitespace-nowrap tabular-nums">
+            <p className="text-2xl sm:text-3xl font-bold tracking-[-0.02em] bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent mt-1 whitespace-nowrap tabular-nums">
               {privacyMode ? HIDDEN : formatCurrency(animatedNetWorth, baseCurrency)}
             </p>
           </div>


### PR DESCRIPTION
## Summary

- Prepends `-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display"` to the `body` font-family in `globals.css`, falling through to Geist (`var(--font-sans)`) on non-Apple platforms — the PWA now uses SF Pro on iOS
- Changes the net-worth hero number from `tracking-tight` (−0.025 em) to `tracking-[-0.02em]`, matching the iOS Stocks-app detail
- Marks UI/UX suggestion #8 ✅ Done in `docs/UI_UX_SUGGESTIONS.md`

## Test plan

- [ ] Open on iOS Safari (or DevTools mobile emulation): DevTools → Computed → `font-family` on `<body>` should list `-apple-system` first
- [ ] Computed `letter-spacing` on the net-worth number should be `-0.02em`
- [ ] On non-iOS (Chrome/Firefox desktop): Geist renders as before — no visual regression
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)