### PR TITLE
perf(analysis): restore F3 settings-waterfall fix

### DIFF
--- a/docs/react_best_practices_review_20260518.md
+++ b/docs/react_best_practices_review_20260518.md
@@ -87,6 +87,12 @@ This lets the i18n + locale promises start immediately in parallel with the sett
 
 ---
 
+## Follow-up — 2026-05-19
+
+**F3 re-applied.** PR #307 (`fix(proxy): keep /api/auth under proxy ...`) refactored `/analysis` to call a new `getCachedAnalysisPayload` aggregator and inadvertently dropped the `settingsP.then(...)` shape, reintroducing a sequential `await settings → await payload` waterfall. Restored the original pattern in `src/app/(main)/analysis/page.tsx`: payload fetch is now kicked off inside the same `Promise.all` via `settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency))`, matching `/goals`, `/history`, `/projections`. F1, F2, F4–F6 remained intact.
+
+---
+
 ## Related docs
 
 - `docs/PERFORMANCE.md` — bundle optimization (B1–B15), already flags `next/dynamic` migration for recharts; this completes the analysis + projections side.

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -16,16 +16,15 @@ async function AnalysisContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
 
-  const [t, messages, locale, settings] = await Promise.all([
-    getTranslations("analysis"),
-    getMessages(),
-    getLocale(),
-    getOrCreateSettings(userId),
-  ]);
-  const { snapshots, cashFlowData, rawHistory, accountCashFlow } = await getCachedAnalysisPayload(
-    userId,
-    settings.baseCurrency,
-  );
+  const settingsP = getOrCreateSettings(userId);
+  const [t, messages, locale, { snapshots, cashFlowData, rawHistory, accountCashFlow }, settings] =
+    await Promise.all([
+      getTranslations("analysis"),
+      getMessages(),
+      getLocale(),
+      settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency)),
+      settingsP,
+    ]);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>


### PR DESCRIPTION
## Summary

- Restores the F3 settings-waterfall fix on `/analysis` that PR #307 inadvertently reverted when refactoring the page to call `getCachedAnalysisPayload`.
- Payload fetch now kicks off inside `Promise.all` via `settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency))`, in parallel with translations/messages/locale — matching the pattern used on `/goals`, `/history`, `/projections`.
- Updates `docs/react_best_practices_review_20260518.md` with a 2026-05-19 follow-up note recording the regression and its fix, so a future reviewer doesn't re-flag it.

## Background

The original P0 batch (PR #300, `c484ba2`) introduced the `settingsP.then(...)` shape on four pages to eliminate a `await settings → await downstream service call` waterfall. Three of those four are still intact. `/analysis` regressed in PR #307 (`fix(proxy): keep /api/auth under proxy ...`) because that PR replaced the four service calls with a new `getCachedAnalysisPayload` aggregator and rewrote the call site as two sequential awaits.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Manual smoke: load `/analysis` and confirm chart data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)