### PR TITLE
feat(goals): Goals & milestones tab

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -131,10 +131,12 @@
     "ofTarget": "of {target}",
     "completed": "Completed",
     "confirmDelete": "Delete this goal?",
-    "dueIn": "{date} ({days} days)",
+    "deleteConfirmDescription": "This action cannot be undone.",
+    "deleteButton": "Delete",
+    "dueIn": "{date} ({days, plural, one {# day} other {# days}})",
     "overdue": "Overdue · {date}",
-    "projectedLinear": "Linear: {date}",
-    "projectedCAGR": "CAGR: {date}",
+    "projectedLinear": "At current pace: {date}",
+    "projectedCAGR": "At growth rate: {date}",
     "scope": {
       "NET_WORTH": "Net Worth",
       "ASSETS_ONLY": "Assets Only",
@@ -165,6 +167,10 @@
       "updated": "Goal updated",
       "deleted": "Goal deleted",
       "failed": "Something went wrong"
+    },
+    "aria": {
+      "editGoal": "Edit {name}",
+      "deleteGoal": "Delete {name}"
     }
   },
   "goalsMilestone": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -131,10 +131,12 @@
     "ofTarget": "/ {target}",
     "completed": "已達成",
     "confirmDelete": "確定刪除此目標？",
+    "deleteConfirmDescription": "此操作無法復原。",
+    "deleteButton": "刪除",
     "dueIn": "{date}（{days} 天後）",
     "overdue": "已逾期 · {date}",
