### PR TITLE
[codex] polish privacy page

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -547,6 +547,10 @@
     "section5Body": "You can export all your data or delete your account at any time from the Settings page.",
     "section6Title": "Authentication",
     "section6Body": "Sign-in is handled entirely by Google OAuth. We receive only a secure session token — your Google password is never shared with or stored by this app.",
+    "section7Title": "Analytics and telemetry",
+    "section7Body": "We use Vercel Analytics and Speed Insights to understand basic usage and page performance. These tools do not include your manually entered account names, holdings, balances, or transaction notes.",
+    "section8Title": "Contact",
+    "section8Body": "For privacy or data requests, email us at",
     "lastUpdated": "Last updated: April 2026"
   },
   "terms": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -547,6 +547,10 @@
     "section5Body": "您可以隨時在設定頁面匯出所有資料或刪除帳號。",
     "section6Title": "身份驗證",
     "section6Body": "登入完全由 Google OAuth 處理。我們只接收安全的工作階段令牌，您的 Google 密碼絕不會被本應用程式接收或儲存。",
+    "section7Title": "分析與遙測",
+    "section7Body": "我們使用 Vercel Analytics 和 Speed Insights 了解基本使用情況與頁面效能。這些工具不包含您手動輸入的帳戶名稱、持倉、餘額或交易備註。",
+    "section8Title": "聯絡方式",
+    "section8Body": "如有隱私或資料請求，請寄信至",
     "lastUpdated": "最後更新：2026 年 4 月"
   },
   "terms": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/layout/theme-provider";
 import { ColorSchemaProvider } from "@/components/layout/color-schema-context";
 import { LazyToaster } from "@/components/layout/lazy-toaster";
 import { CustomSpeedInsights } from "@/components/layout/speed-insights";
+import { HtmlLangSync } from "@/components/layout/html-lang-sync";
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
@@ -242,14 +243,14 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   viewportFit: "cover",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#f9fafb" },
     { media: "(prefers-color-scheme: dark)", color: "#0d1f1e" },
   ],
 };
+
+const enableVercelInsights = process.env.VERCEL === "1";
 
 /**
  * Reads locale from NEXT_LOCALE cookie / Accept-Language header and
@@ -264,6 +265,7 @@ async function LocaleProviders({ children }: { children: React.ReactNode }) {
     <NextIntlClientProvider
       messages={pickMessages(messages, ["app", "nav", "commandPalette", "common"])}
     >
+      <HtmlLangSync />
       {children}
     </NextIntlClientProvider>
   );
@@ -301,8 +303,12 @@ export default function RootLayout({
               <LocaleProviders>{children}</LocaleProviders>
             </Suspense>
             <LazyToaster />
-            <Analytics />
-            <CustomSpeedInsights />
+            {enableVercelInsights ? (
+              <>
+                <Analytics />
+                <CustomSpeedInsights />
+              </>
+            ) : null}
           </ColorSchemaProvider>
         </ThemeProvider>
       </body>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,65 +3,81 @@
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { ShieldCheck } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Assets Tracker",
+  description: "How Assets Tracker collects, uses, and protects your data.",
+};
 
 async function PrivacyContent() {
   const t = await getTranslations("privacy");
 
-  const sections = [
+  const sections: Array<{
+    title: string;
+    body: string;
+    link?: { href: string; label: string };
+  }> = [
     { title: t("section1Title"), body: t("section1Body") },
     { title: t("section2Title"), body: t("section2Body") },
     { title: t("section3Title"), body: t("section3Body") },
     { title: t("section4Title"), body: t("section4Body") },
     { title: t("section5Title"), body: t("section5Body") },
     { title: t("section6Title"), body: t("section6Body") },
+    { title: t("section7Title"), body: t("section7Body") },
+    {
+      title: t("section8Title"),
+      body: t("section8Body"),
+      link: { href: "mailto:support@astt.app", label: "support@astt.app" },
+    },
   ];
 
   return (
-    <div className="flex min-h-screen w-full items-start justify-center relative overflow-x-hidden bg-slate-50 py-12 px-4">
-      {/* Background elements */}
-      <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] rounded-full bg-primary/10 blur-3xl pointer-events-none -z-10" />
-      <div className="absolute bottom-[-10%] right-[-5%] w-[40%] h-[40%] rounded-full bg-chart-4/10 blur-3xl pointer-events-none -z-10" />
-
-      <div className="relative z-10 w-full max-w-2xl bg-white/80 backdrop-blur-xl border border-white/60 shadow-[0_8px_32px_-8px_rgba(0,0,0,0.1)] rounded-3xl p-10 space-y-8">
-        {/* Header */}
+    <main className="flex h-dvh w-full items-start justify-center overflow-x-hidden overflow-y-auto bg-background px-4 py-6 sm:py-12">
+      <article className="w-full max-w-2xl space-y-7 rounded-xl border border-border/50 bg-card p-6 text-card-foreground shadow-sm sm:space-y-8 sm:p-10">
         <div className="flex flex-col space-y-3 text-center">
