### PR TITLE
fix(mobile): prevent navbar truncation and dashboard chip overlap

### DIFF
--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -170,27 +170,27 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
 
   return (
     <Card className="relative border-0 shadow-none bg-transparent">
-      <div className="absolute right-2 top-2 z-10 flex shrink-0 items-center gap-0.5 sm:right-4 sm:top-3">
-        {sortOptions.map(({ field, label }) => (
-          <button
-            key={field}
-            onClick={() => handleSort(field)}
-            aria-pressed={sortField === field}
-            className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-              sortField === field
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted"
-            }`}
-          >
-            {label}
-            {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-          </button>
-        ))}
-      </div>
-      <CardHeader className="pb-2">
+      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
         <CardTitle className="text-lg font-semibold tracking-tight">
           {t("accountsSummary.title")}
         </CardTitle>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-0.5">
+          {sortOptions.map(({ field, label }) => (
+            <button
+              key={field}
+              onClick={() => handleSort(field)}
+              aria-pressed={sortField === field}
+              className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                sortField === field
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {label}
+              {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+            </button>
+          ))}
+        </div>
       </CardHeader>
       <CardContent className={`${isCompact ? "space-y-2" : "space-y-6"} pt-4`}>
         {assets.length > 0 && renderGroup(assets, true)}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -201,61 +201,63 @@ export function TrendChart({
 
   return (
     <Card className="relative border-0 bg-transparent shadow-none h-full flex flex-col pb-0">
-      {!hideRangeFilter && (
-        <div className="absolute right-2 top-2 z-10 flex shrink-0 items-center gap-0.5 sm:right-4 sm:top-3">
-          {ranges.map((r) => (
-            <button
-              key={r.label}
-              onClick={() => setRange(r.label)}
-              aria-pressed={range === r.label}
-              className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
-                range === r.label
-                  ? "bg-primary text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  : "text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2 pb-2 px-2 sm:px-4">
+        <div className="flex flex-col gap-1 min-w-0">
+          <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
+          {periodChange && (
+            <div
+              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold tabular-nums ${
+                periodChange.delta >= 0
+                  ? "bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400"
+                  : "bg-red-50 dark:bg-red-950/50 text-destructive"
               }`}
             >
-              {r.label}
-            </button>
-          ))}
-          <div className="mx-1 h-3 w-px bg-border" />
-          <button
-            onClick={() => setPctMode(isPercentMode ? "off" : "on")}
-            aria-pressed={isPercentMode}
-            title={t("pctToggleTitle")}
-            className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-              isPercentMode
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted"
-            }`}
-          >
-            %
-          </button>
+              {privacyMode ? (
+                "***"
+              ) : (
+                <>
+                  {periodChange.delta >= 0 ? "+" : ""}
+                  {formatCurrency(periodChange.delta, baseCurrency)}
+                  {periodChange.pct !== null && (
+                    <span className="text-[11px] opacity-70">
+                      ({periodChange.delta >= 0 ? "+" : ""}
+                      {periodChange.pct.toFixed(1)}%)
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          )}
         </div>
-      )}
-      <CardHeader className="flex flex-col gap-1 pb-2 px-2 sm:px-4">
-        <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
-        {periodChange && (
-          <div
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold tabular-nums ${
-              periodChange.delta >= 0
-                ? "bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400"
-                : "bg-red-50 dark:bg-red-950/50 text-destructive"
-            }`}
-          >
-            {privacyMode ? (
-              "***"
-            ) : (
-              <>
-                {periodChange.delta >= 0 ? "+" : ""}
-                {formatCurrency(periodChange.delta, baseCurrency)}
-                {periodChange.pct !== null && (
-                  <span className="text-[11px] opacity-70">
-                    ({periodChange.delta >= 0 ? "+" : ""}
-                    {periodChange.pct.toFixed(1)}%)
-                  </span>
-                )}
-              </>
-            )}
+        {!hideRangeFilter && (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-0.5">
+            {ranges.map((r) => (
+              <button
+                key={r.label}
+                onClick={() => setRange(r.label)}
+                aria-pressed={range === r.label}
+                className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
+                  range === r.label
+                    ? "bg-primary text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    : "text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+            <div className="mx-1 h-3 w-px bg-border" />
+            <button
+              onClick={() => setPctMode(isPercentMode ? "off" : "on")}
+              aria-pressed={isPercentMode}
+              title={t("pctToggleTitle")}
+              className={`px-2 py-0.5 text-xs rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                isPercentMode
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              %
+            </button>
           </div>
         )}
       </CardHeader>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -300,7 +300,7 @@ export function MobileNav() {
           >
             <span
               className={cn(
-                "flex w-16 flex-col items-center justify-center gap-1 px-2 py-1.5 rounded-xl text-[10px] uppercase tracking-wider transition-all motion-fast",
+                "flex w-full max-w-20 flex-col items-center justify-center gap-1 px-1 py-1.5 rounded-xl text-[10px] uppercase tracking-normal transition-all motion-fast",
                 isActive
                   ? "text-primary font-semibold bg-primary/12 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.25)] scale-[1.04]"
                   : "text-muted-foreground group-hover:text-foreground",


### PR DESCRIPTION
The mobile bottom nav labels (Dashboard, Accounts, Analysis, Settings) were
clipping under English locale due to a fixed w-16 inner container plus
tracking-wider letter spacing. Both the trend chart and accounts summary
cards positioned their filter/sort chips with `absolute right-2 top-2`,
which visually overlapped the CardTitle on narrow viewports.

- MobileNav: drop the fixed inner width, tighten letter spacing, and
  reclaim padding so labels render in full inside each grid cell.
- TrendChart / AccountsSummary: move the chip rows out of absolute
  positioning into the CardHeader as flex siblings that wrap below the
  title on mobile and stay beside it on sm:+.