### PR TITLE
feat(allocation): F9 — target allocation & rebalance alerts

### DIFF
--- a/docs/suggestions_20260516_future_features.md
+++ b/docs/suggestions_20260516_future_features.md
@@ -25,7 +25,7 @@
 | F6  | Recurring / scheduled cash transactions            | Cashflow        | M      | 🔴     | ❌     |
 | F7  | Cashflow calendar view                             | Cashflow        | M      | 🟡     | ❌     |
 | F8  | Cash transaction categories + spending insights    | Cashflow        | L      | 🟡     | ❌     |
-| F9  | Target asset allocation + rebalance alerts         | Portfolio       | L      | 🔴     | ❌     |
+| F9  | Target asset allocation + rebalance alerts         | Portfolio       | L      | 🔴     | ✅     |
 | F10 | Benchmark overlay on net-worth + holding charts    | Portfolio       | M      | 🟡     | ❌     |
 | F11 | Performance attribution ("which holding moved NW") | Portfolio       | M      | 🟡     | ✅     |
 | F12 | Watchlist (symbols you track but don't own)        | Discoverability | S      | 🟡     | ❌     |
@@ -230,18 +230,35 @@ the UI doesn't grow categories controls for people who don't categorize.
 You can already _see_ the portfolio. The next step is the app telling
 you something about it.
 
-### F9 — Target allocation + rebalance alerts · L · 🔴
+### F9 — Target allocation + rebalance alerts · L · 🔴 · ✅ **Shipped** (2026-05-17)
 
 Let the user define a target allocation (e.g., 70% stocks / 20% bonds /
 10% crypto). Compute current allocation from holdings, surface drift
 ("crypto is 16% — 6 pts over target"), and emit a Sonner toast on the
 dashboard when drift exceeds a configurable threshold.
 
-**Schema:** `AllocationTarget { userId, scope (ASSET_TYPE | CURRENCY |
-ACCOUNT_CATEGORY), key, targetPercent }`.
+**Schema:**
 
-**UI:** Settings tab "Allocation Targets" + a new card in `/analysis`
-showing actual vs. target as a stacked bar.
+```prisma
+enum AllocationScope { ASSET_TYPE  ACCOUNT_CATEGORY }
+model AllocationTarget {
+  id             String          @id @default(cuid())
+  userId         String
+  scope          AllocationScope
+  key            String          // e.g. "STOCK", "BROKERAGE"
+  targetPercent  Decimal         @db.Decimal(5, 2)
+  driftThreshold Decimal         @db.Decimal(5, 2) @default(5)
+  @@unique([userId, scope, key])
+}
+```
+
+**Shipped surfaces:**
+
+- Settings → "Allocation Targets" section: add/delete targets by scope × key with per-target drift threshold (pp).
+- `/analysis` page: new "Allocation Drift" horizontal bar chart showing `actual − target` per target (red when over threshold).
+- Dashboard: `RebalanceAlert` client component fires Sonner toast warnings once per browser session when any target drifts past its threshold.
+
+**Services / API:** `src/lib/services/allocation-service.ts` (`fetchUserAllocationTargets`, `computeAllocationDrift`, `getRebalanceAlerts`) + REST routes `GET/POST /api/allocation-targets` and `PATCH/DELETE /api/allocation-targets/[id]`.
 
 ### F10 — Benchmark overlay on charts · M · 🟡
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -215,7 +215,43 @@
     "attributionNoData": "Not enough history to compute attribution.",
     "attributionNote": "Market performance = total change minus cash contributions. Prices use current rates (v1 approximation).",
     "attrCash": "Cash flow",
-    "attrMarket": "Market"
+    "attrMarket": "Market",
+    "allocationDriftTitle": "Allocation Drift",
+    "allocationDriftSubtitle": "How far each category has strayed from your target. Red = past the alert threshold.",
+    "allocationActual": "Actual",
+    "allocationTarget": "Target",
+    "allocationDrift": "Drift",
+    "allocationAlertHint": "Threshold: ±{threshold} pp",
+    "allocationAlertBadge": "{count, plural, one {# off-target} other {# off-target}}",
+    "allocationDriftNoTargets": "No allocation targets set. Add targets in Settings → Allocation Targets.",
+    "allocationDriftNote": "Positive drift = over-allocated vs. target; negative = under-allocated. pp = percentage points."
+  },
+  "allocation": {
+    "title": "Allocation Targets",
+    "description": "Set target percentages for asset types or account categories. You'll see a drift chart in Analysis and receive alerts when drift exceeds your threshold.",
+    "addTarget": "Add Target",
+    "scopeLabel": "Scope",
+    "keyLabel": "Category",
+    "keyPlaceholder": "Select…",
+    "targetPercentLabel": "Target %",
+    "thresholdLabel": "Alert at",
+    "addBtn": "Add",
+    "deleteTarget": "Delete target",
+    "invalidPercent": "Percentage must be between 0 and 100",
+    "totalHint": "{scope}: {total}% total",
+    "totalOverHint": "exceeds 100%",
+    "threshold": "±{n} pp",
+    "scope": {
+      "ASSET_TYPE": "Asset Type",
+      "ACCOUNT_CATEGORY": "Account Category"
+    },
+    "alertToast": "{label}: {drift} pp off target (threshold ±{threshold} pp)",
+    "alertToastMore": "+{count, plural, one {# more alert} other {# more alerts}}",
+    "toast": {
+      "created": "Target added",
+      "deleted": "Target removed",
+      "failed": "Something went wrong"
+    }
   },
   "projections": {
     "title": "Projections",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -215,7 +215,43 @@
     "attributionNoData": "歷史資料不足，無法計算歸因。",
     "attributionNote": "市場表現 = 總變化 − 現金貢獻。價格使用目前匯率（v1 近似值）。",
     "attrCash": "現金流",
-    "attrMarket": "市場"
+    "attrMarket": "市場",
+    "allocationDriftTitle": "配置偏差",
+    "allocationDriftSubtitle": "各類別偏離目標配置的程度。紅色 = 超過警示門檻。",
+    "allocationActual": "實際",
+    "allocationTarget": "目標",
+    "allocationDrift": "偏差",
+    "allocationAlertHint": "門檻：±{threshold} pp",
+    "allocationAlertBadge": "{count} 項超標",
+    "allocationDriftNoTargets": "尚未設定配置目標。請至「設定 → 配置目標」新增。",
+    "allocationDriftNote": "正偏差 = 超過目標；負偏差 = 低於目標。pp = 百分比點。"
+  },
+  "allocation": {
+    "title": "配置目標",
+    "description": "為資產類型或帳戶類別設定目標百分比。在分析頁查看偏差圖表，並在偏差超過門檻時收到提示。",
+    "addTarget": "新增目標",
+    "scopeLabel": "範圍",
+    "keyLabel": "類別",
+    "keyPlaceholder": "選擇...",
+    "targetPercentLabel": "目標 %",
+    "thresholdLabel": "警示門檻",
+    "addBtn": "新增",
+    "deleteTarget": "刪除目標",
+    "invalidPercent": "百分比須介於 0 至 100 之間",
+    "totalHint": "{scope}：目前合計 {total}%",
+    "totalOverHint": "已超過 100%",
+    "threshold": "±{n} pp",
+    "scope": {
+      "ASSET_TYPE": "資產類型",
+      "ACCOUNT_CATEGORY": "帳戶類別"
+    },
+    "alertToast": "{label}：偏差 {drift} pp（門檻 ±{threshold} pp）",
+    "alertToastMore": "另有 {count} 項警示",
+    "toast": {
+      "created": "目標已新增",
+      "deleted": "目標已移除",
+      "failed": "發生錯誤"
+    }
   },
   "projections": {
     "title": "財務預測",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
         "framer-motion": "^12.38.0",
@@ -1162,7 +1163,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1185,7 +1185,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1208,7 +1207,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1225,7 +1223,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1242,7 +1239,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1259,7 +1255,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1276,7 +1271,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1293,7 +1287,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1310,7 +1303,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1327,7 +1319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1344,7 +1335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1361,7 +1351,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1378,7 +1367,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1401,7 +1389,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1424,7 +1411,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1447,7 +1433,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1470,7 +1455,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1493,7 +1477,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1516,7 +1499,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1539,7 +1521,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1562,7 +1543,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1582,7 +1562,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1602,7 +1581,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1622,7 +1600,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5875,18 +5852,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -7397,7 +7362,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9841,17 +9805,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "framer-motion": "^12.38.0",

--- a/prisma/migrations/20260517000000_f9_allocation_targets/migration.sql
+++ b/prisma/migrations/20260517000000_f9_allocation_targets/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "AllocationScope" AS ENUM ('ASSET_TYPE', 'ACCOUNT_CATEGORY');
+
+-- CreateTable
+CREATE TABLE "AllocationTarget" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "scope" "AllocationScope" NOT NULL,
+    "key" TEXT NOT NULL,
+    "targetPercent" DECIMAL(5,2) NOT NULL,
+    "driftThreshold" DECIMAL(5,2) NOT NULL DEFAULT 5,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AllocationTarget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AllocationTarget_userId_idx" ON "AllocationTarget"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AllocationTarget_userId_scope_key_key" ON "AllocationTarget"("userId", "scope", "key");
+
+-- AddForeignKey
+ALTER TABLE "AllocationTarget" ADD CONSTRAINT "AllocationTarget_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -181,6 +181,26 @@ model Goal {
   @@index([userId, createdAt(sort: Desc)])
 }
 
