### PR TITLE
fix: anchor pull-to-refresh indicator below iOS safe-area-inset-top

### DIFF
--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -35,10 +35,8 @@ export function MobileHeader() {
         "shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)]",
         "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",
         "flex items-center justify-between",
-        "border-b transition-[border-color,transform] motion-normal",
+        "transition-transform motion-normal",
         hidden ? "-translate-y-full" : "translate-y-0",
-        // Separator only appears once the large title is behind the bar (iOS behaviour)
-        isVisible ? "border-transparent" : "border-border/50",
       )}
     >
       {/* Left: logo + app name — fades away when the large title scrolls out */}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -33,7 +33,7 @@ export function MobileHeader() {
         "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md",
         "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",
         "flex items-center justify-between",
-        "border-b transition-[border-color,transform] motion-normal",
+        "border-t-0 border-x-0 border-b transition-[border-color,transform] motion-normal",
         hidden ? "-translate-y-full" : "translate-y-0",
         // Separator only appears once the large title is behind the bar (iOS behaviour)
         isVisible ? "border-transparent" : "border-border/50",

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -30,10 +30,12 @@ export function MobileHeader() {
   return (
     <header
       className={cn(
-        "md:hidden sticky top-0 left-0 right-0 z-50 glass backdrop-blur-md",
+        "md:hidden sticky top-0 left-0 right-0 z-50 backdrop-blur-md",
+        "bg-background/80 dark:bg-card/80",
+        "shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)]",
         "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",
         "flex items-center justify-between",
-        "border-t-0 border-x-0 border-b transition-[border-color,transform] motion-normal",
+        "border-b transition-[border-color,transform] motion-normal",
         hidden ? "-translate-y-full" : "translate-y-0",
         // Separator only appears once the large title is behind the bar (iOS behaviour)
         isVisible ? "border-transparent" : "border-border/50",

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -35,8 +35,10 @@ export function MobileHeader() {
         "shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)]",
         "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",
         "flex items-center justify-between",
-        "transition-transform motion-normal",
+        "border-b transition-[border-color,transform] motion-normal",
         hidden ? "-translate-y-full" : "translate-y-0",
+        // Separator only appears once the large title is behind the bar (iOS behaviour)
+        isVisible ? "border-transparent" : "border-border/50",
       )}
     >
       {/* Left: logo + app name — fades away when the large title scrolls out */}

--- a/src/components/layout/pull-to-refresh-indicator.tsx
+++ b/src/components/layout/pull-to-refresh-indicator.tsx
@@ -23,7 +23,7 @@ export function PullToRefreshIndicator() {
         isPulling ? "transition-none" : "transition-[transform,opacity] duration-300",
       )}
       style={{
-        top: 0,
+        top: "env(safe-area-inset-top)",
         transform: refreshing
           ? `translate(-50%, ${INDICATOR_REST_Y}px)`
           : `translate(-50%, ${pull - 44}px)`,


### PR DESCRIPTION
The indicator was positioned at `top: 0`, which on iPhone home-screen
PWA mode (viewport-fit: cover + black-translucent status bar) sits
behind the status bar / Dynamic Island and stays invisible while
refreshing. Anchoring to `env(safe-area-inset-top)` matches what the
mobile header already does, so the spinner is visible in standalone
mode while behaving identically in normal mobile browsers (inset = 0).

https://claude.ai/code/session_01ALkvGhhivFc6rVrZyWm8oP