### PR TITLE
Refactor: Extract duplicated swipe-row logic into shared component

### DIFF
--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -310,7 +310,7 @@ This addendum captures a deep codebase review and complements the recommendation
 | 2   | Missing `theme-color` meta tag + iOS splash screens                             | High       | ✅ Done  |
 | 3   | Data-freshness live badge on dashboard hero                                     | High       | Proposed |
 | 4   | Accessibility audit: missing `aria-label`, focus rings, sr-only chart summaries | High       | Proposed |
-| 5   | Extract duplicated swipe-row logic into shared component                        | Medium     | Proposed |
+| 5   | Extract duplicated swipe-row logic into shared component                        | Medium     | ✅ Done  |
 | 6   | Sticky sort/filter bar in account detail holdings list                          | Medium     | Proposed |
 | 7   | Unified motion token system in `globals.css`                                    | Medium     | Proposed |
 | 8   | Richer empty states with multi-action onboarding                                | Medium     | Proposed |
@@ -414,7 +414,7 @@ This addendum captures a deep codebase review and complements the recommendation
 
 ---
 
-## 5) Extract duplicated swipe-row logic into shared component (Medium)
+## 5) Extract duplicated swipe-row logic into shared component (Medium) — ✅ Done
 
 **What I observed**
 
@@ -435,6 +435,8 @@ This addendum captures a deep codebase review and complements the recommendation
 - Share `REVEAL_WIDTH`, `SNAP_THRESHOLD`, `FULL_SWIPE` constants from the shared module.
 
 **Target files**: `src/components/accounts/holding-row.tsx`, `src/components/accounts/transaction-history.tsx` → new `src/components/ui/swipeable-row.tsx`
