### PR TITLE
enhance export/import: add goals, option fields, and tighter validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "tailwindcss": "^4"
       },
       "engines": {
-        "node": ">=22"
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -18,17 +18,19 @@ export const GET = withAuth(async (_req, _ctx, userId) => {
           },
         },
         snapshots: true,
+        goals: true,
       },
     });
 
     if (!data) return failure("User not found", 404);
 
     const exportData = {
-      version: "1.0",
+      version: "1.1",
       exportedAt: new Date().toISOString(),
       settings: data.appSettings,
       accounts: data.appAccounts,
       snapshots: data.snapshots,
+      goals: data.goals,
     };
 
     // Return as a raw JSON file download — NOT wrapped in ok() so the blob
@@ -61,6 +63,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
         // 1. Delete existing data for the user (Cascades should handle holdings and transactions)
         await tx.account.deleteMany({ where: { userId } });
         await tx.netWorthSnapshot.deleteMany({ where: { userId } });
+        await tx.goal.deleteMany({ where: { userId } });
 
         // 2. Import settings if present
         if (importData.settings) {
@@ -107,6 +110,11 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                   assetType: h.assetType,
                   createdAt: h.createdAt,
                   updatedAt: h.updatedAt,
+                  underlyingSymbol: h.underlyingSymbol ?? null,
+                  optionType: h.optionType ?? null,
+                  strike: h.strike ?? null,
+                  expiration: h.expiration ? new Date(h.expiration) : null,
+                  contractMultiplier: h.contractMultiplier ?? null,
                 },
               });
 
@@ -156,6 +164,23 @@ export const POST = withAuth(async (request, _ctx, userId) => {
             })),
           });
         }
+
+        // 5. Import goals
+        if (Array.isArray(importData.goals) && importData.goals.length > 0) {
+          await tx.goal.createMany({
+            data: importData.goals.map((g) => ({
+              userId,
+              name: g.name,
+              targetAmount: g.targetAmount,
+              targetCurrency: g.targetCurrency,
+              targetDate: g.targetDate ? new Date(g.targetDate) : null,
+              scope: g.scope,
+              scopeRefId: g.scopeRefId ?? null,
+              ...(g.createdAt && { createdAt: new Date(g.createdAt) }),
+              ...(g.updatedAt && { updatedAt: new Date(g.updatedAt) }),
+            })),
+          });
+        }
       },
       { timeout: 30000 },
     );
@@ -163,6 +188,6 @@ export const POST = withAuth(async (request, _ctx, userId) => {
     return ok({ ok: true });
   } catch (error) {
     log.error("import.failed", { error: String(error) });
-    return failure(error instanceof Error ? error.message : "Failed to import data", 500);
+    return failure("Failed to import data", 500);
   }
 });

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -120,7 +120,7 @@ export const createGoalSchema = z.object({
 
 export const updateGoalSchema = createGoalSchema.partial();
 
-const decimalSchema = z.union([z.number(), z.string(), z.any()]);
+const decimalSchema = z.union([z.string(), z.number()]);
 
 export const dataImportSchema = z.object({
   version: z.string(),
@@ -151,6 +151,11 @@ export const dataImportSchema = z.object({
             assetType: z.enum(HOLDING_ASSET_TYPES),
             createdAt: z.string().optional(),
             updatedAt: z.string().optional(),
+            underlyingSymbol: z.string().optional().nullable(),
+            optionType: z.enum(OPTION_TYPES).optional().nullable(),
+            strike: decimalSchema.optional().nullable(),
+            expiration: z.string().optional().nullable(),
+            contractMultiplier: z.number().int().optional().nullable(),
             transactions: z
               .array(
                 z.object({
@@ -184,8 +189,22 @@ export const dataImportSchema = z.object({
         totalLiabilities: decimalSchema,
         netWorth: decimalSchema,
         baseCurrency: z.string().length(3),
-        breakdown: z.any().optional().nullable(),
+        breakdown: z.record(z.string(), z.unknown()).optional().nullable(),
         createdAt: z.string().optional(),
+      }),
+    )
+    .optional(),
+  goals: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        targetAmount: decimalSchema,
+        targetCurrency: z.string().length(3),
+        targetDate: z.string().optional().nullable(),
+        scope: z.enum(GOAL_SCOPES),
+        scopeRefId: z.string().optional().nullable(),
+        createdAt: z.string().optional(),
+        updatedAt: z.string().optional(),
       }),
     )
     .optional(),


### PR DESCRIPTION
- Include Goal model in export (version bumped to 1.1) and import
  (delete + recreate in the same transaction as accounts/snapshots)
- Preserve option holding fields (underlyingSymbol, optionType, strike,
  expiration, contractMultiplier) through the import schema and
  tx.holding.create call — previously silently dropped
- Fix decimalSchema: remove z.any() fallback (was bypassing type safety)
- Tighten snapshot breakdown: z.any() → z.record(z.string(), z.unknown())
- Stop leaking raw error.message in the import catch block

https://claude.ai/code/session_018fkFu2F7KRtbPmrKoWTdeQ