### PR TITLE
refactor: extract shared chart tick formatter, fix hydration and dead code in F2 projections

### DIFF
--- a/src/app/(main)/projections/page.tsx
+++ b/src/app/(main)/projections/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { getLocale, getMessages, getTranslations } from "next-intl/server";
+import { getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
@@ -17,11 +17,10 @@ async function ProjectionsContent() {
   const userId = session.user.id;
 
   const settings = await getOrCreateSettings(userId);
-  const [t, messages, projectionData, locale] = await Promise.all([
+  const [t, messages, projectionData] = await Promise.all([
     getTranslations("projections"),
     getMessages(),
     getProjectionData(userId, settings.baseCurrency),
-    getLocale(),
   ]);
 
   return (
@@ -35,7 +34,6 @@ async function ProjectionsContent() {
           annualSnapshots={projectionData.annualSnapshots}
           hasData={projectionData.hasData}
           baseCurrency={settings.baseCurrency}
-          locale={locale}
         />
       </div>
     </NextIntlClientProvider>

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
@@ -124,15 +125,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
                 <YAxis
                   width={50}
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) =>
-                    privacyMode
-                      ? ""
-                      : v >= 1000000
-                        ? `${(v / 1000000).toFixed(1)}M`
-                        : v >= 1000
-                          ? `${(v / 1000).toFixed(0)}K`
-                          : String(v)
-                  }
+                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
                 />
                 <Tooltip
                   cursor={{ fill: "var(--muted)", opacity: 0.3 }}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -101,7 +101,6 @@ function CashFlowTooltip({
   );
 }
 
-
 export function CashFlowChart({ buckets, baseCurrency }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { CashFlowBucket } from "@/lib/services/analysis-service";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
@@ -100,12 +101,6 @@ function CashFlowTooltip({
   );
 }
 
-const tickFormatter = (v: number) =>
-  Math.abs(v) >= 1_000_000
-    ? `${(v / 1_000_000).toFixed(1)}M`
-    : Math.abs(v) >= 1_000
-      ? `${(v / 1_000).toFixed(0)}K`
-      : String(v);
 
 export function CashFlowChart({ buckets, baseCurrency }: Props) {
   const t = useTranslations("analysis");
@@ -148,7 +143,7 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
                 <YAxis
                   width={50}
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
+                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
                 />
                 <Tooltip
                   cursor={{ fill: "var(--muted)", opacity: 0.3 }}

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -81,7 +81,6 @@ function CategoryTooltip({
   );
 }
 
-
 export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const tCat = useTranslations("categories");

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
@@ -80,12 +81,6 @@ function CategoryTooltip({
   );
 }
 
-const tickFormatter = (v: number) =>
-  Math.abs(v) >= 1_000_000
-    ? `${(v / 1_000_000).toFixed(1)}M`
-    : Math.abs(v) >= 1_000
-      ? `${(v / 1_000).toFixed(0)}K`
-      : String(v);
 
 export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
@@ -144,7 +139,7 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
                 <YAxis
                   width={50}
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
+                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
                 />
                 <Tooltip
                   content={

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
@@ -128,15 +129,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
                 <YAxis
                   width={50}
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) =>
-                    privacyMode
-                      ? ""
-                      : Math.abs(v) >= 1000000
-                        ? `${(v / 1000000).toFixed(1)}M`
-                        : Math.abs(v) >= 1000
-                          ? `${(v / 1000).toFixed(0)}K`
-                          : String(v)
-                  }
+                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
                 />
                 <Tooltip
                   cursor={{ fill: "var(--muted)", opacity: 0.3 }}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -19,6 +19,7 @@ import { useContainerSize } from "@/hooks/use-container-size";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
@@ -140,14 +141,7 @@ export function TrendChart({
   }, []);
 
   const yTickFormatter = useCallback(
-    (v: number) =>
-      privacyMode
-        ? ""
-        : v >= 1000000
-          ? `${(v / 1000000).toFixed(1)}M`
-          : v >= 1000
-            ? `${(v / 1000).toFixed(0)}K`
-            : v.toString(),
+    (v: number) => (privacyMode ? "" : formatChartTick(v)),
     [privacyMode],
   );
 

--- a/src/components/projections/projection-chart.tsx
+++ b/src/components/projections/projection-chart.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
+import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
 export interface ChartPoint {
@@ -30,12 +31,6 @@ interface Props {
   baseCurrency: string;
 }
 
-const tickFormatter = (v: number) =>
-  Math.abs(v) >= 1_000_000
-    ? `${(v / 1_000_000).toFixed(1)}M`
-    : Math.abs(v) >= 1_000
-      ? `${(v / 1_000).toFixed(0)}K`
-      : String(Math.round(v));
 
 function ProjectionTooltip({
   active,
@@ -101,13 +96,13 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
         <p className="text-xs text-muted-foreground">{t("chartSubtitle")}</p>
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
-        {data.length === 0 ? (
+        {data.length === 0 && (
           <div className="h-[320px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noData")}
           </div>
-        ) : !mounted ? (
-          <div className="h-[320px]" />
-        ) : (
+        )}
+        {data.length > 0 && !mounted && <div className="h-[320px]" />}
+        {data.length > 0 && mounted && (
           <div
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
@@ -117,13 +112,12 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
                 <XAxis
                   dataKey="year"
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) => String(v)}
                   interval="preserveStartEnd"
                 />
                 <YAxis
                   width={52}
                   tick={{ fontSize: 12 }}
-                  tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
+                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
                 />
                 <Tooltip
                   content={
@@ -141,7 +135,6 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
                   )}
                 />
 
-                {/* FIRE target reference line */}
                 {fireNumber > 0 && (
                   <ReferenceLine
                     y={fireNumber}
@@ -156,7 +149,6 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
                   />
                 )}
 
-                {/* Vertical marker at FIRE year */}
                 {fireYear && (
                   <ReferenceLine
                     x={fireYear}

--- a/src/components/projections/projection-chart.tsx
+++ b/src/components/projections/projection-chart.tsx
@@ -31,7 +31,6 @@ interface Props {
   baseCurrency: string;
 }
 
-
 function ProjectionTooltip({
   active,
   payload,
@@ -109,11 +108,7 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
             <ResponsiveContainer width="100%" height={320}>
               <ComposedChart data={data} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="year"
-                  tick={{ fontSize: 12 }}
-                  interval="preserveStartEnd"
-                />
+                <XAxis dataKey="year" tick={{ fontSize: 12 }} interval="preserveStartEnd" />
                 <YAxis
                   width={52}
                   tick={{ fontSize: 12 }}

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -1,21 +1,17 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { formatCurrency, formatNumber } from "@/lib/currencies";
+import { formatCurrency, formatNumber, getCurrencySymbol } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import { ProjectionChart, type ChartPoint } from "./projection-chart";
 
 const GUIDE_STORAGE_KEY = "asset-tracker:projections-guide-open";
-
-// ---------------------------------------------------------------------------
-// Pure projection math (no imports from server-only modules)
-// ---------------------------------------------------------------------------
 
 interface ProjectionResult {
   fireNumber: number;
@@ -74,10 +70,6 @@ function computeProjection(
 
   return { fireNumber, yearsToFire, fireYear, progressPct, projectedPoints };
 }
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
 
 function KpiTile({
   title,
@@ -166,17 +158,12 @@ function NumberInput({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
-
 interface Props {
   latestNetWorth: number;
   trailing12mSavings: number;
   annualSnapshots: { year: number; netWorth: number }[];
   hasData: boolean;
   baseCurrency: string;
-  locale: string;
 }
 
 export function ProjectionView({
@@ -185,7 +172,6 @@ export function ProjectionView({
   annualSnapshots,
   hasData,
   baseCurrency,
-  locale: _locale,
 }: Props) {
   const t = useTranslations("projections");
   const { privacyMode } = usePrivacyMode();
@@ -200,8 +186,13 @@ export function ProjectionView({
   const [annualSavings, setAnnualSavings] = useState(Math.max(0, Math.round(trailing12mSavings)));
   const [expectedReturn, setExpectedReturn] = useState(7); // percent
   const [withdrawalRate, setWithdrawalRate] = useState(4); // percent
-  const [guideOpen, setGuideOpen] = useState(
-    () => typeof window !== "undefined" && window.localStorage.getItem(GUIDE_STORAGE_KEY) === "1",
+  const [guideOpen, setGuideOpen] = useState(false);
+  useEffect(
+    () =>
+      startTransition(() =>
+        setGuideOpen(window.localStorage.getItem(GUIDE_STORAGE_KEY) === "1"),
+      ),
+    [],
   );
 
   const toggleGuide = () => {
@@ -230,29 +221,26 @@ export function ProjectionView({
     ],
   );
 
-  // Build chart data: historical annual snapshots + projected future years
   const chartData = useMemo((): ChartPoint[] => {
     if (!hasData) return [];
 
+    const lastYear = annualSnapshots.at(-1)?.year ?? new Date().getFullYear();
     const historicalYearSet = new Set(annualSnapshots.map((s) => s.year));
     const points: ChartPoint[] = annualSnapshots.map((s) => ({
       year: s.year,
       historical: s.netWorth,
-      // Overlap the last historical point with the projected series so lines connect
-      projected: s.year === lastHistoricalYear ? s.netWorth : undefined,
+      // Overlap last historical point with projected series so lines connect
+      projected: s.year === lastYear ? s.netWorth : undefined,
     }));
 
-    // Add projected points for future years only
     for (const p of projection.projectedPoints) {
-      if (historicalYearSet.has(p.year)) continue; // already in historical
+      if (historicalYearSet.has(p.year)) continue;
       points.push({ year: p.year, projected: p.netWorth });
-
-      // Stop a few years after FIRE year to keep chart readable
       if (projection.fireYear && p.year >= projection.fireYear + 3) break;
     }
 
     return points.sort((a, b) => a.year - b.year);
-  }, [annualSnapshots, projection, lastHistoricalYear, hasData]);
+  }, [annualSnapshots, projection, hasData]);
 
   // --- KPI values ---
   const fireNumberDisplay = privacyMode
@@ -325,8 +313,7 @@ export function ProjectionView({
               onChange={setAnnualExpenses}
               min={0}
               step={1000}
-              prefix={baseCurrency === "USD" ? "$" : undefined}
-              suffix={baseCurrency !== "USD" ? baseCurrency : undefined}
+              prefix={getCurrencySymbol(baseCurrency)}
             />
             <NumberInput
               label={t("annualSavings")}
@@ -335,8 +322,7 @@ export function ProjectionView({
               onChange={setAnnualSavings}
               min={0}
               step={1000}
-              prefix={baseCurrency === "USD" ? "$" : undefined}
-              suffix={baseCurrency !== "USD" ? baseCurrency : undefined}
+              prefix={getCurrencySymbol(baseCurrency)}
             />
             <NumberInput
               label={t("expectedReturn")}
@@ -378,13 +364,11 @@ export function ProjectionView({
         {guideOpen && (
           <CardContent className="space-y-6 pt-0">
             <div className="grid gap-6 sm:grid-cols-3">
-              {(
-                [
-                  { num: "1", title: t("step1Title"), desc: t("step1Desc") },
-                  { num: "2", title: t("step2Title"), desc: t("step2Desc") },
-                  { num: "3", title: t("step3Title"), desc: t("step3Desc") },
-                ] as const
-              ).map((step) => (
+              {[
+                { num: "1", title: t("step1Title"), desc: t("step1Desc") },
+                { num: "2", title: t("step2Title"), desc: t("step2Desc") },
+                { num: "3", title: t("step3Title"), desc: t("step3Desc") },
+              ].map((step) => (
                 <div key={step.num} className="flex gap-3">
                   <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-bold text-primary">
                     {step.num}

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -189,9 +189,7 @@ export function ProjectionView({
   const [guideOpen, setGuideOpen] = useState(false);
   useEffect(
     () =>
-      startTransition(() =>
-        setGuideOpen(window.localStorage.getItem(GUIDE_STORAGE_KEY) === "1"),
-      ),
+      startTransition(() => setGuideOpen(window.localStorage.getItem(GUIDE_STORAGE_KEY) === "1")),
     [],
   );
 

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -145,6 +145,7 @@ function NumberInput({
               isNaN(parsed) ? 0 : Math.max(min, max !== undefined ? Math.min(max, parsed) : parsed),
             );
           }}
+          inputMode="decimal"
           className={`h-9 text-sm ${suffix ? "pr-10" : ""}`}
           style={
             prefix ? { paddingLeft: `calc(0.75rem + ${prefix.length}ch + 0.5rem)` } : undefined

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -145,7 +145,10 @@ function NumberInput({
               isNaN(parsed) ? 0 : Math.max(min, max !== undefined ? Math.min(max, parsed) : parsed),
             );
           }}
-          className={`h-9 text-sm ${prefix ? "pl-7" : ""} ${suffix ? "pr-10" : ""}`}
+          className={`h-9 text-sm ${suffix ? "pr-10" : ""}`}
+          style={
+            prefix ? { paddingLeft: `calc(0.75rem + ${prefix.length}ch + 0.5rem)` } : undefined
+          }
         />
         {suffix && (
           <span className="pointer-events-none absolute right-3 text-sm text-muted-foreground select-none">

--- a/src/lib/chart-formatters.tsx
+++ b/src/lib/chart-formatters.tsx
@@ -1,5 +1,13 @@
 import { formatCurrency } from "@/lib/currencies";
 
+export function formatChartTick(v: number): string {
+  return Math.abs(v) >= 1_000_000
+    ? `${(v / 1_000_000).toFixed(1)}M`
+    : Math.abs(v) >= 1_000
+      ? `${(v / 1_000).toFixed(0)}K`
+      : String(Math.round(v));
+}
+
 /** Currency formatter for area/line chart tooltips (e.g. TrendChart). */
 export function createCurrencyTooltipFormatter(currency: string) {
   return (value: unknown) => formatCurrency(Number(value ?? 0), currency);


### PR DESCRIPTION
## Summary

- **Extract `formatChartTick`** to `src/lib/chart-formatters.tsx` — the K/M compact number formatter was copy-pasted across 6 chart files with slight variations; all now import the shared utility
- **Remove dead `locale` prop** from `ProjectionView` and the wasted `getLocale()` RSC call in the projections page
- **Fix hydration mismatch** in `ProjectionView`: lazy `useState(() => localStorage.getItem(...))` → `useState(false)` + `startTransition`/`useEffect` after mount
- **Use `getCurrencySymbol()`** for currency input prefix instead of hardcoded USD-only `baseCurrency === "USD" ? "$"` check (now correctly shows `NT$`, `€`, etc.)
- **Remove redundant `lastHistoricalYear`** from `chartData` `useMemo` deps — it's derived from `annualSnapshots` which is already in the array
- **Flatten 3-level ternary** in `ProjectionChart` render body into separate `{condition && ...}` blocks
- **Remove no-op `tickFormatter={(v) => String(v)}`** on XAxis and unnecessary section-divider comments

## Test plan

- [x] Projections page loads and chart renders correctly
- [x] Guide open/close state persists across page navigations (localStorage read fires after hydration — no flash)
- [x] Non-USD users (e.g. TWD) see `NT$` prefix on expense/savings inputs instead of the raw currency code as suffix
- [x] All 6 chart components (trend, cashflow, category-trend, assets-liabilities, monthly-change, projection) render Y-axis ticks in K/M format

🤖 Generated with [Claude Code](https://claude.com/claude-code)