### PR TITLE
perf(fx): remove render-time exchange-rate fetching

### DIFF
--- a/docs/codex_vercel_fluid_cpu_optimization_plan.md
+++ b/docs/codex_vercel_fluid_cpu_optimization_plan.md
@@ -23,20 +23,25 @@ Last updated: 2026-05-18.
   - API requests are excluded from `proxy.ts` matcher (`api/`), so route-level auth (e.g. `withAuth`) owns API authorization checks.
 - ✅ Milestone B shipped:
   - Analysis page now uses a cached aggregate payload (`getCachedAnalysisPayload`) with a 5-minute revalidation window and user-scoped cache tags.
+- ✅ Milestone C shipped (render-time FX fetching removed):
+  - Render paths (`getNetWorthSummary`, `/accounts`, `/accounts/[id]`) no longer import or call `resolveMissingRates`. Missing pairs fall back to `1` with a `log.warn("rates.unresolved", …)` so production logs surface gaps.
+  - Daily cron (`/api/cron/snapshot`) now warms `ExchangeRate` for every currency in use across users (account/holding currencies + every distinct `Setting.baseCurrency`) before refreshing prices.
+  - On-write hooks added: account create, settings PATCH (baseCurrency), and holding create fire-and-forget `refreshExchangeRates(newCurrency)` when the currency isn't yet in the rates table.
 - ⏳ Still pending production verification:
   - Measure before/after Active CPU by function family in Vercel runtime logs.
   - Confirm no API routes lost intended behavior by moving auth responsibility to handlers only.
   - Validate analysis cache hit-rate and invalidation behavior under real write traffic.
+  - Confirm `rates.unresolved` warns stay near zero post-deploy (otherwise the warm-up coverage has a gap).
 
 ## Key Findings
 
 Observed in code/config:
 
 - ✅ Manual refresh global-work issue addressed by splitting user-scoped manual refresh from global refresh logic.
-- The daily cron snapshot flow still bundles several CPU-heavy operations into a single function: expired option sweeping, global price refresh, per-user snapshot creation, and cache invalidation.
+- The daily cron snapshot flow still bundles several CPU-heavy operations into a single function: expired option sweeping, exchange-rate warm-up (added in Milestone C), global price refresh, per-user snapshot creation, and cache invalidation.
 - ✅ Duplicate auth execution on API requests addressed by excluding `/api/*` from proxy and using route-level auth.
 - ✅ Analysis payload recomputation addressed for analysis page through aggregate caching.
-- Some render paths can still trigger exchange-rate resolution work at request time, which increases CPU variance and makes cold or invalidated requests more expensive.
+- ✅ Render-time exchange-rate resolution work removed; render paths are now read-only against `ExchangeRate` and rates are warmed in the cron + on-write hooks.
 
 Needs verification in production:
 
@@ -51,7 +56,7 @@ Needs verification in production:
 | 1        | Split interactive refresh from global refresh and make manual refresh user-scoped. | ✅ Shipped            | Very high       | Cuts the most obvious source of over-broad work; aligns CPU usage with the current user instead of total dataset size. | Requires separate code paths for cron/global refresh vs. manual/user refresh.           |
 | 2        | Reduce duplicate auth execution on API routes.                                     | ✅ Shipped            | High            | Lowers CPU on every protected API call; simplifies the request path.                                                   | Requires careful review of which routes remain protected by proxy vs. route-level auth. |
 | 3        | Cache or precompute analysis, goals, and projection payloads.                      | ✅ Partial (analysis) | High            | Reduces repeated full-history recomputation; stabilizes heavy page requests.                                           | Adds invalidation complexity and may introduce bounded staleness.                       |