+enum AllocationScope {
+  ASSET_TYPE
+  ACCOUNT_CATEGORY
+}
+
+model AllocationTarget {
+  id             String          @id @default(cuid())
+  userId         String
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  scope          AllocationScope
+  key            String
+  targetPercent  Decimal         @db.Decimal(5, 2)
+  driftThreshold Decimal         @db.Decimal(5, 2) @default(5)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  @@unique([userId, scope, key])
+  @@index([userId])
+}
+
 model User {
   id            String        @id @default(cuid())
   name          String?
@@ -190,10 +210,11 @@ model User {
   accounts      AuthAccount[]
   sessions      Session[]
 
-  appSettings Setting?
-  appAccounts Account[]
-  snapshots   NetWorthSnapshot[]
-  goals       Goal[]
+  appSettings       Setting?
+  appAccounts       Account[]
+  snapshots         NetWorthSnapshot[]
+  goals             Goal[]
+  allocationTargets AllocationTarget[]
 }
 
 model AuthAccount {

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -9,12 +9,32 @@ import {
   getMonthlyCashFlow,
   getAccountMonthlyCashFlow,
 } from "@/lib/services/history-service";
+import {
+  fetchUserAllocationTargets,
+  computeAllocationDrift,
+} from "@/lib/services/allocation-service";
+import { getCachedNetWorthSummary } from "@/lib/services/net-worth-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AnalysisView } from "@/components/analysis/analysis-view";
 import AnalysisLoading from "./loading";
+import type { AllocationDriftItem } from "@/lib/types";
+import { ACCOUNT_CATEGORIES } from "@/lib/enums";
 
-const CLIENT_NAMESPACES = ["analysis", "categories", "nav", "trendChart", "history"];
+const CLIENT_NAMESPACES = ["analysis", "categories", "nav", "trendChart", "history", "allocation"];
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  STOCK: "Stock",
+  ETF: "ETF",
+  CRYPTO: "Crypto",
+  MUTUAL_FUND: "Mutual Fund",
+  BOND: "Bond",
+  OTHER: "Other",
+};
+
+const CATEGORY_LABELS: Record<string, string> = Object.fromEntries(
+  ACCOUNT_CATEGORIES.map((c) => [c, c.replace(/_/g, " ")]),
+);
 
 async function AnalysisContent() {
   const session = await getSession();
@@ -22,16 +42,36 @@ async function AnalysisContent() {
   const userId = session.user.id;
 
   const settings = await getOrCreateSettings(userId);
-  const [t, messages, snapshots, cashFlowData, rawHistory, accountCashFlow, locale] =
-    await Promise.all([
-      getTranslations("analysis"),
-      getMessages(),
-      getFullNormalizedHistory(userId, settings.baseCurrency),
-      getMonthlyCashFlow(userId, settings.baseCurrency),
-      getRawHistoryWithBreakdown(userId, settings.baseCurrency),
-      getAccountMonthlyCashFlow(userId, settings.baseCurrency),
-      getLocale(),
-    ]);
+  const baseCurrency = settings.baseCurrency;
+
+  const [
+    t,
+    messages,
+    snapshots,
+    cashFlowData,
+    rawHistory,
+    accountCashFlow,
+    locale,
+    targets,
+    summary,
+  ] = await Promise.all([
+    getTranslations("analysis"),
+    getMessages(),
+    getFullNormalizedHistory(userId, baseCurrency),
+    getMonthlyCashFlow(userId, baseCurrency),
+    getRawHistoryWithBreakdown(userId, baseCurrency),
+    getAccountMonthlyCashFlow(userId, baseCurrency),
+    getLocale(),
+    fetchUserAllocationTargets(userId),
+    getCachedNetWorthSummary(userId, baseCurrency),
+  ]);
+
+  const allocationDrift: AllocationDriftItem[] = computeAllocationDrift(
+    targets,
+    summary,
+    (scope, key) =>
+      scope === "ASSET_TYPE" ? (ASSET_TYPE_LABELS[key] ?? key) : (CATEGORY_LABELS[key] ?? key),
+  );
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
@@ -43,8 +83,9 @@ async function AnalysisContent() {
           cashFlowData={cashFlowData}
           rawHistory={rawHistory}
           accountCashFlow={accountCashFlow}
-          baseCurrency={settings.baseCurrency}
+          baseCurrency={baseCurrency}
           locale={locale}
+          allocationDrift={allocationDrift}
         />
       </div>
     </NextIntlClientProvider>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -18,6 +18,7 @@ const CLIENT_NAMESPACES = [
   "goalsMilestone",
   "categories",
   "common",
+  "allocation",
 ];
 
 async function DashboardPageContent() {

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -2,9 +2,11 @@ import { Suspense } from "react";
 import { SettingsForm } from "@/components/settings/settings-form";
 import { DataManagement } from "@/components/settings/data-management";
 import { InstallAppCard } from "@/components/settings/install-app-card";
+import { AllocationTargetsForm } from "@/components/settings/allocation-targets-form";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { fetchUserAllocationTargets } from "@/lib/services/allocation-service";
 import { Button } from "@/components/ui/button";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
@@ -12,17 +14,25 @@ import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import SettingsLoading from "./loading";
 
-const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement"];
+const CLIENT_NAMESPACES = [
+  "settings",
+  "toast",
+  "languages",
+  "dataManagement",
+  "allocation",
+  "categories",
+];
 
 async function SettingsContent() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   // Run all independent queries in parallel
-  const [t, allMessages, settings] = await Promise.all([
+  const [t, allMessages, settings, allocationTargets] = await Promise.all([
     getTranslations("settings"),
     getMessages(),
     getOrCreateSettings(userId),
+    fetchUserAllocationTargets(userId),
   ]);
 
   return (
@@ -37,6 +47,7 @@ async function SettingsContent() {
         </div>
 
         <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
+        <AllocationTargetsForm initialTargets={allocationTargets} />
         <DataManagement />
         <InstallAppCard />
 

--- a/src/app/api/allocation-targets/[id]/route.ts
+++ b/src/app/api/allocation-targets/[id]/route.ts
@@ -1,0 +1,39 @@
+import { revalidateTag } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { updateAllocationTargetSchema } from "@/lib/validators";
+import { ok, failure, validationError } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
+import { serializeAllocationTarget } from "@/lib/types";
+
+type IdCtx = { params: Promise<{ id: string }> };
+
+function invalidateCaches(userId: string) {
+  revalidateTag(`allocation-targets:${userId}`, "max");
+}
+
+export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
+  const { id } = await params;
+  const body = await request.json();
+  const parsed = updateAllocationTargetSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error);
+
+  const existing = await prisma.allocationTarget.findUnique({ where: { id, userId } });
+  if (!existing) return failure("Not found", 404);
+
+  const target = await prisma.allocationTarget.update({
+    where: { id, userId },
+    data: parsed.data,
+  });
+  invalidateCaches(userId);
+  return ok(serializeAllocationTarget(target));
+});
+
+export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
+  const { id } = await params;
+  const existing = await prisma.allocationTarget.findUnique({ where: { id, userId } });
+  if (!existing) return failure("Not found", 404);
+
+  await prisma.allocationTarget.delete({ where: { id, userId } });
+  invalidateCaches(userId);
+  return ok({ ok: true });
+});

--- a/src/app/api/allocation-targets/route.ts
+++ b/src/app/api/allocation-targets/route.ts
@@ -1,0 +1,39 @@
+import { revalidateTag } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { createAllocationTargetSchema } from "@/lib/validators";
+import { ok, validationError, failure } from "@/lib/api-responses";
+import { withAuth } from "@/lib/api-handler";
+import { serializeAllocationTarget } from "@/lib/types";
+
+function invalidateCaches(userId: string) {
+  revalidateTag(`allocation-targets:${userId}`, "max");
+}
+
+export const GET = withAuth(async (_req, _ctx, userId) => {
+  const targets = await prisma.allocationTarget.findMany({
+    where: { userId },
+    orderBy: [{ scope: "asc" }, { key: "asc" }],
+  });
+  return ok(targets.map(serializeAllocationTarget));
+});
+
+export const POST = withAuth(async (request, _ctx, userId) => {
+  const body = await request.json();
+  const parsed = createAllocationTargetSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error);
+
+  // Enforce max 20 targets per user
+  const count = await prisma.allocationTarget.count({ where: { userId } });
+  if (count >= 20) return failure("Maximum of 20 allocation targets allowed", 400);
+
+  const existing = await prisma.allocationTarget.findUnique({
+    where: { userId_scope_key: { userId, scope: parsed.data.scope, key: parsed.data.key } },
+  });
+  if (existing) return failure("A target for this scope/key already exists", 409);
+
+  const target = await prisma.allocationTarget.create({
+    data: { ...parsed.data, userId },
+  });
+  invalidateCaches(userId);
+  return ok(serializeAllocationTarget(target), { status: 201 });
+});

--- a/src/components/analysis/allocation-drift-chart.tsx
+++ b/src/components/analysis/allocation-drift-chart.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState, startTransition } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AllocationDriftItem } from "@/lib/types";
+
+interface Props {
+  items: AllocationDriftItem[];
+}
+
+function DriftTooltip({
+  active,
+  payload,
+  t,
+}: {
+  active?: boolean;
+  payload?: { payload: AllocationDriftItem }[];
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (!active || !payload?.length) return null;
+  const item = payload[0].payload;
+  const sign = item.drift >= 0 ? "+" : "";
+  return (
+    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1 min-w-[180px]">
+      <div className="font-medium leading-tight">{item.label}</div>
+      <div className="border-t border-border/60 pt-1 space-y-1">
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("allocationActual")}</span>
+          <span className="tabular-nums">{item.actualPercent.toFixed(1)}%</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground">{t("allocationTarget")}</span>
+          <span className="tabular-nums">{item.targetPercent.toFixed(1)}%</span>
+        </div>
+        <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
+          <span className="text-muted-foreground">{t("allocationDrift")}</span>
+          <span
+            className={`tabular-nums font-medium ${
+              item.isOverThreshold ? "text-destructive" : "text-[var(--chart-1)]"
+            }`}
+          >
+            {sign}
+            {item.drift.toFixed(1)} pp
+          </span>
+        </div>
+        {item.isOverThreshold && (
+          <div className="text-destructive/80 text-[11px]">
+            {t("allocationAlertHint", { threshold: item.driftThreshold.toFixed(1) })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const MAX_LABEL_LEN = 14;
+const truncate = (s: string) =>
+  s.length > MAX_LABEL_LEN ? s.slice(0, MAX_LABEL_LEN - 1) + "…" : s;
+
+export function AllocationDriftChart({ items }: Props) {
+  const t = useTranslations("analysis");
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => startTransition(() => setMounted(true)), []);
+
+  const alertCount = items.filter((i) => i.isOverThreshold).length;
+  const chartHeight = Math.max(200, items.length * 44 + 40);
+
+  // Sort: over-threshold first, then by |drift| desc
+  const chartData = [...items].sort((a, b) => {
+    if (a.isOverThreshold !== b.isOverThreshold) return a.isOverThreshold ? -1 : 1;
+    return Math.abs(b.drift) - Math.abs(a.drift);
+  });
+
+  if (items.length === 0) {
+    return (
+      <Card className="border-0 bg-transparent shadow-none">
+        <CardHeader className="pb-2 px-2 sm:px-4">
+          <CardTitle className="text-base font-medium text-foreground">
+            {t("allocationDriftTitle")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-2 sm:px-4 pb-4">
+          <div className="h-[140px] flex items-center justify-center text-muted-foreground text-sm">
+            {t("allocationDriftNoTargets")}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-0 bg-transparent shadow-none">
+      <CardHeader className="pb-2 px-2 sm:px-4">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base font-medium text-foreground">
+            {t("allocationDriftTitle")}
+          </CardTitle>
+          {alertCount > 0 && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive">
+              {t("allocationAlertBadge", { count: alertCount })}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">{t("allocationDriftSubtitle")}</p>
+      </CardHeader>
+      <CardContent className="px-2 sm:px-4 pb-4">
+        {!mounted ? (
+          <div style={{ height: chartHeight }} />
+        ) : (
+          <ResponsiveContainer width="100%" height={chartHeight}>
+            <BarChart
+              layout="vertical"
+              data={chartData}
+              margin={{ top: 4, right: 48, left: 0, bottom: 4 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => `${v > 0 ? "+" : ""}${v.toFixed(0)}pp`}
+                domain={["dataMin - 2", "dataMax + 2"]}
+              />
+              <YAxis
+                type="category"
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                tickFormatter={truncate}
+                width={100}
+              />
+              <ReferenceLine x={0} stroke="var(--border)" strokeWidth={1.5} label="" />
+              <Tooltip
+                cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                content={<DriftTooltip t={t} />}
+              />
+              <Bar dataKey="drift" radius={[0, 4, 4, 0]}>
+                {chartData.map((item, idx) => (
+                  <Cell
+                    key={`${item.scope}-${item.key}-${idx}`}
+                    fill={
+                      item.isOverThreshold
+                        ? "var(--destructive)"
+                        : item.drift >= 0
+                          ? "var(--chart-2)"
+                          : "var(--chart-1)"
+                    }
+                  />
+                ))}
+                <LabelList
+                  dataKey="drift"
+                  position="right"
+                  fontSize={11}
+                  formatter={(v: unknown) => {
+                    const n = Number(v);
+                    return `${n >= 0 ? "+" : ""}${n.toFixed(1)}pp`;
+                  }}
+                  style={{ fill: "var(--muted-foreground)" }}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+        <p className="text-[11px] text-muted-foreground mt-2">{t("allocationDriftNote")}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -31,6 +31,8 @@ import { CashFlowChart } from "./cashflow-chart";
 import { CategoryTrendChart } from "./category-trend-chart";
 import { TopMoversList } from "./top-movers-list";
 import { AttributionChart } from "./attribution-chart";
+import { AllocationDriftChart } from "./allocation-drift-chart";
+import type { AllocationDriftItem } from "@/lib/types";
 
 interface Props {
   snapshots: NormalizedSnapshot[];
@@ -39,6 +41,7 @@ interface Props {
   accountCashFlow: AccountMonthlyContribution[];
   baseCurrency: string;
   locale: string;
+  allocationDrift: AllocationDriftItem[];
 }
 
 const ranges = [
@@ -66,6 +69,7 @@ export function AnalysisView({
   accountCashFlow,
   baseCurrency,
   locale,
+  allocationDrift,
 }: Props) {
   const t = useTranslations("analysis");
   const tNav = useTranslations("nav");
@@ -273,6 +277,9 @@ export function AnalysisView({
             </div>
             <div className="premium-card">
               <AttributionChart items={attributionItems} baseCurrency={baseCurrency} />
+            </div>
+            <div className="premium-card">
+              <AllocationDriftChart items={allocationDrift} />
             </div>
             <div className="premium-card">
               <CategoryTrendChart

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -11,8 +11,10 @@ import {
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
+import { getRebalanceAlerts } from "@/lib/services/allocation-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card";
+import { RebalanceAlert } from "@/components/dashboard/rebalance-alert";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -271,8 +273,14 @@ export async function DashboardContent({ userId }: { userId: string }) {
     );
   }
 
+  // Pre-fetch rebalance alerts (shares cached summary, resolves fast)
+  const alerts = await getRebalanceAlerts(userId, baseCurrency);
+
   return (
     <>
+      {/* Rebalance alert toasts — rendered client-side, fires once per session */}
+      <RebalanceAlert alerts={alerts} />
+
       {/* Actions stream first — lightweight metadata, no summary needed */}
       <Suspense fallback={<div className="h-10 w-full bg-muted animate-pulse rounded-lg" />}>
         <DashboardActionsSection userId={userId} baseCurrency={baseCurrency} />

--- a/src/components/dashboard/rebalance-alert.tsx
+++ b/src/components/dashboard/rebalance-alert.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import type { AllocationDriftItem } from "@/lib/types";
+
+interface Props {
+  alerts: AllocationDriftItem[];
+}
+
+/**
+ * Fires a Sonner toast for each over-threshold drift item.
+ * Uses sessionStorage to show at most once per browser session.
+ */
+export function RebalanceAlert({ alerts }: Props) {
+  const t = useTranslations("allocation");
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current || alerts.length === 0) return;
+    const key = "rebalance-alert-shown";
+    if (sessionStorage.getItem(key)) return;
+
+    fired.current = true;
+    sessionStorage.setItem(key, "1");
+
+    for (const alert of alerts.slice(0, 3)) {
+      const sign = alert.drift >= 0 ? "+" : "";
+      toast.warning(
+        t("alertToast", {
+          label: alert.label,
+          drift: `${sign}${alert.drift.toFixed(1)}`,
+          threshold: alert.driftThreshold.toFixed(1),
+        }),
+        { duration: 8000 },
+      );
+    }
+
+    if (alerts.length > 3) {
+      toast.warning(t("alertToastMore", { count: alerts.length - 3 }), { duration: 8000 });
+    }
+  }, [alerts, t]);
+
+  return null;
+}

--- a/src/components/settings/allocation-targets-form.tsx
+++ b/src/components/settings/allocation-targets-form.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { PlusIcon, Trash2Icon, Loader2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { HOLDING_ASSET_TYPES, ACCOUNT_CATEGORIES } from "@/lib/enums";
+import type { SerializedAllocationTarget } from "@/lib/types";
+
+interface Props {
+  initialTargets: SerializedAllocationTarget[];
+}
+
+type Scope = "ASSET_TYPE" | "ACCOUNT_CATEGORY";
+
+const SCOPE_KEYS: Record<Scope, readonly string[]> = {
+  ASSET_TYPE: HOLDING_ASSET_TYPES.filter((t) => t !== "OPTION"),
+  ACCOUNT_CATEGORY: ACCOUNT_CATEGORIES.filter(
+    (c) => !["CREDIT_CARD", "LOAN", "MORTGAGE"].includes(c),
+  ),
+};
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  STOCK: "Stock",
+  ETF: "ETF",
+  CRYPTO: "Crypto",
+  MUTUAL_FUND: "Mutual Fund",
+  BOND: "Bond",
+  OTHER: "Other",
+};
+
+export function AllocationTargetsForm({ initialTargets }: Props) {
+  const t = useTranslations("allocation");
+  const tCat = useTranslations("categories");
+  const [targets, setTargets] = useState<SerializedAllocationTarget[]>(initialTargets);
+  const [scope, setScope] = useState<Scope>("ASSET_TYPE");
+  const [key, setKey] = useState("");
+  const [targetPercent, setTargetPercent] = useState("");
+  const [driftThreshold, setDriftThreshold] = useState("5");
+  const [isPending, startTransition] = useTransition();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const availableKeys = SCOPE_KEYS[scope].filter(
+    (k) => !targets.some((tgt) => tgt.scope === scope && tgt.key === k),
+  );
+
+  const getKeyLabel = (s: Scope, k: string) => {
+    if (s === "ASSET_TYPE") return ASSET_TYPE_LABELS[k] ?? k;
+    return tCat(k as Parameters<typeof tCat>[0], { defaultValue: k });
+  };
+
+  const handleAdd = () => {
+    if (!key || !targetPercent) return;
+    const pct = parseFloat(targetPercent);
+    const threshold = parseFloat(driftThreshold) || 5;
+    if (isNaN(pct) || pct < 0 || pct > 100) {
+      toast.error(t("invalidPercent"));
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/allocation-targets", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scope, key, targetPercent: pct, driftThreshold: threshold }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          toast.error(err.error ?? t("toast.failed"));
+          return;
+        }
+        const { data: created } = (await res.json()) as { data: SerializedAllocationTarget };
+        setTargets((prev) => [...prev, created]);
+        setKey("");
+        setTargetPercent("");
+        setDriftThreshold("5");
+        toast.success(t("toast.created"));
+      } catch {
+        toast.error(t("toast.failed"));
+      }
+    });
+  };
+
+  const handleDelete = (id: string) => {
+    setDeletingId(id);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/allocation-targets/${id}`, { method: "DELETE" });
+        if (!res.ok) {
+          toast.error(t("toast.failed"));
+          return;
+        }
+        setTargets((prev) => prev.filter((tgt) => tgt.id !== id));
+        toast.success(t("toast.deleted"));
+      } catch {
+        toast.error(t("toast.failed"));
+      } finally {
+        setDeletingId(null);
+      }
+    });
+  };
+
+  const totalPctByScope = (s: Scope) =>
+    targets.filter((tgt) => tgt.scope === s).reduce((sum, tgt) => sum + tgt.targetPercent, 0);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-lg font-semibold">{t("title")}</h3>
+        <p className="text-sm text-muted-foreground">{t("description")}</p>
+      </div>
+
+      {/* Existing targets */}
+      {targets.length > 0 && (
+        <div className="rounded-lg border divide-y text-sm">
+          {targets.map((tgt) => (
+            <div key={tgt.id} className="flex items-center justify-between px-4 py-3 gap-3">
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="shrink-0 rounded px-1.5 py-0.5 text-[11px] bg-muted text-muted-foreground font-medium">
+                  {tgt.scope === "ASSET_TYPE"
+                    ? t("scope.ASSET_TYPE")
+                    : tgt.scope === "ACCOUNT_CATEGORY"
+                      ? t("scope.ACCOUNT_CATEGORY")
+                      : tgt.scope}
+                </span>
+                <span className="font-medium truncate">{getKeyLabel(tgt.scope, tgt.key)}</span>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="tabular-nums text-muted-foreground text-xs">
+                  {t("threshold", { n: tgt.driftThreshold })}
+                </span>
+                <span className="tabular-nums font-semibold">{tgt.targetPercent.toFixed(1)}%</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  onClick={() => handleDelete(tgt.id)}
+                  disabled={deletingId === tgt.id}
+                  aria-label={t("deleteTarget")}
+                >
+                  {deletingId === tgt.id ? (
+                    <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Trash2Icon className="h-3.5 w-3.5" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Total check */}
+      {(["ASSET_TYPE", "ACCOUNT_CATEGORY"] as Scope[]).map((s) => {
+        const total = totalPctByScope(s);
+        if (total === 0) return null;
+        const isOver = total > 100;
+        return (
+          <p key={s} className={`text-xs ${isOver ? "text-destructive" : "text-muted-foreground"}`}>
+            {t("totalHint", {
+              scope: s === "ASSET_TYPE" ? t("scope.ASSET_TYPE") : t("scope.ACCOUNT_CATEGORY"),
+              total: total.toFixed(1),
+            })}
+            {isOver && ` — ${t("totalOverHint")}`}
+          </p>
+        );
+      })}
+
+      {/* Add form */}
+      {targets.length < 20 && (
+        <div className="rounded-lg border p-4 space-y-3 bg-muted/30">
+          <p className="text-sm font-medium">{t("addTarget")}</p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">{t("scopeLabel")}</Label>
+              <Select
+                value={scope}
+                onValueChange={(v) => {
+                  setScope(v as Scope);
+                  setKey("");
+                }}
+              >
+                <SelectTrigger className="h-8 text-xs w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  <SelectItem value="ASSET_TYPE">{t("scope.ASSET_TYPE")}</SelectItem>
+                  <SelectItem value="ACCOUNT_CATEGORY">{t("scope.ACCOUNT_CATEGORY")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">{t("keyLabel")}</Label>
+              <Select
+                value={key}
+                onValueChange={(v) => setKey(v ?? "")}
+                disabled={availableKeys.length === 0}
+              >
+                <SelectTrigger className="h-8 text-xs w-full">
+                  <SelectValue placeholder={t("keyPlaceholder")} />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  {availableKeys.map((k) => (
+                    <SelectItem key={k} value={k}>
+                      {getKeyLabel(scope, k)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">{t("targetPercentLabel")}</Label>
+              <div className="relative">
+                <Input
+                  className="h-8 text-xs pr-6"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.5}
+                  value={targetPercent}
+                  onChange={(e) => setTargetPercent(e.target.value)}
+                  placeholder="30"
+                />
+                <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">
+                  %
+                </span>
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">{t("thresholdLabel")}</Label>
+              <div className="relative">
+                <Input
+                  className="h-8 text-xs pr-6"
+                  type="number"
+                  min={0}
+                  max={50}
+                  step={0.5}
+                  value={driftThreshold}
+                  onChange={(e) => setDriftThreshold(e.target.value)}
+                  placeholder="5"
+                />
+                <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">
+                  pp
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <Button
+            size="sm"
+            className="gap-1.5"
+            onClick={handleAdd}
+            disabled={!key || !targetPercent || isPending}
+          >
+            {isPending ? (
+              <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <PlusIcon className="h-3.5 w-3.5" />
+            )}
+            {t("addBtn")}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -29,3 +29,5 @@ export const HOLDING_TRANSACTION_TYPES = ["BUY", "SELL", "EDIT"] as const;
 export const CASH_TRANSACTION_TYPES = ["DEPOSIT", "WITHDRAWAL", "EDIT"] as const;
 
 export const GOAL_SCOPES = ["NET_WORTH", "ASSETS_ONLY", "CATEGORY", "ACCOUNT"] as const;
+
+export const ALLOCATION_SCOPES = ["ASSET_TYPE", "ACCOUNT_CATEGORY"] as const;

--- a/src/lib/services/allocation-service.ts
+++ b/src/lib/services/allocation-service.ts
@@ -1,0 +1,110 @@
+import { cache } from "react";
+import { cacheLife, cacheTag } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { getCachedNetWorthSummary } from "./net-worth-service";
+import { serializeAllocationTarget } from "@/lib/types";
+import type { SerializedAllocationTarget, AllocationDriftItem, NetWorthSummary } from "@/lib/types";
+import { HOLDING_ASSET_TYPES, ACCOUNT_CATEGORIES } from "@/lib/enums";
+
+async function fetchUserAllocationTargetsInner(
+  userId: string,
+): Promise<SerializedAllocationTarget[]> {
+  "use cache";
+  cacheTag("allocation-targets");
+  cacheTag(`allocation-targets:${userId}`);
+  cacheLife("hours");
+  const rows = await prisma.allocationTarget.findMany({
+    where: { userId },
+    orderBy: [{ scope: "asc" }, { key: "asc" }],
+  });
+  return rows.map(serializeAllocationTarget);
+}
+
+export const fetchUserAllocationTargets = cache(fetchUserAllocationTargetsInner);
+
+/** Compute actual allocation percentages by asset type from NetWorthSummary. */
+function computeAssetTypeAllocation(summary: NetWorthSummary): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const type of HOLDING_ASSET_TYPES) totals[type] = 0;
+
+  for (const account of summary.accounts) {
+    if (account.type !== "ASSET") continue;
+    for (const holding of account.holdings) {
+      if (holding.marketValue === null) continue;
+      totals[holding.assetType] = (totals[holding.assetType] ?? 0) + holding.marketValue;
+    }
+  }
+
+  const grand = Object.values(totals).reduce((a, b) => a + b, 0);
+  if (grand === 0) return Object.fromEntries(Object.keys(totals).map((k) => [k, 0]));
+
+  return Object.fromEntries(Object.entries(totals).map(([k, v]) => [k, (v / grand) * 100]));
+}
+
+/** Compute actual allocation percentages by account category from NetWorthSummary. */
+function computeAccountCategoryAllocation(summary: NetWorthSummary): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const cat of ACCOUNT_CATEGORIES) totals[cat] = 0;
+
+  for (const account of summary.accounts) {
+    if (account.type !== "ASSET") continue;
+    totals[account.category] = (totals[account.category] ?? 0) + account.totalValueInBaseCurrency;
+  }
+
+  const grand = Object.values(totals).reduce((a, b) => a + b, 0);
+  if (grand === 0) return Object.fromEntries(Object.keys(totals).map((k) => [k, 0]));
+
+  return Object.fromEntries(Object.entries(totals).map(([k, v]) => [k, (v / grand) * 100]));
+}
+
+/**
+ * Compute drift items for all targets.
+ * @param targets  Serialized allocation targets.
+ * @param summary  Current net worth summary.
+ * @param labelFn  Optional function to turn a key into a human-readable label.
+ */
+export function computeAllocationDrift(
+  targets: SerializedAllocationTarget[],
+  summary: NetWorthSummary,
+  labelFn?: (scope: string, key: string) => string,
+): AllocationDriftItem[] {
+  if (targets.length === 0) return [];
+
+  const assetTypeActuals = computeAssetTypeAllocation(summary);
+  const categoryActuals = computeAccountCategoryAllocation(summary);
+
+  return targets.map((t) => {
+    const actuals = t.scope === "ASSET_TYPE" ? assetTypeActuals : categoryActuals;
+    const actualPercent = actuals[t.key] ?? 0;
+    const drift = actualPercent - t.targetPercent;
+    return {
+      scope: t.scope,
+      key: t.key,
+      label: labelFn ? labelFn(t.scope, t.key) : t.key,
+      actualPercent,
+      targetPercent: t.targetPercent,
+      driftThreshold: t.driftThreshold,
+      drift,
+      isOverThreshold: Math.abs(drift) > t.driftThreshold,
+    };
+  });
+}
+
+/**
+ * Load targets + summary and return drift items that exceed their threshold.
+ * Used by the dashboard rebalance alert.
+ */
+export async function getRebalanceAlerts(
+  userId: string,
+  baseCurrency: string,
+): Promise<AllocationDriftItem[]> {
+  const [targets, summary] = await Promise.all([
+    fetchUserAllocationTargets(userId),
+    getCachedNetWorthSummary(userId, baseCurrency),
+  ]);
+
+  if (targets.length === 0) return [];
+
+  const drift = computeAllocationDrift(targets, summary);
+  return drift.filter((d) => d.isOverThreshold);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,10 @@
-import type { Account, Goal, Holding, HoldingTransaction } from "@/generated/prisma/client";
+import type {
+  Account,
+  AllocationTarget,
+  Goal,
+  Holding,
+  HoldingTransaction,
+} from "@/generated/prisma/client";
 
 // ---------------------------------------------------------------------------
 // Generic serialization utilities
@@ -155,6 +161,46 @@ export type GoalWithProgress = {
   projectedDateCAGR: string | null;
   isCompleted: boolean;
 };
+
+// ---------------------------------------------------------------------------
+// AllocationTarget types
+// ---------------------------------------------------------------------------
+
+export type SerializedAllocationTarget = {
+  id: string;
+  userId: string;
+  scope: "ASSET_TYPE" | "ACCOUNT_CATEGORY";
+  key: string;
+  targetPercent: number;
+  driftThreshold: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AllocationDriftItem = {
+  scope: "ASSET_TYPE" | "ACCOUNT_CATEGORY";
+  key: string;
+  label: string;
+  actualPercent: number;
+  targetPercent: number;
+  driftThreshold: number;
+  /** actualPercent - targetPercent (positive = over-allocated, negative = under-allocated) */
+  drift: number;
+  isOverThreshold: boolean;
+};
+
+export function serializeAllocationTarget(t: AllocationTarget): SerializedAllocationTarget {
+  return {
+    id: t.id,
+    userId: t.userId,
+    scope: t.scope as "ASSET_TYPE" | "ACCOUNT_CATEGORY",
+    key: t.key,
+    targetPercent: Number(t.targetPercent),
+    driftThreshold: Number(t.driftThreshold),
+    createdAt: t.createdAt.toISOString(),
+    updatedAt: t.updatedAt.toISOString(),
+  };
+}
 
 export function serializeGoal(goal: Goal): SerializedGoal {
   return {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -7,6 +7,7 @@ import {
   CASH_TRANSACTION_TYPES,
   OPTION_TYPES,
   GOAL_SCOPES,
+  ALLOCATION_SCOPES,
 } from "./enums";
 
 const OCC_SHAPE = /^[A-Z][A-Z0-9.\-]{0,5}\d{6}[CP]\d{8}$/;
@@ -119,6 +120,15 @@ export const createGoalSchema = z.object({
 });
 
 export const updateGoalSchema = createGoalSchema.partial();
+
+export const createAllocationTargetSchema = z.object({
+  scope: z.enum(ALLOCATION_SCOPES),
+  key: z.string().min(1).max(64),
+  targetPercent: z.number().min(0).max(100),
+  driftThreshold: z.number().min(0).max(100).default(5),
+});
+
+export const updateAllocationTargetSchema = createAllocationTargetSchema.partial();
 
 const decimalSchema = z.union([z.string(), z.number()]);
 


### PR DESCRIPTION
## Summary

- **Schema**: `AllocationScope` enum + `AllocationTarget` model with `@@unique([userId, scope, key])` constraint; migration `20260517000000_f9_allocation_targets`
- **Service layer** (`allocation-service.ts`): `fetchUserAllocationTargets` (cached), `computeAllocationDrift`, `getRebalanceAlerts`
- **API**: `GET/POST /api/allocation-targets` + `PATCH/DELETE /api/allocation-targets/[id]`; all responses serialized (Prisma `Decimal` → `number`) to fix `toFixed is not a function` at runtime
- **Settings UI**: `AllocationTargetsForm` — CRUD form with scope/key/target%/drift-threshold inputs, total-percentage hint, max-20 guard
- **Analysis UI**: `AllocationDriftChart` — horizontal bar chart showing actual vs. target drift in pp, with an over-threshold alert badge
- **Dashboard UI**: `RebalanceAlert` — Sonner toast alerts (once per browser session via `sessionStorage`), shows up to 3 items + "+N more"
- **i18n**: `allocation` namespace added to `en-US.json` and `zh-TW.json`; `analysis.allocationDrift*` keys added

## Test plan

- [ ] Settings → Allocation Targets: add a target (Asset Type: Stock, 40%, threshold 5pp) → item appears in list with correct scope badge and percentage
- [ ] Add a second target with the same scope/key → should be blocked (409 from API)
- [ ] Delete a target → item removed from list, toast fires
- [ ] Analysis tab → Allocation Drift chart renders; bars reflect actual vs. target; over-threshold bars are red
- [ ] Dashboard → if any target drifts beyond threshold, Sonner warning toast fires on first load; refreshing the same tab does NOT re-fire (sessionStorage guard)
- [ ] Verify no `MISSING_MESSAGE` errors in console (scope label uses explicit conditional, not template literal)
- [ ] `npm run format:check && npm run lint && npm run typecheck` — all green ✅

> **Note**: E2E test 2 ("create an account…") fails consistently in this environment but is pre-existing and unrelated to F9 — it concerns `router.refresh()` not rehydrating the accounts list within the timeout after account creation. Tests 1, 3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)