### PR TITLE
fix(ui): expand cash balance input to full width for better number visibility

### DIFF
--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -185,7 +185,7 @@ export function AccountForm({
               </Select>
             </div>
           ) : (
-            <div className="grid grid-cols-2 gap-4">
+            <>
               <div className="space-y-2">
                 <Label>{t("accountForm.labelCurrency")}</Label>
                 <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
@@ -213,7 +213,7 @@ export function AccountForm({
                 />
                 {cashBalanceError && <p className="text-xs text-destructive">{cashBalanceError}</p>}
               </div>
-            </div>
+            </>
           )}
 
           <div className="flex justify-end gap-2 pt-2">

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -84,23 +84,31 @@ export function InlineBalanceEditor({
   if (editing) {
     return (
       <div className="flex flex-col gap-2 mt-1">
+        <Input
+          type="text"
+          inputMode="decimal"
+          placeholder={formatNumber(currentBalance, 0)}
+          value={balance}
+          onChange={handleBalanceChange}
+          onBlur={handleBalanceBlur}
+          className="h-8 w-full min-w-[160px]"
+          autoFocus
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <Input
+          placeholder={notePlaceholder}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          className="h-8 text-sm"
+        />
         <div className="flex gap-2">
-          <Input
-            type="text"
-            inputMode="decimal"
-            placeholder={formatNumber(currentBalance, 0)}
-            value={balance}
-            onChange={handleBalanceChange}
-            onBlur={handleBalanceBlur}
-            className="h-8 flex-1"
-            autoFocus
-          />
-          <Button size="sm" onClick={handleSave} disabled={saving}>
+          <Button size="sm" className="flex-1" onClick={handleSave} disabled={saving}>
             {saving ? "..." : "Save"}
           </Button>
           <Button
             size="sm"
             variant="outline"
+            className="flex-1"
             onClick={() => {
               setEditing(false);
               setNote("");
@@ -109,13 +117,6 @@ export function InlineBalanceEditor({
             Cancel
           </Button>
         </div>
-        {error && <p className="text-xs text-destructive">{error}</p>}
-        <Input
-          placeholder={notePlaceholder}
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          className="h-8 text-sm"
-        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **InlineBalanceEditor**: balance input now takes its own full-width row with `min-w-[160px]` (was crammed alongside Save/Cancel buttons, leaving only ~60–80px for the number in the 1/3-width bank card); note input reordered above buttons; Save/Cancel given equal width via `flex-1`
- **AccountForm**: currency selector and cash balance input now stacked vertically as separate full-width fields (was `grid-cols-2` half-width), giving the balance field the full dialog width

## Test plan

- [x] Open a BANK account detail page — click the cash balance to edit; confirm the input spans the full card width and displays large numbers (e.g. 1,234,567.89) without truncation
- [x] Open "Add Account" dialog — confirm currency selector and cash balance input are now on separate rows, each full width
- [x] Verify Save / Cancel buttons appear below both inputs in the inline editor
- [x] Check on mobile (narrow viewport) — card and inputs should still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)