-| 4        | Remove render-time FX fetching and rely on prepared cached rates.                  | ⏳ Pending            | High            | Makes request CPU more predictable; avoids external-rate work inside render paths.                                     | Rates may be slightly stale until the next refresh/cron cycle.                          |
+| 4        | Remove render-time FX fetching and rely on prepared cached rates.                  | ✅ Shipped            | High            | Makes request CPU more predictable; avoids external-rate work inside render paths.                                     | Rates may be slightly stale until the next refresh/cron cycle.                          |
 | 5        | Narrow invalidation from global tags to per-user tags where applicable.            | ⏳ Pending            | Medium          | Reduces avoidable recomputation after writes and refreshes.                                                            | Requires consistent cache-tag ownership across routes and services.                     |
 | 6        | Rework broad price-cache access patterns if symbol count grows.                    | ⏳ Pending            | Medium          | Prevents dataset-wide filtering from scaling poorly as the portfolio universe expands.                                 | May trade some shared-cache simplicity for more targeted queries.                       |
 | 7        | Reduce noisy search/options traffic with tighter client behavior and caching.      | ⏳ Pending            | Low/Medium      | Lowers avoidable function invocations from typing-driven lookups and options-chain fetches.                            | Small UX tradeoffs if debounce/min-length rules get stricter.                           |
@@ -62,7 +67,7 @@ Needs verification in production:
 1. ✅ User-scope manual refresh endpoints.
 2. ✅ Remove API double-auth.
 3. ✅ Cache or materialize analytics payloads (analysis page aggregate cache shipped).
-4. Eliminate render-time FX fetching.
+4. ✅ Eliminate render-time FX fetching (cron warm-up + on-write hooks + render fallback to 1).
 5. Revisit invalidation scope and noisy auxiliary endpoints.
 
 ## Next Verification Checklist

--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -5,11 +5,8 @@ import { AccountsNavPanel } from "@/components/accounts/accounts-nav-panel";
 import { getAccountDetail, getAccountPriceMap } from "@/lib/services/account-service";
 import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
 import { getSession } from "@/lib/auth-session";
