### PR TITLE
[codex] Mark server modules server-only

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import NextAuth, { type NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import authConfig from "./auth.config";

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { auth } from "@/auth";
 import { failure } from "@/lib/api-responses";
 

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "./prisma";
 

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { auth } from "@/auth";
 

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/goal-service.ts
+++ b/src/lib/services/goal-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@/lib/prisma";
 import { getNetWorthSummary } from "./net-worth-service";
 


### PR DESCRIPTION
## Summary

- Add direct `import "server-only";` guards to auth/session helpers and server data modules.
- Make server-only boundaries explicit for Prisma, auth, server cache, settings, history, projection, goal, and snapshot code.
- Leave client-shared pure analysis helpers untouched.

## Validation

- `npm run check` passed locally before commit.
- Push preflight also ran `format:check`, `lint`, and `typecheck` successfully.

## Notes

Unrelated local workspace artifacts were intentionally left uncommitted.