### PR TITLE
[codex] fix liability direction in analysis cards

### DIFF
--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -45,7 +45,7 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
               </thead>
               <tbody>
                 {movers.map((m) => {
-                  const isPositive = m.absoluteChange >= 0;
+                  const isPositive = m.netWorthChange >= 0;
                   const sign = isPositive ? "+" : "";
                   const pct =
                     m.percentChange === null
@@ -86,7 +86,7 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
                             ) : (
                               <>
                                 {sign}
-                                {formatCurrency(m.absoluteChange, baseCurrency)}
+                                {formatCurrency(m.netWorthChange, baseCurrency)}
                               </>
                             )}
                           </span>

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -251,9 +251,13 @@ export interface TopMover {
   accountId: string;
   accountName: string;
   category: string;
+  accountType: AccountMeta["type"];
   startValue: number;
   endValue: number;
+  /** Raw account balance change: endValue - startValue. */
   absoluteChange: number;
+  /** Impact on net worth. Liability balance increases are negative impact. */
+  netWorthChange: number;
   percentChange: number | null;
 }
 
@@ -390,8 +394,9 @@ export function computePerformanceAttribution(
 }
 
 /**
- * Return the top 10 accounts ranked by absolute value change between the
- * first and last snapshot in the (already-filtered) snapshots array.
+ * Return the top 10 accounts ranked by net-worth impact between the first and
+ * last snapshot in the (already-filtered) snapshots array. Liability balances
+ * are inverted so debt paydown is positive and debt growth is negative.
  *
  * @param snapshots  From getRawHistoryWithBreakdown().snapshots, filtered to range.
  * @param accounts   From getRawHistoryWithBreakdown().accounts.
@@ -410,18 +415,21 @@ export function computeTopMovers(
       const startValue = startSnap.accountValues[a.id] ?? 0;
       const endValue = endSnap.accountValues[a.id] ?? 0;
       const absoluteChange = endValue - startValue;
-      const percentChange = startValue === 0 ? null : (absoluteChange / startValue) * 100;
+      const netWorthChange = a.type === "LIABILITY" ? -absoluteChange : absoluteChange;
+      const percentChange = startValue === 0 ? null : (netWorthChange / startValue) * 100;
       return {
         accountId: a.id,
         accountName: a.name,
         category: a.category,
+        accountType: a.type,
         startValue,
         endValue,
         absoluteChange,
+        netWorthChange,
         percentChange,
       };
     })
-    .filter((m) => m.startValue !== 0 || m.endValue !== 0)
-    .sort((a, b) => Math.abs(b.absoluteChange) - Math.abs(a.absoluteChange))
+    .filter((m) => m.netWorthChange !== 0)
+    .sort((a, b) => Math.abs(b.netWorthChange) - Math.abs(a.netWorthChange))
     .slice(0, 10);
 }

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -334,11 +334,12 @@ export interface AttributionItem {
   accountId: string;
   accountName: string;
   category: string;
+  accountType: AccountMeta["type"];
   startValue: number;
   endValue: number;
-  /** endValue − startValue */
+  /** Net-worth impact over the period. Liability balance increases are negative. */
   totalDelta: number;
-  /** Net cash deposited / withdrawn to this account during the period. */
+  /** Net cash-flow impact on net worth during the period. */
   cashContribution: number;
   /** totalDelta − cashContribution: value created/destroyed by market movement. */
   marketPerformance: number;
@@ -374,13 +375,17 @@ export function computePerformanceAttribution(
     .map((account) => {
       const startValue = startSnap.accountValues[account.id] ?? 0;
       const endValue = endSnap.accountValues[account.id] ?? 0;
-      const totalDelta = endValue - startValue;
-      const cashContribution = cashByAccount.get(account.id) ?? 0;
+      const balanceDelta = endValue - startValue;
+      const totalDelta = account.type === "LIABILITY" ? -balanceDelta : balanceDelta;
+      const rawCashContribution = cashByAccount.get(account.id) ?? 0;
+      const cashContribution =
+        account.type === "LIABILITY" ? -rawCashContribution : rawCashContribution;
       const marketPerformance = totalDelta - cashContribution;
       return {
         accountId: account.id,
         accountName: account.name,
         category: account.category,
+        accountType: account.type,
         startValue,
         endValue,
         totalDelta,

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -185,6 +185,7 @@ export interface AccountMeta {
   id: string;
   name: string;
   category: string;
+  type: "ASSET" | "LIABILITY";
 }
 
 export interface RawHistoryData {
@@ -214,7 +215,7 @@ export async function getRawHistoryWithBreakdown(
     }),
     prisma.account.findMany({
       where: { userId },
-      select: { id: true, name: true, category: true },
+      select: { id: true, name: true, category: true, type: true },
     }),
     getAllExchangeRates(),
   ]);
@@ -249,11 +250,12 @@ export async function getRawHistoryWithBreakdown(
     });
 
   const accounts: AccountMeta[] = (
-    accountsRaw as { id: string; name: string; category: string }[]
+    accountsRaw as { id: string; name: string; category: string; type: "ASSET" | "LIABILITY" }[]
   ).map((a) => ({
     id: a.id,
     name: a.name,
     category: a.category,
+    type: a.type,
   }));
 
   return { snapshots, accounts };


### PR DESCRIPTION
## Summary

Fixes liability account direction in Analysis card calculations so debt movement is colored and signed by net-worth impact instead of raw balance movement.

## Root Cause

Top Movers and Performance Attribution previously used `endValue - startValue` for every account. That works for assets, but it is backwards for liabilities: a larger debt balance hurts net worth, while a smaller debt balance helps it.

## Changes

- Include account `type` in raw analysis account metadata.
- Add `netWorthChange` to `TopMover` and invert liability balance deltas.
- Use `netWorthChange` for Top Movers sign, color, displayed delta, sorting, and zero-mover filtering.
- Convert Performance Attribution totals, cash contribution, market performance, bars, tooltip values, and summary values to net-worth-impact semantics for liabilities.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npx prettier --check src/lib/services/history-service.ts src/lib/services/analysis-service.ts src/components/analysis/top-movers-list.tsx`
- `npx prettier --check src/lib/services/analysis-service.ts`
- Push hook also ran `npm run format:check`, `npm run lint`, and `npm run typecheck` successfully.