### PR TITLE
[codex] refactor account shared utilities

### DIFF
--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -1,9 +1,9 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
+import { invalidateAccountData } from "@/lib/cache-invalidation";
 
 export const POST = withAuth(
   async (request, { params }: { params: Promise<{ id: string }> }, userId) => {
@@ -27,9 +27,7 @@ export const POST = withAuth(
       data: { cashBalance: { increment: delta } },
     });
 
-    revalidateTag(`accounts:${userId}`, "max");
-    revalidateTag(`net-worth:${userId}`, "max");
-    revalidateTag(`history:${userId}`, "max");
+    invalidateAccountData(userId);
 
     return ok(transaction, { status: 201 });
   },

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
@@ -6,15 +5,9 @@ import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 import { parseOccSymbol, formatOptionLabel, OptionError } from "@/lib/options";
 import { log } from "@/lib/logger";
+import { invalidateAccountData } from "@/lib/cache-invalidation";
 
 type IdCtx = { params: Promise<{ id: string }> };
-
-function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
-}
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
@@ -131,7 +124,7 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
     log.error("holdings.price_fetch.failed", { symbol: holding.symbol, error: String(error) });
   }
 
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId);
   return ok(holding, { status: 201 });
 });
 
@@ -163,7 +156,7 @@ export const PATCH = withAuth<IdCtx>(async (request, _ctx, userId) => {
   }
 
   const holding = await prisma.holding.update({ where: { id }, data });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId);
   return ok(holding);
 });
 
@@ -179,6 +172,6 @@ export const DELETE = withAuth<IdCtx>(async (request, _ctx, userId) => {
   if (!owned) return failure("Not found", 404);
 
   await prisma.holding.delete({ where: { id } });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId);
   return ok({ ok: true });
 });

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,17 +1,10 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateAccountSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { invalidateAccountData } from "@/lib/cache-invalidation";
 
 type IdCtx = { params: Promise<{ id: string }> };
-
-function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
-}
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
@@ -52,13 +45,13 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
     where: { id, userId },
     data: parsed.data,
   });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId);
   return ok(account);
 });
 
 export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
   await prisma.account.delete({ where: { id, userId } });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId);
   return ok({ ok: true });
 });

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -1,17 +1,11 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
 import { calculateBalanceDelta } from "@/lib/services/balance";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { invalidateAccountData } from "@/lib/cache-invalidation";
 
 type TxCtx = { params: Promise<{ id: string; transactionId: string }> };
-
-function invalidateAccountCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
-}
 
 export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
@@ -61,7 +55,7 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
       },
     });
 
-    invalidateAccountCaches(userId);
+    invalidateAccountData(userId);
     return ok(updatedTx);
   }
 
@@ -111,7 +105,7 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
       },
     });
 
-    invalidateAccountCaches(userId);
+    invalidateAccountData(userId);
     return ok(updatedTx);
   }
 
@@ -144,7 +138,7 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
     });
 
     await prisma.holdingTransaction.delete({ where: { id: transactionId } });
-    invalidateAccountCaches(userId);
+    invalidateAccountData(userId);
     return ok({ ok: true });
   }
 
@@ -165,7 +159,7 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
     });
 
     await prisma.cashTransaction.delete({ where: { id: transactionId } });
-    invalidateAccountCaches(userId);
+    invalidateAccountData(userId);
     return ok({ ok: true });
   }
 

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,14 +1,8 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createAccountSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
-
-function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-}
+import { invalidateAccountData } from "@/lib/cache-invalidation";
 
 export const GET = withAuth(async (_req, _ctx, userId) => {
   const accounts = await prisma.account.findMany({
@@ -32,7 +26,7 @@ export const DELETE = withAuth(async (request, _ctx, userId) => {
       userId,
     },
   });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId, { includeHistory: false });
   return ok({ ok: true });
 });
 
@@ -44,6 +38,6 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   const account = await prisma.account.create({
     data: { ...parsed.data, userId },
   });
-  invalidateUserCaches(userId);
+  invalidateAccountData(userId, { includeHistory: false });
   return ok(account, { status: 201 });
 });

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -1,10 +1,14 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { refreshAllPrices } from "@/lib/services/price-service";
 import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
 import { log } from "@/lib/logger";
+import {
+  invalidateAllAccountsData,
+  invalidatePriceData,
+  invalidateSnapshotData,
+} from "@/lib/cache-invalidation";
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -43,15 +47,13 @@ export async function GET(request: Request) {
           ]),
         ),
       );
-      revalidateTag("accounts", "max");
+      invalidateAllAccountsData();
     }
 
     // 1. Refresh all prices first to ensure the snapshot is accurate
     log.info("cron.prices.refresh");
     await refreshAllPrices();
-    // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-    revalidateTag("net-worth", "max");
-    revalidateTag("prices:crypto", "max");
+    invalidatePriceData();
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({
@@ -68,10 +70,7 @@ export async function GET(request: Request) {
     );
 
     // 4. Invalidate snapshot/history caches now that new rows exist
-    revalidateTag("snapshots", "max");
-    for (const user of users) {
-      revalidateTag(`history:${user.id}`, "max");
-    }
+    invalidateSnapshotData(users.map((user) => user.id));
 
     return ok({
       success: true,

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -1,8 +1,8 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { withAuth } from "@/lib/api-handler";
 import { ok } from "@/lib/api-responses";
+import { invalidateExchangeRateData } from "@/lib/cache-invalidation";
 
 export const POST = withAuth(async (_request, _ctx, userId) => {
   const settings = await prisma.setting.findUnique({ where: { userId } });
@@ -21,7 +21,6 @@ export const POST = withAuth(async (_request, _ctx, userId) => {
   ]);
   const totalUpdated = results.reduce((a, b) => a + b, 0);
 
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag("exchange-rates", "max");
+  invalidateExchangeRateData();
   return ok({ updated: totalUpdated, baseCurrency });
 });

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,14 +1,10 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateGoalSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { invalidateGoalData } from "@/lib/cache-invalidation";
 
 type IdCtx = { params: Promise<{ id: string }> };
-
-function invalidateGoalCaches(userId: string) {
-  revalidateTag(`goals:${userId}`, "max");
-}
 
 export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const { id } = await params;
@@ -27,7 +23,7 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
       ...(targetDate !== undefined ? { targetDate: targetDate ? new Date(targetDate) : null } : {}),
     },
   });
-  invalidateGoalCaches(userId);
+  invalidateGoalData(userId);
   return ok(goal);
 });
 
@@ -37,6 +33,6 @@ export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
   if (!existing) return failure("Not found", 404);
 
   await prisma.goal.delete({ where: { id, userId } });
