### PR TITLE
fix(dashboard): pin all-accounts sort selector to card corner, unify pill style

### DIFF
--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -169,30 +169,28 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   };
 
   return (
-    <Card className="border-0 shadow-none bg-transparent">
+    <Card className="relative border-0 shadow-none bg-transparent">
+      <div className="absolute right-2 top-2 z-10 flex shrink-0 items-center gap-0.5 sm:right-4 sm:top-3">
+        {sortOptions.map(({ field, label }) => (
+          <button
+            key={field}
+            onClick={() => handleSort(field)}
+            aria-pressed={sortField === field}
+            className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              sortField === field
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            {label}
+            {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+          </button>
+        ))}
+      </div>
       <CardHeader className="pb-2">
-        <div className="flex items-center justify-between gap-4">
-          <CardTitle className="text-lg font-semibold tracking-tight">
-            {t("accountsSummary.title")}
-          </CardTitle>
-          <div className="flex items-center gap-1 flex-shrink-0">
-            {sortOptions.map(({ field, label }) => (
-              <button
-                key={field}
-                onClick={() => handleSort(field)}
-                aria-pressed={sortField === field}
-                className={`text-xs sm:text-[10px] px-3 py-2 sm:px-2 sm:py-1 rounded-md transition-colors ${
-                  sortField === field
-                    ? "bg-primary/10 text-primary font-semibold"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                }`}
-              >
-                {label}
-                {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-              </button>
-            ))}
-          </div>
-        </div>
+        <CardTitle className="text-lg font-semibold tracking-tight">
+          {t("accountsSummary.title")}
+        </CardTitle>
       </CardHeader>
       <CardContent className={`${isCompact ? "space-y-2" : "space-y-6"} pt-4`}>
         {assets.length > 0 && renderGroup(assets, true)}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -208,7 +208,7 @@ export function TrendChart({
               key={r.label}
               onClick={() => setRange(r.label)}
               aria-pressed={range === r.label}
-              className={`px-1.5 py-0.5 text-xs rounded transition-colors ${
+              className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
                 range === r.label
                   ? "bg-primary text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   : "text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -222,7 +222,7 @@ export function TrendChart({
             onClick={() => setPctMode(isPercentMode ? "off" : "on")}
             aria-pressed={isPercentMode}
             title={t("pctToggleTitle")}
-            className={`px-1.5 py-0.5 text-xs rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+            className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
               isPercentMode
                 ? "bg-primary text-primary-foreground"
                 : "text-muted-foreground hover:bg-muted"


### PR DESCRIPTION
## Summary
- The All Accounts sort selector lived inline in the card header, and its four buttons (Value/Account/%/Category) squeezed the title onto two lines on narrower viewports.
- Pin the selector to the card's top-right corner (`absolute right-2 top-2 sm:right-4 sm:top-3`), matching the trend chart's range selector landed in #273.
- Unify both selectors to a rounded-full pill style (`rounded-full`, `px-2 py-0.5`, filled-on-active) so the two dashboard cards read as one design.

## Test plan
- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Visual check on dashboard: title no longer wraps; sort pills sit in the corner; both selectors look consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)