### PR TITLE
feat: iOS typography — SF Pro font stack + tighter net-worth letter-spacing (UI/UX #8)

### DIFF
--- a/docs/UI_UX_SUGGESTIONS.md
+++ b/docs/UI_UX_SUGGESTIONS.md
@@ -68,10 +68,12 @@ The bottom nav at `src/components/layout/sidebar.tsx:129` is close. Two tweaks:
 
 > `apple-mobile-web-app-capable` (`appleWebApp: { capable: true }`) and `viewport-fit: "cover"` are set in `layout.tsx`. Safe-area env vars applied on mobile header. Missing: `theme-color` meta tag and iOS splash screen configuration.
 
-### 8. iOS typography — ❌ Not Done
+### 8. iOS typography — ✅ Done
 
 - Add `-apple-system, "SF Pro Text", "SF Pro Display"` *before* Geist in the body font stack so when run as PWA on iOS it picks up SF and Dynamic Type.
 - Tighten letter-spacing (`-0.02em`) on the big net-worth number — that's the single most "Stocks-app" detail.
+
+> Geist is now loaded under the `--font-geist` CSS variable (renamed from `--font-sans` in `layout.tsx`). The `@theme inline` block in `globals.css` builds `--font-sans` as `-apple-system, "SF Pro Text", "SF Pro Display", var(--font-geist), system-ui, sans-serif` — iOS PWA mode picks up SF Pro; all other platforms fall through to Geist. The mono stack follows the same pattern with `--font-geist-mono`. The net-worth hero `<p>` in `net-worth-card.tsx` now applies `letter-spacing: -0.02em` via an inline style (Tailwind's `tracking-tight` is only `−0.025em` coarsely; the inline value pins it precisely as the Stocks-app detail requires).
 
 ### 9. Swipe actions — ✅ Done
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,8 +11,8 @@
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-mono);
+  --font-sans: -apple-system, "SF Pro Text", "SF Pro Display", var(--font-geist), system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, "SF Mono", Menlo, monospace;
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,14 +12,14 @@ import "./globals.css";
 
 const geist = localFont({
   src: "./fonts/geist-latin.woff2",
-  variable: "--font-sans",
+  variable: "--font-geist",
   display: "swap",
   preload: true,
 });
 
 const geistMono = localFont({
   src: "./fonts/geist-mono-latin.woff2",
-  variable: "--font-mono",
+  variable: "--font-geist-mono",
   display: "swap",
 });
 

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -56,7 +56,7 @@ export function NetWorthCard({
             </p>
           </div>
           <div className="overflow-x-auto scrollbar-none">
-            <p className="text-2xl sm:text-3xl font-bold tracking-tight bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent mt-1 whitespace-nowrap tabular-nums">
+            <p className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent mt-1 whitespace-nowrap tabular-nums" style={{ letterSpacing: "-0.02em" }}>
               {privacyMode ? HIDDEN : formatCurrency(animatedNetWorth, baseCurrency)}
             </p>
           </div>


### PR DESCRIPTION
## Summary

- Renamed Geist CSS variables from `--font-sans`/`--font-mono` to `--font-geist`/`--font-geist-mono` in `layout.tsx`, freeing `--font-sans` to be a proper iOS-first font stack
- `globals.css` `@theme inline` now defines `--font-sans` as `-apple-system, "SF Pro Text", "SF Pro Display", var(--font-geist), system-ui, sans-serif` — on iOS PWA the system SF font is used; other platforms fall through to Geist unchanged
- Net-worth hero number in `net-worth-card.tsx` uses `letter-spacing: -0.02em` (inline, not `tracking-tight`) — the single most "Stocks-app" typographic detail per the suggestion doc
- `docs/UI_UX_SUGGESTIONS.md` item 8 marked ✅ Done

## Test plan

- [ ] Run `npm run dev` and verify the app loads without font-related errors
- [ ] On desktop: confirm Geist renders as before (no visible change)
- [ ] On iOS Safari (or iOS PWA): confirm SF Pro is picked up instead of Geist
- [ ] Dashboard net-worth hero number should appear with slightly tighter letter-spacing than before
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)