### PR TITLE
[codex] polish login page and document design system

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,166 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-21T15:31:11+08:00",
+  "title": "Design System: Assets Tracker",
+  "extensions": {
+    "source": {
+      "designDocument": "DESIGN.md",
+      "productDocument": null,
+      "refreshMode": "merge",
+      "inferredFrom": [
+        "src/app/globals.css",
+        "src/components/ui/button.tsx",
+        "src/components/ui/card.tsx",
+        "src/components/ui/input.tsx",
+        "docs/UI_UX.md",
+        "docs/ROADMAP.md"
+      ]
+    },
+    "stitchFrontmatter": {
+      "colorFormat": "oklch",
+      "colorFormatNote": "The project uses OKLCH as canonical CSS token values, so frontmatter keeps OKLCH and accepts Stitch hex-linter warnings.",
+      "componentPropertyPolicy": "DESIGN.md frontmatter uses only supported component sub-token props: backgroundColor, textColor, typography, rounded, padding, height, width, and size.",
+      "sidecarRole": "Rings, shadows, borders, focus styles, motion, dark-mode behavior, and responsive rules live in this sidecar."
+    },
+    "colorMeta": {
+      "intent": "Calm finance UI with neutral surfaces, emerald primary actions, and broader chart-only color variety.",
+      "tokens": {
+        "primary": {
+          "role": "Main action, active navigation, positive product accent",
+          "light": "oklch(0.6 0.16 150)",
+          "dark": "oklch(0.8 0.17 170)"
+        },
+        "background": {
+          "role": "Page and app shell surface",
+          "light": "oklch(0.99 0.003 260)",
+          "dark": "oklch(0.14 0.03 200)"
+        },
+        "card": {
+          "role": "Grouped financial content and form panels",
+          "light": "oklch(1 0 0)",
+          "dark": "oklch(0.19 0.035 200)"
+        },
+        "muted": {
+          "role": "Subtle panels, inactive tabs, quiet grouped backgrounds",
+          "light": "oklch(0.96 0.01 260)",
+          "dark": "oklch(0.2 0.036 200)"
+        },
+        "destructive": {
+          "role": "Irreversible actions and critical errors",
+          "light": "oklch(0.6 0.18 20)",
+          "dark": "oklch(0.7 0.19 20)"
+        }
+      },
+      "chartPalette": {
+        "light": [
+          "oklch(0.6 0.16 150)",
+          "oklch(0.65 0.12 210)",
+          "oklch(0.6 0.15 260)",
+          "oklch(0.7 0.15 300)",
+          "oklch(0.8 0.1 330)"
+        ],
+        "dark": [
+          "oklch(0.8 0.17 170)",
+          "oklch(0.78 0.15 220)",
+          "oklch(0.74 0.17 270)",
+          "oklch(0.82 0.17 320)",
+          "oklch(0.86 0.13 100)"
+        ]
+      },
+      "guardrails": [
+        "Keep accent usage below 10% of normal product chrome.",
+        "Use chart colors for data visualization, not decorative page sections.",
+        "Pair status color with labels, icons, or text."
+      ]
+    },
+    "typographyMeta": {
+      "primaryStack": "-apple-system, \"SF Pro Text\", \"SF Pro Display\", Geist, system-ui, sans-serif",
+      "monoStack": "var(--font-geist-mono), ui-monospace, \"SF Mono\", Menlo, monospace",
+      "bodyFeatureSettings": "\"cv02\", \"cv03\", \"cv04\", \"cv11\"",
+      "numericRule": "Use tabular numerals for balances, rates, deltas, allocation, and totals.",
+      "scale": {
+        "display": "36px / 1.1 / 700",
+        "headline": "30px / 1.2 / 600",
+        "title": "16px / 1.375 / 500",
+        "body": "16px / 1.5 / 400",
+        "supporting": "14px / 1.43 / 400",
+        "label": "12px / 1.333 / 500"
+      }
+    },
+    "elevation": {
+      "principle": "Use tonal layering, rings, and small shadows before heavy elevation.",
+      "levels": {
+        "surface": "Solid background with no shadow",
+        "card": "bg-card, rounded-xl, ring-1 ring-foreground/10",
+        "raisedCard": "shadow-sm with optional hover shadow-lg and small translate on pointer devices",
+        "overlay": "bg-popover, rounded-xl, ring-1 ring-foreground/10, backdrop only when it improves separation"
+      },
+      "glassPolicy": "Allowed for persistent navigation and overlays; avoided for financial data cards and forms."
+    },
+    "componentDetails": {
+      "buttonVariants": {
+        "default": "bg-primary text-primary-foreground, h-8 default, rounded-lg, text-sm font-medium",
+        "outline": "border-border bg-background, hover bg-muted, dark border-input and bg-input/30",
+        "secondary": "bg-secondary text-secondary-foreground",
+        "ghost": "transparent until hover or expanded state",
+        "destructive": "destructive tint background with destructive text",
+        "link": "text-primary with underline on hover"
+      },
+      "focus": "Interactive elements use focus-visible border-ring and ring-3 ring-ring/50 unless a destructive state overrides it.",
+      "card": "Card defaults to rounded-xl, bg-card, text-card-foreground, py-4, gap-4, ring-1 ring-foreground/10.",
+      "input": "Input defaults to h-8, rounded-lg, border-input, bg-transparent, px-2.5, focus-visible border-ring and ring-3.",
+      "loginControls": "Auth controls intentionally use 48px height while preserving the same token language."
+    },
+    "motion": {
+      "durations": {
+        "fast": "150ms",
+        "normal": "250ms",
+        "slow": "400ms"
+      },
+      "easing": {
+        "micro": "cubic-bezier(0.25, 0.1, 0.25, 1)",
+        "spring": "cubic-bezier(0.34, 1.56, 0.64, 1)",
+        "outExpo": "cubic-bezier(0.16, 1, 0.3, 1)"
+      },
+      "reducedMotion": "Disable decorative transitions, shimmer, hover lift, and view-transition reveals."
+    },
+    "layout": {
+      "breakpoints": {
+        "mobile": "320px-767px",
+        "tablet": "768px-1023px",
+        "desktop": "1024px+"
+      },
+      "mobile": [
+        "Use safe-area-aware headers and bottom navigation.",
+        "Prefer inset grouped lists over tables.",
+        "Use bottom sheets for multi-step mobile tasks."
+      ],
+      "desktop": [
+        "Use collapsible sidebar navigation.",
+        "Keep dashboards dense but aligned.",
+        "Expose command search and quick actions without crowding primary data."
+      ]
+    },
+    "componentNotes": {
+      "buttons": "Compact app-shell controls, 48px mobile/auth targets, icon buttons for tools, visible focus rings.",
+      "cards": "One entity or decision per card, solid surfaces for financial values, subtle rings.",
+      "inputs": "Explicit labels, semantic autocomplete, accessible validation, localized helper text.",
+      "navigation": "Adaptive mobile/desktop model with active state contrast and safe-area support.",
+      "charts": "Color plus labels, legends, tooltips, summaries, and non-color-only status cues."
+    },
+    "dos": [
+      "Use semantic tokens and OKLCH values.",
+      "Use Apple system typography with Geist fallback.",
+      "Align and tabularize financial numbers.",
+      "Treat empty, loading, error, offline, and reduced-motion states as designed states.",
+      "Localize all user-facing product copy."
+    ],
+    "donts": [
+      "Do not use gradient text for core product UI.",
+      "Do not use glassmorphism for financial data cards or forms.",
+      "Do not hard-code colors outside tokens except vendor marks.",
+      "Do not rely on hover-only affordances or color-only status.",
+      "Do not use centered mobile modals for complex tasks."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,192 @@
+---
+name: Assets Tracker
+description: A calm, iOS-native net worth dashboard for tracking assets, liabilities, goals, and portfolio analysis.
+colors:
+  background-light: "oklch(0.99 0.003 260)"
+  foreground-light: "oklch(0.15 0.02 260)"
+  card-light: "oklch(1 0 0)"
+  primary-light: "oklch(0.6 0.16 150)"
+  primary-foreground-light: "oklch(0.98 0.005 150)"
+  secondary-light: "oklch(0.96 0.01 260)"
+  muted-light: "oklch(0.96 0.01 260)"
+  muted-foreground-light: "oklch(0.55 0.02 260)"
+  border-light: "oklch(0.9 0.02 260)"
+  input-light: "oklch(0.9 0.02 260)"
+  background-dark: "oklch(0.14 0.03 200)"
+  foreground-dark: "oklch(0.96 0.01 190)"
+  card-dark: "oklch(0.19 0.035 200)"
+  primary-dark: "oklch(0.8 0.17 170)"
+  primary-foreground-dark: "oklch(0.12 0.03 170)"
+  secondary-dark: "oklch(0.22 0.038 200)"
+  muted-dark: "oklch(0.2 0.036 200)"
+  muted-foreground-dark: "oklch(0.7 0.02 195)"
+  border-dark: "oklch(0.3 0.038 200)"
+  input-dark: "oklch(0.22 0.038 200)"
+  destructive-light: "oklch(0.6 0.18 20)"
+  destructive-dark: "oklch(0.7 0.19 20)"
+  chart-emerald-light: "oklch(0.6 0.16 150)"
+  chart-cyan-light: "oklch(0.65 0.12 210)"
+  chart-indigo-light: "oklch(0.6 0.15 260)"
+  chart-purple-light: "oklch(0.7 0.15 300)"
+  chart-pink-light: "oklch(0.8 0.1 330)"
+  chart-emerald-dark: "oklch(0.8 0.17 170)"
+  chart-blue-dark: "oklch(0.78 0.15 220)"
+  chart-violet-dark: "oklch(0.74 0.17 270)"
+  chart-magenta-dark: "oklch(0.82 0.17 320)"
+  chart-yellow-dark: "oklch(0.86 0.13 100)"
+typography:
+  display:
+    fontFamily: '-apple-system, "SF Pro Text", "SF Pro Display", Geist, system-ui, sans-serif'
+    fontSize: 2.25rem
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: normal
+  headline:
+    fontFamily: '-apple-system, "SF Pro Text", "SF Pro Display", Geist, system-ui, sans-serif'
+    fontSize: 1.875rem
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: normal
+  title:
+    fontFamily: '-apple-system, "SF Pro Text", "SF Pro Display", Geist, system-ui, sans-serif'
+    fontSize: 1rem
+    fontWeight: 500
+    lineHeight: 1.375
+    letterSpacing: normal
+  body:
+    fontFamily: '-apple-system, "SF Pro Text", "SF Pro Display", Geist, system-ui, sans-serif'
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: normal
+  label:
+    fontFamily: '-apple-system, "SF Pro Text", "SF Pro Display", Geist, system-ui, sans-serif'
+    fontSize: 0.75rem
+    fontWeight: 500
+    lineHeight: 1.333
+    letterSpacing: normal
+rounded:
+  sm: 0.5rem
+  md: 0.625rem
+  lg: 0.75rem
+  xl: 1rem
+  2xl: 1.25rem
+spacing:
+  xs: 0.25rem
+  sm: 0.5rem
+  md: 0.75rem
+  lg: 1rem
+  xl: 1.5rem
+  2xl: 2rem
+components:
+  button-primary:
+    backgroundColor: "{colors.primary-light}"
+    textColor: "{colors.primary-foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: "0 0.75rem"
+    height: 2rem
+  button-outline:
+    backgroundColor: "{colors.card-light}"
+    textColor: "{colors.foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: "0 0.75rem"
+    height: 2rem
+  button-auth-primary:
+    backgroundColor: "{colors.primary-light}"
+    textColor: "{colors.primary-foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: "0 1rem"
+    height: 3rem
+  card:
+    backgroundColor: "{colors.card-light}"
+    textColor: "{colors.foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xl}"
+    padding: 1rem
+  input:
+    backgroundColor: "{colors.input-light}"
+    textColor: "{colors.foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: "0 0.625rem"
+    height: 2rem
+  badge:
+    backgroundColor: "{colors.secondary-light}"
+    textColor: "{colors.foreground-light}"
+    typography: "{typography.label}"
+    rounded: "{rounded.2xl}"
+    padding: "0 0.5rem"
+    height: 1.25rem
+  tab-active:
+    backgroundColor: "{colors.background-light}"
+    textColor: "{colors.foreground-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "0 0.75rem"
+    height: 1.75rem
+---
+
+## 1. Overview
+
+**Creative North Star: "The Quiet Ledger."**
+
+Assets Tracker is a private finance console with a calm operational register. It should feel like an iOS-native wealth cockpit on mobile and a dense portfolio workstation on desktop: fast to scan, quiet under pressure, and precise around money movement.
+
+The interface is built for repeated use, not marketing drama. Favor stable navigation, compact controls, grouped lists, strong numeric hierarchy, and immediate access to accounts, assets, liabilities, goals, and portfolio analysis. Visual polish should come from typography, spacing, state quality, and responsive behavior before illustration or decoration.
+
+## 2. Colors
+
+The default light theme uses cool near-white surfaces with a restrained emerald primary. Dark mode shifts to deep teal-blue surfaces with a brighter mint primary so financial data stays legible without becoming neon. Charts may use the broader light set of emerald, cyan, indigo, purple, and pink; in dark mode they shift toward mint, blue, violet, magenta, and yellow for separation.
+
+Use semantic tokens for all product UI: `background`, `foreground`, `card`, `primary`, `secondary`, `muted`, `border`, `input`, `ring`, `destructive`, and `chart-*`. Accent color should normally occupy less than 10% of a screen outside charts, active navigation, key calls to action, and positive deltas.
+
+Alternate color schemes may be offered as personalization, but every scheme must preserve the same roles: neutral surfaces first, one confident action color, clear destructive states, and chart colors that remain distinguishable without relying on red or green alone.
+
+**The Rarity Rule.** Primary color is valuable because it is scarce. Use it for the active path, primary action, positive emphasis, and chart identity, not for decorative wash.
+
+## 3. Typography
+
+Use the Apple system stack first, with Geist as the bundled fallback. This keeps mobile screens native, makes dashboard density readable, and avoids decorative typography in financial workflows.
+
+Numbers are a primary visual asset. Use tabular numerals for balances, rates, performance, allocation, and goal progress. Net worth and total balance figures may use larger, tighter display sizing, but normal panels, cards, sidebars, and forms should stay compact: 12px labels, 14px supporting text, 16px primary body and controls, and 30px page headlines.
+
+Headings should be direct and literal. Avoid dramatic slogans inside the app shell. Use sentence-case labels, concise error copy, and localized strings for every user-facing login, navigation, and financial state.
+
+**The Ledger Rule.** Every number that users compare should align, use tabular figures, and avoid decorative treatments that reduce scan speed.
+
+## 4. Elevation
+
+Depth is tonal before it is shadowed. Cards use solid surfaces, subtle rings, and small shadows only when they clarify grouping. The standard card shape is `rounded-xl` with a foreground tint ring; premium dashboard cards may use `rounded-2xl` with a small hover lift on pointer devices.
+
+Glass effects are reserved for persistent navigation and overlays: mobile headers, desktop sidebar, command palette shells, and bottom sheets. Do not make normal content cards translucent when they contain financial values, forms, or validation states.
+
+Motion should be short and purposeful: 150ms for micro state changes, 250ms for common transitions, 400ms for larger view changes. Respect reduced motion by disabling decorative transitions, view-transition reveals, shimmer, and hover lift.
+
+**The Solid Data Rule.** Values, validation, account rows, and forms sit on solid surfaces. Blur and translucency are for app chrome and overlays only.
+
+## 5. Components
+
+Buttons are compact by default with 8px height rhythm in the app shell and larger 48px targets on login, onboarding, bottom sheets, and mobile primary actions. Use icons for tool actions, text for clear commands, and visible focus rings on every interactive element.
+
+Cards group one decision or one repeated entity. Account, asset, liability, and transaction rows should use inset grouped-list behavior on mobile rather than desktop tables. Keep dividers hairline, section headers small and tracked, and destructive actions confirmed or isolated.
+
+Inputs use explicit labels, semantic autocomplete where available, and localized placeholders only as supporting hints. Validation must be visible, screen-reader reachable, and not color-only. Login and auth screens must preserve password manager support, keyboard order, and OAuth button affordances.
+
+Navigation is adaptive. Mobile uses safe-area-aware headers, bottom navigation, large-title behavior, and bottom sheets. Desktop uses collapsible side navigation, command search, and dense dashboard layouts. Charts should pair color with labels, legends, tooltips, and accessible summaries.
+
+## 6. Do's and Don'ts
+
+Do use semantic tokens, OKLCH colors, system typography, tabular numerals, localized strings, visible focus states, and mobile safe-area spacing.
+
+Do design finance screens for scanning: align numbers, keep labels short, disclose details progressively, and make empty, loading, error, and offline states feel first-class.
+
+Do reserve illustration, mesh backgrounds, and gradients for high-level summary moments where they support hierarchy without obscuring data.
+
+Don't use gradient text, glassmorphism, side stripes, glow effects, decorative blobs, or stock-like visuals as the default design language for financial workflows.
+
+Don't hard-code colors outside tokens except vendor marks, OAuth logos, or unavoidable third-party assets.
+
+Don't rely on hover-only controls, red-versus-green-only meaning, placeholder-only labels, centered mobile modals for complex tasks, or motion that cannot be disabled.

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -528,6 +528,10 @@
     "trust1": "Google OAuth — we never store your password",
     "trust2": "Your data is private & never sold",
     "trust3": "Only you can see your portfolio",
+    "previewMode": "Preview Mode",
+    "previewPasswordLabel": "Preview password",
+    "previewPasswordPlaceholder": "Enter preview password",
+    "previewLogin": "Preview Login",
     "footerBefore": "Your data stays private. Read our",
     "footerLink": "Privacy Policy"
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -528,6 +528,10 @@
     "trust1": "Google OAuth — 我們絕不儲存您的密碼",
     "trust2": "您的資料私密保存，絕不出售",
     "trust3": "只有您能查看自己的投資組合",
+    "previewMode": "預覽模式",
+    "previewPasswordLabel": "預覽密碼",
+    "previewPasswordPlaceholder": "輸入預覽密碼",
+    "previewLogin": "預覽登入",
     "footerBefore": "您的資料受到保護。閱讀我們的",
     "footerLink": "隱私政策"
   },

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,12 +3,19 @@
 import { Suspense } from "react";
 import { signIn } from "@/auth";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { TrendingUp, Lock, ShieldCheck, EyeOff } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Login | Assets Tracker",
+};
 
 async function LoginContent() {
   const t = await getTranslations("login");
+  const locale = await getLocale();
   const isPreviewOrLocal =
     process.env.VERCEL_ENV === "preview" ||
     process.env.VERCEL_ENV === "development" ||
@@ -19,34 +26,19 @@ async function LoginContent() {
   const showPreviewLogin = isPreviewOrLocal;
 
   return (
-    <div className="flex min-h-screen w-full items-center justify-center relative overflow-hidden bg-background">
-      {/* Dynamic Background Elements */}
-      <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] rounded-full bg-primary/10 blur-3xl pointer-events-none -z-10 animate-pulse-slow" />
-      <div
-        className="absolute bottom-[-10%] right-[-5%] w-[40%] h-[40%] rounded-full bg-chart-4/10 blur-3xl pointer-events-none -z-10 animate-pulse-slow"
-        style={{ animationDelay: "2s" }}
-      />
-
-      {/* Glassmorphism Card */}
-      <div className="relative z-10 mx-auto flex w-full max-w-md flex-col justify-center space-y-8 p-6 sm:p-10 bg-card/80 backdrop-blur-xl border border-border/50 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_32px_-8px_rgba(0,0,0,0.5)] rounded-3xl animate-slide-in-bottom">
-        <div className="flex flex-col space-y-3 text-center">
-          <div
-            className="w-16 h-16 mx-auto rounded-xl flex items-center justify-center mb-4 relative group shadow-lg"
-            style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}
-          >
-            <div
-              className="absolute inset-0 rounded-xl blur-md bg-emerald-500/50 opacity-40 group-hover:opacity-70 transition-opacity duration-500 animate-pulse"
-              style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}
-            ></div>
-            <TrendingUp
-              className="w-7 h-7 text-white relative z-10 transform transition-all group-hover:scale-110 group-hover:-rotate-12 duration-300"
-              strokeWidth={2}
-            />
+    <div
+      lang={locale}
+      className="relative flex h-dvh min-h-svh w-full items-start justify-center overflow-y-auto overflow-x-hidden px-4 py-3 [@media(min-height:620px)]:items-center [@media(min-height:620px)]:py-4 sm:px-6 sm:py-8"
+    >
+      <Card className="relative z-10 mx-auto w-full max-w-md gap-0 space-y-4 rounded-xl border-border/70 bg-card p-4 shadow-sm animate-slide-in-bottom [@media(min-height:620px)]:space-y-6 [@media(min-height:620px)]:p-5 sm:space-y-8 sm:p-8">
+        <div className="flex flex-col space-y-2 text-center">
+          <div className="mx-auto mb-1 flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm [@media(min-height:620px)]:h-14 [@media(min-height:620px)]:w-14 sm:mb-3">
+            <TrendingUp className="h-6 w-6" strokeWidth={2} aria-hidden="true" />
           </div>
