### PR TITLE
Fix price refresh timestamp display across manual and pull-to-refresh

### DIFF
--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -37,6 +37,7 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
   const locale = useLocale();
   const [refreshing, setRefreshing] = useState(false);
   const [now, setNow] = useState(() => Date.now());
+  const [clientRefreshAt, setClientRefreshAt] = useState<string | null>(null);
 
   const handleRefreshPrices = useCallback(async () => {
     hapticTick();
@@ -48,6 +49,8 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
       ]);
       const { data: priceData } = await priceRes.json();
       toast.success(t("refreshSuccess", { count: priceData.updated }));
+      setClientRefreshAt(new Date().toISOString());
+      window.dispatchEvent(new CustomEvent("prices:refreshed"));
       router.refresh();
     } catch {
       toast.error(t("refreshFailed"));
@@ -64,20 +67,34 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
     return () => window.removeEventListener("prices:refresh", handler);
   }, [handleRefreshPrices]);
 
+  // Pull-to-refresh runs its own fetch and dispatches "prices:refreshed" when done.
+  // Stamp clientRefreshAt so the badge shows the user's action time even when the
+  // server-side updatedAt didn't move (e.g. refreshAllPrices returned `updated: 0`).
+  useEffect(() => {
+    const handler = () => setClientRefreshAt(new Date().toISOString());
+    window.addEventListener("prices:refreshed", handler);
+    return () => window.removeEventListener("prices:refreshed", handler);
+  }, []);
+
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 30_000);
     return () => window.clearInterval(timer);
   }, []);
 
-  // When the server delivers a fresh lastPriceUpdate (e.g. after pull-to-refresh),
-  // reset now so the badge shows "just now" instead of "in X seconds".
+  // Whenever the displayed timestamp changes (server prop or client stamp), sync
+  // `now` so the badge formats against a fresh wall-clock instead of a stale one.
   // setTimeout keeps setNow out of the synchronous effect body (lint requirement).
+  const effectiveLastUpdate =
+    clientRefreshAt && (!lastPriceUpdate || clientRefreshAt > lastPriceUpdate)
+      ? clientRefreshAt
+      : lastPriceUpdate;
+
   useEffect(() => {
     const t = setTimeout(() => setNow(Date.now()), 0);
     return () => clearTimeout(t);
-  }, [lastPriceUpdate]);
+  }, [effectiveLastUpdate]);
 
-  const priceAge = lastPriceUpdate ? getRelativeTime(lastPriceUpdate, locale, now) : null;
+  const priceAge = effectiveLastUpdate ? getRelativeTime(effectiveLastUpdate, locale, now) : null;
 
   const snapshotAge = lastSnapshotDate ? getRelativeTime(lastSnapshotDate, locale, now) : null;
 

--- a/src/components/dashboard/dashboard-pull-refresh.tsx
+++ b/src/components/dashboard/dashboard-pull-refresh.tsx
@@ -18,6 +18,7 @@ export function DashboardPullRefresh({ children }: { children: React.ReactNode }
       ]);
       const { data: priceData } = await priceRes.json();
       toast.success(t("refreshSuccess", { count: priceData.updated }));
+      window.dispatchEvent(new CustomEvent("prices:refreshed"));
       router.refresh();
     } catch {
       toast.error(t("refreshFailed"));


### PR DESCRIPTION
## Description

This PR fixes the price refresh timestamp badge to consistently show the user's action time, even when the server-side `lastPriceUpdate` doesn't change (e.g., when `refreshAllPrices` returns `updated: 0`).

The issue occurs because pull-to-refresh and manual refresh both trigger server updates, but the badge only updates when the server prop changes. If no prices actually updated, the timestamp stays stale despite the user's action.

### Changes

1. **dashboard-actions.tsx**: 
   - Added `clientRefreshAt` state to track client-side refresh timestamps
   - Dispatch `prices:refreshed` custom event after manual refresh
   - Listen for `prices:refreshed` events (from both manual refresh and pull-to-refresh) to update the client timestamp
   - Compute `effectiveLastUpdate` as the newer of server or client timestamp
   - Use `effectiveLastUpdate` for badge display and effect dependencies

2. **dashboard-pull-refresh.tsx**:
   - Dispatch `prices:refreshed` custom event after pull-to-refresh completes
   - Allows dashboard-actions to synchronize its client timestamp

This ensures the "last updated" badge always reflects the user's most recent refresh action, regardless of whether prices actually changed on the server.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Manual refresh and pull-to-refresh both dispatch the event
- [x] Client timestamp takes precedence when newer than server timestamp
- [x] Badge updates immediately on user action
- [x] Existing functionality preserved (server timestamp still used when fresher)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [x] No new warnings generated

https://claude.ai/code/session_019xNp8aZG9ZhDwR2PQnP1bs