### PR TITLE
feat: extend command palette shortcuts to include Goals and Projections tabs

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -23,7 +23,7 @@
     "openPalette": "Open command palette",
     "navigateTabs": "Go to main tabs",
     "goToShortcut": "Quick go-to sequence",
-    "goSequence": "g then d/a/n/h/s",
+    "goSequence": "g then d/a/g/n/p/h/s",
     "togglePrivacy": "Toggle privacy mode",
     "refreshPrices": "Refresh prices",
     "createNew": "New account or holding (Accounts page only)",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -23,7 +23,7 @@
     "openPalette": "開啟指令面板",
     "navigateTabs": "切換主要分頁",
     "goToShortcut": "快速前往序列",
-    "goSequence": "先按 g 再按 d/a/n/h/s",
+    "goSequence": "先按 g 再按 d/a/g/n/p/h/s",
     "togglePrivacy": "切換隱私模式",
     "refreshPrices": "更新價格",
     "createNew": "新增帳戶或持倉（僅限帳戶頁面）",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "tailwindcss": "^4"
       },
       "engines": {
-        "node": ">=22"
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/components/layout/desktop-command-palette.tsx
+++ b/src/components/layout/desktop-command-palette.tsx
@@ -14,6 +14,8 @@ import {
   RefreshCw,
   Settings,
   Shield,
+  Target,
+  TrendingUp,
 } from "lucide-react";
 import { signOut } from "next-auth/react";
 import {
@@ -42,9 +44,11 @@ export function DesktopCommandPalette() {
     () => [
       { href: "/", label: t("nav.dashboard"), icon: LayoutDashboard, kbd: "1" },
       { href: "/accounts", label: t("nav.accounts"), icon: Copy, kbd: "2" },
-      { href: "/analysis", label: t("nav.analysis"), icon: BarChart3, kbd: "3" },
-      { href: "/history", label: t("nav.history"), icon: History, kbd: "4" },
-      { href: "/settings", label: t("nav.settings"), icon: Settings, kbd: "5" },
+      { href: "/goals", label: t("nav.goals"), icon: Target, kbd: "3" },
+      { href: "/analysis", label: t("nav.analysis"), icon: BarChart3, kbd: "4" },
+      { href: "/projections", label: t("nav.projections"), icon: TrendingUp, kbd: "5" },
+      { href: "/history", label: t("nav.history"), icon: History, kbd: "6" },
+      { href: "/settings", label: t("nav.settings"), icon: Settings, kbd: "7" },
     ],
     [t],
   );
@@ -108,7 +112,7 @@ export function DesktopCommandPalette() {
         return;
       }
 
-      if (/^[1-5]$/.test(e.key)) {
+      if (/^[1-7]$/.test(e.key)) {
         const item = navItems[Number(e.key) - 1];
         if (item) {
           router.push(item.href);
@@ -121,7 +125,9 @@ export function DesktopCommandPalette() {
         pendingGoTo.current = false;
         if (e.key.toLowerCase() === "d") router.push("/");
         if (e.key.toLowerCase() === "a") router.push("/accounts");
+        if (e.key.toLowerCase() === "g") router.push("/goals");
         if (e.key.toLowerCase() === "n") router.push("/analysis");
+        if (e.key.toLowerCase() === "p") router.push("/projections");
         if (e.key.toLowerCase() === "h") router.push("/history");
         if (e.key.toLowerCase() === "s") router.push("/settings");
         setOpen(false);
@@ -177,9 +183,9 @@ export function DesktopCommandPalette() {
             {t("commandPalette.openPalette")}
             <CommandShortcut>?</CommandShortcut>
           </CommandItem>
-          <CommandItem value={`shortcut 1 2 3 4 5 navigation`}>
+          <CommandItem value={`shortcut 1 2 3 4 5 6 7 navigation`}>
             {t("commandPalette.navigateTabs")}
-            <CommandShortcut>1-5</CommandShortcut>
+            <CommandShortcut>1-7</CommandShortcut>
           </CommandItem>
           <CommandItem value={`shortcut ${goShortcut} go to`}>
             {t("commandPalette.goToShortcut")}


### PR DESCRIPTION
Add Goals (/goals, key 3) and Projections (/projections, key 5) to the
navItems list, widen the number-key regex to 1–7, and add g+g / g+p to
the go-to sequence to match the current 7-tab sidebar.

https://claude.ai/code/session_012nMhANPEaczo84tqmZhR4o