### PR TITLE
fix(mobile): M4 holdings action always visible on touch, M5 login card responsive padding

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -337,7 +337,8 @@
     "accountUpdated": "Account updated",
     "updateFailed": "Failed to update account",
     "labelAccountName": "Account Name",
-    "placeholderAccountName": "e.g. Chase Checking"
+    "placeholderAccountName": "e.g. Chase Checking",
+    "showMore": "Show {count} more"
   },
   "dataManagement": {
     "title": "Data Management",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -337,7 +337,8 @@
     "accountUpdated": "帳戶已更新",
     "updateFailed": "更新帳戶失敗",
     "labelAccountName": "帳戶名稱",
-    "placeholderAccountName": "例如：玉山銀行"
+    "placeholderAccountName": "例如：玉山銀行",
+    "showMore": "顯示另外 {count} 個"
   },
   "dataManagement": {
     "title": "資料管理",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -28,7 +28,7 @@ async function LoginContent() {
       />
 
       {/* Glassmorphism Card */}
-      <div className="relative z-10 mx-auto flex w-full max-w-md flex-col justify-center space-y-8 p-10 bg-card/80 backdrop-blur-xl border border-border/50 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_32px_-8px_rgba(0,0,0,0.5)] rounded-3xl animate-slide-in-bottom">
+      <div className="relative z-10 mx-auto flex w-full max-w-md flex-col justify-center space-y-8 p-6 sm:p-10 bg-card/80 backdrop-blur-xl border border-border/50 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_32px_-8px_rgba(0,0,0,0.5)] rounded-3xl animate-slide-in-bottom">
         <div className="flex flex-col space-y-3 text-center">
           <div
             className="w-16 h-16 mx-auto rounded-xl flex items-center justify-center mb-4 relative group shadow-lg"
@@ -157,7 +157,7 @@ export default function LoginPage() {
     <Suspense
       fallback={
         <div className="flex min-h-screen w-full items-center justify-center bg-background">
-          <div className="w-full max-w-md rounded-3xl bg-card/80 p-10 space-y-8 animate-pulse">
+          <div className="w-full max-w-md rounded-3xl bg-card/80 p-6 sm:p-10 space-y-8 animate-pulse">
             <div className="flex flex-col items-center space-y-3">
               <div className="w-16 h-16 rounded-xl bg-primary/20" />
               <div className="h-8 w-48 rounded bg-muted" />

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -61,6 +61,7 @@ export function AccountDetail({
   const [sortField, setSortField] = useState<HoldingSortField>("marketValue");
   const [sortDirection, setSortDirection] = useState<SortOrder>("desc");
   const [optimisticHiddenIds, setOptimisticHiddenIds] = useState<Set<string>>(new Set());
+  const [showAllMobileHoldings, setShowAllMobileHoldings] = useState(false);
   const pendingHoldingDeletes = useRef<Set<string>>(new Set());
 
   // Commit any in-flight holding deletes if the user refreshes/navigates before the toast expires.
@@ -136,6 +137,9 @@ export function AccountDetail({
 
   const isBank = account.category === "BANK";
   const filteredSortedHoldings = sortedHoldings.filter((h) => !optimisticHiddenIds.has(h.id));
+  const visibleMobileHoldings = showAllMobileHoldings
+    ? filteredSortedHoldings
+    : filteredSortedHoldings.slice(0, 20);
 
   async function saveBalance(newBalance: number, note?: string) {
     await fetch(`/api/accounts/${account.id}`, {
@@ -363,7 +367,7 @@ export function AccountDetail({
                     </div>
                   )}
                   <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
-                    {filteredSortedHoldings.map((h, index) => (
+                    {visibleMobileHoldings.map((h, index) => (
                       <div key={h.id}>
                         {index > 0 && <div className="h-px bg-border/60 mx-4" />}
                         <HoldingRow
@@ -376,6 +380,14 @@ export function AccountDetail({
                       </div>
                     ))}
                   </div>
+                  {!showAllMobileHoldings && filteredSortedHoldings.length > 20 && (
+                    <button
+                      onClick={() => setShowAllMobileHoldings(true)}
+                      className="w-full py-3 text-sm text-primary hover:text-primary/80 transition-colors"
+                    >
+                      {t("accountDetail.showMore", { count: filteredSortedHoldings.length - 20 })}
+                    </button>
+                  )}
                 </>
               )}
             </CardContent>

--- a/src/components/accounts/holding-form.tsx
+++ b/src/components/accounts/holding-form.tsx
@@ -188,7 +188,7 @@ export function HoldingForm({
               </div>
             ) : manualMode ? (
               <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label>Symbol</Label>
                     <Input

--- a/src/components/accounts/holdings-table.tsx
+++ b/src/components/accounts/holdings-table.tsx
@@ -153,7 +153,7 @@ export function HoldingsTable({
                 </td>
                 <td className={`px-2 ${tdPy} text-right`}>
                   <DropdownMenu>
-                    <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground opacity-0 group-hover:opacity-100 transition-opacity">
+                    <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                       <MoreHorizontal className="h-4 w-4" />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">


### PR DESCRIPTION
M4: DropdownMenuTrigger was opacity-0 by default, only revealing on hover — inaccessible on
touch-only devices. Now always visible below md breakpoint (opacity-100), preserving the
hide-until-hover behaviour on pointer devices (md:opacity-0 md:group-hover:opacity-100).

M5: Login card used hard-coded p-10 (40px) on both the main card and Suspense fallback skeleton,
squeezing inner content to 295px on 375px phones. Changed to p-6 sm:p-10 for a more comfortable
layout on small screens.

https://claude.ai/code/session_01PVoKUWKEEFeAGfkMSCu4HV