-    "projectedLinear": "線性預測：{date}",
-    "projectedCAGR": "CAGR 預測：{date}",
+    "projectedLinear": "按當前進度：{date}",
+    "projectedCAGR": "複利預測：{date}",
     "scope": {
       "NET_WORTH": "淨資產",
       "ASSETS_ONLY": "總資產",
@@ -165,6 +167,10 @@
       "updated": "目標已更新",
       "deleted": "目標已刪除",
       "failed": "發生錯誤"
+    },
+    "aria": {
+      "editGoal": "編輯{name}",
+      "deleteGoal": "刪除{name}"
     }
   },
   "goalsMilestone": {

--- a/src/components/dashboard/goals-milestone-card.tsx
+++ b/src/components/dashboard/goals-milestone-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { Target, ArrowRight, CheckCircle2 } from "lucide-react";
@@ -22,6 +22,7 @@ export function GoalsMilestoneCard({
   baseCurrency,
 }: GoalsMilestoneCardProps) {
   const t = useTranslations("goalsMilestone");
+  const locale = useLocale();
   const { privacyMode } = usePrivacyMode();
 
   if (totalGoals === 0) return null;
@@ -58,7 +59,14 @@ export function GoalsMilestoneCard({
             </div>
 
             {/* Progress bar */}
-            <div className="h-2 w-full rounded-full bg-muted/60 overflow-hidden">
+            <div
+              role="progressbar"
+              aria-valuenow={progressClamped}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={featured.goal.name}
+              className="h-2 w-full rounded-full bg-muted/60 overflow-hidden"
+            >
               <div
                 className="h-full rounded-full bg-primary/80 transition-all motion-normal"
                 style={{ width: `${progressClamped}%` }}
@@ -77,7 +85,7 @@ export function GoalsMilestoneCard({
             {featured.goal.targetDate && (
               <p className="text-xs text-muted-foreground">
                 {t("due", {
-                  date: new Intl.DateTimeFormat("en-US", {
+                  date: new Intl.DateTimeFormat(locale, {
                     year: "numeric",
                     month: "short",
                     day: "numeric",

--- a/src/components/goals/goal-card.tsx
+++ b/src/components/goals/goal-card.tsx
@@ -2,15 +2,25 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { formatCurrency } from "@/lib/currencies";
 import { Pencil, Trash2, Target, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import type { GoalWithProgress, SerializedAccount, SerializedGoal } from "@/lib/types";
 import { GoalFormDialog } from "./goal-form-dialog";
+
+const HIDDEN = "***";
 
 interface GoalCardProps {
   data: GoalWithProgress;
@@ -41,11 +51,13 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
     isCompleted,
   } = data;
   const t = useTranslations("goals");
+  const locale = useLocale();
   const router = useRouter();
+  const { privacyMode } = usePrivacyMode();
   const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  const locale = typeof navigator !== "undefined" ? navigator.language : "en-US";
   const progressClamped = Math.max(0, Math.min(100, progressPercent));
 
   const scopeLabel = t(`scope.${goal.scope}`);
@@ -61,9 +73,9 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
 
   const targetDateDays = goal.targetDate ? daysFromNow(goal.targetDate) : null;
 
-  async function handleDelete() {
-    if (!confirm(t("confirmDelete"))) return;
+  async function handleDeleteConfirm() {
     setDeleting(true);
+    setConfirmOpen(false);
     try {
       const res = await fetch(`/api/goals/${goal.id}`, { method: "DELETE" });
       if (!res.ok) throw new Error("Failed");
@@ -89,9 +101,9 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
                 className={`h-9 w-9 rounded-full flex items-center justify-center shrink-0 ${isCompleted ? "bg-primary/20 text-primary" : "bg-muted text-muted-foreground"}`}
               >
                 {isCompleted ? (
-                  <CheckCircle2 className="h-5 w-5" />
+                  <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
                 ) : (
-                  <Target className="h-5 w-5" />
+                  <Target className="h-5 w-5" aria-hidden="true" />
                 )}
               </div>
               <div className="min-w-0">
@@ -106,19 +118,21 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 px-2 text-muted-foreground hover:text-foreground"
+                className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground"
+                aria-label={t("aria.editGoal", { name: goal.name })}
                 onClick={() => setEditOpen(true)}
               >
-                <Pencil className="h-3.5 w-3.5" />
+                <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 px-2 text-muted-foreground hover:text-destructive"
-                onClick={handleDelete}
+                className="h-9 w-9 p-0 text-muted-foreground hover:text-destructive"
+                aria-label={t("aria.deleteGoal", { name: goal.name })}
+                onClick={() => setConfirmOpen(true)}
                 disabled={deleting}
               >
-                <Trash2 className="h-3.5 w-3.5" />
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
               </Button>
             </div>
           </div>
@@ -126,10 +140,17 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
           {/* Progress bar */}
           <div className="space-y-1.5">
             <div className="flex justify-between items-baseline text-xs text-muted-foreground">
-              <span>{formatCurrency(currentAmount, baseCurrency)}</span>
+              <span>{privacyMode ? HIDDEN : formatCurrency(currentAmount, baseCurrency)}</span>
               <span className="font-medium text-foreground">{progressClamped.toFixed(1)}%</span>
             </div>
-            <div className="h-2.5 w-full rounded-full bg-muted/60 overflow-hidden">
+            <div
+              role="progressbar"
+              aria-valuenow={progressClamped}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={goal.name}
+              className="h-2.5 w-full rounded-full bg-muted/60 overflow-hidden"
+            >
               <div
                 className={`h-full rounded-full transition-all motion-normal ${isCompleted ? "bg-primary" : "bg-primary/80"}`}
                 style={{ width: `${progressClamped}%` }}
@@ -138,12 +159,12 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
             <div className="flex justify-between items-baseline text-xs">
               <span className="text-muted-foreground">
                 {t("ofTarget", {
-                  target: formatCurrency(targetAmountInBase, baseCurrency),
+                  target: privacyMode ? HIDDEN : formatCurrency(targetAmountInBase, baseCurrency),
                 })}
               </span>
               {goal.targetCurrency !== baseCurrency && (
                 <span className="text-muted-foreground/70">
-                  {formatCurrency(goal.targetAmount, goal.targetCurrency)}
+                  {privacyMode ? HIDDEN : formatCurrency(goal.targetAmount, goal.targetCurrency)}
                 </span>
               )}
             </div>
@@ -193,6 +214,23 @@ export function GoalCard({ data, baseCurrency, accounts, defaultCurrency }: Goal
         accounts={accounts}
         defaultCurrency={defaultCurrency}
       />
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t("confirmDelete")}</DialogTitle>
+            <DialogDescription>{t("deleteConfirmDescription")}</DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={deleting}>
+              {t("form.cancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm} disabled={deleting}>
+              {t("deleteButton")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/components/goals/goal-form-dialog.tsx
+++ b/src/components/goals/goal-form-dialog.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -16,6 +22,7 @@ import {
 } from "@/components/ui/select";
 import { CURRENCIES } from "@/lib/currencies";
 import { ACCOUNT_CATEGORIES } from "@/lib/enums";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { SerializedAccount, SerializedGoal } from "@/lib/types";
 import { toast } from "sonner";
 
@@ -63,6 +70,7 @@ export function GoalFormDialog({
 }: GoalFormDialogProps) {
   const router = useRouter();
   const t = useTranslations("goals");
+  const isMobile = useIsMobile();
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState(() => initialState(editGoal, defaultCurrency));
 
@@ -159,136 +167,175 @@ export function GoalFormDialog({
     }
   }
 
+  const titleText = editGoal ? t("form.editTitle") : t("form.createTitle");
+
+  const formFields = (
+    <>
+      {/* Name */}
+      <div className="space-y-1.5">
+        <Label htmlFor="goal-name">{t("form.name")}</Label>
+        <Input
+          id="goal-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t("form.namePlaceholder")}
+          required
+          maxLength={100}
+        />
+      </div>
+
+      {/* Target Amount + Currency */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="goal-amount">{t("form.targetAmount")}</Label>
+          <Input
+            id="goal-amount"
+            type="text"
+            inputMode="decimal"
+            value={targetAmount}
+            onChange={handleTargetAmountChange}
+            onBlur={handleTargetAmountBlur}
+            placeholder="1,000,000"
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="goal-currency">{t("form.targetCurrency")}</Label>
+          <Select value={targetCurrency} onValueChange={(v) => v && setTargetCurrency(v)}>
+            <SelectTrigger id="goal-currency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CURRENCIES.map((c) => (
+                <SelectItem key={c.code} value={c.code}>
+                  {c.code} — {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Target Date */}
+      <div className="space-y-1.5">
+        <Label htmlFor="goal-date">{t("form.targetDate")}</Label>
+        <Input
+          id="goal-date"
+          type="date"
+          value={targetDate}
+          onChange={(e) => setTargetDate(e.target.value)}
+          min={new Date().toISOString().slice(0, 10)}
+        />
+        <p className="text-xs text-muted-foreground">{t("form.targetDateHint")}</p>
+      </div>
+
+      {/* Scope */}
+      <div className="space-y-1.5">
+        <Label htmlFor="goal-scope">{t("form.scope")}</Label>
+        <Select
+          value={scope}
+          onValueChange={(v) => {
+            setScope(v as GoalScope);
+            setScopeRefId("");
+          }}
+        >
+          <SelectTrigger id="goal-scope">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SCOPE_OPTIONS.map((s) => (
+              <SelectItem key={s} value={s}>
+                {t(`scope.${s}`)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Scope Ref — Category */}
+      {scope === "CATEGORY" && (
+        <div className="space-y-1.5">
+          <Label htmlFor="goal-category">{t("form.category")}</Label>
+          <Select value={scopeRefId} onValueChange={(v) => v && setScopeRefId(v)}>
+            <SelectTrigger id="goal-category">
+              <SelectValue placeholder={t("form.categoryPlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {ACCOUNT_CATEGORIES.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat
+                    .replace(/_/g, " ")
+                    .toLowerCase()
+                    .replace(/^\w/, (c) => c.toUpperCase())}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Scope Ref — Account */}
+      {scope === "ACCOUNT" && (
+        <div className="space-y-1.5">
+          <Label htmlFor="goal-account">{t("form.account")}</Label>
+          <Select value={scopeRefId} onValueChange={(v) => v && setScopeRefId(v)}>
+            <SelectTrigger id="goal-account">
+              <SelectValue placeholder={t("form.accountPlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {accounts.map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={(o) => handleOpenChange(o)}>
+        <DrawerContent showCloseButton={false}>
+          <DrawerHeader>
+            <DrawerTitle>{titleText}</DrawerTitle>
+          </DrawerHeader>
+          <form onSubmit={handleSubmit} className="px-4 pb-4 space-y-4">
+            {formFields}
+            <div className="flex flex-col-reverse gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={saving}
+                className="w-full"
+              >
+                {t("form.cancel")}
+              </Button>
+              <Button
+                type="submit"
+                disabled={saving || (needsScopeRef && !scopeRefId)}
+                className="w-full"
+              >
+                {saving ? t("form.saving") : editGoal ? t("form.save") : t("form.create")}
+              </Button>
+            </div>
+          </form>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={(o) => handleOpenChange(o)}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{editGoal ? t("form.editTitle") : t("form.createTitle")}</DialogTitle>
+          <DialogTitle>{titleText}</DialogTitle>
         </DialogHeader>
-
         <form onSubmit={handleSubmit} className="space-y-4 pt-2">
-          {/* Name */}
-          <div className="space-y-1.5">
-            <Label htmlFor="goal-name">{t("form.name")}</Label>
-            <Input
-              id="goal-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("form.namePlaceholder")}
-              required
-              maxLength={100}
-            />
-          </div>
-
-          {/* Target Amount + Currency */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="goal-amount">{t("form.targetAmount")}</Label>
-              <Input
-                id="goal-amount"
-                type="text"
-                inputMode="decimal"
-                value={targetAmount}
-                onChange={handleTargetAmountChange}
-                onBlur={handleTargetAmountBlur}
-                placeholder="1,000,000"
-                required
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="goal-currency">{t("form.targetCurrency")}</Label>
-              <Select value={targetCurrency} onValueChange={(v) => v && setTargetCurrency(v)}>
-                <SelectTrigger id="goal-currency">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {CURRENCIES.map((c) => (
-                    <SelectItem key={c.code} value={c.code}>
-                      {c.code} — {c.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Target Date */}
-          <div className="space-y-1.5">
-            <Label htmlFor="goal-date">{t("form.targetDate")}</Label>
-            <Input
-              id="goal-date"
-              type="date"
-              value={targetDate}
-              onChange={(e) => setTargetDate(e.target.value)}
-              min={new Date().toISOString().slice(0, 10)}
-            />
-            <p className="text-xs text-muted-foreground">{t("form.targetDateHint")}</p>
-          </div>
-
-          {/* Scope */}
-          <div className="space-y-1.5">
-            <Label htmlFor="goal-scope">{t("form.scope")}</Label>
-            <Select
-              value={scope}
-              onValueChange={(v) => {
-                setScope(v as GoalScope);
-                setScopeRefId("");
-              }}
-            >
-              <SelectTrigger id="goal-scope">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SCOPE_OPTIONS.map((s) => (
-                  <SelectItem key={s} value={s}>
-                    {t(`scope.${s}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Scope Ref — Category */}
-          {scope === "CATEGORY" && (
-            <div className="space-y-1.5">
-              <Label htmlFor="goal-category">{t("form.category")}</Label>
-              <Select value={scopeRefId} onValueChange={(v) => v && setScopeRefId(v)}>
-                <SelectTrigger id="goal-category">
-                  <SelectValue placeholder={t("form.categoryPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {ACCOUNT_CATEGORIES.map((cat) => (
-                    <SelectItem key={cat} value={cat}>
-                      {cat
-                        .replace(/_/g, " ")
-                        .toLowerCase()
-                        .replace(/^\w/, (c) => c.toUpperCase())}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* Scope Ref — Account */}
-          {scope === "ACCOUNT" && (
-            <div className="space-y-1.5">
-              <Label htmlFor="goal-account">{t("form.account")}</Label>
-              <Select value={scopeRefId} onValueChange={(v) => v && setScopeRefId(v)}>
-                <SelectTrigger id="goal-account">
-                  <SelectValue placeholder={t("form.accountPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {accounts.map((a) => (
-                    <SelectItem key={a.id} value={a.id}>
-                      {a.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
+          {formFields}
           <div className="flex justify-end gap-2 pt-2">
             <Button
               type="button"

--- a/src/components/goals/goal-form-dialog.tsx
+++ b/src/components/goals/goal-form-dialog.tsx
@@ -5,12 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -32,13 +32,15 @@ export function GoalsView({
   return (
     <div className="space-y-4">
       {/* Mobile-only tab switcher */}
-      <div className="md:hidden flex border-b">
+      <div role="tablist" className="md:hidden flex border-b">
         {(["goals", "projections"] as const).map((tab) => (
           <button
             key={tab}
+            role="tab"
             type="button"
             onClick={() => setActiveTab(tab)}
-            aria-pressed={activeTab === tab}
+            aria-selected={activeTab === tab}
+            tabIndex={activeTab === tab ? 0 : -1}
             className={cn(
               "pb-2 px-4 text-sm font-medium border-b-2 -mb-px transition-colors capitalize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
               activeTab === tab
@@ -52,7 +54,7 @@ export function GoalsView({
       </div>
 
       {/* Goals tab — always visible on desktop, conditional on mobile */}
-      <div className={activeTab === "projections" ? "hidden md:block" : "block"}>
+      <div role="tabpanel" className={activeTab === "projections" ? "hidden md:block" : "block"}>
         <div className="space-y-6">
           <div className="flex items-center justify-between">
             <div>
@@ -103,7 +105,7 @@ export function GoalsView({
 
       {/* Projections tab — mobile only */}
       {activeTab === "projections" && (
-        <div className="md:hidden">
+        <div role="tabpanel" className="md:hidden">
           <ProjectionView
             latestNetWorth={projectionData.latestNetWorth}
             trailing12mSavings={projectionData.trailing12mSavings}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { XIcon } from "lucide-react";
+
+function DrawerRoot({ ...props }: DrawerPrimitive.Root.Props) {
+  return <DrawerPrimitive.Root data-slot="drawer" swipeDirection="down" {...props} />;
+}
+
+function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({ ...props }: DrawerPrimitive.Close.Props) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerBackdrop({ className, ...props }: DrawerPrimitive.Backdrop.Props) {
+  return (
+    <DrawerPrimitive.Backdrop
+      data-slot="drawer-backdrop"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs",
+        "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "duration-200",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DrawerPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DrawerPortal>
+      <DrawerBackdrop />
+      <DrawerPrimitive.Viewport className="fixed inset-0 z-50 flex items-end pointer-events-none">
+      <DrawerPrimitive.Popup
+        data-slot="drawer-content"
+        className={cn(
+          "flex flex-col pointer-events-auto",
+          "max-h-[90dvh] w-full",
+          "rounded-t-2xl bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10",
+          "outline-none",
+          "data-open:animate-in data-open:slide-in-from-bottom data-open:fade-in-0",
+          "data-closed:animate-out data-closed:slide-out-to-bottom data-closed:fade-out-0",
+          "duration-300 ease-out",
+          className,
+        )}
+        {...props}
+      >
+        {/* Swipe handle */}
+        <div className="flex justify-center py-3 shrink-0" aria-hidden="true">
+          <div className="h-1 w-10 rounded-full bg-foreground/20" />
+        </div>
+        <div className="overflow-y-auto flex-1" style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}>
+          {children}
+        </div>
+        {showCloseButton && (
+          <DrawerPrimitive.Close
+            data-slot="drawer-close"
+            render={<Button variant="ghost" className="absolute top-1 right-2" size="icon-sm" />}
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DrawerPrimitive.Close>
+        )}
+      </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-2 px-4 pb-2", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-heading text-base leading-none font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({ className, ...props }: DrawerPrimitive.Description.Props) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DrawerRoot as Drawer,
+  DrawerTrigger,
+  DrawerPortal,
+  DrawerClose,
+  DrawerBackdrop,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -49,37 +49,40 @@ function DrawerContent({
     <DrawerPortal>
       <DrawerBackdrop />
       <DrawerPrimitive.Viewport className="fixed inset-0 z-50 flex items-end pointer-events-none">
-      <DrawerPrimitive.Popup
-        data-slot="drawer-content"
-        className={cn(
-          "flex flex-col pointer-events-auto",
-          "max-h-[90dvh] w-full",
-          "rounded-t-2xl bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10",
-          "outline-none",
-          "data-open:animate-in data-open:slide-in-from-bottom data-open:fade-in-0",
-          "data-closed:animate-out data-closed:slide-out-to-bottom data-closed:fade-out-0",
-          "duration-300 ease-out",
-          className,
-        )}
-        {...props}
-      >
-        {/* Swipe handle */}
-        <div className="flex justify-center py-3 shrink-0" aria-hidden="true">
-          <div className="h-1 w-10 rounded-full bg-foreground/20" />
-        </div>
-        <div className="overflow-y-auto flex-1" style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}>
-          {children}
-        </div>
-        {showCloseButton && (
-          <DrawerPrimitive.Close
-            data-slot="drawer-close"
-            render={<Button variant="ghost" className="absolute top-1 right-2" size="icon-sm" />}
+        <DrawerPrimitive.Popup
+          data-slot="drawer-content"
+          className={cn(
+            "flex flex-col pointer-events-auto",
+            "max-h-[90dvh] w-full",
+            "rounded-t-2xl bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10",
+            "outline-none",
+            "data-open:animate-in data-open:slide-in-from-bottom data-open:fade-in-0",
+            "data-closed:animate-out data-closed:slide-out-to-bottom data-closed:fade-out-0",
+            "duration-300 ease-out",
+            className,
+          )}
+          {...props}
+        >
+          {/* Swipe handle */}
+          <div className="flex justify-center py-3 shrink-0" aria-hidden="true">
+            <div className="h-1 w-10 rounded-full bg-foreground/20" />
+          </div>
+          <div
+            className="overflow-y-auto flex-1"
+            style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
           >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DrawerPrimitive.Close>
-        )}
-      </DrawerPrimitive.Popup>
+            {children}
+          </div>
+          {showCloseButton && (
+            <DrawerPrimitive.Close
+              data-slot="drawer-close"
+              render={<Button variant="ghost" className="absolute top-1 right-2" size="icon-sm" />}
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </DrawerPrimitive.Close>
+          )}
+        </DrawerPrimitive.Popup>
       </DrawerPrimitive.Viewport>
     </DrawerPortal>
   );

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

- **Goals tab** (`/goals`): full CRUD for financial goals with progress tracking, projected completion dates (linear and CAGR-based), and scope targeting (net worth, assets-only, category, or specific account)
- **Dashboard widget** (`GoalsMilestoneCard`): surfaces the furthest-from-complete goal with a progress bar and due date
- **Responsive form**: bottom-sheet Drawer on mobile, Dialog on desktop — shared field JSX, no duplication

## Accessibility

- `role="progressbar"` + `aria-valuenow/min/max/label` on all progress bars (GoalCard, GoalsMilestoneCard)
- `aria-label` with goal name on icon-only Edit and Delete buttons; `aria-hidden="true"` on icons
- Tab widget converted from `aria-pressed` to `role="tablist"` / `role="tab"` / `aria-selected` / `role="tabpanel"`
- Delete confirmation via Dialog (replaced `window.confirm()`)
- Touch targets on Edit/Delete bumped to 36×36 px

## i18n & Privacy

- Privacy mode masking (`***`) on all monetary values in GoalCard
- `useLocale()` replaces `navigator.language` and hardcoded `"en-US"` strings
- ICU plural for due-date display: `{days, plural, one {# day} other {# days}}`
- Plain-language projection labels ("At current pace" / "At growth rate") replace jargon ("Linear:" / "CAGR:")
- `en-US` and `zh-TW` translations complete

## New files

| File | Purpose |
|------|---------|
| `src/hooks/use-is-mobile.ts` | SSR-safe responsive breakpoint hook |
| `src/components/ui/drawer.tsx` | `@base-ui/react` Drawer primitive wrapper (swipe-to-dismiss, safe-area padding) |

## Test plan

- [x] Create a goal (NET_WORTH, ASSETS_ONLY, CATEGORY, ACCOUNT scopes)
- [x] Edit a goal — form pre-populates correctly
- [x] Delete a goal — confirmation dialog appears, list refreshes
- [x] Progress bar reads correctly with screen reader
- [x] Mobile: form opens as bottom sheet, swipe-to-dismiss works
- [x] Privacy mode: all currency values masked
- [x] zh-TW locale: dates and labels render in Traditional Chinese
- [x] Pluralization: goal due in 1 day shows "1 day" (not "1 days")

🤖 Generated with [Claude Code](https://claude.com/claude-code)