-import {
-  getAllExchangeRates,
-  resolveRate,
-  resolveMissingRates,
-} from "@/lib/services/exchange-rate-service";
+import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
+import { log } from "@/lib/logger";
 import { getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
@@ -39,27 +36,28 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
   const symbols = serialized.holdings.map((h) => h.symbol);
   const priceMap = await getAccountPriceMap(symbols);
 
-  // Build rates map from bulk-loaded data
+  // Build rates map from bulk-loaded data. Render path is read-only
+  // against ExchangeRate — missing pairs fall back to 1 (rates are warmed
+  // by the daily cron and on-write hooks).
   const ratesMap: Record<string, number> = {};
-  const missingPairs: Array<[string, string]> = [];
+  const warnedPairs = new Set<string>();
 
   for (const holding of serialized.holdings) {
     const hc = holding.currency || "USD";
-    if (hc !== serialized.currency) {
-      const key = `${hc}_${serialized.currency}`;
-      if (ratesMap[key] === undefined) {
-        const rate = resolveRate(allRatesMap, hc, serialized.currency);
-        if (rate !== undefined) {
-          ratesMap[key] = rate;
-        } else {
-          missingPairs.push([hc, serialized.currency]);
-        }
-      }
+    if (hc === serialized.currency) continue;
+    const key = `${hc}_${serialized.currency}`;
+    if (ratesMap[key] !== undefined) continue;
+    const rate = resolveRate(allRatesMap, hc, serialized.currency);
+    if (rate !== undefined) {
+      ratesMap[key] = rate;
+      continue;
+    }
+    ratesMap[key] = 1;
+    if (!warnedPairs.has(key)) {
+      warnedPairs.add(key);
+      log.warn("rates.unresolved", { from: hc, to: serialized.currency });
     }
   }
-
-  // Resolve missing pairs with timeout (defaults to 1 if APIs are slow)
-  await resolveMissingRates(missingPairs, ratesMap);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -5,14 +5,11 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AccountsList } from "@/components/accounts/accounts-list";
-import {
-  getAllExchangeRates,
-  resolveRate,
-  resolveMissingRates,
-} from "@/lib/services/exchange-rate-service";
+import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
 import { getCachedPricesForSymbols } from "@/lib/services/price-service";
+import { log } from "@/lib/logger";
 import AccountsLoading from "./loading";
 
 const CLIENT_NAMESPACES = [
@@ -45,38 +42,37 @@ async function AccountsContent() {
     cachedPrices.map((p) => [p.symbol, p.price]),
   );
 
-  // Build rates map from the bulk-loaded rates (no sequential DB calls!)
+  // Build rates map from the bulk-loaded rates. Render path is read-only
+  // against ExchangeRate — missing pairs fall back to 1 (rates are warmed
+  // by the daily cron and on-write hooks).
   const ratesMap: Record<string, number> = {};
-  const missingPairs: Array<[string, string]> = [];
+  const warnedPairs = new Set<string>();
+  const fillRate = (from: string, to: string) => {
+    const key = `${from}_${to}`;
+    if (ratesMap[key] !== undefined) return;
+    const rate = resolveRate(allRatesMap, from, to);
+    if (rate !== undefined) {
+      ratesMap[key] = rate;
+      return;
+    }
+    ratesMap[key] = 1;
+    if (!warnedPairs.has(key)) {
+      warnedPairs.add(key);
+      log.warn("rates.unresolved", { from, to });
+    }
+  };
 
   for (const account of accounts) {
     if (account.currency !== baseCurrency) {
-      const key = `${account.currency}_${baseCurrency}`;
-      const rate = resolveRate(allRatesMap, account.currency, baseCurrency);
-      if (rate !== undefined) {
-        ratesMap[key] = rate;
-      } else {
-        missingPairs.push([account.currency, baseCurrency]);
-      }
+      fillRate(account.currency, baseCurrency);
     }
     for (const holding of account.holdings) {
       const hc = holding.currency || "USD";
       if (hc !== account.currency) {
-        const key = `${hc}_${account.currency}`;
-        if (ratesMap[key] === undefined) {
-          const rate = resolveRate(allRatesMap, hc, account.currency);
-          if (rate !== undefined) {
-            ratesMap[key] = rate;
-          } else {
-            missingPairs.push([hc, account.currency]);
-          }
-        }
+        fillRate(hc, account.currency);
       }
     }
   }
-
-  // Resolve missing pairs with timeout (defaults to 1 if APIs are slow)
-  await resolveMissingRates(missingPairs, ratesMap);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
+import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 import { parseOccSymbol, formatOptionLabel, OptionError } from "@/lib/options";
@@ -14,6 +15,20 @@ function invalidateUserCaches(userId: string) {
   revalidateTag(`accounts:${userId}`, "max");
   revalidateTag(`net-worth:${userId}`, "max");
   revalidateTag(`history:${userId}`, "max");
+}
+
+async function maybeWarmExchangeRate(currency: string) {
+  try {
+    const existing = await prisma.exchangeRate.findFirst({
+      where: { fromCurrency: currency },
+      select: { id: true },
+    });
+    if (existing) return;
+    await refreshExchangeRates(currency);
+    revalidateTag("exchange-rates", "max");
+  } catch (error) {
+    log.warn("rates.warm.failed", { currency, error: String(error) });
+  }
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
@@ -132,6 +147,7 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   }
 
   invalidateUserCaches(userId);
+  if (holding.currency) void maybeWarmExchangeRate(holding.currency);
   return ok(holding, { status: 201 });
 });
 

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -3,11 +3,29 @@ import { prisma } from "@/lib/prisma";
 import { createAccountSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { log } from "@/lib/logger";
 
 function invalidateUserCaches(userId: string) {
   // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
   revalidateTag(`accounts:${userId}`, "max");
   revalidateTag(`net-worth:${userId}`, "max");
+}
+
+// Fire-and-forget rate refresh for a currency that doesn't yet exist in
+// ExchangeRate. Keeps render paths read-only against the rates table.
+async function maybeWarmExchangeRate(currency: string) {
+  try {
+    const existing = await prisma.exchangeRate.findFirst({
+      where: { fromCurrency: currency },
+      select: { id: true },
+    });
+    if (existing) return;
+    await refreshExchangeRates(currency);
+    revalidateTag("exchange-rates", "max");
+  } catch (error) {
+    log.warn("rates.warm.failed", { currency, error: String(error) });
+  }
 }
 
 export const GET = withAuth(async (_req, _ctx, userId) => {
@@ -45,5 +63,6 @@ export const POST = withAuth(async (request, _ctx, userId) => {
     data: { ...parsed.data, userId },
   });
   invalidateUserCaches(userId);
+  void maybeWarmExchangeRate(account.currency);
   return ok(account, { status: 201 });
 });

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { refreshAllPrices } from "@/lib/services/price-service";
+import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
 import { log } from "@/lib/logger";
@@ -46,7 +47,23 @@ export async function GET(request: Request) {
       revalidateTag("accounts", "max");
     }
 
-    // 1. Refresh all prices first to ensure the snapshot is accurate
+    // 1a. Warm the ExchangeRate cache so render paths never need to fetch
+    // live rates inline. Refresh in parallel for every source currency in
+    // use across users (account.currency, holding.currency, baseCurrency).
+    const [accountCurrencies, holdingCurrencies, settings] = await Promise.all([
+      prisma.account.findMany({ select: { currency: true }, distinct: ["currency"] }),
+      prisma.holding.findMany({ select: { currency: true }, distinct: ["currency"] }),
+      prisma.setting.findMany({ select: { baseCurrency: true }, distinct: ["baseCurrency"] }),
+    ]);
+    const sourceCurrencies = new Set<string>(["USD"]);
+    for (const row of accountCurrencies) sourceCurrencies.add(row.currency);
+    for (const row of holdingCurrencies) if (row.currency) sourceCurrencies.add(row.currency);
+    for (const row of settings) sourceCurrencies.add(row.baseCurrency);
+    log.info("cron.rates.refresh", { count: sourceCurrencies.size });
+    await Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c)));
+    revalidateTag("exchange-rates", "max");
+
+    // 1b. Refresh all prices to ensure the snapshot is accurate
     log.info("cron.prices.refresh");
     await refreshAllPrices();
     // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -4,6 +4,22 @@ import { updateSettingsSchema } from "@/lib/validators";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { ok, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { log } from "@/lib/logger";
