### PR TITLE
fix(db): tenant isolation, cache invalidation, and query over-fetch

### DIFF
--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -2,9 +2,10 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
+import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 
-export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export const POST = withAuth(async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
   const { id } = await params;
   const body = await request.json();
   const parsed = createCashTransactionSchema.safeParse(body);
@@ -12,7 +13,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 
   const { type, amount, note } = parsed.data;
 
-  const account = await prisma.account.findUnique({ where: { id } });
+  const account = await prisma.account.findUnique({ where: { id, userId } });
   if (!account) return failure("Account not found", 404);
 
   const transaction = await prisma.cashTransaction.create({
@@ -25,8 +26,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     data: { cashBalance: { increment: delta } },
   });
 
-  revalidateTag(`accounts:${account.userId}`, "max");
-  revalidateTag(`net-worth:${account.userId}`, "max");
+  revalidateTag(`accounts:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`history:${userId}`, "max");
 
   return ok(transaction, { status: 201 });
-}
+});

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -5,30 +5,32 @@ import { calculateBalanceDelta } from "@/lib/services/balance";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 
-export const POST = withAuth(async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
-  const { id } = await params;
-  const body = await request.json();
-  const parsed = createCashTransactionSchema.safeParse(body);
-  if (!parsed.success) return validationError(parsed.error);
+export const POST = withAuth(
+  async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = createCashTransactionSchema.safeParse(body);
+    if (!parsed.success) return validationError(parsed.error);
 
-  const { type, amount, note } = parsed.data;
+    const { type, amount, note } = parsed.data;
 
-  const account = await prisma.account.findUnique({ where: { id, userId } });
-  if (!account) return failure("Account not found", 404);
+    const account = await prisma.account.findUnique({ where: { id, userId } });
+    if (!account) return failure("Account not found", 404);
 
-  const transaction = await prisma.cashTransaction.create({
-    data: { accountId: id, type, amount, note },
-  });
+    const transaction = await prisma.cashTransaction.create({
+      data: { accountId: id, type, amount, note },
+    });
 
-  const delta = calculateBalanceDelta(null, { type, amount });
-  await prisma.account.update({
-    where: { id },
-    data: { cashBalance: { increment: delta } },
-  });
+    const delta = calculateBalanceDelta(null, { type, amount });
+    await prisma.account.update({
+      where: { id },
+      data: { cashBalance: { increment: delta } },
+    });
 
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+    revalidateTag(`accounts:${userId}`, "max");
+    revalidateTag(`net-worth:${userId}`, "max");
+    revalidateTag(`history:${userId}`, "max");
 
-  return ok(transaction, { status: 201 });
-});
+    return ok(transaction, { status: 201 });
+  },
+);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -12,6 +12,7 @@ async function invalidateAccountCaches(accountId: string) {
   if (account) {
     revalidateTag(`accounts:${account.userId}`, "max");
     revalidateTag(`net-worth:${account.userId}`, "max");
+    revalidateTag(`history:${account.userId}`, "max");
   }
 }
 

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -1,5 +1,7 @@
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { ok } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
+import { ok, failure } from "@/lib/api-responses";
 
 interface UnifiedRow {
   id: string;
@@ -11,22 +13,36 @@ interface UnifiedRow {
   holdingId: string | null;
 }
 
+const cursorSchema = z.object({
+  createdAt: z.string().datetime(),
+  id: z.string().min(1),
+});
+
 function encodeCursor(row: { createdAt: Date; id: string }): string {
   return Buffer.from(
     JSON.stringify({ createdAt: row.createdAt.toISOString(), id: row.id }),
   ).toString("base64url");
 }
 
-function decodeCursor(cursor: string): { createdAt: Date; id: string } {
-  const parsed = JSON.parse(Buffer.from(cursor, "base64url").toString()) as {
-    createdAt: string;
-    id: string;
-  };
-  return { createdAt: new Date(parsed.createdAt), id: parsed.id };
+function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
+  try {
+    const raw = JSON.parse(Buffer.from(cursor, "base64url").toString());
+    const parsed = cursorSchema.parse(raw);
+    return { createdAt: new Date(parsed.createdAt), id: parsed.id };
+  } catch {
+    return null;
+  }
 }
 
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export const GET = withAuth(async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
   const { id } = await params;
+
+  const account = await prisma.account.findUnique({
+    where: { id, userId },
+    select: { id: true },
+  });
+  if (!account) return failure("Not found", 404);
+
   const { searchParams } = new URL(request.url);
 
   const limit = Math.max(1, Math.min(100, Number(searchParams.get("limit") || "20")));
@@ -36,7 +52,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 
   if (cursorParam) {
     // Cursor-based keyset pagination — O(1) regardless of position
-    const { createdAt: cursorDate, id: cursorId } = decodeCursor(cursorParam);
+    const decoded = decodeCursor(cursorParam);
+    if (!decoded) return failure("Invalid cursor", 400);
+    const { createdAt: cursorDate, id: cursorId } = decoded;
 
     rows = await prisma.$queryRaw<UnifiedRow[]>`
       SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", "holdingId"
@@ -118,4 +136,4 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   }));
 
   return ok({ transactions, nextCursor, hasMore });
