### PR TITLE
Improve mobile bottom nav, add dashboard freshness badges, and update UI/UX doc

### DIFF
--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -306,10 +306,10 @@ This addendum captures a deep codebase review and complements the recommendation
 
 | #   | Item                                                                            | Impact     | Status   |
 | --- | ------------------------------------------------------------------------------- | ---------- | -------- |
-| 1   | Mobile bottom nav: larger tap targets + pill active state                       | High       | Proposed |
+| 1   | Mobile bottom nav: larger tap targets + pill active state                       | High       | ✅ Done  |
 | 2   | Missing `theme-color` meta tag + iOS splash screens                             | High       | ✅ Done  |
-| 3   | Data-freshness live badge on dashboard hero                                     | High       | Proposed |
-| 4   | Accessibility audit: missing `aria-label`, focus rings, sr-only chart summaries | High       | Proposed |
+| 3   | Data-freshness live badge on dashboard hero                                     | High       | ✅ Done  |
+| 4   | Accessibility audit: missing `aria-label`, focus rings, sr-only chart summaries | High       | ⚠️ Partial |
 | 5   | Extract duplicated swipe-row logic into shared component                        | Medium     | Proposed |
 | 6   | Sticky sort/filter bar in account detail holdings list                          | Medium     | Proposed |
 | 7   | Unified motion token system in `globals.css`                                    | Medium     | Proposed |
@@ -321,7 +321,7 @@ This addendum captures a deep codebase review and complements the recommendation
 
 ---
 
-## 1) Mobile bottom nav: larger tap targets + pill active state (High)
+## 1) Mobile bottom nav: larger tap targets + pill active state (High) — ✅ Done
 
 **What I observed**
 
@@ -339,6 +339,8 @@ This addendum captures a deep codebase review and complements the recommendation
 - Gate haptic: `onClick={() => { if (!isActive) hapticTick(); }}`.
 
 **Target files**: `src/components/layout/sidebar.tsx:266–291`
+
+> **Implemented**: Mobile nav items now use larger `px-4 py-2` spacing with `min-h-12 min-w-12`, active tabs use an iOS-style rounded pill (`bg-primary/10`) instead of the top indicator bar, labels are tightened to `text-[10px] uppercase tracking-wider`, and haptics are gated so they only fire when switching to a different tab. `aria-current="page"` is also set for the active destination.
 
 ---
 
@@ -371,7 +373,7 @@ This addendum captures a deep codebase review and complements the recommendation
 
 ---
 
-## 3) Data-freshness live badge on dashboard hero (High)
+## 3) Data-freshness live badge on dashboard hero (High) — ✅ Done
 
 **What I observed**
 
@@ -389,9 +391,11 @@ This addendum captures a deep codebase review and complements the recommendation
 
 **Target files**: `src/components/dashboard/dashboard-actions.tsx`, `src/components/dashboard/net-worth-card.tsx`
 
+> **Implemented**: Dashboard freshness chips are now rendered as visible badges, include `aria-live="polite"` for assistive updates, and relative timestamps auto-refresh every 30 seconds via a timer so "updated X ago" remains accurate during a long session.
+
 ---
 
-## 4) Accessibility audit: missing labels, focus rings, chart sr-only summaries (High)
+## 4) Accessibility audit: missing labels, focus rings, chart sr-only summaries (High) — ⚠️ Partial
 
 **What I observed**
 

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -304,20 +304,20 @@ This addendum captures a deep codebase review and complements the recommendation
 
 ## Enhancement Summary Table
 
-| #   | Item                                                                            | Impact     | Status   |
-| --- | ------------------------------------------------------------------------------- | ---------- | -------- |
-| 1   | Mobile bottom nav: larger tap targets + pill active state                       | High       | ✅ Done  |
-| 2   | Missing `theme-color` meta tag + iOS splash screens                             | High       | ✅ Done  |
-| 3   | Data-freshness live badge on dashboard hero                                     | High       | ✅ Done  |
+| #   | Item                                                                            | Impact     | Status     |
+| --- | ------------------------------------------------------------------------------- | ---------- | ---------- |
+| 1   | Mobile bottom nav: larger tap targets + pill active state                       | High       | ✅ Done    |
+| 2   | Missing `theme-color` meta tag + iOS splash screens                             | High       | ✅ Done    |
+| 3   | Data-freshness live badge on dashboard hero                                     | High       | ✅ Done    |
 | 4   | Accessibility audit: missing `aria-label`, focus rings, sr-only chart summaries | High       | ⚠️ Partial |
-| 5   | Extract duplicated swipe-row logic into shared component                        | Medium     | Proposed |
-| 6   | Sticky sort/filter bar in account detail holdings list                          | Medium     | Proposed |
-| 7   | Unified motion token system in `globals.css`                                    | Medium     | Proposed |
-| 8   | Richer empty states with multi-action onboarding                                | Medium     | Proposed |
-| 9   | Mobile chart interaction model (crosshair, haptics, range persistence)          | Medium     | Proposed |
-| 10  | Bulk-delete UX: replace `confirm()` with undo-toast pattern                     | Medium     | Proposed |
-| 11  | Transaction edit dialog → bottom sheet on mobile                                | Medium     | Proposed |
-| 12  | Search dropdown keyboard navigation + loading skeleton                          | Low/Medium | Proposed |
+| 5   | Extract duplicated swipe-row logic into shared component                        | Medium     | Proposed   |
+| 6   | Sticky sort/filter bar in account detail holdings list                          | Medium     | Proposed   |
+| 7   | Unified motion token system in `globals.css`                                    | Medium     | Proposed   |
+| 8   | Richer empty states with multi-action onboarding                                | Medium     | Proposed   |
+| 9   | Mobile chart interaction model (crosshair, haptics, range persistence)          | Medium     | Proposed   |
+| 10  | Bulk-delete UX: replace `confirm()` with undo-toast pattern                     | Medium     | Proposed   |
+| 11  | Transaction edit dialog → bottom sheet on mobile                                | Medium     | Proposed   |
+| 12  | Search dropdown keyboard navigation + loading skeleton                          | Low/Medium | Proposed   |
 
 ---
 

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -8,13 +8,13 @@ import { toast } from "sonner";
 import { useTranslations, useLocale } from "next-intl";
 import { hapticTick } from "@/lib/haptics";
 
