### PR TITLE
dashboard: distill chrome, align tokens, cut hero animations

### DIFF
--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
@@ -169,11 +169,9 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   };
 
   return (
-    <Card className="relative border-0 shadow-none bg-transparent">
-      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
-        <CardTitle className="text-lg font-semibold tracking-tight">
-          {t("accountsSummary.title")}
-        </CardTitle>
+    <section className="space-y-4">
+      <div className="flex flex-row flex-wrap items-center justify-between gap-2 px-1">
+        <h2 className="text-lg font-semibold tracking-tight">{t("accountsSummary.title")}</h2>
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-0.5">
           {sortOptions.map(({ field, label }) => (
             <button
@@ -191,11 +189,11 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
             </button>
           ))}
         </div>
-      </CardHeader>
-      <CardContent className={`${isCompact ? "space-y-2" : "space-y-6"} pt-4`}>
+      </div>
+      <div className={isCompact ? "space-y-2" : "space-y-6"}>
         {assets.length > 0 && renderGroup(assets, true)}
         {liabilities.length > 0 && renderGroup(liabilities, false)}
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -91,13 +91,13 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
   );
 
   return (
-    <Card className="border-0 bg-transparent shadow-none">
-      <CardHeader className="pb-1 px-2 sm:px-4">
+    <Card>
+      <CardHeader className="pb-1 px-4">
         <CardTitle className="text-base font-medium text-foreground">
           {t("allocationChart.title")}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-2 sm:px-4 pb-3">
+      <CardContent className="px-4 pb-3">
         {data.length === 0 ? (
           <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
             {t("allocationChart.noAssets")}

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -81,11 +81,11 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
   );
 
   return (
-    <Card className="border-0 bg-transparent shadow-none">
-      <CardHeader className="pb-1 px-2 sm:px-4">
+    <Card>
+      <CardHeader className="pb-1 px-4">
         <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
       </CardHeader>
-      <CardContent className="px-2 sm:px-4 pb-3">
+      <CardContent className="px-4 pb-3">
         {data.length === 0 ? (
           <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noExposure")}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -26,8 +26,6 @@ const fetchPreviousSnapshot = cache((userId: string) =>
   }),
 );
 
-const CARD_CLASS = "premium-card";
-
 /* ---------- Section skeleton helpers ---------- */
 
 function NetWorthSkeleton() {
@@ -50,16 +48,14 @@ function ChartsSkeleton() {
   return (
     <>
       {[...Array(2)].map((_, i) => (
-        <div key={i} className={CARD_CLASS}>
-          <Card className="border-0 shadow-none bg-transparent">
-            <CardHeader className="pb-2">
-              <div className="h-5 w-32 bg-muted animate-pulse rounded" />
-            </CardHeader>
-            <CardContent>
-              <div className="h-[250px] bg-muted animate-pulse rounded" />
-            </CardContent>
-          </Card>
-        </div>
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <div className="h-5 w-32 bg-muted animate-pulse rounded" />
+          </CardHeader>
+          <CardContent>
+            <div className="h-[250px] bg-muted animate-pulse rounded" />
+          </CardContent>
+        </Card>
       ))}
     </>
   );
@@ -67,19 +63,13 @@ function ChartsSkeleton() {
 
 function AccountsSummarySkeleton() {
   return (
-    <div className={CARD_CLASS}>
-      <Card className="border-0 shadow-none bg-transparent">
-        <CardHeader>
-          <div className="h-5 w-40 bg-muted animate-pulse rounded" />
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="h-10 bg-muted animate-pulse rounded" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+    <div className="space-y-3">
+      <div className="h-5 w-40 bg-muted animate-pulse rounded" />
+      <div className="space-y-3">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+        ))}
+      </div>
     </div>
   );
 }
@@ -152,12 +142,8 @@ async function ChartsSection({ userId, baseCurrency }: { userId: string; baseCur
 
   return (
     <>
-      <div className={CARD_CLASS}>
-        <LazyAllocationChart summary={summary} />
-      </div>
-      <div className={CARD_CLASS}>
-        <LazyCurrencyExposureChart summary={summary} />
-      </div>
+      <LazyAllocationChart summary={summary} />
+      <LazyCurrencyExposureChart summary={summary} />
     </>
   );
 }
@@ -190,13 +176,11 @@ async function GoalsMilestoneSection({
     withDeadline[0] ?? byProgress[0] ?? goalsWithProgress[0] ?? null;
 
   return (
-    <div className={CARD_CLASS}>
-      <GoalsMilestoneCard
-        featured={featured}
-        totalGoals={goalsWithProgress.length}
-        baseCurrency={baseCurrency}
-      />
-    </div>
+    <GoalsMilestoneCard
+      featured={featured}
+      totalGoals={goalsWithProgress.length}
+      baseCurrency={baseCurrency}
+    />
   );
 }
 
@@ -214,11 +198,7 @@ async function AccountsSummarySection({
   const summary = await getCachedNetWorthSummary(userId, baseCurrency);
   if (summary.accounts.length === 0) return null;
 
-  return (
-    <div className={CARD_CLASS}>
-      <AccountsSummary summary={summary} />
-    </div>
-  );
+  return <AccountsSummary summary={summary} />;
 }
 
 /* ---------- Orchestrator ---------- */
@@ -290,7 +270,7 @@ export async function DashboardContent({ userId }: { userId: string }) {
 
       {/* Charts grid — trend chart + allocation + currency exposure */}
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-6 items-stretch animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
-        <div className={`${CARD_CLASS} lg:col-span-2 xl:col-span-1`}>
+        <div className="lg:col-span-2 xl:col-span-1">
           <Suspense fallback={<div className="h-[350px] animate-pulse bg-muted rounded-lg" />}>
             <TrendChartSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,7 +1,5 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
-const CARD_CLASS = "premium-card";
-
 export function DashboardSkeleton() {
   return (
     <div className="space-y-4 md:space-y-8">
@@ -28,44 +26,34 @@ export function DashboardSkeleton() {
 
       {/* Charts — 1st = trend (taller, lg col-span-2 xl col-span-1), 2nd + 3rd = h-250 */}
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-6 items-stretch">
-        <div className={`${CARD_CLASS} lg:col-span-2 xl:col-span-1`}>
-          <Card className="border-0 shadow-none bg-transparent">
+        <Card className="lg:col-span-2 xl:col-span-1">
+          <CardHeader className="pb-2">
+            <div className="h-5 w-32 rounded skeleton-shimmer" />
+          </CardHeader>
+          <CardContent>
+            <div className="h-[350px] rounded skeleton-shimmer" />
+          </CardContent>
+        </Card>
+        {[0, 1].map((i) => (
+          <Card key={i}>
             <CardHeader className="pb-2">
               <div className="h-5 w-32 rounded skeleton-shimmer" />
             </CardHeader>
             <CardContent>
-              <div className="h-[350px] rounded skeleton-shimmer" />
+              <div className="h-[250px] rounded skeleton-shimmer" />
             </CardContent>
           </Card>
-        </div>
-        {[0, 1].map((i) => (
-          <div key={i} className={CARD_CLASS}>
-            <Card className="border-0 shadow-none bg-transparent">
-              <CardHeader className="pb-2">
-                <div className="h-5 w-32 rounded skeleton-shimmer" />
-              </CardHeader>
-              <CardContent>
-                <div className="h-[250px] rounded skeleton-shimmer" />
-              </CardContent>
-            </Card>
-          </div>
         ))}
       </div>
 
       {/* Accounts summary — matches AccountsSummarySkeleton */}
-      <div className={CARD_CLASS}>
-        <Card className="border-0 shadow-none bg-transparent">
-          <CardHeader>
-            <div className="h-5 w-40 rounded skeleton-shimmer" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {[...Array(4)].map((_, i) => (
-                <div key={i} className="h-10 rounded skeleton-shimmer" />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+      <div className="space-y-3">
+        <div className="h-5 w-40 rounded skeleton-shimmer" />
+        <div className="space-y-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-10 rounded skeleton-shimmer" />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/goals-milestone-card.tsx
+++ b/src/components/dashboard/goals-milestone-card.tsx
@@ -29,7 +29,7 @@ export function GoalsMilestoneCard({
   const progressClamped = featured ? Math.max(0, Math.min(100, featured.progressPercent)) : 0;
 
   return (
-    <Card className="border-0 shadow-none bg-transparent">
+    <Card>
       <CardHeader className="pb-2 flex flex-row items-center justify-between">
         <div className="flex items-center gap-2">
           <Target className="h-4 w-4 text-primary" />

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -25,8 +25,6 @@ export function NetWorthCard({
   const isCompact = density === "compact";
 
   const animatedNetWorth = useCountUp(netWorth, 600);
-  const animatedAssets = useCountUp(totalAssets, 500);
-  const animatedLiabilities = useCountUp(totalLiabilities, 500);
 
   const delta = previousNetWorth !== undefined ? netWorth - previousNetWorth : null;
   const pct =
@@ -105,7 +103,7 @@ export function NetWorthCard({
           </div>
           <div className="overflow-x-auto scrollbar-none">
             <p className="text-lg sm:text-2xl font-semibold text-primary mt-1 whitespace-nowrap tabular-nums">
-              {privacyMode ? HIDDEN : formatCurrency(animatedAssets, baseCurrency)}
+              {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency)}
             </p>
           </div>
         </CardContent>
@@ -124,7 +122,7 @@ export function NetWorthCard({
           </div>
           <div className="overflow-x-auto scrollbar-none">
             <p className="text-lg sm:text-2xl font-semibold text-destructive mt-1 whitespace-nowrap tabular-nums">
-              {privacyMode ? HIDDEN : formatCurrency(animatedLiabilities, baseCurrency)}
+              {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency)}
             </p>
           </div>
         </CardContent>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -200,16 +200,16 @@ export function TrendChart({
   }, [filtered]);
 
   return (
-    <Card className="relative border-0 bg-transparent shadow-none h-full flex flex-col pb-0">
-      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2 pb-2 px-2 sm:px-4">
+    <Card className="relative h-full flex flex-col pb-0">
+      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2 pb-2 px-4">
         <div className="flex flex-col gap-1 min-w-0">
           <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
           {periodChange && (
             <div
               className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold tabular-nums ${
                 periodChange.delta >= 0
-                  ? "bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400"
-                  : "bg-red-50 dark:bg-red-950/50 text-destructive"
+                  ? "bg-primary/10 text-primary"
+                  : "bg-destructive/10 text-destructive"
               }`}
             >
               {privacyMode ? (
@@ -261,7 +261,7 @@ export function TrendChart({
           </div>
         )}
       </CardHeader>
-      <CardContent className="px-2 sm:px-4 pb-0 flex-1 flex flex-col">
+      <CardContent className="px-4 pb-0 flex-1 flex flex-col">
         {filtered.length === 0 ? (
           <div className="flex-1 min-h-[200px] flex items-center justify-center text-muted-foreground text-sm">
             {t("noData")}

--- a/src/hooks/use-count-up.ts
+++ b/src/hooks/use-count-up.ts
@@ -1,13 +1,18 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useReducedMotion } from "framer-motion";
 
 export function useCountUp(end: number, duration: number = 1000) {
+  const shouldReduceMotion = useReducedMotion();
   const [count, setCount] = useState(0);
 
   useEffect(() => {
+    if (shouldReduceMotion) return;
+    let cancelled = false;
     let startTimestamp: number | null = null;
     const step = (timestamp: number) => {
+      if (cancelled) return;
       if (!startTimestamp) startTimestamp = timestamp;
       const progress = Math.min((timestamp - startTimestamp) / duration, 1);
       // easeOutCubic — decelerates the way iOS does
@@ -18,7 +23,10 @@ export function useCountUp(end: number, duration: number = 1000) {
       }
     };
     window.requestAnimationFrame(step);
-  }, [end, duration]);
+    return () => {
+      cancelled = true;
+    };
+  }, [end, duration, shouldReduceMotion]);
 
-  return count;
+  return shouldReduceMotion ? end : count;
 }


### PR DESCRIPTION
## Summary

Three-part impeccable pass on the dashboard tab.

- **Distill**: drop the `.premium-card` wrapper from five dashboard surfaces (trend chart, allocation, currency exposure, goals milestone, accounts summary). Inner Cards no longer render transparent inside a translucent + primary-radial wrapper, removing decoration-by-default and the universal hover-lift that shifted the trend chart out from under the crosshair. `AccountsSummary` swaps its fake-transparent outer Card for a plain `<section>` to eliminate a real card-in-card nesting.
- **Colorize**: trend-chart period change chip swapped from raw `bg-green-50`/`text-green-700` and `bg-red-50` to `bg-primary/10 text-primary` and `bg-destructive/10 text-destructive`, so the sepia and blue brand-mode tokens in `globals.css` recolor the chip correctly.
- **Optimize**: drop two of three `useCountUp` calls in the hero (Total Assets and Total Liabilities render their final values directly). The remaining hero animation honors `prefers-reduced-motion` via `useReducedMotion`, and the rAF loop now cancels on unmount/update.

`.premium-card` itself is left in place in `globals.css`; `/analysis` and `/projections` still consume it. A separate distill on those tabs is the next move.

## Test plan

- [ ] Dashboard renders with clean Card chrome on goals/trend/allocation/currency/accounts (no translucent wash, no hover-lift jitter on the trend chart)
- [ ] Accounts summary reads as a title + two inset-grouped lists, not as a card containing two cards
- [ ] Trend-chart period chip uses brand emerald on positive delta, destructive red on negative
- [ ] Switch to a non-default brand mode (sepia / blue) in settings; period chip recolors with the brand
- [ ] Hero Net Worth animates once on load; Total Assets and Total Liabilities are static from first paint
- [ ] With `prefers-reduced-motion: reduce`, no count-up animation on the hero
- [ ] Lint, typecheck, prettier all clean (`npm run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)