-  invalidateGoalCaches(userId);
+  invalidateGoalData(userId);
   return ok({ ok: true });
 });

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,12 +1,8 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createGoalSchema } from "@/lib/validators";
 import { ok, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
-
-function invalidateGoalCaches(userId: string) {
-  revalidateTag(`goals:${userId}`, "max");
-}
+import { invalidateGoalData } from "@/lib/cache-invalidation";
 
 export const GET = withAuth(async (_req, _ctx, userId) => {
   const goals = await prisma.goal.findMany({
@@ -29,6 +25,6 @@ export const POST = withAuth(async (request, _ctx, userId) => {
       targetDate: targetDate ? new Date(targetDate) : null,
     },
   });
-  invalidateGoalCaches(userId);
+  invalidateGoalData(userId);
   return ok(goal, { status: 201 });
 });

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -1,11 +1,9 @@
-import { revalidateTag } from "next/cache";
 import { refreshAllPrices } from "@/lib/services/price-service";
 import { ok } from "@/lib/api-responses";
+import { invalidatePriceData } from "@/lib/cache-invalidation";
 
 export async function POST() {
   const result = await refreshAllPrices();
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag("net-worth", "max");
-  revalidateTag("prices:crypto", "max");
+  invalidatePriceData();
   return ok(result);
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,9 +1,9 @@
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { updateSettingsSchema } from "@/lib/validators";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { ok, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { invalidateSettingsData } from "@/lib/cache-invalidation";
 
 export const GET = withAuth(async (_req, _ctx, userId) => {
   const settings = await getOrCreateSettings(userId);
@@ -28,13 +28,7 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
     },
   });
 
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`settings:${userId}`, "max");
-  // If the base currency changed, the cached net-worth summary for this
-  // user is stale (values are denominated in the old currency).
-  if (parsed.data.baseCurrency !== undefined) {
-    revalidateTag(`net-worth:${userId}`, "max");
-  }
+  invalidateSettingsData(userId, { affectsNetWorth: parsed.data.baseCurrency !== undefined });
 
   const response = ok(settings);
 

--- a/src/components/accounts/account-category-meta.ts
+++ b/src/components/accounts/account-category-meta.ts
@@ -1,0 +1,73 @@
+export const HIDDEN_VALUE = "***";
+
+export const CATEGORY_ICONS: Record<string, string> = {
+  BANK: "🏦",
+  BROKERAGE: "📈",
+  CRYPTO_WALLET: "🪙",
+  PROPERTY: "🏠",
+  VEHICLE: "🚗",
+  CREDIT_CARD: "💳",
+  LOAN: "📋",
+  MORTGAGE: "🏡",
+  OTHER: "📁",
+};
+
+export const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string }> = {
+  BANK: {
+    bg: "bg-blue-50 dark:bg-blue-950/60",
+    border: "border-blue-200 dark:border-blue-800/40",
+    text: "text-blue-700 dark:text-blue-300",
+  },
+  BROKERAGE: {
+    bg: "bg-emerald-50 dark:bg-emerald-950/60",
+    border: "border-emerald-200 dark:border-emerald-800/40",
+    text: "text-emerald-700 dark:text-emerald-300",
+  },
+  CRYPTO_WALLET: {
+    bg: "bg-amber-50 dark:bg-amber-950/60",
+    border: "border-amber-200 dark:border-amber-800/40",
+    text: "text-amber-700 dark:text-amber-300",
+  },
+  PROPERTY: {
+    bg: "bg-violet-50 dark:bg-violet-950/60",
+    border: "border-violet-200 dark:border-violet-800/40",
+    text: "text-violet-700 dark:text-violet-300",
+  },
+  VEHICLE: {
+    bg: "bg-slate-50 dark:bg-slate-950/60",
+    border: "border-slate-200 dark:border-slate-800/40",
+    text: "text-slate-700 dark:text-slate-300",
+  },
+  CREDIT_CARD: {
+    bg: "bg-red-50 dark:bg-red-950/60",
+    border: "border-red-200 dark:border-red-800/40",
+    text: "text-red-700 dark:text-red-300",
+  },
+  LOAN: {
+    bg: "bg-orange-50 dark:bg-orange-950/60",
+    border: "border-orange-200 dark:border-orange-800/40",
+    text: "text-orange-700 dark:text-orange-300",
+  },
+  MORTGAGE: {
+    bg: "bg-pink-50 dark:bg-pink-950/60",
+    border: "border-pink-200 dark:border-pink-800/40",
+    text: "text-pink-700 dark:text-pink-300",
+  },
+  OTHER: {
+    bg: "bg-gray-50 dark:bg-gray-950/60",
+    border: "border-gray-200 dark:border-gray-800/40",
+    text: "text-gray-700 dark:text-gray-300",
+  },
+};
+
+export const CATEGORY_ORDER = [
+  "BANK",
+  "BROKERAGE",
+  "CRYPTO_WALLET",
+  "PROPERTY",
+  "VEHICLE",
+  "CREDIT_CARD",
+  "LOAN",
+  "MORTGAGE",
+  "OTHER",
+];

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -16,6 +16,7 @@ import {
 import { CURRENCIES } from "@/lib/currencies";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
+import { useFormattedNumberInput } from "@/hooks/use-formatted-number-input";
 
 const CATEGORY_KEYS = [
   "BANK",
@@ -45,37 +46,24 @@ export function AccountForm({
   const [type, setType] = useState<"ASSET" | "LIABILITY">("ASSET");
   const [category, setCategory] = useState("BANK");
   const [currency, setCurrency] = useState(defaultCurrency);
-  const [cashBalance, setCashBalance] = useState("0");
   const [cashBalanceError, setCashBalanceError] = useState("");
-
-  function handleCashBalanceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    setCashBalanceError("");
-    if (!raw) {
-      setCashBalance("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setCashBalance(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleCashBalanceBlur() {
-    const val = cashBalance.replace(/,/g, "");
-    if (!val) {
-      setCashBalance("0");
-      setCashBalanceError("");
-      return;
-    }
-    const parsed = parseFloat(val);
-    if (isNaN(parsed)) {
-      setCashBalanceError(t("accountForm.invalidAmount", { defaultValue: "Invalid amount" }));
-      return;
-    }
-    setCashBalanceError("");
-    setCashBalance(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(parsed));
-  }
+  const {
+    value: cashBalance,
+    rawValue: cashBalanceRawValue,
+    setValue: setCashBalance,
+    handleChange: handleCashBalanceChange,
+    handleBlur: handleCashBalanceBlur,
+  } = useFormattedNumberInput({
+    initialValue: "0",
+    maximumFractionDigits: 2,
+    emptyValueOnBlur: "0",
+    invalidMessage: t("accountForm.invalidAmount", { defaultValue: "Invalid amount" }),
+    onValid: () => setCashBalanceError(""),
+    onInvalid: (message) =>
+      setCashBalanceError(
+        message ?? t("accountForm.invalidAmount", { defaultValue: "Invalid amount" }),
+      ),
+  });
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -90,7 +78,7 @@ export function AccountForm({
           type,
           category,
           currency,
-          cashBalance: parseFloat(cashBalance.replace(/,/g, "")) || 0,
+          cashBalance: parseFloat(cashBalanceRawValue) || 0,
         }),
       });
 

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -1,119 +1,19 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
-import Link from "next/link";
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ChevronUp, ChevronDown, ChevronsUpDown, MoreHorizontal, Trash2 } from "lucide-react";
-import { formatCurrency } from "@/lib/currencies";
-import { springConfig } from "@/lib/motion";
-import { toast } from "sonner";
 import { useTranslations } from "next-intl";
-import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
-import { useDensity } from "@/components/layout/density-context";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+import { DesktopAccountsTable } from "./desktop-accounts-table";
+import { MobileAccountSections } from "./mobile-account-sections";
+import { useAccountListModel } from "./use-account-list-model";
 
 const AccountForm = dynamic(() => import("./account-form").then((m) => m.AccountForm));
 
 const QuickAddHolding = dynamic(() => import("./quick-add-holding").then((m) => m.QuickAddHolding));
-
-const HIDDEN = "***";
-
-const CATEGORY_ICONS: Record<string, string> = {
-  BANK: "🏦",
-  BROKERAGE: "📈",
-  CRYPTO_WALLET: "🪙",
-  PROPERTY: "🏠",
-  VEHICLE: "🚗",
-  CREDIT_CARD: "💳",
-  LOAN: "📋",
-  MORTGAGE: "🏡",
-  OTHER: "📁",
-};
-
-const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string }> = {
-  BANK: {
-    bg: "bg-blue-50 dark:bg-blue-950/60",
-    border: "border-blue-200 dark:border-blue-800/40",
-    text: "text-blue-700 dark:text-blue-300",
-  },
-  BROKERAGE: {
-    bg: "bg-emerald-50 dark:bg-emerald-950/60",
-    border: "border-emerald-200 dark:border-emerald-800/40",
-    text: "text-emerald-700 dark:text-emerald-300",
-  },
-  CRYPTO_WALLET: {
-    bg: "bg-amber-50 dark:bg-amber-950/60",
-    border: "border-amber-200 dark:border-amber-800/40",
-    text: "text-amber-700 dark:text-amber-300",
-  },
-  PROPERTY: {
-    bg: "bg-violet-50 dark:bg-violet-950/60",
-    border: "border-violet-200 dark:border-violet-800/40",
-    text: "text-violet-700 dark:text-violet-300",
-  },
-  VEHICLE: {
-    bg: "bg-slate-50 dark:bg-slate-950/60",
-    border: "border-slate-200 dark:border-slate-800/40",
-    text: "text-slate-700 dark:text-slate-300",
-  },
-  CREDIT_CARD: {
-    bg: "bg-red-50 dark:bg-red-950/60",
-    border: "border-red-200 dark:border-red-800/40",
-    text: "text-red-700 dark:text-red-300",
-  },
-  LOAN: {
-    bg: "bg-orange-50 dark:bg-orange-950/60",
-    border: "border-orange-200 dark:border-orange-800/40",
-    text: "text-orange-700 dark:text-orange-300",
-  },
-  MORTGAGE: {
-    bg: "bg-pink-50 dark:bg-pink-950/60",
-    border: "border-pink-200 dark:border-pink-800/40",
-    text: "text-pink-700 dark:text-pink-300",
-  },
-  OTHER: {
-    bg: "bg-gray-50 dark:bg-gray-950/60",
-    border: "border-gray-200 dark:border-gray-800/40",
-    text: "text-gray-700 dark:text-gray-300",
-  },
-};
-
-const CATEGORY_ORDER = [
-  "BANK",
-  "BROKERAGE",
-  "CRYPTO_WALLET",
-  "PROPERTY",
-  "VEHICLE",
-  "CREDIT_CARD",
-  "LOAN",
-  "MORTGAGE",
-  "OTHER",
-];
-
-function getAccountValue(
-  account: SerializedAccountWithHoldings,
-  priceMap: Record<string, number>,
-  ratesMap: Record<string, number>,
-): number {
-  const holdingsValue = account.holdings.reduce((sum, h) => {
-    const price = (priceMap || {})[h.symbol] ?? 0;
-    const hc = h.currency || "USD";
-    const rate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
-    const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
-    return sum + price * h.quantity * multiplier * rate;
-  }, 0);
-  return account.cashBalance + holdingsValue;
-}
 
 export function AccountsList({
   accounts,
@@ -130,6 +30,9 @@ export function AccountsList({
   const t = useTranslations();
   const [showForm, setShowForm] = useState(false);
   const [showQuickAdd, setShowQuickAdd] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const model = useAccountListModel({ accounts, priceMap, ratesMap, baseCurrency });
 
   useEffect(() => {
     const handler = () => setShowForm(true);
@@ -142,92 +45,6 @@ export function AccountsList({
     window.addEventListener("add-item", handler);
     return () => window.removeEventListener("add-item", handler);
   }, []);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<"name" | "value">("value");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(() => {
-    const all = new Set<string>();
-    for (const a of accounts) all.add(`${a.type}_${a.category}`);
-    return all;
-  });
-
-  const assets = accounts.filter((a) => a.type === "ASSET");
-  const liabilities = accounts.filter((a) => a.type === "LIABILITY");
-
-  const accountBaseValues = useMemo(() => {
-    const map: Record<string, number> = {};
-    for (const account of accounts) {
-      const value = getAccountValue(account, priceMap, ratesMap);
-      const rate =
-        account.currency === baseCurrency
-          ? 1
-          : (ratesMap[`${account.currency}_${baseCurrency}`] ?? 1);
-      map[account.id] = value * rate;
-    }
-    return map;
-  }, [accounts, priceMap, ratesMap, baseCurrency]);
-
-  function toggleSort(key: "name" | "value") {
-    if (sortKey === key) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(key);
-      setSortDir("desc");
-    }
-  }
-
-  function sortedAccounts(accts: SerializedAccountWithHoldings[]) {
-    return [...accts].sort((a, b) => {
-      const aVal = sortKey === "value" ? (accountBaseValues[a.id] ?? 0) : a.name.toLowerCase();
-      const bVal = sortKey === "value" ? (accountBaseValues[b.id] ?? 0) : b.name.toLowerCase();
-      if (aVal < bVal) return sortDir === "asc" ? -1 : 1;
-      if (aVal > bVal) return sortDir === "asc" ? 1 : -1;
-      return 0;
-    });
-  }
-
-  const totalAssets = useMemo(
-    () => assets.reduce((s, a) => s + (accountBaseValues[a.id] ?? 0), 0),
-    [assets, accountBaseValues],
-  );
-  const totalLiabilities = useMemo(
-    () => liabilities.reduce((s, a) => s + (accountBaseValues[a.id] ?? 0), 0),
-    [liabilities, accountBaseValues],
-  );
-
-  const assetsByCategory = useMemo(() => {
-    const grouped: Record<string, SerializedAccountWithHoldings[]> = {};
-    for (const account of assets) {
-      if (!grouped[account.category]) grouped[account.category] = [];
-      grouped[account.category].push(account);
-    }
-    return CATEGORY_ORDER.filter((cat) => grouped[cat]?.length > 0).map((cat) => ({
-      category: cat,
-      accounts: grouped[cat],
-    }));
-  }, [assets]);
-
-  const liabilitiesByCategory = useMemo(() => {
-    const grouped: Record<string, SerializedAccountWithHoldings[]> = {};
-    for (const account of liabilities) {
-      if (!grouped[account.category]) grouped[account.category] = [];
-      grouped[account.category].push(account);
-    }
-    return CATEGORY_ORDER.filter((cat) => grouped[cat]?.length > 0).map((cat) => ({
-      category: cat,
-      accounts: grouped[cat],
-    }));
-  }, [liabilities]);
-
-  function toggleCategory(type: string, category: string) {
-    const key = `${type}_${category}`;
-    setExpandedCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }
 
   async function deleteAccount(id: string) {
     if (!confirm(t("accountsList.deleteConfirm"))) return;
@@ -262,164 +79,39 @@ export function AccountsList({
         <p className="text-center text-muted-foreground py-12">{t("accountsList.noAccounts")}</p>
       )}
 
-      {/* Desktop table — lg+ */}
       {accounts.length > 0 && (
-        <div className="hidden lg:block rounded-xl border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30">
-                <th
-                  className="px-4 py-3 text-left font-semibold cursor-pointer select-none hover:text-foreground"
-                  onClick={() => toggleSort("name")}
-                >
-                  <div className="flex items-center gap-1.5">
-                    {t("accountsList.colName")}
-                    <SortIcon active={sortKey === "name"} dir={sortDir} />
-                  </div>
-                </th>
-                <th className="px-4 py-3 text-left font-semibold">
-                  {t("accountsList.colCategory")}
-                </th>
-                <th className="hidden lg:table-cell px-4 py-3 text-left font-semibold w-16">
-                  {t("accountsList.colCurrency")}
-                </th>
-                <th className="px-4 py-3 text-left font-semibold">
-                  {t("accountsList.colHoldings")}
-                </th>
-                <th className="hidden lg:table-cell px-4 py-3 text-right font-semibold">
-                  {t("accountsList.colNative")}
-                </th>
-                <th
-                  className="px-4 py-3 text-right font-semibold cursor-pointer select-none hover:text-foreground"
-                  onClick={() => toggleSort("value")}
-                >
-                  <div className="flex items-center justify-end gap-1.5">
-                    {t("accountsList.colValue")}
-                    <SortIcon active={sortKey === "value"} dir={sortDir} />
-                  </div>
-                </th>
-                <th className="hidden lg:table-cell px-4 py-3 text-right font-semibold w-24">
-                  {t("accountsList.colAllocation")}
-                </th>
-                <th className="w-12 px-4 py-3" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {assets.length > 0 && (
-                <>
-                  <tr className="bg-green-50/60 dark:bg-green-950/20">
-                    <td
-                      colSpan={8}
-                      className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-green-700 dark:text-green-400"
-                    >
-                      {t("accountsList.assets")}
-                    </td>
-                  </tr>
-                  {sortedAccounts(assets).map((account) => (
-                    <DesktopAccountRow
-                      key={account.id}
-                      account={account}
-                      baseValue={accountBaseValues[account.id] ?? 0}
-                      baseCurrency={baseCurrency}
-                      priceMap={priceMap}
-                      ratesMap={ratesMap}
-                      onNavigate={() => router.push(`/accounts/${account.id}`)}
-                      onDelete={deleteAccount}
-                      isDeleting={deletingId === account.id}
-                      allocationDenominator={totalAssets}
-                    />
-                  ))}
-                </>
-              )}
-              {liabilities.length > 0 && (
-                <>
-                  <tr className="bg-red-50/60 dark:bg-red-950/20">
-                    <td
-                      colSpan={8}
-                      className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-700 dark:text-red-400"
-                    >
-                      {t("accountsList.liabilities")}
-                    </td>
-                  </tr>
-                  {sortedAccounts(liabilities).map((account) => (
-                    <DesktopAccountRow
-                      key={account.id}
-                      account={account}
-                      baseValue={accountBaseValues[account.id] ?? 0}
-                      baseCurrency={baseCurrency}
-                      priceMap={priceMap}
-                      ratesMap={ratesMap}
-                      onNavigate={() => router.push(`/accounts/${account.id}`)}
-                      onDelete={deleteAccount}
-                      isDeleting={deletingId === account.id}
-                      allocationDenominator={totalLiabilities}
-                    />
-                  ))}
-                </>
-              )}
-            </tbody>
-          </table>
-        </div>
+        <DesktopAccountsTable
+          assets={model.assets}
+          liabilities={model.liabilities}
+          sortedAccounts={model.sortedAccounts}
+          accountBaseValues={model.accountBaseValues}
+          totalAssets={model.totalAssets}
+          totalLiabilities={model.totalLiabilities}
+          baseCurrency={baseCurrency}
+          priceMap={priceMap}
+          ratesMap={ratesMap}
+          sortKey={model.sortKey}
+          sortDir={model.sortDir}
+          onToggleSort={model.toggleSort}
+          onNavigate={(accountId) => router.push(`/accounts/${accountId}`)}
+          onDelete={deleteAccount}
+          deletingId={deletingId}
+        />
       )}
 
-      {/* Mobile card view — hidden on lg+ */}
-      <div className="lg:hidden space-y-6">
-        {accounts.length > 0 && (
-          <MobileSummaryStrip
-            totalAssets={totalAssets}
-            totalLiabilities={totalLiabilities}
-            baseCurrency={baseCurrency}
-          />
-        )}
-
-        {assetsByCategory.length > 0 && (
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-green-700 dark:text-green-400">
-              {t("accountsList.assets")}
-            </h3>
-            <div className="space-y-3">
-              {assetsByCategory.map(({ category, accounts: catAccounts }) => (
-                <CategorySection
-                  key={`asset_${category}`}
-                  category={category}
-                  accounts={catAccounts}
-                  priceMap={priceMap}
-                  ratesMap={ratesMap}
-                  baseCurrency={baseCurrency}
-                  isExpanded={expandedCategories.has(`ASSET_${category}`)}
-                  onToggleExpand={() => toggleCategory("ASSET", category)}
-                  onDelete={deleteAccount}
-                  deletingId={deletingId}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {liabilitiesByCategory.length > 0 && (
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-red-700 dark:text-red-400">
-              {t("accountsList.liabilities")}
-            </h3>
-            <div className="space-y-3">
-              {liabilitiesByCategory.map(({ category, accounts: catAccounts }) => (
-                <CategorySection
-                  key={`liability_${category}`}
-                  category={category}
-                  accounts={catAccounts}
-                  priceMap={priceMap}
-                  ratesMap={ratesMap}
-                  baseCurrency={baseCurrency}
-                  isExpanded={expandedCategories.has(`LIABILITY_${category}`)}
-                  onToggleExpand={() => toggleCategory("LIABILITY", category)}
-                  onDelete={deleteAccount}
-                  deletingId={deletingId}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+      <MobileAccountSections
+        assetsByCategory={model.assetsByCategory}
+        liabilitiesByCategory={model.liabilitiesByCategory}
+        expandedCategories={model.expandedCategories}
+        totalAssets={model.totalAssets}
+        totalLiabilities={model.totalLiabilities}
+        baseCurrency={baseCurrency}
+        priceMap={priceMap}
+        ratesMap={ratesMap}
+        deletingId={deletingId}
+        onToggleCategory={model.toggleCategory}
+        onDelete={deleteAccount}
+      />
 
       {showForm && (
         <AccountForm
@@ -436,401 +128,6 @@ export function AccountsList({
           defaultCurrency={baseCurrency}
         />
       )}
-    </div>
-  );
-}
-
-function SortIcon({ active, dir }: { active: boolean; dir: "asc" | "desc" }) {
-  if (!active) return <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground/50" />;
-  return dir === "asc" ? (
-    <ChevronUp className="h-3.5 w-3.5" />
-  ) : (
-    <ChevronDown className="h-3.5 w-3.5" />
-  );
-}
-
-function DesktopAccountRow({
-  account,
-  baseValue,
-  baseCurrency,
-  priceMap,
-  ratesMap,
-  onNavigate,
-  onDelete,
-  isDeleting,
-  allocationDenominator,
-}: {
-  account: SerializedAccountWithHoldings;
-  baseValue: number;
-  baseCurrency: string;
-  priceMap: Record<string, number>;
-  ratesMap: Record<string, number>;
-  onNavigate: () => void;
-  onDelete: (id: string) => void;
-  isDeleting: boolean;
-  allocationDenominator: number;
-}) {
-  const { privacyMode } = usePrivacyMode();
-  const t = useTranslations();
-  const colors = CATEGORY_COLORS[account.category] ?? CATEGORY_COLORS.OTHER;
-  const icon = CATEGORY_ICONS[account.category] ?? "📁";
-  const label = t(`categories.${account.category}`, { defaultValue: account.category });
-  const nativeValue = getAccountValue(account, priceMap, ratesMap);
-  const isSameCurrency = account.currency === baseCurrency;
-  const pct =
-    allocationDenominator > 0 ? (Math.abs(baseValue) / allocationDenominator) * 100 : null;
-
-  return (
-    <tr className="group hover:bg-muted/40 cursor-pointer transition-colors" onClick={onNavigate}>
-      <td className="px-4 py-3.5 font-medium max-w-[220px] xl:max-w-[280px]">
-        <span className="truncate block" title={account.name}>
-          {account.name}
-        </span>
-      </td>
-      <td className="px-4 py-3.5">
-        <span
-          className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${colors.bg} ${colors.border} ${colors.text}`}
-        >
-          <span>{icon}</span>
-          <span>{label}</span>
-        </span>
-      </td>
-      <td className="hidden lg:table-cell px-4 py-3.5 text-xs font-mono text-muted-foreground w-16">
-        {account.currency}
-      </td>
-      <td className="px-4 py-3.5 text-sm text-muted-foreground tabular-nums">
-        {account.holdings.length > 0 ? (
-          t("accountsList.nHoldings", { count: account.holdings.length })
-        ) : (
-          <span className="text-muted-foreground/40">—</span>
-        )}
-      </td>
-      <td className="hidden lg:table-cell px-4 py-3.5 text-right text-sm text-muted-foreground tabular-nums">
-        {isSameCurrency ? (
-          <span className="text-muted-foreground/40">—</span>
-        ) : privacyMode ? (
-          HIDDEN
-        ) : (
-          formatCurrency(nativeValue, account.currency)
-        )}
-      </td>
-      <td className="px-4 py-3.5 text-right">
-        <p className="font-semibold tabular-nums">
-          {privacyMode ? HIDDEN : formatCurrency(baseValue, baseCurrency)}
-        </p>
-      </td>
-      <td className="hidden lg:table-cell px-4 py-3.5 text-right w-24">
-        <div className="flex flex-col items-end gap-1">
-          <span className="tabular-nums text-xs text-muted-foreground">
-            {privacyMode ? "—" : pct !== null ? `${pct.toFixed(1)}%` : "—"}
-          </span>
-          {!privacyMode && pct !== null && (
-            <div className="w-14 h-1 bg-muted rounded-full overflow-hidden">
-              <div
-                className="h-full bg-primary rounded-full"
-                style={{ width: `${Math.min(pct, 100)}%` }}
-              />
-            </div>
-          )}
-        </div>
-      </td>
-      <td className="px-2 py-3.5 w-10 text-center" onClick={(e) => e.stopPropagation()}>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
-            disabled={isDeleting}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem variant="destructive" onClick={() => onDelete(account.id)}>
-              <Trash2 className="h-4 w-4" />
-              {isDeleting ? t("common.deleting") : t("common.delete")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </td>
-    </tr>
-  );
-}
-
-function MobileSummaryStrip({
-  totalAssets,
-  totalLiabilities,
-  baseCurrency,
-}: {
-  totalAssets: number;
-  totalLiabilities: number;
-  baseCurrency: string;
-}) {
-  const { privacyMode } = usePrivacyMode();
-  const t = useTranslations();
-  const netWorth = totalAssets - totalLiabilities;
-  return (
-    <div className="rounded-xl border bg-muted/20 px-4 py-3 grid grid-cols-3 gap-2 text-center">
-      <div>
-        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.assets")}</p>
-        <p className="text-sm font-bold tabular-nums text-green-600 dark:text-green-400">
-          {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency, true)}
-        </p>
-      </div>
-      <div className="border-x border-border/40">
-        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.netWorth")}</p>
-        <p
-          className={`text-sm font-bold tabular-nums ${netWorth >= 0 ? "text-foreground" : "text-destructive"}`}
-        >
-          {privacyMode ? HIDDEN : formatCurrency(netWorth, baseCurrency, true)}
-        </p>
-      </div>
-      <div>
-        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.liabilities")}</p>
-        <p className="text-sm font-bold tabular-nums text-red-600 dark:text-red-400">
-          {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency, true)}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function CategorySection({
-  category,
-  accounts,
-  priceMap,
-  ratesMap,
-  baseCurrency,
-  isExpanded,
-  onToggleExpand,
-  onDelete,
-  deletingId,
-}: {
-  category: string;
-  accounts: SerializedAccountWithHoldings[];
-  priceMap: Record<string, number>;
-  ratesMap: Record<string, number>;
-  baseCurrency: string;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onDelete: (id: string) => void;
-  deletingId: string | null;
-}) {
-  const t = useTranslations();
-  const { privacyMode } = usePrivacyMode();
-  const { density } = useDensity();
-  const isCompact = density === "compact";
-  const colors = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.OTHER;
-  const icon = CATEGORY_ICONS[category] ?? "📁";
-  const label = t(`categories.${category}`, { defaultValue: category });
-
-  const totalInBaseCurrency = useMemo(() => {
-    let total = 0;
-    for (const account of accounts) {
-      const value = getAccountValue(account, priceMap, ratesMap);
-      const rate =
-        account.currency === baseCurrency
-          ? 1
-          : (ratesMap[`${account.currency}_${baseCurrency}`] ?? 1);
-      total += value * rate;
-    }
-    return total;
-  }, [accounts, priceMap, ratesMap, baseCurrency]);
-
-  const totalHoldings = accounts.reduce((sum, a) => sum + a.holdings.length, 0);
-  const shouldReduceMotion = useReducedMotion();
-
-  return (
-    <div
-      className={`rounded-xl border overflow-hidden transition-all motion-normal ${colors.border} ${isExpanded ? "shadow-md" : "shadow-sm hover:shadow-md"}`}
-    >
-      <button
-        onClick={onToggleExpand}
-        className={`w-full text-left ${isCompact ? "px-4 py-2.5" : "px-5 py-4"} flex items-center justify-between transition-colors ${colors.bg} hover:brightness-95 dark:hover:brightness-110`}
-      >
-        <div className="flex items-center gap-3 min-w-0">
-          <span className="text-2xl flex-shrink-0">{icon}</span>
-          <div className="min-w-0">
-            <p className={`font-semibold text-base ${colors.text}`}>{label}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {t("accountsList.nAccounts", { count: accounts.length })}
-              {totalHoldings > 0 && category !== "BANK" && (
-                <span>
-                  {" · "}
-                  {t("accountsList.nHoldings", { count: totalHoldings })}
-                </span>
-              )}
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-3 flex-shrink-0">
-          <div className="text-right">
-            <p className="text-sm font-bold tabular-nums">
-              {privacyMode ? HIDDEN : formatCurrency(totalInBaseCurrency, baseCurrency)}
-            </p>
-          </div>
-          <svg
-            className={`w-5 h-5 text-muted-foreground transition-transform motion-normal ${isExpanded ? "rotate-180" : ""}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-          </svg>
-        </div>
-      </button>
-
-      <div
-        className={`grid transition-all motion-normal ${isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}
-      >
-        <div className="overflow-hidden">
-          <div
-            className={`${isCompact ? "px-3 py-2.5 space-y-2" : "px-4 py-4 space-y-3"} bg-background/50`}
-          >
-            <AnimatePresence initial={false}>
-              {accounts.map((account) => (
-                <motion.div
-                  key={account.id}
-                  layout={shouldReduceMotion ? false : "position"}
-                  initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
-                  transition={shouldReduceMotion ? { duration: 0 } : springConfig}
-                >
-                  <AccountCardWithHoldings
-                    account={account}
-                    priceMap={priceMap}
-                    ratesMap={ratesMap}
-                    baseCurrency={baseCurrency}
-                    onDelete={onDelete}
-                    isDeleting={deletingId === account.id}
-                  />
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AccountCardWithHoldings({
-  account,
-  priceMap,
-  ratesMap,
-  baseCurrency,
-  onDelete,
-  isDeleting,
-}: {
-  account: SerializedAccountWithHoldings;
-  priceMap: Record<string, number>;
-  ratesMap: Record<string, number>;
-  baseCurrency: string;
-  onDelete: (id: string) => void;
-  isDeleting: boolean;
-}) {
-  const { privacyMode } = usePrivacyMode();
-  const { density } = useDensity();
-  const t = useTranslations();
-  const isCompact = density === "compact";
-  const displayValue = getAccountValue(account, priceMap, ratesMap);
-  const displayCurrency = account.currency;
-  const rate =
-    displayCurrency === baseCurrency ? 1 : (ratesMap[`${displayCurrency}_${baseCurrency}`] ?? 1);
-  const convertedValue = displayValue * rate;
-
-  const holdingsWithValue = account.holdings.map((h) => {
-    const price = priceMap[h.symbol] ?? null;
-    const hc = h.currency || "USD";
-    const hRate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
-    const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
-    const marketValue = price !== null ? price * h.quantity * multiplier * hRate : null;
-    return { ...h, currentPrice: price, marketValue };
-  });
-
-  const isBank = account.category === "BANK";
-  const hasHoldings = !isBank && holdingsWithValue.length > 0;
-
-  const subtitle = hasHoldings
-    ? t("accountsList.nHoldings", { count: account.holdings.length }) +
-      (account.cashBalance > 0
-        ? ` · ${privacyMode ? HIDDEN : formatCurrency(account.cashBalance, account.currency)} cash`
-        : "")
-    : null;
-
-  return (
-    <div className="relative group">
-      <div className="absolute top-2 right-2 z-10">
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
-            disabled={isDeleting}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem variant="destructive" onClick={() => onDelete(account.id)}>
-              <Trash2 className="h-4 w-4" />
-              {isDeleting ? t("common.deleting") : t("common.delete")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <Link href={`/accounts/${account.id}`} prefetch={false} transitionTypes={["nav-forward"]}>
-        <Card className="hover:shadow-md transition-all cursor-pointer">
-          <CardContent className={isCompact ? "pt-3 pb-2" : "pt-5 pb-4"}>
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="font-semibold">{account.name}</p>
-                {/* D: secondary subtitle line */}
-                {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
-              </div>
-              {/* B: plain value + muted currency text, no badge */}
-              <div className="flex flex-col items-end flex-shrink-0 ml-3">
-                <p className="text-lg font-bold tabular-nums text-foreground">
-                  {privacyMode ? HIDDEN : formatCurrency(convertedValue, baseCurrency)}
-                </p>
-                {displayCurrency !== baseCurrency ? (
-                  <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
-                    {privacyMode ? HIDDEN : formatCurrency(displayValue, displayCurrency)}
-                  </p>
-                ) : (
-                  <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">
-                    {baseCurrency}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            {hasHoldings && (
-              <div className="mt-3">
-                <div className="space-y-1.5">
-                  {holdingsWithValue.map((h) => (
-                    <div
-                      key={h.id}
-                      className="flex items-center justify-between py-1.5 border-t border-border/40 first:border-t-0"
-                    >
-                      {/* C: symbol + name only, no qty column */}
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="text-xs font-mono font-medium text-muted-foreground w-16 flex-shrink-0 truncate">
-                          {h.symbol}
-                        </span>
-                        <span className="text-sm truncate">{h.name}</span>
-                      </div>
-                      <span className="text-sm font-medium tabular-nums w-20 text-right flex-shrink-0">
-                        {privacyMode
-                          ? HIDDEN
-                          : h.marketValue !== null
-                            ? formatCurrency(h.marketValue, account.currency)
-                            : "—"}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </Link>
     </div>
   );
 }

--- a/src/components/accounts/desktop-accounts-table.tsx
+++ b/src/components/accounts/desktop-accounts-table.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ChevronDown, ChevronUp, ChevronsUpDown, MoreHorizontal, Trash2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+import { getAccountValue } from "@/lib/valuation";
+import type { SerializedAccountWithHoldings } from "@/lib/types";
+import { CATEGORY_COLORS, CATEGORY_ICONS, HIDDEN_VALUE } from "./account-category-meta";
+import type { AccountSortDir, AccountSortKey } from "./use-account-list-model";
+
+export function DesktopAccountsTable({
+  assets,
+  liabilities,
+  sortedAccounts,
+  accountBaseValues,
+  totalAssets,
+  totalLiabilities,
+  baseCurrency,
+  priceMap,
+  ratesMap,
+  sortKey,
+  sortDir,
+  onToggleSort,
+  onNavigate,
+  onDelete,
+  deletingId,
+}: {
+  assets: SerializedAccountWithHoldings[];
+  liabilities: SerializedAccountWithHoldings[];
+  sortedAccounts: (accounts: SerializedAccountWithHoldings[]) => SerializedAccountWithHoldings[];
+  accountBaseValues: Record<string, number>;
+  totalAssets: number;
+  totalLiabilities: number;
+  baseCurrency: string;
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  sortKey: AccountSortKey;
+  sortDir: AccountSortDir;
+  onToggleSort: (key: AccountSortKey) => void;
+  onNavigate: (accountId: string) => void;
+  onDelete: (accountId: string) => void;
+  deletingId: string | null;
+}) {
+  const t = useTranslations();
+
+  return (
+    <div className="hidden lg:block rounded-xl border overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/30">
+            <th
+              className="px-4 py-3 text-left font-semibold cursor-pointer select-none hover:text-foreground"
+              onClick={() => onToggleSort("name")}
+            >
+              <div className="flex items-center gap-1.5">
+                {t("accountsList.colName")}
+                <SortIcon active={sortKey === "name"} dir={sortDir} />
+              </div>
+            </th>
+            <th className="px-4 py-3 text-left font-semibold">{t("accountsList.colCategory")}</th>
+            <th className="hidden lg:table-cell px-4 py-3 text-left font-semibold w-16">
+              {t("accountsList.colCurrency")}
+            </th>
+            <th className="px-4 py-3 text-left font-semibold">{t("accountsList.colHoldings")}</th>
+            <th className="hidden lg:table-cell px-4 py-3 text-right font-semibold">
+              {t("accountsList.colNative")}
+            </th>
+            <th
+              className="px-4 py-3 text-right font-semibold cursor-pointer select-none hover:text-foreground"
+              onClick={() => onToggleSort("value")}
+            >
+              <div className="flex items-center justify-end gap-1.5">
+                {t("accountsList.colValue")}
+                <SortIcon active={sortKey === "value"} dir={sortDir} />
+              </div>
+            </th>
+            <th className="hidden lg:table-cell px-4 py-3 text-right font-semibold w-24">
+              {t("accountsList.colAllocation")}
+            </th>
+            <th className="w-12 px-4 py-3" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60">
+          {assets.length > 0 && (
+            <>
+              <tr className="bg-green-50/60 dark:bg-green-950/20">
+                <td
+                  colSpan={8}
+                  className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-green-700 dark:text-green-400"
+                >
+                  {t("accountsList.assets")}
+                </td>
+              </tr>
+              {sortedAccounts(assets).map((account) => (
+                <DesktopAccountRow
+                  key={account.id}
+                  account={account}
+                  baseValue={accountBaseValues[account.id] ?? 0}
+                  baseCurrency={baseCurrency}
+                  priceMap={priceMap}
+                  ratesMap={ratesMap}
+                  onNavigate={() => onNavigate(account.id)}
+                  onDelete={onDelete}
+                  isDeleting={deletingId === account.id}
+                  allocationDenominator={totalAssets}
+                />
+              ))}
+            </>
+          )}
+          {liabilities.length > 0 && (
+            <>
+              <tr className="bg-red-50/60 dark:bg-red-950/20">
+                <td
+                  colSpan={8}
+                  className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-700 dark:text-red-400"
+                >
+                  {t("accountsList.liabilities")}
+                </td>
+              </tr>
+              {sortedAccounts(liabilities).map((account) => (
+                <DesktopAccountRow
+                  key={account.id}
+                  account={account}
+                  baseValue={accountBaseValues[account.id] ?? 0}
+                  baseCurrency={baseCurrency}
+                  priceMap={priceMap}
+                  ratesMap={ratesMap}
+                  onNavigate={() => onNavigate(account.id)}
+                  onDelete={onDelete}
+                  isDeleting={deletingId === account.id}
+                  allocationDenominator={totalLiabilities}
+                />
+              ))}
+            </>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: AccountSortDir }) {
+  if (!active) return <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground/50" />;
+  return dir === "asc" ? (
+    <ChevronUp className="h-3.5 w-3.5" />
+  ) : (
+    <ChevronDown className="h-3.5 w-3.5" />
+  );
+}
+
+function DesktopAccountRow({
+  account,
+  baseValue,
+  baseCurrency,
+  priceMap,
+  ratesMap,
+  onNavigate,
+  onDelete,
+  isDeleting,
+  allocationDenominator,
+}: {
+  account: SerializedAccountWithHoldings;
+  baseValue: number;
+  baseCurrency: string;
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  onNavigate: () => void;
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+  allocationDenominator: number;
+}) {
+  const { privacyMode } = usePrivacyMode();
+  const t = useTranslations();
+  const colors = CATEGORY_COLORS[account.category] ?? CATEGORY_COLORS.OTHER;
+  const icon = CATEGORY_ICONS[account.category] ?? CATEGORY_ICONS.OTHER;
+  const label = t(`categories.${account.category}`, { defaultValue: account.category });
+  const nativeValue = getAccountValue(account, priceMap, ratesMap);
+  const isSameCurrency = account.currency === baseCurrency;
+  const pct =
+    allocationDenominator > 0 ? (Math.abs(baseValue) / allocationDenominator) * 100 : null;
+
+  return (
+    <tr className="group hover:bg-muted/40 cursor-pointer transition-colors" onClick={onNavigate}>
+      <td className="px-4 py-3.5 font-medium max-w-[220px] xl:max-w-[280px]">
+        <span className="truncate block" title={account.name}>
+          {account.name}
+        </span>
+      </td>
+      <td className="px-4 py-3.5">
+        <span
+          className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${colors.bg} ${colors.border} ${colors.text}`}
+        >
+          <span>{icon}</span>
+          <span>{label}</span>
+        </span>
+      </td>
+      <td className="hidden lg:table-cell px-4 py-3.5 text-xs font-mono text-muted-foreground w-16">
+        {account.currency}
+      </td>
+      <td className="px-4 py-3.5 text-sm text-muted-foreground tabular-nums">
+        {account.holdings.length > 0 ? (
+          t("accountsList.nHoldings", { count: account.holdings.length })
+        ) : (
+          <span className="text-muted-foreground/40">—</span>
+        )}
+      </td>
+      <td className="hidden lg:table-cell px-4 py-3.5 text-right text-sm text-muted-foreground tabular-nums">
+        {isSameCurrency ? (
+          <span className="text-muted-foreground/40">—</span>
+        ) : privacyMode ? (
+          HIDDEN_VALUE
+        ) : (
+          formatCurrency(nativeValue, account.currency)
+        )}
+      </td>
+      <td className="px-4 py-3.5 text-right">
+        <p className="font-semibold tabular-nums">
+          {privacyMode ? HIDDEN_VALUE : formatCurrency(baseValue, baseCurrency)}
+        </p>
+      </td>
+      <td className="hidden lg:table-cell px-4 py-3.5 text-right w-24">
+        <div className="flex flex-col items-end gap-1">
+          <span className="tabular-nums text-xs text-muted-foreground">
+            {privacyMode ? "—" : pct !== null ? `${pct.toFixed(1)}%` : "—"}
+          </span>
+          {!privacyMode && pct !== null && (
+            <div className="w-14 h-1 bg-muted rounded-full overflow-hidden">
+              <div
+                className="h-full bg-primary rounded-full"
+                style={{ width: `${Math.min(pct, 100)}%` }}
+              />
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="px-2 py-3.5 w-10 text-center" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+            disabled={isDeleting}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem variant="destructive" onClick={() => onDelete(account.id)}>
+              <Trash2 className="h-4 w-4" />
+              {isDeleting ? t("common.deleting") : t("common.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </td>
+    </tr>
+  );
+}

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -11,6 +11,10 @@ import { toast } from "sonner";
 import type { SerializedHolding } from "@/lib/types";
 
 import { getOptionDisplay } from "@/lib/options";
+import {
+  formatNumberInputValue,
+  useFormattedNumberInput,
+} from "@/hooks/use-formatted-number-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -36,41 +40,27 @@ export function EditHoldingDialog({
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [quantity, setQuantity] = useState(() =>
-    new Intl.NumberFormat("en-US", {
-      maximumFractionDigits: holding.assetType === "OPTION" ? 0 : 6,
-    }).format(Number(holding.quantity)),
-  );
+  const isOption = holding.assetType === "OPTION";
+  const {
+    value: quantity,
+    rawValue: quantityRawValue,
+    setValue: setQuantity,
+    handleChange: handleQuantityChange,
+    handleBlur: handleQuantityBlur,
+  } = useFormattedNumberInput({
+    initialValue: () =>
+      formatNumberInputValue(Number(holding.quantity), {
+        maximumFractionDigits: isOption ? 0 : 6,
+        integer: isOption,
+      }),
+    maximumFractionDigits: isOption ? 0 : 6,
+    integer: isOption,
+  });
   const [name, setName] = useState(holding.name);
   const [assetType, setAssetType] = useState<
     "STOCK" | "ETF" | "CRYPTO" | "MUTUAL_FUND" | "BOND" | "OTHER" | "OPTION"
   >(holding.assetType);
-  const isOption = holding.assetType === "OPTION";
   const optionDisplay = getOptionDisplay(holding);
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleQuantityBlur() {
-    const val = quantity.replace(/,/g, "");
-    if (!val) return;
-    const parsed = isOption ? parseInt(val, 10) : parseFloat(val);
-    if (isNaN(parsed)) return;
-    setQuantity(
-      isOption
-        ? new Intl.NumberFormat("en-US").format(parsed)
-        : new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed),
-    );
-  }
 
   function handleOpen(isOpen: boolean) {
     if (!isOpen) {
@@ -89,7 +79,7 @@ export function EditHoldingDialog({
     e.preventDefault();
     setLoading(true);
 
-    const parsedQty = parseFloat(quantity.replace(/,/g, ""));
+    const parsedQty = parseFloat(quantityRawValue);
     const minAllowed = isOption ? 0 : Number.MIN_VALUE;
     if (isNaN(parsedQty) || parsedQty < minAllowed) {
       toast.error(

--- a/src/components/accounts/holding-form.tsx
+++ b/src/components/accounts/holding-form.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
 import { OptionBuilder } from "./option-builder";
+import { useFormattedNumberInput } from "@/hooks/use-formatted-number-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -41,39 +42,23 @@ export function HoldingForm({
 
   const [symbol, setSymbol] = useState("");
   const [name, setName] = useState("");
-  const [quantity, setQuantity] = useState("");
   const [assetType, setAssetType] = useState("STOCK");
   const [currency, setCurrency] = useState("USD");
   const [manualMode, setManualMode] = useState(false);
   const [quantityError, setQuantityError] = useState("");
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    setQuantityError("");
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleQuantityBlur() {
-    const val = quantity.replace(/,/g, "");
-    if (!val) {
-      setQuantityError("");
-      return;
-    }
-    const parsed = parseFloat(val);
-    if (isNaN(parsed) || parsed <= 0) {
-      setQuantityError("Invalid quantity");
-      return;
-    }
-    setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
-  }
+  const {
+    value: quantity,
+    rawValue: quantityRawValue,
+    setValue: setQuantity,
+    handleChange: handleQuantityChange,
+    handleBlur: handleQuantityBlur,
+  } = useFormattedNumberInput({
+    maximumFractionDigits: 6,
+    min: Number.MIN_VALUE,
+    invalidMessage: "Invalid quantity",
+    onValid: () => setQuantityError(""),
+    onInvalid: (message) => setQuantityError(message ?? "Invalid quantity"),
+  });
 
   function selectResult(result: SearchResult) {
     setSymbol(result.symbol);
@@ -141,7 +126,7 @@ export function HoldingForm({
     await postHolding({
       symbol,
       name,
-      quantity: parseFloat(quantity.replace(/,/g, "")),
+      quantity: parseFloat(quantityRawValue),
       assetType,
       currency,
     });
@@ -151,7 +136,7 @@ export function HoldingForm({
   const canSubmit =
     (tickerSelected || (manualMode && symbol && name)) &&
     !!quantity &&
-    parseFloat(quantity.replace(/,/g, "")) > 0;
+    parseFloat(quantityRawValue) > 0;
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { formatCurrency, formatNumber } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useFormattedNumberInput } from "@/hooks/use-formatted-number-input";
 
 interface InlineBalanceEditorProps {
   currentBalance: number;
@@ -20,42 +21,25 @@ export function InlineBalanceEditor({
   onSave,
 }: InlineBalanceEditorProps) {
   const [editing, setEditing] = useState(false);
-  const [balance, setBalance] = useState("");
   const [error, setError] = useState("");
+  const {
+    value: balance,
+    rawValue: balanceRawValue,
+    setValue: setBalance,
+    handleChange: handleBalanceChange,
+    handleBlur: handleBalanceBlur,
+  } = useFormattedNumberInput({
+    maximumFractionDigits: 2,
+    invalidMessage: "Invalid amount",
+    onValid: () => setError(""),
+    onInvalid: (message) => setError(message ?? "Invalid amount"),
+  });
   const [note, setNote] = useState("");
   const [saving, setSaving] = useState(false);
   const { privacyMode } = usePrivacyMode();
 
-  function handleBalanceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    setError("");
-    if (!raw) {
-      setBalance("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setBalance(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleBalanceBlur() {
-    const val = balance.replace(/,/g, "");
-    if (!val) {
-      setError("");
-      return;
-    }
-    const parsed = parseFloat(val);
-    if (isNaN(parsed)) {
-      setError("Invalid amount");
-      return;
-    }
-    setError("");
-    setBalance(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(parsed));
-  }
-
   async function handleSave() {
-    const val = balance.replace(/,/g, "");
+    const val = balanceRawValue;
     if (val.trim() === "") {
       setEditing(false);
       setNote("");

--- a/src/components/accounts/mobile-account-sections.tsx
+++ b/src/components/accounts/mobile-account-sections.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useDensity } from "@/components/layout/density-context";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+import { springConfig } from "@/lib/motion";
+import { getAccountValue, getAccountValueInCurrency, getHoldingMarketValue } from "@/lib/valuation";
+import type { SerializedAccountWithHoldings } from "@/lib/types";
+import { CATEGORY_COLORS, CATEGORY_ICONS, HIDDEN_VALUE } from "./account-category-meta";
+import type { AccountCategoryGroup, AccountTypeGroup } from "./use-account-list-model";
+
+export function MobileAccountSections({
+  assetsByCategory,
+  liabilitiesByCategory,
+  expandedCategories,
+  totalAssets,
+  totalLiabilities,
+  baseCurrency,
+  priceMap,
+  ratesMap,
+  deletingId,
+  onToggleCategory,
+  onDelete,
+}: {
+  assetsByCategory: AccountCategoryGroup[];
+  liabilitiesByCategory: AccountCategoryGroup[];
+  expandedCategories: Set<string>;
+  totalAssets: number;
+  totalLiabilities: number;
+  baseCurrency: string;
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  deletingId: string | null;
+  onToggleCategory: (type: AccountTypeGroup, category: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const t = useTranslations();
+  const hasAccounts = assetsByCategory.length > 0 || liabilitiesByCategory.length > 0;
+
+  return (
+    <div className="lg:hidden space-y-6">
+      {hasAccounts && (
+        <MobileSummaryStrip
+          totalAssets={totalAssets}
+          totalLiabilities={totalLiabilities}
+          baseCurrency={baseCurrency}
+        />
+      )}
+
+      {assetsByCategory.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-lg font-semibold text-green-700 dark:text-green-400">
+            {t("accountsList.assets")}
+          </h3>
+          <div className="space-y-3">
+            {assetsByCategory.map(({ category, accounts }) => (
+              <CategorySection
+                key={`asset_${category}`}
+                category={category}
+                accounts={accounts}
+                priceMap={priceMap}
+                ratesMap={ratesMap}
+                baseCurrency={baseCurrency}
+                isExpanded={expandedCategories.has(`ASSET_${category}`)}
+                onToggleExpand={() => onToggleCategory("ASSET", category)}
+                onDelete={onDelete}
+                deletingId={deletingId}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {liabilitiesByCategory.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-lg font-semibold text-red-700 dark:text-red-400">
+            {t("accountsList.liabilities")}
+          </h3>
+          <div className="space-y-3">
+            {liabilitiesByCategory.map(({ category, accounts }) => (
+              <CategorySection
+                key={`liability_${category}`}
+                category={category}
+                accounts={accounts}
+                priceMap={priceMap}
+                ratesMap={ratesMap}
+                baseCurrency={baseCurrency}
+                isExpanded={expandedCategories.has(`LIABILITY_${category}`)}
+                onToggleExpand={() => onToggleCategory("LIABILITY", category)}
+                onDelete={onDelete}
+                deletingId={deletingId}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MobileSummaryStrip({
+  totalAssets,
+  totalLiabilities,
+  baseCurrency,
+}: {
+  totalAssets: number;
+  totalLiabilities: number;
+  baseCurrency: string;
+}) {
+  const { privacyMode } = usePrivacyMode();
+  const t = useTranslations();
+  const netWorth = totalAssets - totalLiabilities;
+
+  return (
+    <div className="rounded-xl border bg-muted/20 px-4 py-3 grid grid-cols-3 gap-2 text-center">
+      <div>
+        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.assets")}</p>
+        <p className="text-sm font-bold tabular-nums text-green-600 dark:text-green-400">
+          {privacyMode ? HIDDEN_VALUE : formatCurrency(totalAssets, baseCurrency, true)}
+        </p>
+      </div>
+      <div className="border-x border-border/40">
+        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.netWorth")}</p>
+        <p
+          className={`text-sm font-bold tabular-nums ${netWorth >= 0 ? "text-foreground" : "text-destructive"}`}
+        >
+          {privacyMode ? HIDDEN_VALUE : formatCurrency(netWorth, baseCurrency, true)}
+        </p>
+      </div>
+      <div>
+        <p className="text-xs text-muted-foreground mb-0.5">{t("accountsList.liabilities")}</p>
+        <p className="text-sm font-bold tabular-nums text-red-600 dark:text-red-400">
+          {privacyMode ? HIDDEN_VALUE : formatCurrency(totalLiabilities, baseCurrency, true)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CategorySection({
+  category,
+  accounts,
+  priceMap,
+  ratesMap,
+  baseCurrency,
+  isExpanded,
+  onToggleExpand,
+  onDelete,
+  deletingId,
+}: {
+  category: string;
+  accounts: SerializedAccountWithHoldings[];
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  baseCurrency: string;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onDelete: (id: string) => void;
+  deletingId: string | null;
+}) {
+  const t = useTranslations();
+  const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
+  const colors = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.OTHER;
+  const icon = CATEGORY_ICONS[category] ?? CATEGORY_ICONS.OTHER;
+  const label = t(`categories.${category}`, { defaultValue: category });
+
+  const totalInBaseCurrency = useMemo(
+    () =>
+      accounts.reduce(
+        (sum, account) =>
+          sum + getAccountValueInCurrency(account, priceMap, ratesMap, baseCurrency),
+        0,
+      ),
+    [accounts, baseCurrency, priceMap, ratesMap],
+  );
+
+  const totalHoldings = accounts.reduce((sum, account) => sum + account.holdings.length, 0);
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div
+      className={`rounded-xl border overflow-hidden transition-all motion-normal ${colors.border} ${isExpanded ? "shadow-md" : "shadow-sm hover:shadow-md"}`}
+    >
+      <button
+        onClick={onToggleExpand}
+        className={`w-full text-left ${isCompact ? "px-4 py-2.5" : "px-5 py-4"} flex items-center justify-between transition-colors ${colors.bg} hover:brightness-95 dark:hover:brightness-110`}
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-2xl flex-shrink-0">{icon}</span>
+          <div className="min-w-0">
+            <p className={`font-semibold text-base ${colors.text}`}>{label}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t("accountsList.nAccounts", { count: accounts.length })}
+              {totalHoldings > 0 && category !== "BANK" && (
+                <span>
+                  {" · "}
+                  {t("accountsList.nHoldings", { count: totalHoldings })}
+                </span>
+              )}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="text-right">
+            <p className="text-sm font-bold tabular-nums">
+              {privacyMode ? HIDDEN_VALUE : formatCurrency(totalInBaseCurrency, baseCurrency)}
+            </p>
+          </div>
+          <svg
+            className={`w-5 h-5 text-muted-foreground transition-transform motion-normal ${isExpanded ? "rotate-180" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </div>
+      </button>
+
+      <div
+        className={`grid transition-all motion-normal ${isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}
+      >
+        <div className="overflow-hidden">
+          <div
+            className={`${isCompact ? "px-3 py-2.5 space-y-2" : "px-4 py-4 space-y-3"} bg-background/50`}
+          >
+            <AnimatePresence initial={false}>
+              {accounts.map((account) => (
+                <motion.div
+                  key={account.id}
+                  layout={shouldReduceMotion ? false : "position"}
+                  initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+                  transition={shouldReduceMotion ? { duration: 0 } : springConfig}
+                >
+                  <AccountCardWithHoldings
+                    account={account}
+                    priceMap={priceMap}
+                    ratesMap={ratesMap}
+                    baseCurrency={baseCurrency}
+                    onDelete={onDelete}
+                    isDeleting={deletingId === account.id}
+                  />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccountCardWithHoldings({
+  account,
+  priceMap,
+  ratesMap,
+  baseCurrency,
+  onDelete,
+  isDeleting,
+}: {
+  account: SerializedAccountWithHoldings;
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  baseCurrency: string;
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}) {
+  const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const t = useTranslations();
+  const isCompact = density === "compact";
+  const displayValue = getAccountValue(account, priceMap, ratesMap);
+  const convertedValue = getAccountValueInCurrency(account, priceMap, ratesMap, baseCurrency);
+
+  const holdingsWithValue = account.holdings.map((holding) => ({
+    ...holding,
+    currentPrice: priceMap[holding.symbol] ?? null,
+    marketValue: getHoldingMarketValue(holding, priceMap, account.currency, ratesMap),
+  }));
+
+  const isBank = account.category === "BANK";
+  const hasHoldings = !isBank && holdingsWithValue.length > 0;
+
+  const subtitle = hasHoldings
+    ? t("accountsList.nHoldings", { count: account.holdings.length }) +
+      (account.cashBalance > 0
+        ? ` · ${privacyMode ? HIDDEN_VALUE : formatCurrency(account.cashBalance, account.currency)} cash`
+        : "")
+    : null;
+
+  return (
+    <div className="relative group">
+      <div className="absolute top-2 right-2 z-10">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+            disabled={isDeleting}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem variant="destructive" onClick={() => onDelete(account.id)}>
+              <Trash2 className="h-4 w-4" />
+              {isDeleting ? t("common.deleting") : t("common.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <Link href={`/accounts/${account.id}`} prefetch={false} transitionTypes={["nav-forward"]}>
+        <Card className="hover:shadow-md transition-all cursor-pointer">
+          <CardContent className={isCompact ? "pt-3 pb-2" : "pt-5 pb-4"}>
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="font-semibold">{account.name}</p>
+                {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+              </div>
+              <div className="flex flex-col items-end flex-shrink-0 ml-3">
+                <p className="text-lg font-bold tabular-nums text-foreground">
+                  {privacyMode ? HIDDEN_VALUE : formatCurrency(convertedValue, baseCurrency)}
+                </p>
+                {account.currency !== baseCurrency ? (
+                  <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
+                    {privacyMode ? HIDDEN_VALUE : formatCurrency(displayValue, account.currency)}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">
+                    {baseCurrency}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {hasHoldings && (
+              <div className="mt-3">
+                <div className="space-y-1.5">
+                  {holdingsWithValue.map((holding) => (
+                    <div
+                      key={holding.id}
+                      className="flex items-center justify-between py-1.5 border-t border-border/40 first:border-t-0"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-xs font-mono font-medium text-muted-foreground w-16 flex-shrink-0 truncate">
+                          {holding.symbol}
+                        </span>
+                        <span className="text-sm truncate">{holding.name}</span>
+                      </div>
+                      <span className="text-sm font-medium tabular-nums w-20 text-right flex-shrink-0">
+                        {privacyMode
+                          ? HIDDEN_VALUE
+                          : holding.marketValue !== null
+                            ? formatCurrency(holding.marketValue, account.currency)
+                            : "—"}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/accounts/option-builder.tsx
+++ b/src/components/accounts/option-builder.tsx
@@ -23,6 +23,7 @@ import {
   tryParseOccSymbol,
   type OptionSide,
 } from "@/lib/options";
+import { useFormattedNumberInput } from "@/hooks/use-formatted-number-input";
 
 function fmtExp(iso: string) {
   const [y, m, d] = iso.split("-").map(Number);
@@ -73,34 +74,19 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
   const [expiration, setExpiration] = useState("");
   const [side, setSide] = useState<OptionSide>("CALL");
   const [strike, setStrike] = useState<string>("");
-  const [quantity, setQuantity] = useState("");
   const [quantityError, setQuantityError] = useState("");
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*$/.test(raw)) return;
-    setQuantityError("");
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    setQuantity(raw.replace(/\B(?=(\d{3})+(?!\d))/g, ","));
-  }
-
-  function handleQuantityBlur() {
-    const val = quantity.replace(/,/g, "");
-    if (!val) {
-      setQuantityError("");
-      return;
-    }
-    const parsed = parseInt(val, 10);
-    if (isNaN(parsed) || parsed <= 0) {
-      setQuantityError("Invalid quantity");
-      return;
-    }
-    setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US").format(parsed));
-  }
+  const {
+    value: quantity,
+    rawValue: quantityRawValue,
+    handleChange: handleQuantityChange,
+    handleBlur: handleQuantityBlur,
+  } = useFormattedNumberInput({
+    integer: true,
+    min: 1,
+    invalidMessage: "Invalid quantity",
+    onValid: () => setQuantityError(""),
+    onInvalid: (message) => setQuantityError(message ?? "Invalid quantity"),
+  });
 
   const [showSearch, setShowSearch] = useState(false);
   const [pasteMode, setPasteMode] = useState(false);
@@ -262,7 +248,7 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
     if (!underlying || !expiration || !strike || !quantity) return;
     const strikeNum = Number(strike);
     if (!Number.isFinite(strikeNum) || strikeNum <= 0) return;
-    const qty = parseInt(quantity.replace(/,/g, ""), 10);
+    const qty = parseInt(quantityRawValue, 10);
     if (!Number.isFinite(qty) || qty <= 0) return;
     try {
       const occ = buildOccSymbol({
@@ -312,7 +298,7 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
   const previewParsed = previewOcc ? tryParseOccSymbol(previewOcc) : null;
 
   const ask = selectedContract?.ask ?? null;
-  const qtyNum = parseInt(quantity.replace(/,/g, ""), 10);
+  const qtyNum = parseInt(quantityRawValue, 10);
   const previewCost =
     ask !== null && Number.isFinite(qtyNum) && qtyNum > 0 ? ask * qtyNum * 100 : null;
 
@@ -322,7 +308,7 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
     !!expiration &&
     !!strike &&
     !!quantity &&
-    parseInt(quantity.replace(/,/g, ""), 10) > 0;
+    parseInt(quantityRawValue, 10) > 0;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/accounts/quick-add-holding.tsx
+++ b/src/components/accounts/quick-add-holding.tsx
@@ -21,6 +21,7 @@ import { useTranslations } from "next-intl";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
+import { useFormattedNumberInput } from "@/hooks/use-formatted-number-input";
 
 const OptionBuilder = dynamic(() => import("./option-builder").then((m) => m.OptionBuilder));
 
@@ -57,40 +58,27 @@ export function QuickAddHolding({
 
   const [symbol, setSymbol] = useState("");
   const [name, setName] = useState("");
-  const [quantity, setQuantity] = useState("");
   const [assetType, setAssetType] = useState("STOCK");
   const [currency, setCurrency] = useState(defaultCurrency);
   const [manualMode, setManualMode] = useState(false);
   const [selectedAccountId, setSelectedAccountId] = useState("");
   const [quantityError, setQuantityError] = useState("");
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    setQuantityError("");
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleQuantityBlur() {
-    const val = quantity.replace(/,/g, "");
-    if (!val) {
-      setQuantityError("");
-      return;
-    }
-    const parsed = parseFloat(val);
-    if (isNaN(parsed) || parsed <= 0) {
-      setQuantityError(t("quickAddHolding.invalidQuantity", { defaultValue: "Invalid quantity" }));
-      return;
-    }
-    setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
-  }
+  const invalidQuantityMessage = t("quickAddHolding.invalidQuantity", {
+    defaultValue: "Invalid quantity",
+  });
+  const {
+    value: quantity,
+    rawValue: quantityRawValue,
+    setValue: setQuantity,
+    handleChange: handleQuantityChange,
+    handleBlur: handleQuantityBlur,
+  } = useFormattedNumberInput({
+    maximumFractionDigits: 6,
+    min: Number.MIN_VALUE,
+    invalidMessage: invalidQuantityMessage,
+    onValid: () => setQuantityError(""),
+    onInvalid: (message) => setQuantityError(message ?? invalidQuantityMessage),
+  });
 
   function selectResult(result: SearchResult) {
     setSymbol(result.symbol);
@@ -167,7 +155,7 @@ export function QuickAddHolding({
         body: JSON.stringify({
           symbol,
           name,
-          quantity: parseFloat(quantity.replace(/,/g, "")),
+          quantity: parseFloat(quantityRawValue),
           assetType,
           currency,
         }),
@@ -200,7 +188,7 @@ export function QuickAddHolding({
   const canProceed =
     (tickerSelected || (manualMode && symbol && name)) &&
     !!quantity &&
-    parseFloat(quantity.replace(/,/g, "")) > 0;
+    parseFloat(quantityRawValue) > 0;
 
   const matchingAccounts = getMatchingAccounts();
   const targetCategory = ASSET_TYPE_TO_CATEGORY[assetType] || "BROKERAGE";
@@ -403,7 +391,7 @@ export function QuickAddHolding({
               </div>
               <p className="text-sm text-muted-foreground mt-0.5">
                 {assetType === "OPTION"
-                  ? `${name} · ${quantity} contract${parseFloat(quantity.replace(/,/g, "")) !== 1 ? "s" : ""}`
+                  ? `${name} · ${quantity} contract${parseFloat(quantityRawValue) !== 1 ? "s" : ""}`
                   : t("quickAddHolding.sharesSummary", { name, quantity })}
               </p>
             </div>

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -34,6 +34,10 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { showUndoDeleteToast } from "@/lib/undo-delete";
+import {
+  formatNumberInputValue,
+  useFormattedNumberInput,
+} from "@/hooks/use-formatted-number-input";
 
 const TYPE_VARIANTS: Record<string, "default" | "secondary" | "destructive"> = {
   BUY: "default",
@@ -156,30 +160,16 @@ export function TransactionHistory({
 
   // Form state
   const [editType, setEditType] = useState("BUY");
-  const [editQuantity, setEditQuantity] = useState("");
+  const {
+    value: editQuantity,
+    rawValue: editQuantityRawValue,
+    setValue: setEditQuantity,
+    handleChange: handleEditQuantityChange,
+    handleBlur: handleEditQuantityBlur,
+  } = useFormattedNumberInput({ maximumFractionDigits: 6 });
   const [editNote, setEditNote] = useState("");
   const [editDate, setEditDate] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  function handleEditQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setEditQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setEditQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
-  }
-
-  function handleEditQuantityBlur() {
-    const val = editQuantity.replace(/,/g, "");
-    if (!val) return;
-    const parsed = parseFloat(val);
-    if (isNaN(parsed)) return;
-    setEditQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
-  }
 
   const [transactions, setTransactions] = useState<SerializedTransaction[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -239,9 +229,7 @@ export function TransactionHistory({
   const handleEditClick = (t: SerializedTransaction) => {
     setEditingTx(t);
     setEditType(t.type);
-    setEditQuantity(
-      new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(t.quantity),
-    );
+    setEditQuantity(formatNumberInputValue(t.quantity, { maximumFractionDigits: 6 }));
     setEditNote(t.note || "");
 
     // Format date for datetime-local input
@@ -262,7 +250,7 @@ export function TransactionHistory({
         body: JSON.stringify({
           id: editingTx.id,
           type: editType,
-          quantity: Number(editQuantity.replace(/,/g, "")),
+          quantity: Number(editQuantityRawValue),
           note: editNote,
           createdAt: new Date(editDate).toISOString(),
         }),

--- a/src/components/accounts/use-account-list-model.ts
+++ b/src/components/accounts/use-account-list-model.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { SerializedAccountWithHoldings } from "@/lib/types";
+import { getAccountValueInCurrency } from "@/lib/valuation";
+import { CATEGORY_ORDER } from "./account-category-meta";
+
+export type AccountSortKey = "name" | "value";
+export type AccountSortDir = "asc" | "desc";
+export type AccountTypeGroup = "ASSET" | "LIABILITY";
+
+export type AccountCategoryGroup = {
+  category: string;
+  accounts: SerializedAccountWithHoldings[];
+};
+
+function groupByCategory(accounts: SerializedAccountWithHoldings[]): AccountCategoryGroup[] {
+  const grouped: Record<string, SerializedAccountWithHoldings[]> = {};
+  for (const account of accounts) {
+    if (!grouped[account.category]) grouped[account.category] = [];
+    grouped[account.category].push(account);
+  }
+
+  return CATEGORY_ORDER.filter((category) => grouped[category]?.length > 0).map((category) => ({
+    category,
+    accounts: grouped[category],
+  }));
+}
+
+export function useAccountListModel({
+  accounts,
+  priceMap,
+  ratesMap,
+  baseCurrency,
+}: {
+  accounts: SerializedAccountWithHoldings[];
+  priceMap: Record<string, number>;
+  ratesMap: Record<string, number>;
+  baseCurrency: string;
+}) {
+  const [sortKey, setSortKey] = useState<AccountSortKey>("value");
+  const [sortDir, setSortDir] = useState<AccountSortDir>("desc");
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(() => {
+    const all = new Set<string>();
+    for (const account of accounts) all.add(`${account.type}_${account.category}`);
+    return all;
+  });
+
+  const assets = useMemo(() => accounts.filter((account) => account.type === "ASSET"), [accounts]);
+  const liabilities = useMemo(
+    () => accounts.filter((account) => account.type === "LIABILITY"),
+    [accounts],
+  );
+
+  const accountBaseValues = useMemo(() => {
+    const values: Record<string, number> = {};
+    for (const account of accounts) {
+      values[account.id] = getAccountValueInCurrency(account, priceMap, ratesMap, baseCurrency);
+    }
+    return values;
+  }, [accounts, baseCurrency, priceMap, ratesMap]);
+
+  const totalAssets = useMemo(
+    () => assets.reduce((sum, account) => sum + (accountBaseValues[account.id] ?? 0), 0),
+    [accountBaseValues, assets],
+  );
+  const totalLiabilities = useMemo(
+    () => liabilities.reduce((sum, account) => sum + (accountBaseValues[account.id] ?? 0), 0),
+    [accountBaseValues, liabilities],
+  );
+
+  const assetsByCategory = useMemo(() => groupByCategory(assets), [assets]);
+  const liabilitiesByCategory = useMemo(() => groupByCategory(liabilities), [liabilities]);
+
+  function toggleSort(key: AccountSortKey) {
+    if (sortKey === key) {
+      setSortDir((current) => (current === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
+  function sortedAccounts(accountList: SerializedAccountWithHoldings[]) {
+    return [...accountList].sort((a, b) => {
+      const aVal = sortKey === "value" ? (accountBaseValues[a.id] ?? 0) : a.name.toLowerCase();
+      const bVal = sortKey === "value" ? (accountBaseValues[b.id] ?? 0) : b.name.toLowerCase();
+      if (aVal < bVal) return sortDir === "asc" ? -1 : 1;
+      if (aVal > bVal) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }
+
+  function toggleCategory(type: AccountTypeGroup, category: string) {
+    const key = `${type}_${category}`;
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return {
+    sortKey,
+    sortDir,
+    toggleSort,
+    sortedAccounts,
+    expandedCategories,
+    toggleCategory,
+    assets,
+    liabilities,
+    accountBaseValues,
+    totalAssets,
+    totalLiabilities,
+    assetsByCategory,
+    liabilitiesByCategory,
+  };
+}

--- a/src/hooks/use-formatted-number-input.ts
+++ b/src/hooks/use-formatted-number-input.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+type FormattedNumberInputOptions = {
+  initialValue?: string | number | (() => string | number);
+  maximumFractionDigits?: number;
+  integer?: boolean;
+  min?: number;
+  emptyValueOnBlur?: string;
+  onValid?: () => void;
+  onInvalid?: (message?: string) => void;
+  invalidMessage?: string;
+};
+
+function toInitialString(value: string | number | (() => string | number) | undefined) {
+  const resolved = typeof value === "function" ? value() : value;
+  return resolved === undefined ? "" : String(resolved);
+}
+
+export function stripNumberFormatting(value: string) {
+  return value.replace(/,/g, "");
+}
+
+export function parseFormattedNumber(value: string) {
+  const raw = stripNumberFormatting(value);
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function formatNumberInputValue(
+  value: number,
+  options?: { maximumFractionDigits?: number; integer?: boolean },
+) {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: options?.integer ? 0 : options?.maximumFractionDigits,
+  }).format(value);
+}
+
+export function useFormattedNumberInput({
+  initialValue,
+  maximumFractionDigits = 6,
+  integer = false,
+  min,
+  emptyValueOnBlur,
+  onValid,
+  onInvalid,
+  invalidMessage,
+}: FormattedNumberInputOptions = {}) {
+  const [value, setValue] = useState(() => toInitialString(initialValue));
+
+  const numberValue = useMemo(() => parseFormattedNumber(value), [value]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = stripNumberFormatting(e.target.value);
+      const validShape = integer ? /^\d*$/.test(raw) : /^\d*\.?\d*$/.test(raw);
+      if (raw !== "" && !validShape) return;
+
+      onValid?.();
+      if (!raw) {
+        setValue("");
+        return;
+      }
+
+      const [intPart, decPart] = raw.split(".");
+      const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      setValue(decPart !== undefined && !integer ? `${formatted}.${decPart}` : formatted);
+    },
+    [integer, onValid],
+  );
+
+  const handleBlur = useCallback(() => {
+    const raw = stripNumberFormatting(value);
+    if (!raw) {
+      onValid?.();
+      if (emptyValueOnBlur !== undefined) setValue(emptyValueOnBlur);
+      return;
+    }
+
+    const parsed = integer ? parseInt(raw, 10) : parseFloat(raw);
+    if (Number.isNaN(parsed) || (min !== undefined && parsed < min)) {
+      onInvalid?.(invalidMessage);
+      return;
+    }
+
+    onValid?.();
+    setValue(formatNumberInputValue(parsed, { maximumFractionDigits, integer }));
+  }, [
+    emptyValueOnBlur,
+    integer,
+    invalidMessage,
+    maximumFractionDigits,
+    min,
+    onInvalid,
+    onValid,
+    value,
+  ]);
+
+  return {
+    value,
+    setValue,
+    numberValue,
+    rawValue: stripNumberFormatting(value),
+    handleChange,
+    handleBlur,
+  };
+}

--- a/src/lib/cache-invalidation.ts
+++ b/src/lib/cache-invalidation.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import { revalidateTag } from "next/cache";
+
+function revalidate(tag: string) {
+  revalidateTag(tag, "max");
+}
+
+export function invalidateAccountData(userId: string, options: { includeHistory?: boolean } = {}) {
+  const { includeHistory = true } = options;
+  revalidate(`accounts:${userId}`);
+  revalidate(`net-worth:${userId}`);
+  if (includeHistory) {
+    revalidate(`history:${userId}`);
+  }
+}
+
+export function invalidateGoalData(userId: string) {
+  revalidate(`goals:${userId}`);
+}
+
+export function invalidateSettingsData(userId: string, options?: { affectsNetWorth?: boolean }) {
+  revalidate(`settings:${userId}`);
+  if (options?.affectsNetWorth) {
+    revalidate(`net-worth:${userId}`);
+  }
+}
+
+export function invalidateAllAccountsData() {
+  revalidate("accounts");
+}
+
+export function invalidatePriceData() {
+  revalidate("net-worth");
+  revalidate("prices:crypto");
+}
+
+export function invalidateExchangeRateData() {
+  revalidate("exchange-rates");
+}
+
+export function invalidateSnapshotData(userIds: string[]) {
+  revalidate("snapshots");
+  for (const userId of userIds) {
+    revalidate(`history:${userId}`);
+  }
+}

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -4,6 +4,7 @@ import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate, resolveMissingRates } from "./exchange-rate-service";
 import { serializeAccountWithHoldings } from "@/lib/types";
+import { getHoldingMultiplier } from "@/lib/valuation";
 import type {
   AccountWithValue,
   NetWorthSummary,
@@ -79,7 +80,7 @@ async function computeNetWorthSummary(
       const cached = priceMap[h.symbol];
       const currentPrice = cached?.price ?? null;
       const quantity = h.quantity;
-      const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
+      const multiplier = getHoldingMultiplier(h);
       const marketValue = currentPrice !== null ? currentPrice * quantity * multiplier : null;
       return {
         ...h,

--- a/src/lib/valuation.ts
+++ b/src/lib/valuation.ts
@@ -1,0 +1,54 @@
+import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/types";
+
+export type NumericPriceMap = Record<string, number | null | undefined>;
+export type RateMap = Record<string, number | undefined>;
+
+export function getHoldingMultiplier(
+  holding: Pick<SerializedHolding, "assetType" | "contractMultiplier">,
+) {
+  return holding.assetType === "OPTION" ? (holding.contractMultiplier ?? 100) : 1;
+}
+
+export function resolveRateFromRecord(ratesMap: RateMap, fromCurrency: string, toCurrency: string) {
+  if (fromCurrency === toCurrency) return 1;
+  return ratesMap[`${fromCurrency}_${toCurrency}`] ?? 1;
+}
+
+export function getHoldingMarketValue(
+  holding: Pick<
+    SerializedHolding,
+    "symbol" | "quantity" | "currency" | "assetType" | "contractMultiplier"
+  >,
+  priceMap: NumericPriceMap,
+  targetCurrency: string,
+  ratesMap: RateMap,
+) {
+  const price = priceMap[holding.symbol] ?? null;
+  if (price === null) return null;
+
+  const holdingCurrency = holding.currency || "USD";
+  const rate = resolveRateFromRecord(ratesMap, holdingCurrency, targetCurrency);
+  return price * holding.quantity * getHoldingMultiplier(holding) * rate;
+}
+
+export function getAccountValue(
+  account: SerializedAccountWithHoldings,
+  priceMap: NumericPriceMap,
+  ratesMap: RateMap,
+) {
+  const holdingsValue = account.holdings.reduce((sum, holding) => {
+    return sum + (getHoldingMarketValue(holding, priceMap, account.currency, ratesMap) ?? 0);
+  }, 0);
+
+  return account.cashBalance + holdingsValue;
+}
+
+export function getAccountValueInCurrency(
+  account: SerializedAccountWithHoldings,
+  priceMap: NumericPriceMap,
+  ratesMap: RateMap,
+  targetCurrency: string,
+) {
+  const accountValue = getAccountValue(account, priceMap, ratesMap);
+  return accountValue * resolveRateFromRecord(ratesMap, account.currency, targetCurrency);
+}


### PR DESCRIPTION
## Summary

- Centralize Next cache tag invalidation behind shared helpers.
- Extract account and holding valuation helpers for shared client/server use.
- Split the large accounts list component into model, desktop table, mobile sections, and category metadata modules.
- Add a reusable formatted number input hook and migrate repeated account/holding/transaction numeric inputs.

## Impact

This is intended to preserve existing behavior while reducing duplicated logic in account UI, mutation routes, and numeric form handling.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- push hook: `npm run format:check`, `npm run lint`, `npm run typecheck`