### PR TITLE
feat(analysis): F11 — performance attribution chart

### DIFF
--- a/docs/suggestions_20260516_future_features.md
+++ b/docs/suggestions_20260516_future_features.md
@@ -27,7 +27,7 @@
 | F8  | Cash transaction categories + spending insights    | Cashflow        | L      | 🟡     | ❌     |
 | F9  | Target asset allocation + rebalance alerts         | Portfolio       | L      | 🔴     | ❌     |
 | F10 | Benchmark overlay on net-worth + holding charts    | Portfolio       | M      | 🟡     | ❌     |
-| F11 | Performance attribution ("which holding moved NW") | Portfolio       | M      | 🟡     | ❌     |
+| F11 | Performance attribution ("which holding moved NW") | Portfolio       | M      | 🟡     | ✅     |
 | F12 | Watchlist (symbols you track but don't own)        | Discoverability | S      | 🟡     | ❌     |
 | F13 | Tags on accounts and holdings                      | Discoverability | M      | 🟡     | ❌     |
 | F14 | Holding journal / notes (per-symbol thesis log)    | Discoverability | S      | 🟢     | ❌     |

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -156,7 +156,13 @@
     "topMoversAccount": "Account",
     "topMoversChange": "Change",
     "topMoversNoData": "Not enough history to show movers.",
-    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only."
+    "cashFlowNote": "Contributions reflect cash deposits and withdrawals only.",
+    "attribution": "Performance Attribution",
+    "attributionSubtitle": "Which accounts drove your net worth change this period.",
+    "attributionNoData": "Not enough history to compute attribution.",
+    "attributionNote": "Market performance = total change minus cash contributions. Prices use current rates (v1 approximation).",
+    "attrCash": "Cash flow",
+    "attrMarket": "Market"
   },
   "projections": {
     "title": "Projections",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -156,7 +156,13 @@
     "topMoversAccount": "帳戶",
     "topMoversChange": "變化",
     "topMoversNoData": "歷史資料不足，無法顯示變動。",
-    "cashFlowNote": "貢獻僅反映現金存入與提領。"
+    "cashFlowNote": "貢獻僅反映現金存入與提領。",
+    "attribution": "績效歸因",
+    "attributionSubtitle": "哪些帳戶推動了本期淨資產變化。",
+    "attributionNoData": "歷史資料不足，無法計算歸因。",
+    "attributionNote": "市場表現 = 總變化 − 現金貢獻。價格使用目前匯率（v1 近似值）。",
+    "attrCash": "現金流",
+    "attrMarket": "市場"
   },
   "projections": {
     "title": "財務預測",

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -7,6 +7,7 @@ import {
   getFullNormalizedHistory,
   getRawHistoryWithBreakdown,
   getMonthlyCashFlow,
+  getAccountMonthlyCashFlow,
 } from "@/lib/services/history-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
@@ -21,14 +22,16 @@ async function AnalysisContent() {
   const userId = session.user.id;
 
   const settings = await getOrCreateSettings(userId);
-  const [t, messages, snapshots, cashFlowData, rawHistory, locale] = await Promise.all([
-    getTranslations("analysis"),
-    getMessages(),
-    getFullNormalizedHistory(userId, settings.baseCurrency),
-    getMonthlyCashFlow(userId, settings.baseCurrency),
-    getRawHistoryWithBreakdown(userId, settings.baseCurrency),
-    getLocale(),
-  ]);
+  const [t, messages, snapshots, cashFlowData, rawHistory, accountCashFlow, locale] =
+    await Promise.all([
+      getTranslations("analysis"),
+      getMessages(),
+      getFullNormalizedHistory(userId, settings.baseCurrency),
+      getMonthlyCashFlow(userId, settings.baseCurrency),
+      getRawHistoryWithBreakdown(userId, settings.baseCurrency),
+      getAccountMonthlyCashFlow(userId, settings.baseCurrency),
+      getLocale(),
+    ]);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
@@ -39,6 +42,7 @@ async function AnalysisContent() {
           snapshots={snapshots}
           cashFlowData={cashFlowData}
           rawHistory={rawHistory}
+          accountCashFlow={accountCashFlow}
           baseCurrency={settings.baseCurrency}
           locale={locale}
         />

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
 import { useDensity } from "@/components/layout/density-context";
@@ -168,10 +168,26 @@ export function AnalysisView({
 
   const hasData = snapshots.length > 0;
 
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isStuck, setIsStuck] = useState(false);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(([entry]) => setIsStuck(!entry.isIntersecting), {
+      threshold: [1],
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="space-y-4">
-      {/* Range selector + subtitle row */}
-      <div className="flex items-center justify-between">
+      {/* Sentinel: when this scrolls off-screen the range bar is stuck */}
+      <div ref={sentinelRef} className="h-px -mt-px" aria-hidden />
+      {/* Range selector + subtitle row — floats while scrolling */}
+      <div
+        className={`sticky top-0 z-40 -mx-4 md:-mx-6 px-4 md:px-6 py-2 backdrop-blur-md bg-background/80 dark:bg-card/80 flex items-center justify-between transition-[border-color,box-shadow] border-b ${isStuck ? "border-border/50 shadow-sm" : "border-transparent"}`}
+      >
         <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
         <div className="flex gap-1">
           {ranges.map((r) => (

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -5,7 +5,11 @@ import { useTranslations } from "next-intl";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
 import { useDensity } from "@/components/layout/density-context";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
-import type { RawHistoryData, SnapshotBreakdown } from "@/lib/services/history-service";
+import type {
+  RawHistoryData,
+  SnapshotBreakdown,
+  AccountMonthlyContribution,
+} from "@/lib/services/history-service";
 import {
   aggregateMonthlyChange,
   computeKpis,
@@ -13,6 +17,7 @@ import {
   buildCashFlowBuckets,
   aggregateCategoryHistory,
   computeTopMovers,
+  computePerformanceAttribution,
 } from "@/lib/services/analysis-service";
 import type { MonthlyContribution, CategoryDataPoint } from "@/lib/services/analysis-service";
 import { MonthlyChangeChart } from "./monthly-change-chart";
@@ -21,11 +26,13 @@ import { KpiTiles } from "./kpi-tiles";
 import { CashFlowChart } from "./cashflow-chart";
 import { CategoryTrendChart } from "./category-trend-chart";
 import { TopMoversList } from "./top-movers-list";
+import { AttributionChart } from "./attribution-chart";
 
 interface Props {
   snapshots: NormalizedSnapshot[];
   cashFlowData: MonthlyContribution[];
   rawHistory: RawHistoryData;
+  accountCashFlow: AccountMonthlyContribution[];
   baseCurrency: string;
   locale: string;
 }
@@ -48,7 +55,14 @@ function rangeCutoff(months: number): Date {
   return d;
 }
 
-export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency, locale }: Props) {
+export function AnalysisView({
+  snapshots,
+  cashFlowData,
+  rawHistory,
+  accountCashFlow,
+  baseCurrency,
+  locale,
+}: Props) {
   const t = useTranslations("analysis");
   const { density } = useDensity();
   const isCompact = density === "compact";
@@ -141,6 +155,17 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
     [filteredRawSnapshots, rawHistory.accounts],
   );
 
+  const attributionItems = useMemo(
+    () =>
+      computePerformanceAttribution(
+        filteredRawSnapshots,
+        rawHistory.accounts,
+        accountCashFlow,
+        rangeStartIso.slice(0, 7),
+      ),
+    [filteredRawSnapshots, rawHistory.accounts, accountCashFlow, rangeStartIso],
+  );
+
   const hasData = snapshots.length > 0;
 
   return (
@@ -182,6 +207,9 @@ export function AnalysisView({ snapshots, cashFlowData, rawHistory, baseCurrency
           </div>
           <div className="premium-card">
             <CashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
+          </div>
+          <div className="premium-card">
+            <AttributionChart items={attributionItems} baseCurrency={baseCurrency} />
           </div>
           <div className="premium-card">
             <CategoryTrendChart

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useState, startTransition } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/currencies";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import type { AttributionItem } from "@/lib/services/analysis-service";
+
+interface Props {
+  items: AttributionItem[];
+  baseCurrency: string;
+}
+
+interface TooltipEntry {
+  payload: AttributionItem;
+}
+
+function AttributionTooltip({
+  active,
+  payload,
+  baseCurrency,
+  t,
+  getCategoryLabel,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  baseCurrency: string;
+  t: (key: string) => string;
+  getCategoryLabel: (cat: string) => string;
+  privacyMode?: boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const item = payload[0].payload;
+  const cashSign = item.cashContribution >= 0 ? "+" : "";
+  const mktSign = item.marketPerformance >= 0 ? "+" : "";
+  const totalSign = item.totalDelta >= 0 ? "+" : "";
+
+  return (
+    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1 min-w-[180px]">
+      <div className="font-medium leading-tight">{item.accountName}</div>
+      <div className="text-muted-foreground text-[11px]">{getCategoryLabel(item.category)}</div>
+      <div className="border-t border-border/60 pt-1 space-y-1">
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("attrCash")}</span>
+          <span className="tabular-nums">
+            {privacyMode
+              ? "***"
+              : `${cashSign}${formatCurrency(item.cashContribution, baseCurrency)}`}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("attrMarket")}</span>
+          <span
+            className={`tabular-nums ${
+              item.marketPerformance >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
+            }`}
+          >
+            {privacyMode
+              ? "***"
+              : `${mktSign}${formatCurrency(item.marketPerformance, baseCurrency)}`}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
+          <span className="text-muted-foreground">{t("tooltipChange")}</span>
+          <span
+            className={`tabular-nums font-medium ${
+              item.totalDelta >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
+            }`}
+          >
+            {privacyMode ? "***" : `${totalSign}${formatCurrency(item.totalDelta, baseCurrency)}`}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const tickFormatter = (v: number) =>
+  Math.abs(v) >= 1_000_000
+    ? `${(v / 1_000_000).toFixed(1)}M`
+    : Math.abs(v) >= 1_000
+      ? `${(v / 1_000).toFixed(0)}K`
+      : String(Math.round(v));
+
+const MAX_LABEL_LEN = 18;
+const truncate = (s: string) =>
+  s.length > MAX_LABEL_LEN ? s.slice(0, MAX_LABEL_LEN - 1) + "…" : s;
+
+export function AttributionChart({ items, baseCurrency }: Props) {
+  const t = useTranslations("analysis");
+  const tCat = useTranslations("categories");
+  const { privacyMode } = usePrivacyMode();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => startTransition(() => setMounted(true)), []);
+
+  const getCategoryLabel = (cat: string) =>
+    tCat(cat as Parameters<typeof tCat>[0], { defaultValue: cat });
+
+  const totalCash = items.reduce((s, i) => s + i.cashContribution, 0);
+  const totalMarket = items.reduce((s, i) => s + i.marketPerformance, 0);
+  const totalDelta = items.reduce((s, i) => s + i.totalDelta, 0);
+
+  // Recharts vertical layout renders bottom-to-top, so reverse to put the
+  // largest bar at the top of the chart.
+  const chartData = [...items].reverse();
+
+  const chartHeight = Math.max(200, chartData.length * 36 + 40);
+
+  return (
+    <Card className="border-0 bg-transparent shadow-none">
+      <CardHeader className="pb-2 px-2 sm:px-4">
+        <CardTitle className="text-base font-medium text-foreground">{t("attribution")}</CardTitle>
+        <p className="text-xs text-muted-foreground">{t("attributionSubtitle")}</p>
+      </CardHeader>
+      <CardContent className="px-2 sm:px-4 pb-4">
+        {items.length === 0 ? (
+          <div className="h-[200px] flex items-center justify-center text-muted-foreground text-sm">
+            {t("attributionNoData")}
+          </div>
+        ) : !mounted ? (
+          <div style={{ height: chartHeight }} />
+        ) : (
+          <div
+            className={`space-y-4 transition-[filter] duration-300 ${
+              privacyMode ? "blur-sm pointer-events-none select-none" : ""
+            }`}
+          >
+            <ResponsiveContainer width="100%" height={chartHeight}>
+              <BarChart
+                layout="vertical"
+                data={chartData}
+                margin={{ top: 4, right: 16, left: 0, bottom: 4 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 11 }}
+                  tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="accountName"
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={truncate}
+                  width={130}
+                />
+                <ReferenceLine x={0} stroke="var(--border)" strokeWidth={1.5} />
+                <Tooltip
+                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                  content={
+                    <AttributionTooltip
+                      baseCurrency={baseCurrency}
+                      t={t}
+                      getCategoryLabel={getCategoryLabel}
+                      privacyMode={privacyMode}
+                    />
+                  }
+                />
+                <Bar dataKey="totalDelta" radius={[0, 4, 4, 0]}>
+                  {chartData.map((item) => (
+                    <Cell
+                      key={item.accountId}
+                      fill={item.totalDelta >= 0 ? "var(--chart-1)" : "var(--destructive)"}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+
+            {/* Summary row */}
+            <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs">
+              <div>
+                <div className="text-muted-foreground">{t("attrCash")}</div>
+                <div className="tabular-nums font-medium mt-0.5">
+                  {totalCash >= 0 ? "+" : ""}
+                  {formatCurrency(totalCash, baseCurrency)}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">{t("attrMarket")}</div>
+                <div
+                  className={`tabular-nums font-medium mt-0.5 ${
+                    totalMarket >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
+                  }`}
+                >
+                  {totalMarket >= 0 ? "+" : ""}
+                  {formatCurrency(totalMarket, baseCurrency)}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">{t("tooltipChange")}</div>
+                <div
+                  className={`tabular-nums font-medium mt-0.5 ${
+                    totalDelta >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
+                  }`}
+                >
+                  {totalDelta >= 0 ? "+" : ""}
+                  {formatCurrency(totalDelta, baseCurrency)}
+                </div>
+              </div>
+            </div>
+
+            <p className="text-[11px] text-muted-foreground">{t("attributionNote")}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -1,4 +1,9 @@
-import type { NormalizedSnapshot, SnapshotBreakdown, AccountMeta } from "./history-service";
+import type {
+  NormalizedSnapshot,
+  SnapshotBreakdown,
+  AccountMeta,
+  AccountMonthlyContribution,
+} from "./history-service";
 
 /**
  * One month's worth of net-worth aggregation.
@@ -314,6 +319,74 @@ export function aggregateCategoryHistory(
       }
       return point;
     });
+}
+
+// ---------------------------------------------------------------------------
+// F11 — Performance attribution
+// ---------------------------------------------------------------------------
+
+/** Per-account attribution of net-worth change for a selected period. */
+export interface AttributionItem {
+  accountId: string;
+  accountName: string;
+  category: string;
+  startValue: number;
+  endValue: number;
+  /** endValue − startValue */
+  totalDelta: number;
+  /** Net cash deposited / withdrawn to this account during the period. */
+  cashContribution: number;
+  /** totalDelta − cashContribution: value created/destroyed by market movement. */
+  marketPerformance: number;
+}
+
+/**
+ * Compute per-account performance attribution for a period.
+ *
+ * @param snapshots         Breakdown snapshots filtered to the selected range.
+ * @param accounts          All user accounts (from getRawHistoryWithBreakdown).
+ * @param accountCashFlows  Per-account monthly cash flows (from getAccountMonthlyCashFlow).
+ * @param rangeStartMonthKey "YYYY-MM" — cash flows before this month are excluded.
+ */
+export function computePerformanceAttribution(
+  snapshots: SnapshotBreakdown[],
+  accounts: AccountMeta[],
+  accountCashFlows: AccountMonthlyContribution[],
+  rangeStartMonthKey: string,
+): AttributionItem[] {
+  if (snapshots.length < 2) return [];
+
+  const startSnap = snapshots[0];
+  const endSnap = snapshots[snapshots.length - 1];
+
+  const cashByAccount = new Map<string, number>();
+  for (const c of accountCashFlows) {
+    if (c.monthKey >= rangeStartMonthKey) {
+      cashByAccount.set(c.accountId, (cashByAccount.get(c.accountId) ?? 0) + c.contributions);
+    }
+  }
+
+  return accounts
+    .map((account) => {
+      const startValue = startSnap.accountValues[account.id] ?? 0;
+      const endValue = endSnap.accountValues[account.id] ?? 0;
+      const totalDelta = endValue - startValue;
+      const cashContribution = cashByAccount.get(account.id) ?? 0;
+      const marketPerformance = totalDelta - cashContribution;
+      return {
+        accountId: account.id,
+        accountName: account.name,
+        category: account.category,
+        startValue,
+        endValue,
+        totalDelta,
+        cashContribution,
+        marketPerformance,
+      };
+    })
+    .filter((a) => a.totalDelta !== 0 || a.cashContribution !== 0)
+    .sort((a, b) => Math.abs(b.totalDelta) - Math.abs(a.totalDelta))
+    .slice(0, 10);
 }
 
 /**

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -258,6 +258,66 @@ export async function getRawHistoryWithBreakdown(
   return { snapshots, accounts };
 }
 
+/** Net cash contribution for a single account in one calendar month. */
+export interface AccountMonthlyContribution {
+  accountId: string;
+  /** "YYYY-MM" */
+  monthKey: string;
+  /** Net DEPOSIT − WITHDRAWAL in baseCurrency. */
+  contributions: number;
+}
+
+/**
+ * Like getMonthlyCashFlow but scoped per account, enabling F11 attribution math.
+ * Returns one entry per (accountId, month) pair that has any cash activity.
+ */
+export async function getAccountMonthlyCashFlow(
+  userId: string,
+  baseCurrency: string,
+): Promise<AccountMonthlyContribution[]> {
+  "use cache";
+  cacheTag(`accounts:${userId}`);
+  cacheTag(`history:${userId}`);
+  cacheLife("hours");
+
+  const [accounts, allRatesMap] = await Promise.all([
+    prisma.account.findMany({ where: { userId }, select: { id: true, currency: true } }),
+    getAllExchangeRates(),
+  ]);
+
+  const accountCurrencyMap = new Map(accounts.map((a) => [a.id, a.currency]));
+
+  const transactions = await prisma.cashTransaction.findMany({
+    where: {
+      accountId: { in: accounts.map((a) => a.id) },
+      type: { in: ["DEPOSIT", "WITHDRAWAL"] },
+    },
+    select: { amount: true, type: true, createdAt: true, accountId: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const byKey = new Map<string, number>();
+
+  for (const tx of transactions) {
+    const monthKey = tx.createdAt.toISOString().slice(0, 7);
+    const key = `${tx.accountId}::${monthKey}`;
+    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
+    const amount = Number(tx.amount) * rate;
+    const signed = tx.type === "DEPOSIT" ? amount : -amount;
+    byKey.set(key, (byKey.get(key) ?? 0) + signed);
+  }
+
+  return Array.from(byKey.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, contributions]) => {
+      const sep = key.indexOf("::");
+      const accountId = key.slice(0, sep);
+      const monthKey = key.slice(sep + 2);
+      return { accountId, monthKey, contributions };
+    });
+}
+
 /**
  * Aggregate CashTransaction (DEPOSIT/WITHDRAWAL) records into per-month net
  * contribution amounts, converted to baseCurrency at current rates (v1 drift).

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { log, withTiming } from "@/lib/logger";
 
@@ -178,21 +178,31 @@ export async function fetchCryptoPrices(
   return results;
 }
 
+// Fetch all cached prices once and hold in a single stable cache entry.
+// Using unstable_cache (not "use cache") so slow-query logs from Neon cold
+// starts are NOT replayed on cache hits.
+const fetchAllCachedPrices = unstable_cache(
+  async () => {
+    const results = await prisma.priceCache.findMany({
+      select: { symbol: true, price: true, currency: true },
+    });
+    return results.map((p) => ({
+      symbol: p.symbol,
+      price: Number(p.price),
+      currency: p.currency,
+    }));
+  },
+  ["all-prices"],
+  { tags: ["prices"], revalidate: 300 },
+);
+
 export async function getCachedPricesForSymbols(
   symbols: string[],
 ): Promise<{ symbol: string; price: number; currency: string }[]> {
-  "use cache";
-  cacheTag("prices");
-  cacheLife("minutes");
   if (symbols.length === 0) return [];
-  const results = await prisma.priceCache.findMany({
-    where: { symbol: { in: symbols } },
-  });
-  return results.map((p) => ({
-    symbol: p.symbol,
-    price: Number(p.price),
-    currency: p.currency,
-  }));
+  const all = await fetchAllCachedPrices();
+  const symbolSet = new Set(symbols);
+  return all.filter((p) => symbolSet.has(p.symbol));
 }
 
 export async function refreshAllPrices(): Promise<{


### PR DESCRIPTION
## Summary
- **F11 Performance Attribution chart**: per-account breakdown of net-worth change into cash contributions vs. market performance, rendered as a horizontal bar chart in `/analysis`. Attribution math: `totalDelta = endValue − startValue`, `cashContribution = Σ(DEPOSIT−WITHDRAWAL)`, `marketPerformance = totalDelta − cashContribution`. Top 10 accounts ranked by absolute delta.
- **Sticky range picker**: the YTD/6M/1Y/2Y/All selector floats over the charts while scrolling. An `IntersectionObserver` sentinel shows the border + shadow only when the bar is actually stuck (mirrors the mobile header's behaviour).
- **Fix replayed slow-query log on cache hits**: `getCachedPricesForSymbols` used `"use cache"` which caused Next.js to replay the Neon cold-start slow-query warning on every cache hit. Switched to `unstable_cache` (single stable `all-prices` entry, filtered in memory) — logs now only appear during actual slow queries.

## New files
- `src/components/analysis/attribution-chart.tsx` — horizontal `BarChart` (Recharts `layout="vertical"`) with green/red bars, zero baseline, footer summary grid, privacy mode blur
- New service function: `getAccountMonthlyCashFlow()` in `history-service.ts`
- New pure function: `computePerformanceAttribution()` in `analysis-service.ts`
- i18n keys added to `en-US.json` + `zh-TW.json`: `attribution`, `attributionSubtitle`, `attributionNoData`, `attributionNote`, `attrCash`, `attrMarket`

## Test plan
- [x] `/analysis` page loads without error
- [x] Range picker sticks to top when scrolling; border appears only after scrolling past the title
- [x] Attribution chart renders with correct account names, cash vs. market breakdown, and footer totals
- [x] Switching range (YTD → All → 6M etc.) updates the attribution chart correctly
- [x] Accounts with zero delta and zero cash flow are excluded from the chart
- [x] No `Cache ... prisma.slow_query` warnings in dev logs after the first cold cache fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)