-          <h1 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-muted-foreground bg-clip-text text-transparent">
+          <h1 className="text-2xl font-semibold tracking-normal text-foreground sm:text-3xl">
             {t("title")}
           </h1>
-          <p className="text-sm text-muted-foreground font-medium">{t("subtitle")}</p>
+          <p className="text-sm font-medium text-muted-foreground">{t("subtitle")}</p>
         </div>
 
         <form
@@ -54,16 +46,19 @@ async function LoginContent() {
             "use server";
             await signIn("google", { redirectTo: "/" });
           }}
-          className="pt-4"
+          className="sm:pt-4"
         >
           <Button
-            className="w-full h-12 text-[15px] font-medium tracking-wide bg-background text-foreground hover:bg-secondary border border-border shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 rounded-xl flex items-center justify-center gap-3"
+            variant="outline"
+            className="flex h-12 w-full items-center justify-center gap-3 rounded-lg text-[15px] font-medium tracking-normal shadow-sm"
             type="submit"
           >
             <svg
               className="w-5 h-5 shrink-0"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -86,27 +81,26 @@ async function LoginContent() {
           </Button>
         </form>
 
-        {/* Trust badges */}
-        <div className="flex flex-col gap-2 pt-2">
-          <div className="flex items-center gap-2.5 text-xs text-muted-foreground">
-            <Lock className="w-4 h-4 shrink-0 text-primary" />
+        <div className="flex flex-col gap-1.5 sm:gap-2 sm:pt-1">
+          <div className="flex min-w-0 items-start gap-2.5 text-xs leading-5 text-muted-foreground">
+            <Lock className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
             <span>{t("trust1")}</span>
           </div>
-          <div className="flex items-center gap-2.5 text-xs text-muted-foreground">
-            <ShieldCheck className="w-4 h-4 shrink-0 text-primary" />
+          <div className="flex min-w-0 items-start gap-2.5 text-xs leading-5 text-muted-foreground">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
             <span>{t("trust2")}</span>
           </div>
-          <div className="flex items-center gap-2.5 text-xs text-muted-foreground">
-            <EyeOff className="w-4 h-4 shrink-0 text-primary" />
+          <div className="flex min-w-0 items-start gap-2.5 text-xs leading-5 text-muted-foreground">
+            <EyeOff className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
             <span>{t("trust3")}</span>
           </div>
         </div>
 
         {showPreviewLogin && (
           <>
-            <div className="flex items-center gap-3 pt-2">
+            <div className="flex items-center gap-3 sm:pt-2">
               <div className="flex-1 h-px bg-border" />
-              <span className="text-xs text-muted-foreground font-medium">Preview Mode</span>
+              <span className="text-xs font-medium text-muted-foreground">{t("previewMode")}</span>
               <div className="flex-1 h-px bg-border" />
             </div>
 
@@ -121,33 +115,47 @@ async function LoginContent() {
             >
               <div className="flex flex-col gap-3">
                 {!previewAuthDisabled && (
-                  <input
-                    name="password"
-                    type="password"
-                    placeholder="Preview password"
-                    required
-                    className="h-12 w-full rounded-xl border border-border bg-input px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-all"
-                  />
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="preview-password"
+                      className="text-xs font-medium text-muted-foreground"
+                    >
+                      {t("previewPasswordLabel")}
+                    </label>
+                    <input
+                      id="preview-password"
+                      name="password"
+                      type="password"
+                      autoComplete="current-password"
+                      placeholder={t("previewPasswordPlaceholder")}
+                      required
+                      className="h-12 w-full rounded-lg border border-border bg-input px-4 text-sm text-foreground placeholder:text-muted-foreground transition-all focus:border-primary focus:ring-2 focus:ring-primary/30 focus:outline-none"
+                    />
+                  </div>
                 )}
                 <Button
                   type="submit"
-                  className="w-full h-12 text-[15px] font-medium tracking-wide bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/30 border border-amber-200 dark:border-amber-800/50 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 rounded-xl"
+                  variant="secondary"
+                  className="h-12 w-full rounded-lg text-[15px] font-medium tracking-normal"
                 >
-                  Preview Login
+                  {t("previewLogin")}
                 </Button>
               </div>
             </form>
           </>
         )}
 
-        <div className="text-center text-xs text-muted-foreground pt-2 mb-[-1rem]">
+        <div className="text-center text-xs text-muted-foreground sm:pt-1">
           {t("footerBefore")}{" "}
-          <Link href="/privacy" className="underline hover:text-foreground transition-colors">
+          <Link
+            href="/privacy"
+            className="inline-flex min-h-6 items-center rounded-sm underline underline-offset-2 transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
+          >
             {t("footerLink")}
           </Link>
           .
         </div>
-      </div>
+      </Card>
     </div>
   );
 }
