### PR TITLE
feat(mobile-nav): floating pill tab bar, no backdrop-blur for perf

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -208,6 +208,10 @@
     transition-timing-function: var(--ease-spring);
   }
 
+  .ios-tab-pop {
+    animation: ios-tab-pop 320ms var(--ease-spring) both;
+  }
+
   .skeleton-shimmer {
     position: relative;
     overflow: hidden;
@@ -257,6 +261,18 @@
 @keyframes skeleton-shimmer {
   100% {
     transform: translateX(100%);
+  }
+}
+
+@keyframes ios-tab-pop {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1);
   }
 }
 

--- a/src/components/layout/mobile-main-shell.tsx
+++ b/src/components/layout/mobile-main-shell.tsx
@@ -12,7 +12,7 @@ export function MobileMainShell({ children }: { children: React.ReactNode }) {
   return (
     <main
       className={cn(
-        "flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0 relative w-full",
+        "flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+0.75rem+env(safe-area-inset-bottom))] md:pb-0 relative w-full",
         isPulling ? "transition-none" : "transition-transform duration-300",
       )}
       style={offset > 0 ? { transform: `translateY(${offset}px)` } : undefined}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -266,8 +266,8 @@ export function MobileNav() {
   return (
     <nav
       className={cn(
-        "md:hidden fixed bottom-0 left-0 right-0 z-50 glass backdrop-blur-md border-t border-border/50 grid grid-cols-5 py-2 pb-safe transition-transform motion-normal",
-        hidden && "translate-y-full",
+        "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 flex items-center gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.3)] dark:shadow-[0_10px_28px_-8px_rgba(0,0,0,0.65)] transition-transform motion-normal will-change-transform",
+        hidden && "translate-y-[150%]",
       )}
     >
       {navItems.map((item) => {
@@ -294,24 +294,19 @@ export function MobileNav() {
                 router.push(item.href);
               });
             }}
-            className="group relative flex min-h-12 w-full items-center justify-center rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            className="group relative flex min-h-12 min-w-14 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             aria-label={item.label}
             aria-current={isActive ? "page" : undefined}
           >
             <span
               className={cn(
-                "flex w-full max-w-20 flex-col items-center justify-center gap-1 px-1 py-1.5 rounded-xl text-[10px] uppercase tracking-normal transition-all motion-fast",
+                "flex flex-col items-center justify-center gap-0.5 px-3 py-1.5 rounded-full text-[10px] uppercase tracking-normal transition-colors motion-fast",
                 isActive
-                  ? "text-primary font-semibold bg-primary/12 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.25)] scale-[1.04]"
+                  ? "text-primary font-semibold bg-primary/15 dark:bg-primary/20"
                   : "text-muted-foreground group-hover:text-foreground",
               )}
             >
-              <Icon
-                className={cn(
-                  "transition-all motion-fast",
-                  isActive ? "h-6 w-6" : "h-5 w-5 group-hover:scale-110",
-                )}
-              />
+              <Icon className={cn("motion-fast", isActive ? "h-6 w-6" : "h-5 w-5")} />
               <span className="truncate w-full text-center">{item.label}</span>
             </span>
           </button>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -266,7 +266,7 @@ export function MobileNav() {
   return (
     <nav
       className={cn(
-        "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 flex items-center gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.3)] dark:shadow-[0_10px_28px_-8px_rgba(0,0,0,0.65)] transition-transform motion-normal will-change-transform",
+        "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 w-[calc(100%-1.5rem)] max-w-sm flex items-stretch gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.3)] dark:shadow-[0_10px_28px_-8px_rgba(0,0,0,0.65)] transition-transform motion-normal will-change-transform",
         hidden && "translate-y-[150%]",
       )}
     >
@@ -294,13 +294,13 @@ export function MobileNav() {
                 router.push(item.href);
               });
             }}
-            className="group relative flex min-h-12 min-w-14 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="group relative flex flex-1 basis-0 min-w-0 min-h-12 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             aria-label={item.label}
             aria-current={isActive ? "page" : undefined}
           >
             <span
               className={cn(
-                "flex flex-col items-center justify-center gap-0.5 px-3 py-1.5 rounded-full text-[10px] uppercase tracking-normal transition-colors motion-fast",
+                "flex w-full h-full flex-col items-center justify-center gap-0.5 px-1 py-1.5 rounded-full text-[10px] uppercase tracking-normal transition-colors motion-fast",
                 isActive
                   ? "text-primary font-semibold bg-primary/15 dark:bg-primary/20"
                   : "text-muted-foreground group-hover:text-foreground",

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -294,19 +294,25 @@ export function MobileNav() {
                 router.push(item.href);
               });
             }}
-            className="group relative flex flex-1 basis-0 min-w-0 min-h-12 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="group relative flex flex-1 basis-0 min-w-0 min-h-12 items-center justify-center rounded-full select-none touch-manipulation transition-transform motion-fast will-change-transform active:scale-[0.92] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             aria-label={item.label}
             aria-current={isActive ? "page" : undefined}
           >
             <span
               className={cn(
-                "flex w-full h-full flex-col items-center justify-center gap-0.5 px-1 py-1.5 rounded-full text-[10px] uppercase tracking-normal transition-colors motion-fast",
+                "flex w-full h-full flex-col items-center justify-center gap-0.5 px-1 py-1 rounded-full text-[10px] font-medium tracking-tight normal-case transition-colors motion-normal",
                 isActive
                   ? "text-primary font-semibold bg-primary/15 dark:bg-primary/20"
                   : "text-muted-foreground group-hover:text-foreground",
               )}
             >
-              <Icon className={cn("motion-fast", isActive ? "h-6 w-6" : "h-5 w-5")} />
+              <Icon
+                key={isActive ? "on" : "off"}
+                className={cn(
+                  "transition-transform motion-fast",
+                  isActive ? "motion-safe:ios-tab-pop h-[20px] w-[20px]" : "h-[18px] w-[18px]",
+                )}
+              />
               <span className="truncate w-full text-center">{item.label}</span>
             </span>
           </button>


### PR DESCRIPTION
Restyle the mobile bottom nav from a flush full-width bar into a
centered, floating pill — App Store / Facebook style — while
prioritizing scroll performance:

- Drop backdrop-blur entirely (compositor cost on every scroll frame).
  Use a near-opaque background (bg-background/95) so legibility holds
  without runtime blur.
- Replace transition-all with transition-colors on inner buttons and
  remove hover-scale on icons to avoid repaints on touch.
- Add will-change-transform on the nav root so the scroll-hide slide
  stays on the compositor.
- Replace grid grid-cols-5 with flex so the bar sizes to content.
- Pill geometry: centered via left-1/2 / -translate-x-1/2, lifted with
  bottom-[calc(0.75rem+safe-area-inset-bottom)], rounded-full, full
  border (no border-t), elevation shadow.
- Active item: solid rounded-full primary tint (no inset ring).
- Hidden translate bumped from translate-y-full to translate-y-[150%]
  so the floating pill fully clears the viewport on scroll-hide.
- Bump MobileMainShell bottom-padding by 0.75rem to match the new
  bottom offset so content still clears the floating pill.

https://claude.ai/code/session_01EjSdYBpvMvT37Y4WVqBskE