-}
+});

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -34,29 +34,30 @@ function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
   }
 }
 
-export const GET = withAuth(async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
-  const { id } = await params;
+export const GET = withAuth(
+  async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
+    const { id } = await params;
 
-  const account = await prisma.account.findUnique({
-    where: { id, userId },
-    select: { id: true },
-  });
-  if (!account) return failure("Not found", 404);
+    const account = await prisma.account.findUnique({
+      where: { id, userId },
+      select: { id: true },
+    });
+    if (!account) return failure("Not found", 404);
 
-  const { searchParams } = new URL(request.url);
+    const { searchParams } = new URL(request.url);
 
-  const limit = Math.max(1, Math.min(100, Number(searchParams.get("limit") || "20")));
-  const cursorParam = searchParams.get("cursor");
+    const limit = Math.max(1, Math.min(100, Number(searchParams.get("limit") || "20")));
+    const cursorParam = searchParams.get("cursor");
 
-  let rows: UnifiedRow[];
+    let rows: UnifiedRow[];
 
-  if (cursorParam) {
-    // Cursor-based keyset pagination — O(1) regardless of position
-    const decoded = decodeCursor(cursorParam);
-    if (!decoded) return failure("Invalid cursor", 400);
-    const { createdAt: cursorDate, id: cursorId } = decoded;
+    if (cursorParam) {
+      // Cursor-based keyset pagination — O(1) regardless of position
+      const decoded = decodeCursor(cursorParam);
+      if (!decoded) return failure("Invalid cursor", 400);
+      const { createdAt: cursorDate, id: cursorId } = decoded;
 
-    rows = await prisma.$queryRaw<UnifiedRow[]>`
+      rows = await prisma.$queryRaw<UnifiedRow[]>`
       SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", "holdingId"
       FROM "HoldingTransaction"
       WHERE "holdingId" IN (SELECT id FROM "Holding" WHERE "accountId" = ${id})
@@ -72,12 +73,12 @@ export const GET = withAuth(async (request, { params }: { params: Promise<{ id: 
       ORDER BY "createdAt" DESC, id DESC
       LIMIT ${limit + 1}
     `;
-  } else {
-    // Initial load or legacy page-param fallback
-    const page = Math.max(1, Number(searchParams.get("page") || "1"));
-    const offset = (page - 1) * limit;
+    } else {
+      // Initial load or legacy page-param fallback
+      const page = Math.max(1, Number(searchParams.get("page") || "1"));
+      const offset = (page - 1) * limit;
 
-    rows = await prisma.$queryRaw<UnifiedRow[]>`
+      rows = await prisma.$queryRaw<UnifiedRow[]>`
       SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", "holdingId"
       FROM "HoldingTransaction"
       WHERE "holdingId" IN (SELECT id FROM "Holding" WHERE "accountId" = ${id})
@@ -92,48 +93,49 @@ export const GET = withAuth(async (request, { params }: { params: Promise<{ id: 
       LIMIT ${limit + 1}
       OFFSET ${offset}
     `;
-  }
-
-  // N+1 trick: fetching limit+1 tells us if there are more rows without a COUNT()
-  const hasMore = rows.length > limit;
-  if (hasMore) rows = rows.slice(0, limit);
-  const nextCursor = hasMore ? encodeCursor(rows[rows.length - 1]) : undefined;
-
-  // Hydrate holding details only for the holding transactions on this page
-  const holdingIds = [
-    ...new Set(rows.filter((r) => r.holdingId).map((r) => r.holdingId as string)),
-  ];
-
-  const holdingsMap = new Map<
-    string,
-    { symbol: string; name: string | null; currency: string; assetType: string }
-  >();
-  if (holdingIds.length > 0) {
-    const holdings = await prisma.holding.findMany({
-      where: { id: { in: holdingIds } },
-      select: { id: true, symbol: true, name: true, currency: true, assetType: true },
-    });
-    for (const h of holdings) {
-      holdingsMap.set(h.id, {
-        symbol: h.symbol,
-        name: h.name,
-        currency: h.currency,
-        assetType: h.assetType,
-      });
     }
-  }
 
-  const transactions = rows.map((row) => ({
-    id: row.id,
-    isCash: row.isCash,
-    type: row.type,
-    quantity: row.quantity,
-    note: row.note,
-    createdAt: row.createdAt,
-    ...(row.holdingId
-      ? { holdingId: row.holdingId, holding: holdingsMap.get(row.holdingId) ?? null }
-      : {}),
-  }));
+    // N+1 trick: fetching limit+1 tells us if there are more rows without a COUNT()
+    const hasMore = rows.length > limit;
+    if (hasMore) rows = rows.slice(0, limit);
+    const nextCursor = hasMore ? encodeCursor(rows[rows.length - 1]) : undefined;
 
-  return ok({ transactions, nextCursor, hasMore });
-});
+    // Hydrate holding details only for the holding transactions on this page
+    const holdingIds = [
+      ...new Set(rows.filter((r) => r.holdingId).map((r) => r.holdingId as string)),
+    ];
+
+    const holdingsMap = new Map<
+      string,
+      { symbol: string; name: string | null; currency: string; assetType: string }
+    >();
+    if (holdingIds.length > 0) {
+      const holdings = await prisma.holding.findMany({
+        where: { id: { in: holdingIds } },
+        select: { id: true, symbol: true, name: true, currency: true, assetType: true },
+      });
+      for (const h of holdings) {
+        holdingsMap.set(h.id, {
+          symbol: h.symbol,
+          name: h.name,
+          currency: h.currency,
+          assetType: h.assetType,
+        });
+      }
+    }
+
+    const transactions = rows.map((row) => ({
+      id: row.id,
+      isCash: row.isCash,
+      type: row.type,
+      quantity: row.quantity,
+      note: row.note,
+      createdAt: row.createdAt,
+      ...(row.holdingId
+        ? { holdingId: row.holdingId, holding: holdingsMap.get(row.holdingId) ?? null }
+        : {}),
+    }));
+
+    return ok({ transactions, nextCursor, hasMore });
+  },
+);

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -25,22 +25,24 @@ export async function GET(request: Request) {
     });
     if (expiredOptions.length > 0) {
       log.info("cron.options.expire", { count: expiredOptions.length });
-      for (const h of expiredOptions) {
-        await prisma.$transaction([
-          prisma.holdingTransaction.create({
-            data: {
-              holdingId: h.id,
-              type: "SELL",
-              quantity: Number(h.quantity),
-              note: "Expired",
-            },
-          }),
-          prisma.holding.update({
-            where: { id: h.id },
-            data: { quantity: 0 },
-          }),
-        ]);
-      }
+      await Promise.all(
+        expiredOptions.map((h) =>
+          prisma.$transaction([
+            prisma.holdingTransaction.create({
+              data: {
+                holdingId: h.id,
+                type: "SELL",
+                quantity: Number(h.quantity),
+                note: "Expired",
+              },
+            }),
+            prisma.holding.update({
+              where: { id: h.id },
+              data: { quantity: 0 },
+            }),
+          ]),
+        ),
+      );
       revalidateTag("accounts", "max");
     }
 

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -1,13 +1,15 @@
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { withAuth } from "@/lib/api-handler";
 import { ok } from "@/lib/api-responses";
 
-export async function POST() {
-  const settings = await prisma.setting.findFirst();
+export const POST = withAuth(async (_request, _ctx, userId) => {
+  const settings = await prisma.setting.findUnique({ where: { userId } });
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
   const accounts = await prisma.account.findMany({
+    where: { userId },
     select: { currency: true },
     distinct: ["currency"],
   });
@@ -22,4 +24,4 @@ export async function POST() {
   // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
   revalidateTag("exchange-rates", "max");
   return ok({ updated: totalUpdated, baseCurrency });
-}
+});

--- a/src/app/api/exchange-rates/route.ts
+++ b/src/app/api/exchange-rates/route.ts
@@ -6,7 +6,9 @@ export async function GET(request: Request) {
   const limited = rateLimitCheckWithPrune(request, { limit: 30, prefix: "exchange-rates" });
   if (limited) return limited;
 
-  const rates = await prisma.exchangeRate.findMany();
+  const rates = await prisma.exchangeRate.findMany({
+    select: { fromCurrency: true, toCurrency: true, rate: true },
+  });
   return ok(rates, {
     headers: {
       "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -15,7 +15,9 @@ async function getCachedExchangeRates(): Promise<Record<string, number>> {
   "use cache";
   cacheTag("exchange-rates");
   cacheLife("minutes");
-  const rates = await prisma.exchangeRate.findMany();
+  const rates = await prisma.exchangeRate.findMany({
+    select: { fromCurrency: true, toCurrency: true, rate: true },
+  });
   const map: Record<string, number> = {};
   for (const r of rates) {
     map[`${r.fromCurrency}_${r.toCurrency}`] = Number(r.rate);

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -81,7 +81,14 @@ export async function getNormalizedHistory(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId, date: { gte: fromDate } },
-      select: { id: true, date: true, netWorth: true, totalAssets: true, totalLiabilities: true, baseCurrency: true },
+      select: {
+        id: true,
+        date: true,
+        netWorth: true,
+        totalAssets: true,
+        totalLiabilities: true,
+        baseCurrency: true,
+      },
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),
@@ -120,7 +127,14 @@ async function fetchFullHistoryCached(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId },
-      select: { id: true, date: true, netWorth: true, totalAssets: true, totalLiabilities: true, baseCurrency: true },
+      select: {
+        id: true,
+        date: true,
+        netWorth: true,
+        totalAssets: true,
+        totalLiabilities: true,
+        baseCurrency: true,
+      },
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,7 +1,7 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
-import type { NetWorthSnapshot } from "@/generated/prisma/client";
+import type { Decimal } from "@/generated/prisma/runtime/library";
 import type { MonthlyContribution } from "./analysis-service";
 
 export interface NormalizedSnapshot {
@@ -16,13 +16,22 @@ export interface NormalizedSnapshot {
 /** Default history window: last 90 days. Keeps the query fast for the dashboard. */
 const DEFAULT_HISTORY_DAYS = 90;
 
+interface SnapshotRow {
+  id: string;
+  date: Date;
+  netWorth: Decimal;
+  totalAssets: Decimal;
+  totalLiabilities: Decimal;
+  baseCurrency: string;
+}
+
 /**
  * Pure transformation: convert and dedupe raw snapshots into NormalizedSnapshot[].
  * If multiple snapshots exist for the same date (e.g. from a currency change),
  * prefers the one whose baseCurrency already matches the target, otherwise the latest seen.
  */
 function normalizeSnapshots(
-  snapshots: NetWorthSnapshot[],
+  snapshots: SnapshotRow[],
   allRatesMap: Map<string, number>,
   targetBaseCurrency: string,
 ): NormalizedSnapshot[] {
@@ -72,6 +81,7 @@ export async function getNormalizedHistory(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId, date: { gte: fromDate } },
+      select: { id: true, date: true, netWorth: true, totalAssets: true, totalLiabilities: true, baseCurrency: true },
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),
@@ -110,6 +120,7 @@ async function fetchFullHistoryCached(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId },
+      select: { id: true, date: true, netWorth: true, totalAssets: true, totalLiabilities: true, baseCurrency: true },
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,7 +1,7 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
-import type { Decimal } from "@/generated/prisma/runtime/library";
+import type { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import type { MonthlyContribution } from "./analysis-service";
 
 export interface NormalizedSnapshot {


### PR DESCRIPTION
## Summary

- **Tenant isolation (security):** `GET /api/accounts/[id]/transactions`, `POST /api/accounts/[id]/cash-transactions`, and `POST /api/exchange-rates/refresh` had no auth guard — any authenticated user could read/write another user's data by guessing account IDs. All three now use `withAuth` and scope DB queries to `userId`.
- **Cursor validation:** `decodeCursor()` in the transactions route previously threw an unhandled exception on malformed base64/JSON input, causing a 500. Now returns `null` and the route responds with 400.
- **Cache invalidation gap:** `history:${userId}` was not invalidated when cash-transaction or holding-transaction mutations were written, causing the `/analysis` cash-flow chart and `/history` page to show stale data until the 5-min TTL expired. Added the missing `revalidateTag` call to both mutation paths.
- **Query over-fetch:** `getNormalizedHistory` and `fetchFullHistoryCached` fetched the `breakdown` JSON column (per-account values, can be several KB per snapshot) even though `normalizeSnapshots` never reads it. Added `select` to skip it. Same treatment for `getAllExchangeRates()` and `GET /api/exchange-rates` (dropped unused `id`/`createdAt`/`updatedAt` columns).
- **Cron efficiency:** The expired-option sweep in `/api/cron/snapshot` ran each `$transaction()` sequentially; replaced with `Promise.all` to parallelize across expiring options.

## Files changed

| File | Change |
|------|--------|
| `src/app/api/accounts/[id]/transactions/route.ts` | `withAuth` + ownership check + Zod cursor validation |
| `src/app/api/exchange-rates/refresh/route.ts` | `withAuth` + scope queries to `userId` |
| `src/app/api/accounts/[id]/cash-transactions/route.ts` | `withAuth` + `userId` match + `history:` revalidation |
| `src/app/api/accounts/[id]/transactions/[transactionId]/route.ts` | `history:` revalidation in `invalidateAccountCaches` |
| `src/lib/services/history-service.ts` | `select` to skip `breakdown` in normalized history queries |
| `src/lib/services/exchange-rate-service.ts` | `select` on bulk exchange-rate fetch |
| `src/app/api/exchange-rates/route.ts` | `select` on GET response |
| `src/app/api/cron/snapshot/route.ts` | Parallelize option expiration with `Promise.all` |

## Test plan

- [x] Unauthenticated `GET /api/accounts/<id>/transactions` → 302 (confirmed via curl)
- [x] Unauthenticated `POST /api/exchange-rates/refresh` → 302 (confirmed via curl)
- [x] Unauthenticated `POST /api/accounts/<id>/cash-transactions` → 302 (confirmed via curl)
- [x] `GET /api/accounts/<id>/transactions?cursor=GARBAGE` → 400 (logic verified in code; auth gate blocks unauthenticated curl)
- [x] Add a cash deposit → navigate to `/analysis` immediately → cash-flow chart reflects it without waiting for cache TTL
- [x] Prisma query logs show normalized-history queries no longer include `breakdown` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)