### PR TITLE
fix(mobile-nav): fully hide floating bar on scroll-down

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -267,7 +267,7 @@ export function MobileNav() {
     <nav
       className={cn(
         "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 w-[calc(100%-1.5rem)] max-w-sm flex items-stretch gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.3)] dark:shadow-[0_10px_28px_-8px_rgba(0,0,0,0.65)] transition-transform motion-normal will-change-transform",
-        hidden && "translate-y-[150%]",
+        hidden && "translate-y-[calc(100%+1.75rem+env(safe-area-inset-bottom))]",
       )}
     >
       {navItems.map((item) => {


### PR DESCRIPTION
## Summary

- `translate-y-[150%]` only cleared the bar's own height; it ignored the `0.75rem + env(safe-area-inset-bottom)` gap the floating pill sits above and the drop-shadow blur, so the top edge of the nav still peeked into the viewport when "hidden."
- Switch the hidden state to `translate-y-[calc(100%+1.75rem+env(safe-area-inset-bottom))]` — translates by bar height + the bottom offset + a `1rem` shadow buffer + safe-area inset.
- One-line change in `src/components/layout/sidebar.tsx`. Tailwind 4 transform composition (`-translate-x-1/2` + `translate-y-[calc(...)]`) keeps the centering intact during the hide/reveal transition.

## Test plan

- [ ] On `/history` or a long account detail at mobile width (Chrome DevTools 390×844), scroll down past 64px — the floating pill must fully clear the viewport with no top-edge sliver, in both light and dark mode.
- [ ] Scroll back up — bar returns smoothly with the existing `motion-normal` ease-out-expo curve.
- [ ] Use a notched preset (e.g. iPhone 14 Pro) — bar still fully hides behind the home-indicator zone.
- [ ] Use a non-notched preset / desktop narrowed to mobile width — `env(safe-area-inset-bottom)` resolves to `0` and the bar still fully hides (height + 1.75rem is enough).
- [ ] During the hide/reveal, the bar stays horizontally centered (no sideways drift — confirms `-translate-x-1/2` composes with the new Y translate).
- [ ] `npm run format:check && npm run lint && npm run typecheck` all pass.

https://claude.ai/code/session_01EjSdYBpvMvT37Y4WVqBskE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjSdYBpvMvT37Y4WVqBskE)_