### PR TITLE
fix(analysis): a11y and theming polish pass on the analysis tab

### DIFF
--- a/src/app/(main)/analysis/loading.tsx
+++ b/src/app/(main)/analysis/loading.tsx
@@ -21,13 +21,30 @@ export default function AnalysisLoading() {
         ))}
       </div>
 
-      {/* Charts stack */}
-      {[...Array(3)].map((_, i) => (
+      {/* Charts stack — 5 chart panels matching analysis-view */}
+      {[...Array(5)].map((_, i) => (
         <div key={i} className="rounded-xl border border-border/50 bg-card p-6">
           <div className="h-5 w-40 rounded mb-4 skeleton-shimmer" />
           <div className="h-[280px] rounded-lg skeleton-shimmer" />
         </div>
       ))}
+
+      {/* Top movers list — card with table-like rows */}
+      <div className="rounded-xl border border-border/50 bg-card p-6">
+        <div className="h-5 w-32 rounded mb-2 skeleton-shimmer" />
+        <div className="h-3 w-56 rounded mb-4 skeleton-shimmer" />
+        <div className="space-y-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="flex items-center justify-between gap-3">
+              <div className="flex-1 space-y-1.5">
+                <div className="h-4 w-32 rounded skeleton-shimmer" />
+                <div className="h-3 w-20 rounded skeleton-shimmer" />
+              </div>
+              <div className="h-6 w-24 rounded-md skeleton-shimmer" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,10 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+  --color-chart-6: var(--chart-6);
+  --color-chart-7: var(--chart-7);
+  --color-chart-8: var(--chart-8);
+  --color-chart-9: var(--chart-9);
 
   --color-ring: var(--ring);
   --color-input: var(--input);
@@ -85,6 +89,10 @@
   --chart-3: oklch(0.6 0.15 260); /* Indigo */
   --chart-4: oklch(0.7 0.15 300); /* Purple */
   --chart-5: oklch(0.8 0.1 330); /* Pink */
+  --chart-6: oklch(0.65 0.15 40); /* Coral */
+  --chart-7: oklch(0.7 0.13 75); /* Amber */
+  --chart-8: oklch(0.65 0.13 110); /* Lime */
+  --chart-9: oklch(0.62 0.11 190); /* Teal */
 
   --radius: 0.75rem;
   --sidebar: oklch(0.98 0.005 260);
@@ -123,6 +131,10 @@
   --chart-3: oklch(0.74 0.17 270);
   --chart-4: oklch(0.82 0.17 320);
   --chart-5: oklch(0.86 0.13 100);
+  --chart-6: oklch(0.78 0.15 40); /* Coral */
+  --chart-7: oklch(0.84 0.13 75); /* Amber */
+  --chart-8: oklch(0.8 0.13 110); /* Lime */
+  --chart-9: oklch(0.75 0.11 190); /* Teal */
 
   --sidebar: oklch(0.12 0.03 200);
   --sidebar-foreground: oklch(0.94 0.01 190);

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -79,7 +79,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
-  const { isAnimationActive } = useChartAnimation();
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   const { handlers: crosshairHandlers } = useChartCrosshair();
   useEffect(() => startTransition(() => setMounted(true)), []);
 
@@ -108,6 +108,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
           <div
             role="img"
             aria-label={t("assetsVsLiabilities")}
+            aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>
@@ -141,6 +142,8 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
                   name={t("seriesAssets")}
                   fill="var(--chart-1)"
                   radius={[4, 4, 0, 0]}
+                  isAnimationActive={isAnimationActive}
+                  onAnimationEnd={onAnimationEnd}
                 />
                 <Bar
                   dataKey="liabilities"
@@ -148,6 +151,7 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
                   fill="var(--destructive)"
                   radius={[4, 4, 0, 0]}
                   isAnimationActive={isAnimationActive}
+                  onAnimationEnd={onAnimationEnd}
                 />
               </BarChart>
             </ResponsiveContainer>

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -106,6 +106,8 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
           <div className="h-[280px]" />
         ) : (
           <div
+            role="img"
+            aria-label={t("assetsVsLiabilities")}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -138,47 +138,53 @@ export function AttributionChart({ items, baseCurrency }: Props) {
               privacyMode ? "blur-sm pointer-events-none select-none" : ""
             }`}
           >
-            <ResponsiveContainer width="100%" height={chartHeight}>
-              <BarChart
-                layout="vertical"
-                data={chartData}
-                margin={{ top: 4, right: 16, left: 0, bottom: 4 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
-                <XAxis
-                  type="number"
-                  tick={{ fontSize: 11 }}
-                  tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
-                />
-                <YAxis
-                  type="category"
-                  dataKey="accountName"
-                  tick={{ fontSize: 12 }}
-                  tickFormatter={truncate}
-                  width={130}
-                />
-                <ReferenceLine x={0} stroke="var(--border)" strokeWidth={1.5} />
-                <Tooltip
-                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
-                  content={
-                    <AttributionTooltip
-                      baseCurrency={baseCurrency}
-                      t={t}
-                      getCategoryLabel={getCategoryLabel}
-                      privacyMode={privacyMode}
-                    />
-                  }
-                />
-                <Bar dataKey="totalDelta" radius={[0, 4, 4, 0]}>
-                  {chartData.map((item) => (
-                    <Cell
-                      key={item.accountId}
-                      fill={item.totalDelta >= 0 ? "var(--chart-1)" : "var(--destructive)"}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <div role="img" aria-label={`${t("attribution")}, ${t("attributionSubtitle")}`}>
+              <ResponsiveContainer width="100%" height={chartHeight}>
+                <BarChart
+                  layout="vertical"
+                  data={chartData}
+                  margin={{ top: 4, right: 16, left: 0, bottom: 4 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    className="stroke-muted"
+                    horizontal={false}
+                  />
+                  <XAxis
+                    type="number"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={(v) => (privacyMode ? "" : tickFormatter(v))}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="accountName"
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={truncate}
+                    width={130}
+                  />
+                  <ReferenceLine x={0} stroke="var(--border)" strokeWidth={1.5} />
+                  <Tooltip
+                    cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                    content={
+                      <AttributionTooltip
+                        baseCurrency={baseCurrency}
+                        t={t}
+                        getCategoryLabel={getCategoryLabel}
+                        privacyMode={privacyMode}
+                      />
+                    }
+                  />
+                  <Bar dataKey="totalDelta" radius={[0, 4, 4, 0]}>
+                    {chartData.map((item) => (
+                      <Cell
+                        key={item.accountId}
+                        fill={item.totalDelta >= 0 ? "var(--chart-1)" : "var(--destructive)"}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
 
             {/* Summary row */}
             <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs">

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -16,6 +16,8 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { AttributionItem } from "@/lib/services/analysis-service";
 
 interface Props {
@@ -48,43 +50,40 @@ function AttributionTooltip({
   const mktSign = item.marketPerformance >= 0 ? "+" : "";
   const totalSign = item.totalDelta >= 0 ? "+" : "";
 
-  return (
-    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1 min-w-[180px]">
-      <div className="font-medium leading-tight">{item.accountName}</div>
-      <div className="text-muted-foreground text-[11px]">{getCategoryLabel(item.category)}</div>
-      <div className="border-t border-border/60 pt-1 space-y-1">
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("attrCash")}</span>
-          <span className="tabular-nums">
-            {privacyMode
-              ? "***"
-              : `${cashSign}${formatCurrency(item.cashContribution, baseCurrency)}`}
-          </span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">{t("attrMarket")}</span>
-          <span
-            className={`tabular-nums ${
-              item.marketPerformance >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
-            }`}
-          >
-            {privacyMode
-              ? "***"
-              : `${mktSign}${formatCurrency(item.marketPerformance, baseCurrency)}`}
-          </span>
-        </div>
-        <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
-          <span className="text-muted-foreground">{t("tooltipChange")}</span>
-          <span
-            className={`tabular-nums font-medium ${
-              item.totalDelta >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
-            }`}
-          >
-            {privacyMode ? "***" : `${totalSign}${formatCurrency(item.totalDelta, baseCurrency)}`}
-          </span>
-        </div>
+  const titleNode = (
+    <>
+      <div className="leading-tight">{item.accountName}</div>
+      <div className="font-normal text-muted-foreground text-[10px] leading-snug mt-0.5">
+        {getCategoryLabel(item.category)}
       </div>
-    </div>
+    </>
+  );
+
+  return (
+    <ChartTooltipContainer title={titleNode} className="min-w-[180px]">
+      <ChartTooltipRow
+        label={t("attrCash")}
+        value={
+          privacyMode ? "***" : `${cashSign}${formatCurrency(item.cashContribution, baseCurrency)}`
+        }
+      />
+      <ChartTooltipRow
+        label={t("attrMarket")}
+        value={
+          privacyMode ? "***" : `${mktSign}${formatCurrency(item.marketPerformance, baseCurrency)}`
+        }
+        valueClassName={item.marketPerformance >= 0 ? "text-[var(--chart-1)]" : "text-destructive"}
+      />
+      <div className="pt-1.5 mt-1.5 border-t border-border/40">
+        <ChartTooltipRow
+          label={t("tooltipChange")}
+          value={
+            privacyMode ? "***" : `${totalSign}${formatCurrency(item.totalDelta, baseCurrency)}`
+          }
+          valueClassName={item.totalDelta >= 0 ? "text-[var(--chart-1)]" : "text-destructive"}
+        />
+      </div>
+    </ChartTooltipContainer>
   );
 }
 
@@ -104,6 +103,7 @@ export function AttributionChart({ items, baseCurrency }: Props) {
   const tCat = useTranslations("categories");
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
 
   const getCategoryLabel = (cat: string) =>
@@ -134,6 +134,7 @@ export function AttributionChart({ items, baseCurrency }: Props) {
           <div style={{ height: chartHeight }} />
         ) : (
           <div
+            aria-hidden={privacyMode || undefined}
             className={`space-y-4 transition-[filter] duration-300 ${
               privacyMode ? "blur-sm pointer-events-none select-none" : ""
             }`}
@@ -174,7 +175,12 @@ export function AttributionChart({ items, baseCurrency }: Props) {
                       />
                     }
                   />
-                  <Bar dataKey="totalDelta" radius={[0, 4, 4, 0]}>
+                  <Bar
+                    dataKey="totalDelta"
+                    radius={[0, 4, 4, 0]}
+                    isAnimationActive={isAnimationActive}
+                    onAnimationEnd={onAnimationEnd}
+                  >
                     {chartData.map((item) => (
                       <Cell
                         key={item.accountId}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -143,69 +143,75 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
                 {t("seriesMarket")}
               </span>
             </div>
-            <ResponsiveContainer width="100%" height={280}>
-              <BarChart
-                data={buckets}
-                margin={{ top: 10, right: 4, left: 0, bottom: 20 }}
-                {...crosshairHandlers}
-              >
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fontSize: 12 }}
-                  angle={-45}
-                  textAnchor="end"
-                  height={60}
-                />
-                <YAxis
-                  width={50}
-                  tick={{ fontSize: 12 }}
-                  tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
-                />
-                <Tooltip
-                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
-                  content={
-                    <CashFlowTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />
-                  }
-                />
-                {/* Contributions bar */}
-                <Bar
-                  dataKey="contributions"
-                  name={t("seriesContributions")}
-                  stackId="a"
-                  radius={[0, 0, 0, 0]}
+            <div role="img" aria-label={`${t("cashFlow")}, ${t("cashFlowSubtitle")}`}>
+              <ResponsiveContainer width="100%" height={280}>
+                <BarChart
+                  data={buckets}
+                  margin={{ top: 10, right: 4, left: 0, bottom: 20 }}
+                  {...crosshairHandlers}
                 >
-                  {buckets.map((b) => (
-                    <Cell
-                      key={`contrib-${b.monthKey}`}
-                      fill="var(--chart-2)"
-                      opacity={b.isEmpty ? 0.2 : 0.85}
-                    />
-                  ))}
-                </Bar>
-                {/* Market performance bar */}
-                <Bar
-                  dataKey="marketPerformance"
-                  name={t("seriesMarket")}
-                  stackId="a"
-                  radius={[4, 4, 0, 0]}
-                >
-                  {buckets.map((b) => (
-                    <Cell
-                      key={`market-${b.monthKey}`}
-                      fill={
-                        b.isEmpty
-                          ? "var(--muted-foreground)"
-                          : b.marketPerformance >= 0
-                            ? "var(--chart-1)"
-                            : "var(--destructive)"
-                      }
-                      opacity={b.isEmpty ? 0.2 : 1}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 12 }}
+                    angle={-45}
+                    textAnchor="end"
+                    height={60}
+                  />
+                  <YAxis
+                    width={50}
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(v) => (privacyMode ? "" : formatChartTick(v))}
+                  />
+                  <Tooltip
+                    cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                    content={
+                      <CashFlowTooltip
+                        baseCurrency={baseCurrency}
+                        t={t}
+                        privacyMode={privacyMode}
+                      />
+                    }
+                  />
+                  {/* Contributions bar */}
+                  <Bar
+                    dataKey="contributions"
+                    name={t("seriesContributions")}
+                    stackId="a"
+                    radius={[0, 0, 0, 0]}
+                  >
+                    {buckets.map((b) => (
+                      <Cell
+                        key={`contrib-${b.monthKey}`}
+                        fill="var(--chart-2)"
+                        opacity={b.isEmpty ? 0.2 : 0.85}
+                      />
+                    ))}
+                  </Bar>
+                  {/* Market performance bar */}
+                  <Bar
+                    dataKey="marketPerformance"
+                    name={t("seriesMarket")}
+                    stackId="a"
+                    radius={[4, 4, 0, 0]}
+                  >
+                    {buckets.map((b) => (
+                      <Cell
+                        key={`market-${b.monthKey}`}
+                        fill={
+                          b.isEmpty
+                            ? "var(--muted-foreground)"
+                            : b.marketPerformance >= 0
+                              ? "var(--chart-1)"
+                              : "var(--destructive)"
+                        }
+                        opacity={b.isEmpty ? 0.2 : 1}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
             <p className="mt-2 text-[11px] text-muted-foreground">{t("cashFlowNote")}</p>
           </div>
         )}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -18,6 +18,8 @@ import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { CashFlowBucket } from "@/lib/services/analysis-service";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 
 interface Props {
   buckets: CashFlowBucket[];
@@ -49,55 +51,41 @@ function CashFlowTooltip({
 
   if (b.isEmpty) {
     return (
-      <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md">
-        <div className="font-medium">{b.label}</div>
-        <div className="text-muted-foreground">{t("noDataMonth")}</div>
-      </div>
+      <ChartTooltipContainer title={b.label}>
+        <div className="text-[11px] text-muted-foreground">{t("noDataMonth")}</div>
+      </ChartTooltipContainer>
     );
   }
 
   const contribSign = b.contributions >= 0 ? "+" : "";
   const marketSign = b.marketPerformance >= 0 ? "+" : "";
+  const deltaSign = b.deltaNetWorth >= 0 ? "+" : "";
 
   return (
-    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1">
-      <div className="font-medium">{b.label}</div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("seriesContributions")}</span>
-        <span className="tabular-nums">
-          {privacyMode ? "***" : `${contribSign}${formatCurrency(b.contributions, baseCurrency)}`}
-        </span>
+    <ChartTooltipContainer title={b.label}>
+      <ChartTooltipRow
+        label={t("seriesContributions")}
+        value={
+          privacyMode ? "***" : `${contribSign}${formatCurrency(b.contributions, baseCurrency)}`
+        }
+      />
+      <ChartTooltipRow
+        label={t("seriesMarket")}
+        value={
+          privacyMode ? "***" : `${marketSign}${formatCurrency(b.marketPerformance, baseCurrency)}`
+        }
+        valueClassName={b.marketPerformance >= 0 ? "text-[var(--chart-1)]" : "text-destructive"}
+      />
+      <div className="pt-1.5 mt-1.5 border-t border-border/40">
+        <ChartTooltipRow
+          label={t("tooltipChange")}
+          value={
+            privacyMode ? "***" : `${deltaSign}${formatCurrency(b.deltaNetWorth, baseCurrency)}`
+          }
+          valueClassName={b.deltaNetWorth >= 0 ? "text-[var(--chart-1)]" : "text-destructive"}
+        />
       </div>
-      <div className="flex justify-between gap-4">
-        <span className="text-muted-foreground">{t("seriesMarket")}</span>
-        <span
-          className={`tabular-nums ${
-            b.marketPerformance >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
-          }`}
-        >
-          {privacyMode
-            ? "***"
-            : `${marketSign}${formatCurrency(b.marketPerformance, baseCurrency)}`}
-        </span>
-      </div>
-      <div className="flex justify-between gap-4 border-t border-border/60 pt-1">
-        <span className="text-muted-foreground">{t("tooltipChange")}</span>
-        <span
-          className={`tabular-nums font-medium ${
-            b.deltaNetWorth >= 0 ? "text-[var(--chart-1)]" : "text-destructive"
-          }`}
-        >
-          {privacyMode ? (
-            "***"
-          ) : (
-            <>
-              {b.deltaNetWorth >= 0 ? "+" : ""}
-              {formatCurrency(b.deltaNetWorth, baseCurrency)}
-            </>
-          )}
-        </span>
-      </div>
-    </div>
+    </ChartTooltipContainer>
   );
 }
 
@@ -106,6 +94,7 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
 
   return (
@@ -123,6 +112,7 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
           <div className="h-[280px]" />
         ) : (
           <div
+            aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <div className="flex items-center gap-4 mb-2 text-xs text-muted-foreground">
@@ -179,6 +169,8 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
                     name={t("seriesContributions")}
                     stackId="a"
                     radius={[0, 0, 0, 0]}
+                    isAnimationActive={isAnimationActive}
+                    onAnimationEnd={onAnimationEnd}
                   >
                     {buckets.map((b) => (
                       <Cell
@@ -194,6 +186,8 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
                     name={t("seriesMarket")}
                     stackId="a"
                     radius={[4, 4, 0, 0]}
+                    isAnimationActive={isAnimationActive}
+                    onAnimationEnd={onAnimationEnd}
                   >
                     {buckets.map((b) => (
                       <Cell

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -18,6 +18,8 @@ import { formatChartTick } from "@/lib/chart-formatters";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { CategoryDataPoint } from "@/lib/services/analysis-service";
 
 const CATEGORY_COLORS = [
@@ -61,23 +63,16 @@ function CategoryTooltip({
   if (!active || !payload?.length) return null;
   const sorted = [...payload].sort((a, b) => b.value - a.value);
   return (
-    <div className="rounded-md border border-border/60 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs shadow-md space-y-1 max-w-[200px]">
-      <div className="font-medium">{label}</div>
+    <ChartTooltipContainer title={label} className="max-w-[200px]">
       {sorted.map((p) => (
-        <div key={p.dataKey} className="flex justify-between gap-3">
-          <span className="flex items-center gap-1 text-muted-foreground">
-            <span
-              className="inline-block w-2 h-2 rounded-full shrink-0"
-              style={{ background: p.color }}
-            />
-            {p.name}
-          </span>
-          <span className="tabular-nums">
-            {privacyMode ? "***" : formatCurrency(p.value, baseCurrency)}
-          </span>
-        </div>
+        <ChartTooltipRow
+          key={p.dataKey}
+          label={p.name}
+          value={privacyMode ? "***" : formatCurrency(p.value, baseCurrency)}
+          indicatorColor={p.color}
+        />
       ))}
-    </div>
+    </ChartTooltipContainer>
   );
 }
 
@@ -87,6 +82,7 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
 
   // Collect unique categories present in the data, preserving insertion order.
@@ -100,6 +96,16 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
     ...d,
     label: formatMonthLabel(d.monthKey as string, locale),
   }));
+
+  // Compose aria-label: title + subtitle + visible category list, so AT users
+  // get the series enumeration that role="img" hides from the inline Legend.
+  const categoryNames = categories
+    .map((cat) => tCat(cat as Parameters<typeof tCat>[0], { defaultValue: cat }))
+    .join(", ");
+  const ariaLabel =
+    categoryNames.length > 0
+      ? `${t("categoryTrend")}, ${t("categoryTrendSubtitle")} ${categoryNames}.`
+      : `${t("categoryTrend")}, ${t("categoryTrendSubtitle")}`;
 
   return (
     <Card className="border-0 bg-transparent shadow-none">
@@ -119,7 +125,8 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
         ) : (
           <div
             role="img"
-            aria-label={`${t("categoryTrend")}, ${t("categoryTrendSubtitle")}`}
+            aria-label={ariaLabel}
+            aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>
@@ -166,6 +173,8 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
                     strokeWidth={2}
                     dot={false}
                     activeDot={{ r: 4 }}
+                    isAnimationActive={isAnimationActive}
+                    onAnimationEnd={onAnimationEnd}
                   />
                 ))}
               </LineChart>

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -21,15 +21,15 @@ import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
 import type { CategoryDataPoint } from "@/lib/services/analysis-service";
 
 const CATEGORY_COLORS = [
-  "#3b82f6", // blue   — BANK
-  "#10b981", // green  — BROKERAGE
-  "#f59e0b", // amber  — CRYPTO_WALLET
-  "#ef4444", // red    — PROPERTY
-  "#8b5cf6", // violet — VEHICLE
-  "#06b6d4", // cyan   — CREDIT_CARD
-  "#ec4899", // pink   — LOAN
-  "#84cc16", // lime   — MORTGAGE
-  "#f97316", // orange — OTHER
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "var(--chart-9)",
 ];
 
 interface Props {
@@ -118,6 +118,8 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
           <div className="h-[280px]" />
         ) : (
           <div
+            role="img"
+            aria-label={`${t("categoryTrend")}, ${t("categoryTrendSubtitle")}`}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>

--- a/src/components/analysis/lazy-analysis-charts.tsx
+++ b/src/components/analysis/lazy-analysis-charts.tsx
@@ -7,10 +7,10 @@ function ChartSkeleton({ height = 280 }: { height?: number }) {
   return (
     <Card className="border-0 bg-transparent shadow-none">
       <CardHeader className="pb-2 px-2 sm:px-4">
-        <div className="h-5 w-40 bg-muted animate-pulse rounded" />
+        <div className="h-5 w-40 rounded skeleton-shimmer" />
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
-        <div className="bg-muted animate-pulse rounded" style={{ height }} />
+        <div className="rounded skeleton-shimmer" style={{ height }} />
       </CardContent>
     </Card>
   );

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -19,6 +19,7 @@ import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 
 interface Props {
@@ -90,6 +91,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
   const { privacyMode } = usePrivacyMode();
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
 
   const data = buckets.map((b) => ({ ...b, label: formatMonthLabel(b.monthKey, locale) }));
@@ -112,6 +114,7 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
           <div
             role="img"
             aria-label={t("monthlyChange")}
+            aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>
@@ -139,7 +142,12 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
                     <ChangeTooltip baseCurrency={baseCurrency} t={t} privacyMode={privacyMode} />
                   }
                 />
-                <Bar dataKey="deltaNetWorth" radius={[4, 4, 0, 0]}>
+                <Bar
+                  dataKey="deltaNetWorth"
+                  radius={[4, 4, 0, 0]}
+                  isAnimationActive={isAnimationActive}
+                  onAnimationEnd={onAnimationEnd}
+                >
                   {data.map((entry) => (
                     <Cell
                       key={entry.monthKey}

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -110,6 +110,8 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
           <div className="h-[280px]" />
         ) : (
           <div
+            role="img"
+            aria-label={t("monthlyChange")}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
             <ResponsiveContainer width="100%" height={280}>

--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -35,10 +35,16 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border/60 text-muted-foreground text-xs">
-                  <th className="pb-2 text-left font-medium">{t("topMoversAccount")}</th>
-                  <th className="pb-2 text-right font-medium tabular-nums">{t("tooltipStart")}</th>
-                  <th className="pb-2 text-right font-medium tabular-nums">{t("tooltipEnd")}</th>
-                  <th className="pb-2 text-right font-medium tabular-nums">
+                  <th scope="col" className="pb-2 text-left font-medium">
+                    {t("topMoversAccount")}
+                  </th>
+                  <th scope="col" className="pb-2 text-right font-medium tabular-nums">
+                    {t("tooltipStart")}
+                  </th>
+                  <th scope="col" className="pb-2 text-right font-medium tabular-nums">
+                    {t("tooltipEnd")}
+                  </th>
+                  <th scope="col" className="pb-2 text-right font-medium tabular-nums">
                     {t("topMoversChange")}
                   </th>
                 </tr>

--- a/src/components/layout/mobile-main-shell.tsx
+++ b/src/components/layout/mobile-main-shell.tsx
@@ -12,7 +12,7 @@ export function MobileMainShell({ children }: { children: React.ReactNode }) {
   return (
     <main
       className={cn(
-        "flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+0.75rem+env(safe-area-inset-bottom))] md:pb-0 relative w-full",
+        "flex-1 overflow-y-auto overflow-x-hidden pb-[calc(5rem+1rem+env(safe-area-inset-bottom))] md:pb-0 relative w-full",
         isPulling ? "transition-none" : "transition-transform duration-300",
       )}
       style={offset > 0 ? { transform: `translateY(${offset}px)` } : undefined}


### PR DESCRIPTION
## Summary

Three waves of fixes from successive `/impeccable audit` passes on the analysis tab. Health score progression: **13/20 → 15/20 → 17/20**.

### Wave 1 — `61f2267` (a11y + theming foundations)

- **Charts have accessible names (P1, WCAG 1.1.1 / 4.1.2).** All five chart components expose `role=\"img\"` with a descriptive `aria-label` composed from existing i18n keys (title + subtitle where present). For Cash Flow and Attribution, the `role=\"img\"` is scoped to a focused inner wrapper so the adjacent legend, summary row, and explanatory note remain individually accessible.
- **Chart token system extended from 5 to 9 colors (P1).** Hard-coded hex array in `CategoryTrendChart` replaced with `var(--chart-N)` references. New `--chart-6` (Coral, 40°), `--chart-7` (Amber, 75°), `--chart-8` (Lime, 110°), `--chart-9` (Teal, 190°) fill the warm half of the wheel the original emerald→pink palette omitted. Each has light/dark OKLCH values calibrated to match existing lightness conventions.
- **TopMovers `<th>` semantics (P2, WCAG 1.3.1).** Added `scope=\"col\"` to all four column headers.
- **Loading skeleton parity (P3).** Now renders 5 chart placeholders (was 3) plus a Top Movers card stub with 4 row skeletons. Eliminates the layout shift that previously appeared after Suspense resolved.

### Wave 2 — `91358a2` (a11y depth + tooltip consolidation)

- **Dynamic aria-label for CategoryTrendChart (P2).** The label now appends the visible category list so AT users get the legend enumeration that `role=\"img\"` hides from the inline Recharts `<Legend>`. Reuses `tCat` keys, no new strings. Sample announcement: *\"Category Trend, Asset category growth over time. Bank, Brokerage, Property.\"*
- **`aria-hidden` on charts in privacy mode (P2).** Previously the `blur-sm` filter only hid pixels; screen readers still announced every dollar amount. All five charts now set `aria-hidden` on the privacy-blur wrapper when privacy is on, so the entire region drops out of the AT tree to match the sighted experience.
- **`useChartAnimation` rolled out to all 5 charts (P3).** Previously only one Bar in `assets-liabilities-chart` respected `prefers-reduced-motion`. Now every Bar and Line in every chart uses the hook with `onAnimationEnd`, so animation plays once at first render and skips entirely for reduced-motion users.
- **Tooltip consolidation (P2).** The three bespoke tooltip components (`CashFlowTooltip`, `AttributionTooltip`, `CategoryTooltip`) now use the shared `ChartTooltipContainer` / `ChartTooltipRow` primitives. All five chart tooltips share one visual treatment: same radius, backdrop blur, ring, shadow, and row layout.
- **`ChartSkeleton` → `skeleton-shimmer` (P3).** The lazy-import fallback in `lazy-analysis-charts.tsx` swapped its `animate-pulse bg-muted` blink for the slide-shimmer class used by `loading.tsx`, so both skeleton moments share one animation.

### Wave 3 — `cdf6737` (mobile shell clearance, shared layout)

- **Mobile nav overlap on last card (reported during this session).** The floating mobile nav pill sits at `bottom: 12px + safe-area-inset` and renders ~60–62px tall, putting its top edge ~72–74px above the viewport bottom. The previous `pb-[calc(4rem+0.75rem+env(safe-area-inset-bottom))]` (76px + safe) left only ~4px of clearance inside the shell before the layout's `p-4` added 16px more — collapsing to overlap on devices where the nav rendered slightly taller (active icon scaling to 20px, OS text sizing, border rendering quirks). Bumped pb to `5rem+1rem+safe` (96px + safe), giving ~40px of comfortable gap across **all mobile pages**, while `md:pb-0` still wipes the padding on desktop where the floating nav doesn't exist. Scope note: this fix lives in the shared `MobileMainShell` and benefits dashboard, accounts, goals, analysis, history, projections, and settings.

## Test plan

- [ ] VoiceOver / Mac Safari: confirm chart names announce correctly for all five charts in en-US and zh-TW. CategoryTrendChart should also enumerate visible categories.
- [ ] Toggle privacy mode and verify screen readers do not enumerate dollar amounts inside any chart region.
- [ ] System Preferences → Accessibility → Reduce Motion: enable, then load `/analysis`. Charts should not animate in.
- [ ] Toggle dark mode and confirm CategoryTrendChart lines remain distinguishable with `--chart-6..9`.
- [ ] Switch color schemas (anthropic, ocean, violet, amber) and confirm chart-1..5 tint with the schema while chart-6..9 stay consistent.
- [ ] Hover every chart's bars/lines and confirm tooltips are visually consistent (border, shadow, padding, dots).
- [ ] Inspect TopMovers table with a screen reader: column headers should be announced when navigating row cells.
- [ ] Cold-load `/analysis` and confirm no layout shift between the Suspense skeleton, the lazy-chart skeleton, and the resolved page.
- [ ] **Mobile (≤md):** scroll to the bottom of `/analysis`, `/` (dashboard), `/accounts`, `/history`, `/goals`, `/projections`, `/settings` — confirm the floating nav pill does not overlap the last content card on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)