@@ -156,14 +164,14 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen w-full items-center justify-center bg-background">
-          <div className="w-full max-w-md rounded-3xl bg-card/80 p-6 sm:p-10 space-y-8 animate-pulse">
+        <div className="flex h-dvh min-h-svh w-full items-start justify-center overflow-y-auto overflow-x-hidden px-4 py-3 [@media(min-height:620px)]:items-center [@media(min-height:620px)]:py-4 sm:px-6 sm:py-8">
+          <div className="w-full max-w-md space-y-4 rounded-xl bg-card p-4 shadow-sm animate-pulse [@media(min-height:620px)]:space-y-6 [@media(min-height:620px)]:p-5 sm:space-y-8 sm:p-8">
             <div className="flex flex-col items-center space-y-3">
-              <div className="w-16 h-16 rounded-xl bg-primary/20" />
+              <div className="h-12 w-12 rounded-lg bg-primary/20 [@media(min-height:620px)]:h-14 [@media(min-height:620px)]:w-14" />
               <div className="h-8 w-48 rounded bg-muted" />
               <div className="h-4 w-56 rounded bg-muted" />
             </div>
-            <div className="h-12 w-full rounded-xl bg-muted" />
+            <div className="h-12 w-full rounded-lg bg-muted" />
           </div>
         </div>
       }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,46 @@
 import NextAuth from "next-auth";
 import authConfig from "./auth.config";
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
+import { SUPPORTED_LOCALES, type Locale } from "./i18n/config";
 
 const { auth } = NextAuth(authConfig);