+
+async function maybeWarmExchangeRate(currency: string) {
+  try {
+    const existing = await prisma.exchangeRate.findFirst({
+      where: { fromCurrency: currency },
+      select: { id: true },
+    });
+    if (existing) return;
+    await refreshExchangeRates(currency);
+    revalidateTag("exchange-rates", "max");
+  } catch (error) {
+    log.warn("rates.warm.failed", { currency, error: String(error) });
+  }
+}
 
 export const GET = withAuth(async (_req, _ctx, userId) => {
   const settings = await getOrCreateSettings(userId);
@@ -34,6 +50,7 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
   // user is stale (values are denominated in the old currency).
   if (parsed.data.baseCurrency !== undefined) {
     revalidateTag(`net-worth:${userId}`, "max");
+    void maybeWarmExchangeRate(parsed.data.baseCurrency);
   }
 
   const response = ok(settings);

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -2,8 +2,9 @@ import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { getAllExchangeRates, resolveRate, resolveMissingRates } from "./exchange-rate-service";
+import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
 import { serializeAccountWithHoldings } from "@/lib/types";
+import { log } from "@/lib/logger";
 import type {
   AccountWithValue,
   NetWorthSummary,
@@ -63,16 +64,7 @@ async function computeNetWorthSummary(
   let totalLiabilities = 0;
   const accountsWithValue: AccountWithValue[] = [];
 
-  // Collect missing rate pairs for batch-fetching
-  const missingPairs = new Set<string>();
-
   for (const account of accounts) {
-    // Try to resolve rate from bulk map first
-    const rate = resolveRate(allRatesMap, account.currency, baseCurrency);
-    if (rate === undefined) {
-      missingPairs.add(`${account.currency}_${baseCurrency}`);
-    }
-
     const cashBalance = account.cashBalance;
 
     const holdingsWithPrice: HoldingWithPrice[] = account.holdings.map((h) => {
@@ -88,44 +80,28 @@ async function computeNetWorthSummary(
       };
     });
 
-    for (const h of holdingsWithPrice) {
-      if (h.marketValue !== null) {
-        const holdingCurrency = h.currency || priceMap[h.symbol]?.currency || "USD";
-        if (resolveRate(allRatesMap, holdingCurrency, baseCurrency) === undefined) {
-          missingPairs.add(`${holdingCurrency}_${baseCurrency}`);
-        }
-        if (resolveRate(allRatesMap, holdingCurrency, account.currency) === undefined) {
-          missingPairs.add(`${holdingCurrency}_${account.currency}`);
-        }
-      }
-    }
-
     accountsWithValue.push({
       ...account,
       holdings: holdingsWithPrice,
-      totalValue: 0, // will be filled after missing rates are resolved
+      totalValue: 0,
       totalValueInBaseCurrency: 0,
       _cashBalance: cashBalance,
       _currency: account.currency,
     } as AccountWithValue & { _cashBalance: number; _currency: string });
   }
 
-  // Fetch any truly missing rates with timeout (defaults to 1 if APIs are slow)
-  if (missingPairs.size > 0) {
-    const pairs: Array<[string, string]> = [...missingPairs].map((key) => {
-      const [from, to] = key.split("_");
-      return [from, to];
-    });
-    const resolvedMap: Record<string, number> = {};
-    await resolveMissingRates(pairs, resolvedMap);
-    for (const [key, rate] of Object.entries(resolvedMap)) {
-      allRatesMap.set(key, rate);
-    }
-  }
-
-  // Helper using the now-complete map
+  // Render-time helper: read-only against ExchangeRate. Missing pairs fall
+  // back to 1 (rates are warmed by the daily cron and on-write hooks).
+  const warnedPairs = new Set<string>();
   function getRate(from: string, to: string): number {
-    return resolveRate(allRatesMap, from, to) ?? 1;
+    const resolved = resolveRate(allRatesMap, from, to);
+    if (resolved !== undefined) return resolved;
+    const key = `${from}_${to}`;
+    if (!warnedPairs.has(key)) {
+      warnedPairs.add(key);
+      log.warn("rates.unresolved", { from, to, userId, baseCurrency });
+    }
+    return 1;
   }
 
   // Second pass: compute values using the complete rate map


### PR DESCRIPTION
## Summary

- Render paths (`getNetWorthSummary`, `/accounts`, `/accounts/[id]`) no longer import `resolveMissingRates` or trigger inline external HTTP fetches + DB upserts. Missing pairs fall back to `1` with a once-per-render `log.warn("rates.unresolved", …)`.
- Daily cron (`/api/cron/snapshot`) now warms the `ExchangeRate` table for every currency in use (account.currency, holding.currency, every distinct `Setting.baseCurrency`, plus USD) before refreshing prices, then `revalidateTag("exchange-rates", "max")`.
- Account create, settings baseCurrency PATCH, and holding create now fire-and-forget `refreshExchangeRates(newCurrency)` when the currency isn't yet in the rates table — so brand-new currencies don't render at rate=1 until the next cron tick.

Implements priority 4 / Milestone C of `docs/codex_vercel_fluid_cpu_optimization_plan.md`. Accepted tradeoff per the plan: rates may be slightly stale until the next refresh/cron cycle.

## Why

We are on Vercel Hobby and approaching the Active CPU cap on Fluid Compute. Each render that hit a missing rate pair was racing `fetchExchangeRates` (frankfurter.app + open.er-api.com fallback) against a 1.2s timeout and writing back to `ExchangeRate` during render. Moving that work to the cron + on-write hooks makes RSC CPU predictable and amortises the external-fetch cost.

## Test plan

- [x] `npm run format:check`, `npm run lint`, `npm run typecheck` — all green
- [x] `npm run test:e2e` — 6/6 Playwright specs pass (chromium + Mobile Chrome, 27.2s)
- [ ] Post-merge: `DELETE FROM "ExchangeRate"` against a preview branch, then hit `GET /api/cron/snapshot` with `Authorization: Bearer $CRON_SECRET` — confirm `ExchangeRate` repopulates and subsequent `/accounts` renders show no `rates.unresolved` warns
- [ ] Post-deploy: compare Active CPU in Vercel runtime logs for `/api/cron/snapshot` (expected slight uptick — now also refreshes rates) and RSC routes that read `getNetWorthSummary` (expected drop — no inline `fetchExchangeRates`)
- [ ] Watch production logs for sustained `rates.unresolved` warns; persistent warns indicate a warm-up gap (likely a currency that escapes the on-write hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)