### PR TITLE
feat(ui): make mobile nav tab items same size with content-hugged active pill

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -266,7 +266,7 @@ export function MobileNav() {
   return (
     <nav
       className={cn(
-        "md:hidden fixed bottom-0 left-0 right-0 z-50 glass backdrop-blur-md border-t border-border/50 flex justify-around py-3 pb-safe transition-transform motion-normal",
+        "md:hidden fixed bottom-0 left-0 right-0 z-50 glass backdrop-blur-md border-t border-border/50 grid grid-cols-5 py-2 pb-safe transition-transform motion-normal",
         hidden && "translate-y-full",
       )}
     >
@@ -294,22 +294,26 @@ export function MobileNav() {
                 router.push(item.href);
               });
             }}
-            className={cn(
-              "relative flex min-h-12 min-w-12 flex-col items-center justify-center gap-1 px-4 py-2 text-[10px] uppercase tracking-wider transition-all group rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-              isActive
-                ? "text-primary font-semibold bg-primary/10 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.2)]"
-                : "text-muted-foreground hover:text-foreground",
-            )}
+            className="group relative flex min-h-12 w-full items-center justify-center rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             aria-label={item.label}
             aria-current={isActive ? "page" : undefined}
           >
-            <Icon
+            <span
               className={cn(
-                "h-5 w-5 transition-transform motion-fast",
-                isActive ? "scale-110" : "group-hover:scale-110",
+                "flex w-16 flex-col items-center justify-center gap-1 px-2 py-1.5 rounded-xl text-[10px] uppercase tracking-wider transition-all motion-fast",
+                isActive
+                  ? "text-primary font-semibold bg-primary/12 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.25)] scale-[1.04]"
+                  : "text-muted-foreground group-hover:text-foreground",
               )}
-            />
-            <span>{item.label}</span>
+            >
+              <Icon
+                className={cn(
+                  "transition-all motion-fast",
+                  isActive ? "h-6 w-6" : "h-5 w-5 group-hover:scale-110",
+                )}
+              />
+              <span className="truncate w-full text-center">{item.label}</span>
+            </span>
           </button>
         );
       })}


### PR DESCRIPTION
## Summary

- Switch mobile bottom nav container from `flex justify-around` to `grid grid-cols-5` so every tab cell is identical width regardless of label length ("Dashboard" vs "Goals" vs "Settings").
- Replace the per-button active background with an inner content-hugged pill (`w-16`, `rounded-xl`), so the selected indicator no longer carries the old wide L/R padding and active/inactive items share the same visual width.
- Active state now pops via tint (`bg-primary/12`), inset border, slight `scale-[1.04]`, larger icon (`h-6 w-6`), and bolder text — without shifting neighboring cells.
- Long labels truncate cleanly inside the fixed-width pill (`truncate w-full text-center`) so zh-TW translations don't overflow.

Touches only `src/components/layout/sidebar.tsx → MobileNav()`. Routing, prefetch, optimistic-href, hide-on-scroll, haptics, and aria attributes are unchanged.

## Test plan

- [ ] `npm run format:check && npm run lint && npm run typecheck` all green (verified locally)
- [ ] On iPhone 14 / Pixel 7 widths, cycle Dashboard → Accounts → Goals → Analysis → Settings and confirm every tab cell renders at the same width
- [ ] Confirm the active pill hugs its content (no wasted L/R space) and the inactive → active transition does not shift any other cell
- [ ] Switch `NEXT_LOCALE` cookie to `zh-TW` and verify labels stay inside their cells (truncate if needed)
- [ ] Verify focus ring still shows on the full button (keyboard tab) and `aria-current="page"` is set on the active tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)