### PR TITLE
feat(analysis): add benchmark comparison chart vs S&P 500, NASDAQ, Russell 2000

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -145,7 +145,11 @@
     "topMoversAccount": "Account",
     "topMoversChange": "Change",
     "topMoversNoData": "Not enough history to show movers.",
-    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only."
+    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only.",
+    "benchmarkTitle": "Benchmark Comparison",
+    "benchmarkSubtitle": "Your net worth % return vs. major indices over the same period.",
+    "benchmarkNetWorth": "Net Worth",
+    "benchmarkNoData": "Index data unavailable."
   },
   "history": {
     "title": "Net Worth History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -145,7 +145,11 @@
     "topMoversAccount": "帳戶",
     "topMoversChange": "變化",
     "topMoversNoData": "歷史資料不足，無法顯示變動。",
-    "cashFlowNote": "貢獻僅反映現金存入與提領。"
+    "cashFlowNote": "貢獻僅反映現金存入與提領。",
+    "benchmarkTitle": "基準比較",
+    "benchmarkSubtitle": "您的淨資產報酬率 vs. 主要指數（同期間）。",
+    "benchmarkNetWorth": "淨資產",
+    "benchmarkNoData": "指數資料無法取得。"
   },
   "history": {
     "title": "淨資產歷史",

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -8,6 +8,7 @@ import {
   getRawHistoryWithBreakdown,
   getMonthlyCashFlow,
 } from "@/lib/services/history-service";
+import { getIndexHistory } from "@/lib/services/benchmark-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AnalysisView } from "@/components/analysis/analysis-view";
@@ -21,14 +22,16 @@ async function AnalysisContent() {
   const userId = session.user.id;
 
   const settings = await getOrCreateSettings(userId);
-  const [t, messages, snapshots, cashFlowData, rawHistory, locale] = await Promise.all([
-    getTranslations("analysis"),
-    getMessages(),
-    getFullNormalizedHistory(userId, settings.baseCurrency),
-    getMonthlyCashFlow(userId, settings.baseCurrency),
-    getRawHistoryWithBreakdown(userId, settings.baseCurrency),
-    getLocale(),
-  ]);
+  const [t, messages, snapshots, cashFlowData, rawHistory, locale, indexHistory] =
+    await Promise.all([
+      getTranslations("analysis"),
+      getMessages(),
+      getFullNormalizedHistory(userId, settings.baseCurrency),
+      getMonthlyCashFlow(userId, settings.baseCurrency),
+      getRawHistoryWithBreakdown(userId, settings.baseCurrency),
+      getLocale(),
+      getIndexHistory().catch(() => []),
+    ]);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
@@ -41,6 +44,7 @@ async function AnalysisContent() {
           rawHistory={rawHistory}
           baseCurrency={settings.baseCurrency}
           locale={locale}
+          indexHistory={indexHistory}
         />
       </div>
     </NextIntlClientProvider>

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -13,13 +13,16 @@ import {
   buildCashFlowBuckets,
   aggregateCategoryHistory,
   computeTopMovers,
+  buildBenchmarkSeries,
 } from "@/lib/services/analysis-service";
 import type { MonthlyContribution, CategoryDataPoint } from "@/lib/services/analysis-service";
+import type { IndexHistory } from "@/lib/services/benchmark-service";
 import { MonthlyChangeChart } from "./monthly-change-chart";
 import { AssetsLiabilitiesChart } from "./assets-liabilities-chart";
 import { KpiTiles } from "./kpi-tiles";
 import { CashFlowChart } from "./cashflow-chart";
 import { CategoryTrendChart } from "./category-trend-chart";
+import { BenchmarkComparisonChart } from "./benchmark-comparison-chart";
 import { TopMoversList } from "./top-movers-list";
 
 interface Props {
@@ -28,6 +31,7 @@ interface Props {
   rawHistory: RawHistoryData;
   baseCurrency: string;
   locale: string;
+  indexHistory: IndexHistory[];
 }
 
 const ranges = [
@@ -48,7 +52,14 @@ function rangeCutoff(months: number): Date {
   return d;
 }
 
-export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency, locale }: Props) {
+export function AnalysisView({
+  snapshots,
+  cashFlowData,
+  rawHistory,
+  baseCurrency,
+  locale,
+  indexHistory,
+}: Props) {
   const t = useTranslations("analysis");
   const { density } = useDensity();
   const isCompact = density === "compact";
@@ -141,6 +152,11 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
     [filteredRawSnapshots, rawHistory.accounts],
   );
 
+  const benchmarkSeries = useMemo(
+    () => buildBenchmarkSeries(buckets, filteredSnapshots, indexHistory, rangeStartIso, locale),
+    [buckets, filteredSnapshots, indexHistory, rangeStartIso, locale],
+  );
+
   const hasData = snapshots.length > 0;
 
   return (
@@ -190,6 +206,11 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
               locale={locale}
             />
           </div>
+          {indexHistory.length > 0 && (
+            <div className="premium-card">
+              <BenchmarkComparisonChart data={benchmarkSeries} indexHistory={indexHistory} />
+            </div>
+          )}
           <TopMoversList movers={topMovers} baseCurrency={baseCurrency} />
         </div>
       )}

--- a/src/components/analysis/benchmark-comparison-chart.tsx
+++ b/src/components/analysis/benchmark-comparison-chart.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState, startTransition } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  Legend,
+} from "recharts";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
+import type { BenchmarkPoint } from "@/lib/services/analysis-service";
+import type { IndexHistory } from "@/lib/services/benchmark-service";
+
+const INDEX_COLORS: Record<string, string> = {
+  "^GSPC": "#3b82f6", // blue
+  "^IXIC": "#f59e0b", // amber
+  "^RUT": "#8b5cf6", // violet
+};
+
+interface TooltipPayload {
+  dataKey: string;
+  value: number | null;
+  color: string;
+  name: string;
+}
+
+function BenchmarkTooltip({
+  active,
+  payload,
+  label,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+  privacyMode?: boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const visible = payload.filter((p) => p.value != null);
+  return (
+    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1 max-w-[200px]">
+      <div className="font-medium">{label}</div>
+      {visible.map((p) => (
+        <div key={p.dataKey} className="flex justify-between gap-3">
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <span
+              className="inline-block w-2 h-2 rounded-full shrink-0"
+              style={{ background: p.color }}
+            />
+            {p.name}
+          </span>
+          <span className="tabular-nums font-medium">
+            {privacyMode ? "***" : `${p.value! >= 0 ? "+" : ""}${p.value!.toFixed(2)}%`}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const tickFormatter = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(0)}%`;
+
+interface Props {
+  data: BenchmarkPoint[];
+  indexHistory: IndexHistory[];
+}
+
+type IndexSymbol = "^GSPC" | "^IXIC" | "^RUT";
+
+const INDEX_ORDER: IndexSymbol[] = ["^GSPC", "^IXIC", "^RUT"];
+
+export function BenchmarkComparisonChart({ data, indexHistory }: Props) {
+  const t = useTranslations("analysis");
+  const { privacyMode } = usePrivacyMode();
+  const [mounted, setMounted] = useState(false);
+  const { handlers: crosshairHandlers } = useChartCrosshair();
+
+  // S&P 500 on by default; others toggled by user
+  const [enabled, setEnabled] = useState<Record<IndexSymbol, boolean>>({
+    "^GSPC": true,
+    "^IXIC": false,
+    "^RUT": false,
+  });
+
+  useEffect(() => startTransition(() => setMounted(true)), []);
+
+  const toggle = (sym: IndexSymbol) =>
+    setEnabled((prev: Record<IndexSymbol, boolean>) => ({ ...prev, [sym]: !prev[sym] }));
+
+  // Build a label map from IndexHistory
+  const labelOf = (sym: string) => indexHistory.find((i) => i.symbol === sym)?.label ?? sym;
+
+  // Only include indices that have data
+  const availableSymbols = INDEX_ORDER.filter((sym) =>
+    indexHistory.some((i) => i.symbol === sym && i.data.length > 0),
+  );
+
+  const hasData = data.some(
+    (d) => d.netWorth != null || availableSymbols.some((sym) => d[sym] != null),
+  );
+
+  return (
+    <Card className="border-0 bg-transparent shadow-none">
+      <CardHeader className="pb-2 px-2 sm:px-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <CardTitle className="text-base font-medium text-foreground">
+              {t("benchmarkTitle")}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-0.5">{t("benchmarkSubtitle")}</p>
+          </div>
+          {availableSymbols.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {availableSymbols.map((sym) => (
+                <button
+                  key={sym}
+                  type="button"
+                  onClick={() => toggle(sym)}
+                  aria-pressed={enabled[sym]}
+                  className={`px-2 py-1 text-xs rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                    enabled[sym] ? "text-white" : "text-muted-foreground hover:bg-muted"
+                  }`}
+                  style={enabled[sym] ? { backgroundColor: INDEX_COLORS[sym] } : undefined}
+                >
+                  {labelOf(sym)}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="px-2 sm:px-4 pb-4">
+        {!hasData ? (
+          <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+            {t("benchmarkNoData")}
+          </div>
+        ) : !mounted ? (
+          <div className="h-[280px]" />
+        ) : (
+          <div
+            className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
+          >
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart
+                data={data}
+                margin={{ top: 10, right: 4, left: 0, bottom: 20 }}
+                {...crosshairHandlers}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="label"
+                  padding={{ left: 16, right: 16 }}
+                  tick={{ fontSize: 12 }}
+                  angle={-45}
+                  textAnchor="end"
+                  height={60}
+                />
+                <YAxis
+                  width={54}
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={(v: number) => (privacyMode ? "" : tickFormatter(v))}
+                />
+                <Tooltip content={<BenchmarkTooltip privacyMode={privacyMode} />} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                {/* Net worth line — always visible */}
+                <Line
+                  type="monotone"
+                  dataKey="netWorth"
+                  name={t("benchmarkNetWorth")}
+                  stroke="var(--chart-1)"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                  connectNulls={false}
+                />
+                {/* Index lines — toggled by user */}
+                {availableSymbols
+                  .filter((sym) => enabled[sym])
+                  .map((sym) => (
+                    <Line
+                      key={sym}
+                      type="monotone"
+                      dataKey={sym}
+                      name={labelOf(sym)}
+                      stroke={INDEX_COLORS[sym]}
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{ r: 4 }}
+                      connectNulls={false}
+                    />
+                  ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -1,4 +1,5 @@
 import type { NormalizedSnapshot, SnapshotBreakdown, AccountMeta } from "./history-service";
+import type { IndexHistory } from "./benchmark-service";
 
 /**
  * One month's worth of net-worth aggregation.
@@ -241,6 +242,27 @@ export interface CategoryDataPoint {
   [category: string]: number | string;
 }
 
+/**
+ * One data point in the benchmark comparison series.
+ * `netWorth` and each index symbol hold a % return value (e.g. 12.5 = +12.5 %)
+ * relative to the first data point in the selected range. null means no data
+ * for that month (Recharts renders a gap in the line).
+ */
+export interface BenchmarkPoint {
+  /** "YYYY-MM" */
+  monthKey: string;
+  /** Formatted label, e.g. "Apr 2026". */
+  label: string;
+  /** % return of net worth from range start, or null if no snapshot. */
+  netWorth: number | null;
+  /** % return of ^GSPC from range start, or null if no data. */
+  "^GSPC": number | null;
+  /** % return of ^IXIC from range start, or null if no data. */
+  "^IXIC": number | null;
+  /** % return of ^RUT from range start, or null if no data. */
+  "^RUT": number | null;
+}
+
 /** One account's value change over the selected period. */
 export interface TopMover {
   accountId: string;
@@ -351,4 +373,84 @@ export function computeTopMovers(
     .filter((m) => m.startValue !== 0 || m.endValue !== 0)
     .sort((a, b) => Math.abs(b.absoluteChange) - Math.abs(a.absoluteChange))
     .slice(0, 10);
+}
+
+/**
+ * Build a normalized % return series for net worth and each index, aligned by
+ * calendar month. Every series is independently rebased to 0 % at its first
+ * data point on or after `rangeStartIso`.
+ *
+ * The output covers exactly the months spanned by `buckets` (already padded by
+ * fillMonthRange), so the X-axis stays consistent with the other charts.
+ *
+ * @param buckets        Output of fillMonthRange() for the selected range.
+ * @param snapshots      Filtered NormalizedSnapshot[] for the selected range.
+ * @param indexHistory   Output of getIndexHistory().
+ * @param rangeStartIso  First date of the selected range ("YYYY-MM-DD").
+ * @param locale         For formatMonthLabel.
+ */
+export function buildBenchmarkSeries(
+  buckets: MonthlyBucket[],
+  snapshots: NormalizedSnapshot[],
+  indexHistory: IndexHistory[],
+  rangeStartIso: string,
+  locale: string,
+): BenchmarkPoint[] {
+  if (buckets.length === 0) return [];
+
+  // Build a map of monthKey → last net worth value in that month
+  const nwByMonth = new Map<string, number>();
+  for (const s of snapshots) {
+    nwByMonth.set(s.date.slice(0, 7), s.netWorth);
+  }
+
+  // For each index, build a monthKey → close price map
+  const indexByMonth = new Map<string, Map<string, number>>();
+  for (const idx of indexHistory) {
+    const m = new Map<string, number>();
+    for (const pt of idx.data) {
+      m.set(pt.date.slice(0, 7), pt.close);
+    }
+    indexByMonth.set(idx.symbol, m);
+  }
+
+  // Find base values (first available on or after rangeStartIso) for each series
+  const rangeStartMonth = rangeStartIso.slice(0, 7);
+  const monthKeys = buckets.map((b) => b.monthKey).sort();
+
+  const findBase = (valueMap: Map<string, number>): number | null => {
+    for (const mk of monthKeys) {
+      if (mk >= rangeStartMonth) {
+        const v = valueMap.get(mk);
+        if (v != null && v !== 0) return v;
+      }
+    }
+    return null;
+  };
+
+  const nwBase = findBase(nwByMonth);
+  const indexBases = new Map<string, number | null>();
+  for (const idx of indexHistory) {
+    indexBases.set(idx.symbol, findBase(indexByMonth.get(idx.symbol) ?? new Map()));
+  }
+
+  const pct = (value: number | undefined | null, base: number | null): number | null => {
+    if (value == null || base == null || base === 0) return null;
+    return ((value - base) / base) * 100;
+  };
+
+  const symbols = ["^GSPC", "^IXIC", "^RUT"] as const;
+
+  return buckets.map((b) => ({
+    monthKey: b.monthKey,
+    label: formatMonthLabel(b.monthKey, locale),
+    netWorth: pct(nwByMonth.get(b.monthKey), nwBase),
+    "^GSPC": pct(indexByMonth.get("^GSPC")?.get(b.monthKey), indexBases.get("^GSPC") ?? null),
+    "^IXIC": pct(indexByMonth.get("^IXIC")?.get(b.monthKey), indexBases.get("^IXIC") ?? null),
+    "^RUT": pct(indexByMonth.get("^RUT")?.get(b.monthKey), indexBases.get("^RUT") ?? null),
+    // Satisfy the index-signature constraint; the four named keys above cover all symbols
+    ...Object.fromEntries(
+      symbols.filter((s) => !["^GSPC", "^IXIC", "^RUT"].includes(s)).map((s) => [s, null]),
+    ),
+  }));
 }

--- a/src/lib/services/benchmark-service.ts
+++ b/src/lib/services/benchmark-service.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { cacheLife, cacheTag } from "next/cache";
+
+export interface IndexDataPoint {
+  /** ISO date of the month-end row: "YYYY-MM-DD". */
+  date: string;
+  close: number;
+}
+
+export interface IndexHistory {
+  symbol: string;
+  /** Human-readable label shown in the chart legend. */
+  label: string;
+  data: IndexDataPoint[];
+}
+
+const INDEX_META = [
+  { symbol: "^GSPC", label: "S&P 500" },
+  { symbol: "^IXIC", label: "NASDAQ" },
+  { symbol: "^RUT", label: "Russell 2000" },
+] as const;
+
+export const INDEX_SYMBOLS = INDEX_META.map((m) => m.symbol);
+
+export async function getIndexHistory(): Promise<IndexHistory[]> {
+  "use cache";
+  cacheTag("index-prices");
+  cacheLife("hours");
+
+  const YahooFinance = (await import("yahoo-finance2")).default;
+  const yahooFinance = new YahooFinance();
+
+  // 3-year lookback covers All/2Y/1Y/6M/YTD range selectors without extra fetches
+  const period1 = new Date();
+  period1.setFullYear(period1.getFullYear() - 3);
+  const period1Str = period1.toISOString().split("T")[0];
+
+  const results = await Promise.allSettled(
+    INDEX_META.map(async ({ symbol, label }): Promise<IndexHistory> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows: any[] = await yahooFinance.historical(symbol, {
+        period1: period1Str,
+        interval: "1mo",
+      });
+      return {
+        symbol,
+        label,
+        data: rows
+          .filter((r) => (r.adjClose ?? r.close) != null)
+          .map((r) => ({
+            date: (r.date as Date).toISOString().split("T")[0],
+            close: (r.adjClose ?? r.close) as number,
+          })),
+      };
+    }),
+  );
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<IndexHistory> => r.status === "fulfilled")
+    .map((r) => r.value);
+}


### PR DESCRIPTION
Adds a new Benchmark Comparison card to the analysis page that shows net
worth % return alongside major equity indices over the same selected period,
all rebased to 0% at range start so the comparison is apples-to-apples.

- New benchmark-service.ts fetches 3 years of monthly closes for GSPC,
  IXIC, RUT via yahoo-finance2.historical(); cached for hours (user-agnostic)
- New buildBenchmarkSeries() in analysis-service.ts normalises net worth
  snapshots and index data into aligned % return series
- New BenchmarkComparisonChart: LineChart with toggle buttons per index,
  S&P 500 on by default, privacy-mode blur, mobile crosshair support
- page.tsx fetches index history in parallel; falls back to empty array on
  failure so the rest of the page is never affected
- i18n strings added for en-US and zh-TW

https://claude.ai/code/session_017L4ZQWhgdzzrAiSHfGmLiV