-          <div
-            className="w-16 h-16 mx-auto rounded-xl flex items-center justify-center shadow-lg"
-            style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}
-          >
-            <ShieldCheck className="w-7 h-7 text-white" strokeWidth={2} />
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
+            <ShieldCheck className="h-6 w-6" strokeWidth={2} />
           </div>
-          <h1 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-            {t("title")}
-          </h1>
-          <p className="text-sm text-slate-500 font-medium">{t("subtitle")}</p>
+          <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
+          <p className="text-sm font-medium text-muted-foreground">{t("subtitle")}</p>
         </div>
 
-        {/* Sections */}
         <div className="space-y-6">
           {sections.map((section) => (
             <div key={section.title} className="space-y-1.5">
-              <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wide">
-                {section.title}
-              </h2>
-              <p className="text-sm text-slate-600 leading-relaxed">{section.body}</p>
+              <h2 className="text-sm font-semibold text-foreground">{section.title}</h2>
+              <p className="text-base leading-7 text-muted-foreground sm:text-sm sm:leading-relaxed">
+                {section.body}
+                {section.link ? (
+                  <>
+                    {" "}
+                    <a
+                      href={section.link.href}
+                      className="font-medium text-foreground underline underline-offset-4 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+                    >
+                      {section.link.label}
+                    </a>
+                  </>
+                ) : null}
+              </p>
             </div>
           ))}
         </div>
 
-        {/* Footer */}
-        <div className="pt-2 border-t border-slate-100 flex items-center justify-between">
-          <p className="text-xs text-slate-400">{t("lastUpdated")}</p>
+        <div className="flex flex-col items-start gap-3 border-t border-border/50 pt-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground">{t("lastUpdated")}</p>
           <Link
             href="/login"
-            className="text-xs text-slate-500 hover:text-slate-700 underline transition-colors"
+            prefetch={false}
+            className="inline-flex min-h-11 items-center rounded-md text-xs font-medium text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
           >
             {t("backToLogin")}
           </Link>
         </div>
-      </div>
-    </div>
+      </article>
+    </main>
   );
 }
 
@@ -69,17 +85,17 @@ export default function PrivacyPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen w-full items-center justify-center bg-slate-50">
-          <div className="w-full max-w-2xl rounded-3xl bg-white/80 p-10 animate-pulse space-y-6">
+        <div className="flex h-dvh w-full items-start justify-center overflow-y-auto bg-background px-4 py-6 sm:py-12">
+          <div className="w-full max-w-2xl animate-pulse space-y-6 rounded-xl border border-border/50 bg-card p-6 sm:p-10">
             <div className="flex flex-col items-center space-y-3">