-function getRelativeTime(dateString: string, locale: string) {
+function getRelativeTime(dateString: string, locale: string, now: number) {
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
   // Parse as local noon to avoid UTC-midnight causing off-by-one-day in non-UTC timezones
   const localDate = dateString.includes("T")
     ? new Date(dateString)
     : new Date(`${dateString}T12:00:00`);
-  const diffInSeconds = Math.round((localDate.getTime() - Date.now()) / 1000);
+  const diffInSeconds = Math.round((localDate.getTime() - now) / 1000);
   const absDiff = Math.abs(diffInSeconds);
 
   if (absDiff < 60) return rtf.format(Math.sign(diffInSeconds) * absDiff, "second");
@@ -36,6 +36,7 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
   const t = useTranslations("dashboardActions");
   const locale = useLocale();
   const [refreshing, setRefreshing] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
 
   const handleRefreshPrices = useCallback(async () => {
     hapticTick();
@@ -63,21 +64,29 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
     return () => window.removeEventListener("prices:refresh", handler);
   }, [handleRefreshPrices]);
 
-  const priceAge = lastPriceUpdate ? getRelativeTime(lastPriceUpdate, locale) : null;
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
-  const snapshotAge = lastSnapshotDate ? getRelativeTime(lastSnapshotDate, locale) : null;
+  const priceAge = lastPriceUpdate ? getRelativeTime(lastPriceUpdate, locale, now) : null;
+
+  const snapshotAge = lastSnapshotDate ? getRelativeTime(lastSnapshotDate, locale, now) : null;
 
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 justify-between">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+      <div
+        className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground"
+        aria-live="polite"
+      >
         {priceAge && (
-          <span className="inline-flex items-center gap-1">
+          <span className="inline-flex items-center gap-1 rounded-full border border-primary/25 bg-primary/5 px-2.5 py-1 text-primary">
             <Clock className="h-3 w-3" />
             {t("pricesUpdated", { age: priceAge })}
           </span>
         )}
         {snapshotAge && (
-          <span className="inline-flex items-center gap-1">
+          <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-muted/30 px-2.5 py-1">
             <Camera className="h-3 w-3" />
             {t("snapshot", { age: snapshotAge })}
           </span>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -270,16 +270,18 @@ export function MobileNav() {
           <Link
             key={item.href}
             href={item.href}
-            onClick={hapticTick}
+            onClick={() => {
+              if (!isActive) hapticTick();
+            }}
             className={cn(
-              "relative flex min-h-12 min-w-12 flex-col items-center justify-center gap-1 px-3 py-1 text-[11px] uppercase tracking-wide transition-colors group rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-              isActive ? "text-primary font-medium" : "text-muted-foreground hover:text-foreground",
+              "relative flex min-h-12 min-w-12 flex-col items-center justify-center gap-1 px-4 py-2 text-[10px] uppercase tracking-wider transition-all group rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              isActive
+                ? "text-primary font-semibold bg-primary/10 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.2)]"
+                : "text-muted-foreground hover:text-foreground",
             )}
             aria-label={item.label}
+            aria-current={isActive ? "page" : undefined}
           >
-            {isActive && (
-              <div className="absolute inset-x-2 -top-3 h-0.5 bg-primary rounded-b-full shadow-[0_2px_8px_rgba(0,0,0,0.5)] shadow-primary/50 transition-all duration-200" />
-            )}
             <Icon
               className={cn(
                 "h-5 w-5 transition-transform duration-200 ease-spring",


### PR DESCRIPTION
### Motivation
- Implement the high-impact UI/UX items called out in `docs/UI_UX.md` to improve mobile ergonomics and user trust. 
- Make dashboard data-freshness visible and reliably up-to-date so users can see when prices/snapshots were last refreshed. 
- Reflect implemented work and current status in the `UI_UX` documentation so the roadmap remains accurate. 

### Description
- Updated the mobile bottom navigation in `src/components/layout/sidebar.tsx` to increase tap targets (`px-4 py-2` / `min-h-12 min-w-12`), tighten labels to `text-[10px] uppercase`, apply an iOS-style active pill (`bg-primary/10`) and `aria-current="page"`, and gate haptic feedback so it only fires when switching tabs. 
- Enhanced dashboard freshness UI in `src/components/dashboard/dashboard-actions.tsx` by converting price/snapshot text into visible badge chips, adding `aria-live="polite"` for assistive updates, changing `getRelativeTime()` to accept a `now` parameter, and adding a 30s `setInterval` to auto-refresh relative timestamps. 
- Updated `docs/UI_UX.md` to mark the mobile bottom nav and data-freshness badge items as implemented and to mark the accessibility audit as partially complete, with implementation notes added. 

### Testing
- Ran `npm run -s lint` which passed. 
- Code style and formatting tools (`prettier` and `eslint --fix`) were executed as part of the staging pipeline and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001c0f95148321910dd2fd51b4b066)