+const PUBLIC_ROUTES = new Set(["/login", "/privacy", "/terms"]);
+
+function getCanonicalPathname(pathname: string): { pathname: string; locale?: Locale } {
+  const locale = SUPPORTED_LOCALES.find(
+    (candidate) => pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
+  );
+
+  if (!locale) return { pathname };
+
+  return {
+    locale,
+    pathname: pathname === `/${locale}` ? "/" : pathname.slice(locale.length + 1),
+  };
+}
+
+function setLocaleCookie(response: NextResponse, locale?: Locale) {
+  if (!locale) return response;
+
+  response.cookies.set("NEXT_LOCALE", locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+
+  return response;
+}
+
+function createRedirectUrl(req: NextRequest, pathname: string, preserveSearch = false) {
+  const protocol = req.headers.get("x-forwarded-proto") ?? req.nextUrl.protocol.replace(/:$/, "");
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  const origin = host ? `${protocol}://${host}` : req.nextUrl.origin;
+  const url = new URL(pathname, origin);
+
+  if (preserveSearch) url.search = req.nextUrl.search;
+
+  return url;
+}
 
 // ---------------------------------------------------------------------------
 // R3 — Inline rate limiter for /api/auth/* (20 req/min per IP).
@@ -50,16 +88,22 @@ export default auth((req) => {
   }
 
   const isLoggedIn = !!req.auth;
-  const isPublicRoute = ["/login", "/privacy", "/terms"].includes(req.nextUrl.pathname);
+  const canonicalPath = getCanonicalPathname(req.nextUrl.pathname);
+  const isPublicRoute = PUBLIC_ROUTES.has(canonicalPath.pathname);
 
-  if (!isLoggedIn && !isPublicRoute) {
-    const newUrl = new URL("/login", req.nextUrl.origin);
-    return Response.redirect(newUrl);
+  if (canonicalPath.locale && isPublicRoute) {
+    const newUrl = createRedirectUrl(req, canonicalPath.pathname, true);
+    return setLocaleCookie(NextResponse.redirect(newUrl), canonicalPath.locale);
   }
 
-  if (isLoggedIn && req.nextUrl.pathname === "/login") {
-    const newUrl = new URL("/", req.nextUrl.origin);
-    return Response.redirect(newUrl);
+  if (!isLoggedIn && !isPublicRoute) {
+    const newUrl = createRedirectUrl(req, "/login");
+    return setLocaleCookie(NextResponse.redirect(newUrl), canonicalPath.locale);
+  }
+
+  if (isLoggedIn && canonicalPath.pathname === "/login") {
+    const newUrl = createRedirectUrl(req, "/");
+    return setLocaleCookie(NextResponse.redirect(newUrl), canonicalPath.locale);
   }
 
   // On first visit (no locale cookie), detect from Accept-Language and set cookie


### PR DESCRIPTION
## Summary
- polished the login page to use the shared Card/Button system, tokenized styling, localized preview auth copy, accessible labels, and route-specific metadata
- added locale-aware public-route canonicalization in proxy so `/zh-TW/login` preserves locale and redirects to the canonical login route on the current host
- documented the current visual design system in `DESIGN.md` plus `.impeccable/design.json`

## Validation
- `npm run check`
- `npm run lint -- src/app/login/page.tsx src/proxy.ts`
- `npm run typecheck`
- `npm run build`
- Playwright smoke checks for `/login` at 320x568, 390x844, 1440x900, reduced motion, and `/zh-TW/login` locale redirect