-              <div className="w-16 h-16 rounded-xl bg-emerald-100" />
-              <div className="h-8 w-48 rounded bg-slate-200" />
-              <div className="h-4 w-56 rounded bg-slate-100" />
+              <div className="h-12 w-12 rounded-lg bg-muted" />
+              <div className="h-8 w-48 rounded bg-muted" />
+              <div className="h-4 w-56 rounded bg-muted" />
             </div>
-            {[...Array(6)].map((_, i) => (
+            {[...Array(8)].map((_, i) => (
               <div key={i} className="space-y-2">
-                <div className="h-4 w-32 rounded bg-slate-200" />
-                <div className="h-12 w-full rounded bg-slate-100" />
+                <div className="h-4 w-32 rounded bg-muted" />
+                <div className="h-12 w-full rounded bg-muted" />
               </div>
             ))}
           </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -37,8 +37,11 @@ async function PrivacyContent() {
     <main className="flex h-dvh w-full items-start justify-center overflow-x-hidden overflow-y-auto bg-background px-4 py-6 sm:py-12">
       <article className="w-full max-w-2xl space-y-7 rounded-xl border border-border/50 bg-card p-6 text-card-foreground shadow-sm sm:space-y-8 sm:p-10">
         <div className="flex flex-col space-y-3 text-center">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <ShieldCheck className="h-6 w-6" strokeWidth={2} />
+          <div
+            className="mx-auto flex h-16 w-16 items-center justify-center rounded-xl shadow-lg"
+            style={{ background: "linear-gradient(135deg, #34d399 0%, #065f46 100%)" }}
+          >
+            <ShieldCheck className="h-7 w-7 text-white" strokeWidth={2} />
           </div>
           <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
           <p className="text-sm font-medium text-muted-foreground">{t("subtitle")}</p>
@@ -88,7 +91,7 @@ export default function PrivacyPage() {
         <div className="flex h-dvh w-full items-start justify-center overflow-y-auto bg-background px-4 py-6 sm:py-12">
           <div className="w-full max-w-2xl animate-pulse space-y-6 rounded-xl border border-border/50 bg-card p-6 sm:p-10">
             <div className="flex flex-col items-center space-y-3">
-              <div className="h-12 w-12 rounded-lg bg-muted" />
+              <div className="h-16 w-16 rounded-xl bg-emerald-100" />
               <div className="h-8 w-48 rounded bg-muted" />
               <div className="h-4 w-56 rounded bg-muted" />
             </div>

--- a/src/components/layout/html-lang-sync.tsx
+++ b/src/components/layout/html-lang-sync.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLocale } from "next-intl";
+
+export function HtmlLangSync() {
+  const locale = useLocale();
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return null;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -78,8 +78,9 @@ export default auth((req) => {
 });
 
 // Negative-lookahead exclusions:
-//   - Next internals + cron + file-based metadata (already excluded before P1).
+//   - Next/Vercel internals + cron + file-based metadata (already excluded before P1).
 //   - robots.txt / sitemap.xml served from `public/`.
+//   - Public legal pages, so they can render without NextAuth cookie work.
 //   - Common bot/scanner probes observed in production logs and in the wild:
 //     wp-admin/wp-login/wp-content/wp-includes/wordpress, xmlrpc, cgi-bin,
 //     phpmyadmin/adminer, cmd_*, vendor/phpunit, plus any path containing
@@ -90,6 +91,6 @@ export default auth((req) => {
 // component carrying them is excluded.
 export const config = {
   matcher: [
-    "/((?!api/(?!auth)|_next/static|_next/image|favicon\\.ico|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
+    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Rework the public privacy page to use app design tokens and a scrollable legal-page layout
- Add privacy metadata, telemetry/contact disclosure copy, and an actionable support mailto link
- Harden public legal routes by excluding them and Vercel analytics assets from proxy auth/cookie handling
- Sync hydrated document language to the resolved next-intl locale and only mount Vercel insights on Vercel deployments

## Validation
- npm run check
- Production render smoke check: mobile/desktop scroll, no horizontal overflow, no console warnings/errors, mailto link and focus ring present