+
+> **Implemented**: Extracted the duplicate framer-motion swipe-to-reveal logic into a new `<SwipeableRow>` component in `src/components/ui/swipeable-row.tsx`. Both `HoldingRow` and `SwipeableTxRow` now pass `actions` as props instead of re-implementing `useMotionValue` and `useTransform`. All motion primitives and constants (`REVEAL_WIDTH`, `SNAP_THRESHOLD`, `FULL_SWIPE`) are now localized to `SwipeableRow`.
 
 ---
 

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -47,7 +47,6 @@ export function HoldingRow({
   const nameLabel = optionDisplay ? optionDisplay.long : h.name;
   const isOption = h.assetType === "OPTION";
 
-
   return (
     <SwipeableRow
       actions={[

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
-import { motion, useMotionValue, useTransform, animate } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -15,15 +13,10 @@ import { getOptionDisplay } from "@/lib/options";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
-import { hapticTick } from "@/lib/haptics";
-import { registerSwipeRow, closeOtherSwipeRows } from "@/lib/swipe-row-registry";
+import { SwipeableRow } from "@/components/ui/swipeable-row";
 import type { SerializedHolding } from "@/lib/types";
 
 const HIDDEN = "***";
-const ACTION_WIDTH = 60;
-const REVEAL_WIDTH = 144; // fixed: accommodates gap-2 + px-2 while keeping both action buttons equal width
-const SNAP_THRESHOLD = REVEAL_WIDTH * 0.4;
-const FULL_SWIPE = REVEAL_WIDTH + 80; // past this → delete on release
 
 export interface HoldingWithPrice extends SerializedHolding {
   currentPrice: number | null;
@@ -54,204 +47,83 @@ export function HoldingRow({
   const nameLabel = optionDisplay ? optionDisplay.long : h.name;
   const isOption = h.assetType === "OPTION";
 
-  const x = useMotionValue(0);
-  const hasFiredHaptic = useRef(false);
-  const hasFiredDangerHaptic = useRef(false);
-  const [isOpen, setIsOpen] = useState(false);
-  const closeRef = useRef<() => void>(() => {});
-
-  useEffect(() => {
-    function close() {
-      animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
-      setIsOpen(false);
-      hasFiredHaptic.current = false;
-      hasFiredDangerHaptic.current = false;
-    }
-    closeRef.current = close;
-    return registerSwipeRow(close);
-  }, [x]);
-
-  // Reveal opacity: fades in as row slides open
-  const actionsOpacity = useTransform(x, [-REVEAL_WIDTH * 0.5, 0], [1, 0], { clamp: true });
-  // Icon scale: pops from 65% → 100% as row reveals
-  const iconScale = useTransform(x, [0, -REVEAL_WIDTH], [0.65, 1.0], { clamp: true });
-  // Edit button shrinks away in the danger zone
-  const editOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1, 0], { clamp: true });
-  const editWidth = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [ACTION_WIDTH, 0], {
-    clamp: true,
-  });
-  // Delete icon grows in the danger zone
-  const deleteIconScale = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1.0, 1.3], {
-    clamp: true,
-  });
-  // Red edge tint on the row itself
-  const dangerOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [0, 1], { clamp: true });
-
-  function snapOpen() {
-    closeOtherSwipeRows(closeRef.current);
-    animate(x, -REVEAL_WIDTH, { type: "spring", stiffness: 300, damping: 30 });
-    setIsOpen(true);
-  }
-
-  function snapClose() {
-    animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
-    setIsOpen(false);
-    hasFiredHaptic.current = false;
-    hasFiredDangerHaptic.current = false;
-  }
-
-  function handleDrag() {
-    const cur = x.get();
-    if (!hasFiredHaptic.current && cur < -SNAP_THRESHOLD) {
-      hapticTick();
-      hasFiredHaptic.current = true;
-    } else if (hasFiredHaptic.current && cur > -SNAP_THRESHOLD) {
-      hasFiredHaptic.current = false;
-    }
-    if (!hasFiredDangerHaptic.current && cur < -FULL_SWIPE) {
-      hapticTick();
-      hapticTick(); // double-tick signals danger zone
-      hasFiredDangerHaptic.current = true;
-    } else if (hasFiredDangerHaptic.current && cur > -FULL_SWIPE) {
-      hasFiredDangerHaptic.current = false;
-    }
-  }
-
-  function handleDragEnd() {
-    const cur = x.get();
-    if (cur < -FULL_SWIPE) {
-      snapClose();
-      hapticTick();
-      onDelete(h.id);
-    } else if (cur < -SNAP_THRESHOLD) {
-      snapOpen();
-      hapticTick();
-    } else {
-      snapClose();
-    }
-  }
 
   return (
-    <div className="relative overflow-hidden bg-card select-none">
-      {/* Action buttons revealed on left swipe */}
-      <motion.div
-        className="absolute inset-y-0 right-0 flex gap-2 px-2"
-        style={{ opacity: actionsOpacity, width: REVEAL_WIDTH }}
-        aria-hidden="true"
-      >
-        <motion.button
-          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
-          style={{ opacity: editOpacity, width: editWidth, minWidth: 0 }}
-          onClick={() => {
-            snapClose();
-            onEdit(h);
-          }}
-          aria-label={t("common.edit")}
-        >
-          <motion.div className="flex flex-col items-center gap-1" style={{ scale: iconScale }}>
-            <Pencil className="h-4 w-4" />
-            <span>{t("common.edit")}</span>
-          </motion.div>
-        </motion.button>
-        <button
-          className="flex-1 flex items-center justify-center bg-destructive text-white text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
-          onClick={() => {
-            snapClose();
-            onDelete(h.id);
-          }}
-          aria-label={t("common.delete")}
-        >
-          <motion.div
-            className="flex flex-col items-center gap-1"
-            style={{ scale: deleteIconScale }}
+    <SwipeableRow
+      actions={[
+        {
+          label: t("common.edit"),
+          icon: Pencil,
+          color: "bg-blue-500",
+          onClick: () => onEdit(h),
+        },
+        {
+          label: t("common.delete"),
+          icon: Trash2,
+          color: "bg-destructive",
+          onClick: () => onDelete(h.id),
+        },
+      ]}
+      onFullSwipe={() => onDelete(h.id)}
+      className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span
+            className="font-mono font-semibold text-sm"
+            title={isOption ? optionDisplay?.occ : undefined}
           >
-            <Trash2 className="h-4 w-4" />
-            <span>{t("common.delete")}</span>
-          </motion.div>
-        </button>
-      </motion.div>
-
-      {/* Draggable row */}
-      <motion.div
-        className={`flex items-center gap-3 px-4 ${isCompact ? "py-2" : "py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10`}
-        style={{ x }}
-        drag="x"
-        dragDirectionLock
-        dragConstraints={{ left: -(FULL_SWIPE + 60), right: 0 }}
-        dragElastic={{ left: 0.12, right: 0.15 }}
-        onDrag={handleDrag}
-        onDragEnd={handleDragEnd}
-        onClick={() => {
-          if (isOpen) snapClose();
-        }}
-      >
-        {/* Danger-zone red tint bleeds in from the right edge */}
-        <motion.div
-          className="absolute inset-y-0 right-0 w-28 pointer-events-none rounded-r-none"
-          style={{
-            opacity: dangerOpacity,
-            background: "linear-gradient(to left, oklch(0.55 0.22 27 / 0.35), transparent)",
-          }}
-        />
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <span
-              className="font-mono font-semibold text-sm"
-              title={isOption ? optionDisplay?.occ : undefined}
-            >
-              {symbolLabel}
+            {symbolLabel}
+          </span>
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
+            {h.assetType}
+          </Badge>
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
+            {h.currency || "USD"}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">{nameLabel}</p>
+        <p className="text-xs text-muted-foreground/70 mt-0.5 tabular-nums">
+          {formatQuantity(h.quantity, h.assetType)}
+          {isOption && <span className="ml-1">contracts</span>}
+          {!privacyMode && h.currentPrice !== null && (
+            <span className="ml-2">
+              @ {formatCurrency(h.currentPrice, h.currency || "USD")}
+              {isOption && <span>/share</span>}
             </span>
-            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
-              {h.assetType}
-            </Badge>
-            <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
-              {h.currency || "USD"}
-            </Badge>
-          </div>
-          <p className="text-xs text-muted-foreground mt-0.5 truncate">{nameLabel}</p>
-          <p className="text-xs text-muted-foreground/70 mt-0.5 tabular-nums">
-            {formatQuantity(h.quantity, h.assetType)}
-            {isOption && <span className="ml-1">contracts</span>}
-            {!privacyMode && h.currentPrice !== null && (
-              <span className="ml-2">
-                @ {formatCurrency(h.currentPrice, h.currency || "USD")}
-                {isOption && <span>/share</span>}
-              </span>
-            )}
-          </p>
-        </div>
-        <div className="text-right shrink-0">
-          <p className="text-sm font-medium tabular-nums">
-            {privacyMode
-              ? HIDDEN
-              : h.marketValue !== null
-                ? formatCurrency(h.marketValue, accountCurrency)
-                : "—"}
-          </p>
-          <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
-            {privacyMode
-              ? "—"
-              : h.marketValue !== null && totalValue > 0
-                ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
-                : "—"}
-          </p>
-        </div>
-        {/* Desktop fallback: three-dot menu */}
-        <div className="hidden sm:block">
-          <DropdownMenu>
-            <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0">
-              <MoreHorizontal className="h-4 w-4" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => onEdit(h)}>{t("common.edit")}</DropdownMenuItem>
-              <DropdownMenuItem className="text-destructive" onClick={() => onDelete(h.id)}>
-                {t("common.delete")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </motion.div>
-    </div>
+          )}
+        </p>
+      </div>
+      <div className="text-right shrink-0">
+        <p className="text-sm font-medium tabular-nums">
+          {privacyMode
+            ? HIDDEN
+            : h.marketValue !== null
+              ? formatCurrency(h.marketValue, accountCurrency)
+              : "—"}
+        </p>
+        <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
+          {privacyMode
+            ? "—"
+            : h.marketValue !== null && totalValue > 0
+              ? `${((h.marketValue / totalValue) * 100).toFixed(1)}%`
+              : "—"}
+        </p>
+      </div>
+      {/* Desktop fallback: three-dot menu */}
+      <div className="hidden sm:block">
+        <DropdownMenu>
+          <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0">
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(h)}>{t("common.edit")}</DropdownMenuItem>
+            <DropdownMenuItem className="text-destructive" onClick={() => onDelete(h.id)}>
+              {t("common.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </SwipeableRow>
   );
 }

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -43,8 +43,6 @@ const TYPE_VARIANTS: Record<string, "default" | "secondary" | "destructive"> = {
   EDIT: "secondary",
 };
 
-
-
 interface TxRowProps {
   tx: SerializedTransaction;
   typeLabel: string;
@@ -68,8 +66,6 @@ function SwipeableTxRow({
   onDelete,
   tCommon,
 }: TxRowProps) {
-
-
   return (
     <SwipeableRow
       actions={[

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -3,7 +3,6 @@
 import { useRef, useState, useEffect, useCallback, startTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { motion, useMotionValue, useTransform, animate } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatQuantity } from "@/lib/currencies";
@@ -16,8 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { hapticTick } from "@/lib/haptics";
-import { registerSwipeRow, closeOtherSwipeRows } from "@/lib/swipe-row-registry";
+import { SwipeableRow } from "@/components/ui/swipeable-row";
 import {
   Dialog,
   DialogContent,
@@ -45,10 +43,7 @@ const TYPE_VARIANTS: Record<string, "default" | "secondary" | "destructive"> = {
   EDIT: "secondary",
 };
 
-const ACTION_WIDTH = 60;
-const REVEAL_WIDTH = 144; // fixed: accommodates gap-2 + px-2 while keeping both action buttons equal width
-const SNAP_THRESHOLD = REVEAL_WIDTH * 0.4;
-const FULL_SWIPE = REVEAL_WIDTH + 80; // past this → trigger delete on release
+
 
 interface TxRowProps {
   tx: SerializedTransaction;
@@ -73,175 +68,61 @@ function SwipeableTxRow({
   onDelete,
   tCommon,
 }: TxRowProps) {
-  const x = useMotionValue(0);
-  const hasFiredHaptic = useRef(false);
-  const hasFiredDangerHaptic = useRef(false);
-  const [isOpen, setIsOpen] = useState(false);
-  const closeRef = useRef<() => void>(() => {});
 
-  useEffect(() => {
-    function close() {
-      animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
-      setIsOpen(false);
-      hasFiredHaptic.current = false;
-      hasFiredDangerHaptic.current = false;
-    }
-    closeRef.current = close;
-    return registerSwipeRow(close);
-  }, [x]);
-
-  const actionsOpacity = useTransform(x, [-REVEAL_WIDTH * 0.5, 0], [1, 0], { clamp: true });
-  const iconScale = useTransform(x, [0, -REVEAL_WIDTH], [0.65, 1.0], { clamp: true });
-  const editOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1, 0], { clamp: true });
-  const editWidth = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [ACTION_WIDTH, 0], {
-    clamp: true,
-  });
-  const deleteIconScale = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1.0, 1.3], {
-    clamp: true,
-  });
-  const dangerOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [0, 1], { clamp: true });
-
-  function snapOpen() {
-    closeOtherSwipeRows(closeRef.current);
-    animate(x, -REVEAL_WIDTH, { type: "spring", stiffness: 300, damping: 30 });
-    setIsOpen(true);
-  }
-
-  function snapClose() {
-    animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
-    setIsOpen(false);
-    hasFiredHaptic.current = false;
-    hasFiredDangerHaptic.current = false;
-  }
-
-  function handleDrag() {
-    const cur = x.get();
-    if (!hasFiredHaptic.current && cur < -SNAP_THRESHOLD) {
-      hapticTick();
-      hasFiredHaptic.current = true;
-    } else if (hasFiredHaptic.current && cur > -SNAP_THRESHOLD) {
-      hasFiredHaptic.current = false;
-    }
-    if (!hasFiredDangerHaptic.current && cur < -FULL_SWIPE) {
-      hapticTick();
-      hapticTick();
-      hasFiredDangerHaptic.current = true;
-    } else if (hasFiredDangerHaptic.current && cur > -FULL_SWIPE) {
-      hasFiredDangerHaptic.current = false;
-    }
-  }
-
-  function handleDragEnd() {
-    const cur = x.get();
-    if (cur < -FULL_SWIPE) {
-      snapClose();
-      hapticTick();
-      onDelete(); // opens the confirm dialog
-    } else if (cur < -SNAP_THRESHOLD) {
-      snapOpen();
-      hapticTick();
-    } else {
-      snapClose();
-    }
-  }
 
   return (
-    <div className="relative overflow-hidden bg-card select-none">
-      {/* Action buttons revealed on left swipe */}
-      <motion.div
-        className="absolute inset-y-0 right-0 flex gap-2 px-2"
-        style={{ opacity: actionsOpacity, width: REVEAL_WIDTH }}
-        aria-hidden="true"
-      >
-        <motion.button
-          className="flex items-center justify-center bg-blue-500 text-white text-xs font-medium overflow-hidden rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
-          style={{ opacity: editOpacity, width: editWidth, minWidth: 0 }}
-          onClick={() => {
-            snapClose();
-            onEdit();
-          }}
-          aria-label={tCommon("edit")}
-        >
-          <motion.div className="flex flex-col items-center gap-1" style={{ scale: iconScale }}>
-            <Pencil className="h-4 w-4" />
-            <span>{tCommon("edit")}</span>
-          </motion.div>
-        </motion.button>
-        <button
-          className="flex-1 flex items-center justify-center bg-destructive text-white text-xs font-medium rounded-2xl my-1.5 active:brightness-90 transition-[filter]"
-          onClick={() => {
-            snapClose();
-            onDelete();
-          }}
-          aria-label={tCommon("delete")}
-        >
-          <motion.div
-            className="flex flex-col items-center gap-1"
-            style={{ scale: deleteIconScale }}
-          >
-            <Trash2 className="h-4 w-4" />
-            <span>{tCommon("delete")}</span>
-          </motion.div>
-        </button>
-      </motion.div>
-
-      {/* Draggable row content */}
-      <motion.div
-        className="flex items-center gap-3 px-4 py-3.5 bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10"
-        style={{ x }}
-        drag="x"
-        dragDirectionLock
-        dragConstraints={{ left: -(FULL_SWIPE + 60), right: 0 }}
-        dragElastic={{ left: 0.12, right: 0.15 }}
-        onDrag={handleDrag}
-        onDragEnd={handleDragEnd}
-        onClick={() => {
-          if (isOpen) snapClose();
-        }}
-      >
-        {/* Danger-zone red tint bleeds in from the right edge */}
-        <motion.div
-          className="absolute inset-y-0 right-0 w-28 pointer-events-none"
-          style={{
-            opacity: dangerOpacity,
-            background: "linear-gradient(to left, oklch(0.55 0.22 27 / 0.35), transparent)",
-          }}
-        />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            {symbol && <span className="font-mono font-semibold text-sm">{symbol}</span>}
-            <Badge variant={typeVariant} className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
-              {typeLabel}
-            </Badge>
-          </div>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            {time}
-            {tx.note ? ` · ${tx.note}` : ""}
-          </p>
+    <SwipeableRow
+      actions={[
+        {
+          label: tCommon("edit"),
+          icon: Pencil,
+          color: "bg-blue-500",
+          onClick: onEdit,
+        },
+        {
+          label: tCommon("delete"),
+          icon: Trash2,
+          color: "bg-destructive",
+          onClick: onDelete,
+        },
+      ]}
+      onFullSwipe={onDelete}
+      className="flex items-center gap-3 px-4 py-3.5 bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors relative z-10"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {symbol && <span className="font-mono font-semibold text-sm">{symbol}</span>}
+          <Badge variant={typeVariant} className="text-[10px] px-1.5 py-0 h-4 rounded-sm">
+            {typeLabel}
+          </Badge>
         </div>
-        <div className="text-right shrink-0">
-          <p className="text-sm font-medium tabular-nums">{qty}</p>
-        </div>
-        {/* Desktop fallback: three-dot menu */}
-        <div className="hidden sm:block">
-          <DropdownMenu>
-            <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0">
-              <MoreHorizontal className="h-4 w-4" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={onEdit}>
-                <Pencil className="mr-2 h-4 w-4" />
-                {tCommon("edit")}
-              </DropdownMenuItem>
-              <DropdownMenuItem className="text-destructive" onClick={onDelete}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                {tCommon("delete")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </motion.div>
-    </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {time}
+          {tx.note ? ` · ${tx.note}` : ""}
+        </p>
+      </div>
+      <div className="text-right shrink-0">
+        <p className="text-sm font-medium tabular-nums">{qty}</p>
+      </div>
+      {/* Desktop fallback: three-dot menu */}
+      <div className="hidden sm:block">
+        <DropdownMenu>
+          <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0">
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onEdit}>
+              <Pencil className="mr-2 h-4 w-4" />
+              {tCommon("edit")}
+            </DropdownMenuItem>
+            <DropdownMenuItem className="text-destructive" onClick={onDelete}>
+              <Trash2 className="mr-2 h-4 w-4" />
+              {tCommon("delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </SwipeableRow>
   );
 }
 

--- a/src/components/ui/swipeable-row.tsx
+++ b/src/components/ui/swipeable-row.tsx
@@ -50,7 +50,7 @@ export function SwipeableRow({
 
   const actionsOpacity = useTransform(x, [-REVEAL_WIDTH * 0.5, 0], [1, 0], { clamp: true });
   const iconScale = useTransform(x, [0, -REVEAL_WIDTH], [0.65, 1.0], { clamp: true });
-  
+
   // Specific transforms for when we have exactly 2 actions (edit/delete pattern)
   const editOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1, 0], { clamp: true });
   const editWidth = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [ACTION_WIDTH, 0], {
@@ -122,7 +122,7 @@ export function SwipeableRow({
           const buttonStyle = isFirstOfTwo
             ? { opacity: editOpacity, width: editWidth, minWidth: 0 }
             : {};
-            
+
           const innerStyle = isLastOfTwo ? { scale: deleteIconScale } : { scale: iconScale };
 
           return (

--- a/src/components/ui/swipeable-row.tsx
+++ b/src/components/ui/swipeable-row.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+import { motion, useMotionValue, useTransform, animate } from "framer-motion";
+import { hapticTick } from "@/lib/haptics";
+import { registerSwipeRow, closeOtherSwipeRows } from "@/lib/swipe-row-registry";
+import { LucideIcon } from "lucide-react";
+
+export const REVEAL_WIDTH = 144;
+export const SNAP_THRESHOLD = REVEAL_WIDTH * 0.4;
+export const FULL_SWIPE = REVEAL_WIDTH + 80;
+const ACTION_WIDTH = 60;
+
+export interface SwipeAction {
+  label: string;
+  icon: LucideIcon;
+  color: string;
+  onClick: () => void;
+}
+
+interface SwipeableRowProps {
+  children: React.ReactNode;
+  actions: SwipeAction[];
+  onFullSwipe?: () => void;
+  className?: string;
+}
+
+export function SwipeableRow({
+  children,
+  actions,
+  onFullSwipe,
+  className = "",
+}: SwipeableRowProps) {
+  const x = useMotionValue(0);
+  const hasFiredHaptic = useRef(false);
+  const hasFiredDangerHaptic = useRef(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const closeRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    function close() {
+      animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
+      setIsOpen(false);
+      hasFiredHaptic.current = false;
+      hasFiredDangerHaptic.current = false;
+    }
+    closeRef.current = close;
+    return registerSwipeRow(close);
+  }, [x]);
+
+  const actionsOpacity = useTransform(x, [-REVEAL_WIDTH * 0.5, 0], [1, 0], { clamp: true });
+  const iconScale = useTransform(x, [0, -REVEAL_WIDTH], [0.65, 1.0], { clamp: true });
+  
+  // Specific transforms for when we have exactly 2 actions (edit/delete pattern)
+  const editOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1, 0], { clamp: true });
+  const editWidth = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [ACTION_WIDTH, 0], {
+    clamp: true,
+  });
+  const deleteIconScale = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [1.0, 1.3], {
+    clamp: true,
+  });
+  const dangerOpacity = useTransform(x, [-REVEAL_WIDTH, -FULL_SWIPE], [0, 1], { clamp: true });
+
+  function snapOpen() {
+    closeOtherSwipeRows(closeRef.current);
+    animate(x, -REVEAL_WIDTH, { type: "spring", stiffness: 300, damping: 30 });
+    setIsOpen(true);
+  }
+
+  function snapClose() {
+    animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
+    setIsOpen(false);
+    hasFiredHaptic.current = false;
+    hasFiredDangerHaptic.current = false;
+  }
+
+  function handleDrag() {
+    const cur = x.get();
+    if (!hasFiredHaptic.current && cur < -SNAP_THRESHOLD) {
+      hapticTick();
+      hasFiredHaptic.current = true;
+    } else if (hasFiredHaptic.current && cur > -SNAP_THRESHOLD) {
+      hasFiredHaptic.current = false;
+    }
+    if (onFullSwipe) {
+      if (!hasFiredDangerHaptic.current && cur < -FULL_SWIPE) {
+        hapticTick();
+        hapticTick(); // double-tick signals danger zone
+        hasFiredDangerHaptic.current = true;
+      } else if (hasFiredDangerHaptic.current && cur > -FULL_SWIPE) {
+        hasFiredDangerHaptic.current = false;
+      }
+    }
+  }
+
+  function handleDragEnd() {
+    const cur = x.get();
+    if (onFullSwipe && cur < -FULL_SWIPE) {
+      snapClose();
+      hapticTick();
+      onFullSwipe();
+    } else if (cur < -SNAP_THRESHOLD) {
+      snapOpen();
+      hapticTick();
+    } else {
+      snapClose();
+    }
+  }
+
+  return (
+    <div className="relative overflow-hidden bg-card select-none">
+      {/* Action buttons revealed on left swipe */}
+      <motion.div
+        className="absolute inset-y-0 right-0 flex gap-2 px-2"
+        style={{ opacity: actionsOpacity, width: REVEAL_WIDTH }}
+        aria-hidden="true"
+      >
+        {actions.map((action, idx) => {
+          const isFirstOfTwo = actions.length === 2 && idx === 0;
+          const isLastOfTwo = actions.length === 2 && idx === 1;
+
+          const buttonStyle = isFirstOfTwo
+            ? { opacity: editOpacity, width: editWidth, minWidth: 0 }
+            : {};
+            
+          const innerStyle = isLastOfTwo ? { scale: deleteIconScale } : { scale: iconScale };
+
+          return (
+            <motion.button
+              key={idx}
+              className={`flex items-center justify-center ${action.color} text-white text-xs font-medium overflow-hidden rounded-2xl my-1.5 active:brightness-90 transition-[filter] ${!isFirstOfTwo ? "flex-1" : ""}`}
+              style={buttonStyle}
+              onClick={() => {
+                snapClose();
+                action.onClick();
+              }}
+              aria-label={action.label}
+            >
+              <motion.div className="flex flex-col items-center gap-1" style={innerStyle}>
+                <action.icon className="h-4 w-4" />
+                <span>{action.label}</span>
+              </motion.div>
+            </motion.button>
+          );
+        })}
+      </motion.div>
+
+      {/* Draggable row */}
+      <motion.div
+        className={className}
+        style={{ x }}
+        drag="x"
+        dragDirectionLock
+        dragConstraints={{ left: onFullSwipe ? -(FULL_SWIPE + 60) : -REVEAL_WIDTH, right: 0 }}
+        dragElastic={{ left: 0.12, right: 0.15 }}
+        onDrag={handleDrag}
+        onDragEnd={handleDragEnd}
+        onClick={() => {
+          if (isOpen) snapClose();
+        }}
+      >
+        {/* Danger-zone red tint bleeds in from the right edge */}
+        {onFullSwipe && (
+          <motion.div
+            className="absolute inset-y-0 right-0 w-28 pointer-events-none rounded-r-none"
+            style={{
+              opacity: dangerOpacity,
+              background: "linear-gradient(to left, oklch(0.55 0.22 27 / 0.35), transparent)",
+            }}
+          />
+        )}
+        {children}
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR extracts the duplicate framer-motion swipe-to-reveal logic from `HoldingRow` and `SwipeableTxRow` into a new `<SwipeableRow>` shared component, completing item #5 in the `UI_UX.md` roadmap.