### PR TITLE
Align net worth trend chart x-axis label slope with other charts

### DIFF
--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -201,8 +201,10 @@ export function TrendChart({
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis
                   dataKey="date"
-                  height={20}
+                  height={60}
                   tick={{ fontSize: 12 }}
+                  angle={-45}
+                  textAnchor="end"
                   tickFormatter={xTickFormatter}
                 />
                 <YAxis width={42} tick={{ fontSize: 12 }} tickFormatter={yTickFormatter} />


### PR DESCRIPTION
Apply angle={-45}, textAnchor="end", height={60} to the TrendChart XAxis
to match the consistent sloped-label style used across all analysis charts.

https://claude.ai/code/session_017RPtyGF8zco1AubaAkPj82