### PR TITLE
feat(history+dashboard): full-year activity heatmap with dashboard integration

### DIFF
--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -7,6 +7,7 @@ import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
 import { HistoryTable } from "@/components/history/history-table";
+import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { getNormalizedHistory } from "@/lib/services/history-service";
 import HistoryLoading from "./loading";
@@ -39,7 +40,10 @@ async function HistoryContent() {
             />
           </div>
 
-          <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-1 card-gradient transition-shadow hover:shadow-lg">
+          <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-4 card-gradient transition-shadow hover:shadow-lg">
+            <div className="mb-4">
+              <HistoryHeatmap snapshots={snapshots} baseCurrency={settings.baseCurrency} />
+            </div>
             <HistoryTable snapshots={snapshots} baseCurrency={settings.baseCurrency} />
           </div>
         </div>

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,7 +1,7 @@
 import { Suspense, cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { NetWorthCard } from "@/components/dashboard/net-worth-card";
-import { LazyAllocationChart, LazyCurrencyExposureChart } from "@/components/dashboard/lazy-charts";
+import { LazyAllocationChart, LazyCurrencyExposureChart, TrendChartSkeleton } from "@/components/dashboard/lazy-charts";
 import { AccountsSummary } from "@/components/dashboard/accounts-summary";
 import { DashboardActions } from "@/components/dashboard/dashboard-actions";
 import {
@@ -10,6 +10,8 @@ import {
 } from "@/lib/services/net-worth-service";
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { getNormalizedHistory } from "@/lib/services/history-service";
+import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card";
@@ -46,7 +48,7 @@ function NetWorthSkeleton() {
 
 function ChartsSkeleton() {
   return (
-    <>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
       {[...Array(2)].map((_, i) => (
         <Card key={i}>
           <CardHeader className="pb-2">
@@ -57,7 +59,7 @@ function ChartsSkeleton() {
           </CardContent>
         </Card>
       ))}
-    </>
+    </div>
   );
 }
 
@@ -141,10 +143,10 @@ async function ChartsSection({ userId, baseCurrency }: { userId: string; baseCur
   if (summary.accounts.length === 0) return null;
 
   return (
-    <>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
       <LazyAllocationChart summary={summary} />
       <LazyCurrencyExposureChart summary={summary} />
-    </>
+    </div>
   );
 }
 
@@ -212,6 +214,11 @@ export async function DashboardContent({ userId }: { userId: string }) {
   void fetchUserAccountsWithHoldings(userId);
   void getAllExchangeRates();
 
+  // Fetch snapshot history once — shared by TrendChartSection and HistoryHeatmap.
+  // getNormalizedHistory is "use cache" with cacheLife("hours"), so this is a
+  // cache read on warm requests. No extra DB query on repeat renders.
+  const snapshots = await getNormalizedHistory(userId, baseCurrency);
+
   // Fast check: does this user have any active accounts?
   const accountCount = await prisma.account.count({
     where: { userId, isActive: true },
@@ -268,13 +275,19 @@ export async function DashboardContent({ userId }: { userId: string }) {
         <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
 
-      {/* Charts grid — trend chart + allocation + currency exposure */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-6 items-stretch animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
-        <div className="lg:col-span-2 xl:col-span-1">
-          <Suspense fallback={<div className="h-[350px] animate-pulse bg-muted rounded-lg" />}>
-            <TrendChartSection userId={userId} baseCurrency={baseCurrency} />
-          </Suspense>
-        </div>
+      {/* Trend chart + activity heatmap footer — share the same card */}
+      <div className="animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
+        <Suspense fallback={<TrendChartSkeleton />}>
+          <TrendChartSection
+            baseCurrency={baseCurrency}
+            snapshots={snapshots}
+            footer={<HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />}
+          />
+        </Suspense>
+      </div>
+
+      {/* Allocation + currency exposure charts */}
+      <div className="animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
         <Suspense fallback={<ChartsSkeleton />}>
           <ChartsSection userId={userId} baseCurrency={baseCurrency} />
         </Suspense>

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -16,9 +16,42 @@ function ChartSkeleton() {
   );
 }
 
+export function TrendChartSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="h-5 w-32 skeleton-shimmer rounded" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-[250px] skeleton-shimmer rounded" />
+      </CardContent>
+      {/* Heatmap footer skeleton */}
+      <div className="border-t border-border/40 px-4 pt-3 pb-4">
+        <div className="h-3 w-48 skeleton-shimmer rounded mb-2 ml-6" />
+        <div className="flex gap-2">
+          <div className="flex flex-col gap-1">
+            {[...Array(7)].map((_, i) => (
+              <div key={i} className="w-4 h-[10px] skeleton-shimmer rounded-sm" />
+            ))}
+          </div>
+          <div className="flex flex-col gap-1 overflow-hidden">
+            {[...Array(7)].map((_, row) => (
+              <div key={row} className="flex gap-1">
+                {[...Array(44)].map((_, col) => (
+                  <div key={col} className="w-[10px] h-[10px] shrink-0 skeleton-shimmer rounded-[2px]" />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 export const LazyTrendChart = dynamic(() => import("./trend-chart").then((m) => m.TrendChart), {
   ssr: false,
-  loading: () => <ChartSkeleton />,
+  loading: () => <TrendChartSkeleton />,
 });
 
 export const LazyAllocationChart = dynamic(

--- a/src/components/dashboard/trend-chart-section.tsx
+++ b/src/components/dashboard/trend-chart-section.tsx
@@ -1,13 +1,15 @@
-import { getNormalizedHistory } from "@/lib/services/history-service";
+import { type ReactNode } from "react";
+import { type NormalizedSnapshot } from "@/lib/services/history-service";
 import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
 
-export async function TrendChartSection({
-  userId,
+export function TrendChartSection({
   baseCurrency,
+  snapshots,
+  footer,
 }: {
-  userId: string;
   baseCurrency: string;
+  snapshots: NormalizedSnapshot[];
+  footer?: ReactNode;
 }) {
-  const snapshots = await getNormalizedHistory(userId, baseCurrency);
-  return <LazyTrendChart baseCurrency={baseCurrency} snapshots={snapshots} />;
+  return <LazyTrendChart baseCurrency={baseCurrency} snapshots={snapshots} footer={footer} />;
 }

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback, useRef } from "react";
+import { useMemo, useCallback, useRef, type ReactNode } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -133,10 +133,12 @@ export function TrendChart({
   snapshots,
   baseCurrency = "USD",
   hideRangeFilter = false,
+  footer,
 }: {
   snapshots: SnapshotData[];
   baseCurrency?: string;
   hideRangeFilter?: boolean;
+  footer?: ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width: containerWidth, height: containerHeight } = useContainerSize(containerRef);
@@ -330,6 +332,11 @@ export function TrendChart({
           </div>
         )}
       </CardContent>
+      {footer && (
+        <div className="border-t border-border/40 px-4 pt-3 pb-4">
+          {footer}
+        </div>
+      )}
     </Card>
   );
 }

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -22,13 +22,29 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
   const { privacyMode } = usePrivacyMode();
 
   const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow } = useMemo(() => {
-    // 1. Create a lookup map of snapshot dates
-    const snapshotMap = new Map<string, SnapshotRow>();
-    for (const snap of snapshots) {
-      snapshotMap.set(snap.date, snap);
+    // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
+    const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
+    
+    let maxPositiveChange = 0;
+    let maxNegativeChange = 0;
+
+    // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
+    const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
+    
+    for (let i = 0; i < sortedSnapshots.length; i++) {
+      const snap = sortedSnapshots[i]!;
+      const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
+      const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
+      
+      if (change !== null) {
+        if (change > maxPositiveChange) maxPositiveChange = change;
+        if (change < maxNegativeChange) maxNegativeChange = change;
+      }
+      
+      snapshotMap.set(snap.date, { ...snap, change });
     }
 
-    // 2. Determine end date (Saturday on or after Dec 31st of current year)
+    // 3. Determine end date (Saturday on or after Dec 31st of current year)
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const currentYear = today.getFullYear();
@@ -38,13 +54,13 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
     const endDate = new Date(dec31);
     endDate.setDate(dec31.getDate() + daysToAddToReachSaturday);
 
-    // 3. Determine start date (Sunday on or before Jan 1st of current year)
+    // 4. Determine start date (Sunday on or before Jan 1st of current year)
     const jan1 = new Date(currentYear, 0, 1);
     const dayOfWeekStart = jan1.getDay();
     const startDate = new Date(jan1);
     startDate.setDate(jan1.getDate() - dayOfWeekStart);
 
-    // 4. Calculate total days to show
+    // 5. Calculate total days to show
     const daysToShow =
       Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
     const weeksToShow = daysToShow / 7;
@@ -52,8 +68,6 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
     const days = [];
     const mLabels: { col: number; label: string }[] = [];
     let currentMonth = -1;
-    let maxPositiveChange = 0;
-    let maxNegativeChange = 0;
 
     for (let i = 0; i < daysToShow; i++) {
       const current = new Date(startDate);
@@ -64,7 +78,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
       const day = String(current.getDate()).padStart(2, "0");
       const dateString = `${year}-${month}-${day}`;
 
-      const snap = snapshotMap.get(dateString);
+      const snapData = snapshotMap.get(dateString);
 
       // Track month boundaries for labels (only if we are still in the current year)
       if (year === currentYear && current.getMonth() !== currentMonth && current.getDate() < 15) {
@@ -75,25 +89,12 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
         });
       }
 
-      // Calculate change
-      let change: number | null = null;
-      if (snap) {
-        const previousSnapshots = snapshots.filter((s) => s.date < snap.date);
-        if (previousSnapshots.length > 0) {
-          previousSnapshots.sort((a, b) => b.date.localeCompare(a.date));
-          change = snap.netWorth - previousSnapshots[0].netWorth;
-
-          if (change > maxPositiveChange) maxPositiveChange = change;
-          if (change < maxNegativeChange) maxNegativeChange = change;
-        }
-      }
-
       days.push({
         date: current,
         dateString,
-        hasSnapshot: !!snap,
-        netWorth: snap?.netWorth,
-        change,
+        hasSnapshot: !!snapData,
+        netWorth: snapData?.netWorth,
+        change: snapData?.change ?? null,
         isFuture: current > today,
         isNextYear: year > currentYear,
       });

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -1,15 +1,41 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import { useFormatter } from "next-intl";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+
+const CELL_PX = 10;
+const GAP_PX = 4;
+const COL_WIDTH = CELL_PX + GAP_PX;
+
+// Fixed reference dates for day-of-week label generation
+const DOW_REF: (Date | null)[] = [
+  new Date(2024, 0, 7), // Sun
+  null,
+  new Date(2024, 0, 9), // Tue
+  null,
+  new Date(2024, 0, 11), // Thu
+  null,
+  new Date(2024, 0, 13), // Sat
+];
 
 type SnapshotRow = {
   id: string;
   date: string; // YYYY-MM-DD
   netWorth: number;
+};
+
+type GridDay = {
+  date: Date;
+  dateString: string;
+  hasSnapshot: boolean;
+  netWorth?: number;
+  change: number | null;
+  isFuture: boolean;
+  isNextYear: boolean;
 };
 
 type Props = {
@@ -20,8 +46,10 @@ type Props = {
 export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
   const format = useFormatter();
   const { privacyMode } = usePrivacyMode();
+  const [selectedDay, setSelectedDay] = useState<GridDay | null>(null);
 
-  const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow } = useMemo(() => {
+  const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow, currentYear, todayColIndex } =
+    useMemo(() => {
     // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
     const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
 
@@ -65,7 +93,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
       Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
     const weeksToShow = daysToShow / 7;
 
-    const days = [];
+    const days: GridDay[] = [];
     const mLabels: { col: number; label: string }[] = [];
     let currentMonth = -1;
 
@@ -100,43 +128,68 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
       });
     }
 
+    // Column index of the current week, used to seed the initial scroll position
+    const todayDayOffset = Math.round(
+      (today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    const todayColIndex = Math.floor(todayDayOffset / 7);
+
     return {
       gridDays: days,
       monthLabels: mLabels,
       maxPos: maxPositiveChange,
       maxNeg: Math.abs(maxNegativeChange),
       weeksToShow,
+      currentYear,
+      todayColIndex,
     };
   }, [snapshots, format]);
 
-  // Transpose the 1D array into 7 rows (Sunday - Saturday)
-  const rows = [];
-  for (let i = 0; i < 7; i++) {
-    const row = [];
-    for (let j = 0; j < weeksToShow; j++) {
-      row.push(gridDays[j * 7 + i]);
+  // Transpose the flat array into 7 rows (Sunday–Saturday)
+  const rows = useMemo(() => {
+    const result: (GridDay | undefined)[][] = [];
+    for (let i = 0; i < 7; i++) {
+      const row: (GridDay | undefined)[] = [];
+      for (let j = 0; j < weeksToShow; j++) {
+        row.push(gridDays[j * 7 + i]);
+      }
+      result.push(row);
     }
-    rows.push(row);
-  }
+    return result;
+  }, [gridDays, weeksToShow]);
 
-  const daysOfWeek = [
-    format.dateTime(new Date(2024, 0, 7), { weekday: "narrow" }), // Sun
-    "",
-    format.dateTime(new Date(2024, 0, 9), { weekday: "narrow" }), // Tue
-    "",
-    format.dateTime(new Date(2024, 0, 11), { weekday: "narrow" }), // Thu
-    "",
-    format.dateTime(new Date(2024, 0, 13), { weekday: "narrow" }), // Sat
-  ];
+  const daysOfWeek = useMemo(
+    () => DOW_REF.map((d) => (d ? format.dateTime(d, { weekday: "narrow" }) : "")),
+    [format],
+  );
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // On mount, position the scroll so today sits near the right edge of the visible window.
+  // This shows recent activity immediately without requiring the user to scroll on mobile.
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const targetLeft = (todayColIndex - 8) * COL_WIDTH;
+    el.scrollLeft = Math.max(0, targetLeft);
+  }, [todayColIndex]);
 
   return (
     <div className="w-full">
-      <div className="overflow-x-auto pb-4 custom-scrollbar">
+      {/*
+        Relative wrapper lets the fade overlay sit on top of the scroll container
+        without affecting layout. The fade uses mask-image on the scroll div itself
+        so it fades the content edge, not a positioned overlay that blocks interaction.
+      */}
+      <div
+        ref={scrollContainerRef}
+        className="overflow-x-auto scrollbar-none pb-1 [mask-image:linear-gradient(to_right,black_0%,black_88%,transparent_100%)]"
+      >
         <div className="inline-flex flex-col min-w-max">
           {/* Month Labels */}
           <div className="flex text-xs text-muted-foreground/70 mb-1 ml-6 relative h-4">
             {monthLabels.map((m, i) => (
-              <span key={i} className="absolute" style={{ left: `${m.col * 14}px` }}>
+              <span key={i} className="absolute" style={{ left: `${m.col * COL_WIDTH}px` }}>
                 {m.label}
               </span>
             ))}
@@ -146,33 +199,75 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
             {/* Day Labels */}
             <div className="flex flex-col justify-between text-[10px] text-muted-foreground/50 leading-[10px] py-[2px]">
               {daysOfWeek.map((day, i) => (
-                <span key={i} className="h-[10px] w-4 text-right">
+                <span
+                  key={i}
+                  aria-hidden={day === "" ? true : undefined}
+                  className="h-[10px] w-4 text-right"
+                >
                   {day}
                 </span>
               ))}
             </div>
 
             {/* Grid */}
-            <div className="flex flex-col gap-1">
+            <div
+              role="grid"
+              aria-label={`${currentYear} net worth activity`}
+              aria-rowcount={7}
+              aria-colcount={weeksToShow}
+              className="flex flex-col gap-1"
+            >
               {rows.map((row, rIdx) => (
-                <div key={rIdx} className="flex gap-1">
+                <div key={rIdx} role="row" aria-rowindex={rIdx + 1} className="flex gap-1">
                   {row.map((day, cIdx) => {
+                    // Padding cells outside the current year — hide from AT
+                    if (!day || day.isNextYear) {
+                      return (
+                        <div
+                          key={cIdx}
+                          role="gridcell"
+                          aria-hidden="true"
+                          className="w-[10px] h-[10px]"
+                        />
+                      );
+                    }
+
+                    const isClickable = day.hasSnapshot && !day.isFuture;
+
+                    const dateLabel = format.dateTime(day.date, { dateStyle: "medium" });
+                    const cellLabel = day.isFuture
+                      ? `${dateLabel}, no data yet`
+                      : day.hasSnapshot
+                        ? `${dateLabel}, net worth ${
+                            privacyMode
+                              ? "hidden"
+                              : formatCurrency(day.netWorth!, baseCurrency)
+                          }${
+                            day.change !== null
+                              ? `, change ${
+                                  privacyMode
+                                    ? "hidden"
+                                    : (day.change >= 0 ? "+" : "") +
+                                      formatCurrency(day.change, baseCurrency)
+                                }`
+                              : ""
+                          }`
+                        : `${dateLabel}, no snapshot`;
+
                     const title = day.isFuture
                       ? undefined
                       : day.hasSnapshot
-                        ? `${format.dateTime(day.date, { dateStyle: "medium" })}\n${
+                        ? `${dateLabel}\n${
                             privacyMode ? "***" : formatCurrency(day.netWorth!, baseCurrency)
                           }${
                             day.change !== null && !privacyMode
                               ? ` (${day.change >= 0 ? "+" : ""}${formatCurrency(day.change, baseCurrency)})`
                               : ""
                           }`
-                        : format.dateTime(day.date, { dateStyle: "medium" });
+                        : dateLabel;
 
                     let bgClass = "bg-muted/40 dark:bg-muted/20";
-                    if (day.isNextYear) {
-                      bgClass = "bg-transparent";
-                    } else if (!day.isFuture && day.hasSnapshot) {
+                    if (!day.isFuture && day.hasSnapshot) {
                       if (day.change !== null && day.change < 0) {
                         const intensity = maxNeg > 0 ? Math.abs(day.change) / maxNeg : 1;
                         if (intensity < 0.25) bgClass = "bg-destructive/20";
@@ -181,7 +276,6 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                         else if (intensity < 0.95) bgClass = "bg-destructive/80";
                         else bgClass = "bg-destructive";
                       } else {
-                        // Positive or zero change, or no previous snapshot
                         const intensity =
                           maxPos > 0 && day.change !== null ? day.change / maxPos : 1;
                         if (intensity < 0.25) bgClass = "bg-primary/20";
@@ -195,8 +289,28 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                     return (
                       <div
                         key={cIdx}
+                        role="gridcell"
+                        aria-colindex={cIdx + 1}
+                        aria-label={cellLabel}
+                        aria-selected={selectedDay?.dateString === day.dateString}
                         title={title}
-                        className={cn("w-[10px] h-[10px] rounded-[2px]", bgClass)}
+                        tabIndex={isClickable ? 0 : -1}
+                        onClick={isClickable ? () => setSelectedDay(day) : undefined}
+                        onKeyDown={
+                          isClickable
+                            ? (e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  setSelectedDay(day);
+                                }
+                              }
+                            : undefined
+                        }
+                        className={cn(
+                          "w-[10px] h-[10px] rounded-[2px]",
+                          isClickable && "cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
+                          bgClass,
+                        )}
                       />
                     );
                   })}
@@ -206,6 +320,49 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Tap-to-reveal callout — works on all devices, unlike title attribute */}
+      {selectedDay && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 animate-in fade-in duration-150">
+          <div className="flex gap-6 min-w-0">
+            <div className="min-w-0">
+              <p className="text-xs text-muted-foreground">
+                {format.dateTime(selectedDay.date, { dateStyle: "medium" })}
+              </p>
+              <p className="text-sm font-semibold tabular-nums mt-0.5">
+                {privacyMode ? "***" : formatCurrency(selectedDay.netWorth!, baseCurrency)}
+              </p>
+            </div>
+            {selectedDay.change !== null && (
+              <div className="shrink-0">
+                <p className="text-xs text-muted-foreground">Change</p>
+                <p
+                  className={cn(
+                    "text-sm font-medium tabular-nums mt-0.5",
+                    selectedDay.change > 0
+                      ? "text-primary"
+                      : selectedDay.change < 0
+                        ? "text-destructive"
+                        : "text-muted-foreground",
+                  )}
+                >
+                  {privacyMode
+                    ? "***"
+                    : (selectedDay.change >= 0 ? "+" : "") +
+                      formatCurrency(selectedDay.change, baseCurrency)}
+                </p>
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => setSelectedDay(null)}
+            aria-label="Dismiss"
+            className="shrink-0 rounded-md p-1 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50 transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useMemo } from "react";
+import { useFormatter } from "next-intl";
+import { cn } from "@/lib/utils";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+
+type SnapshotRow = {
+  id: string;
+  date: string; // YYYY-MM-DD
+  netWorth: number;
+};
+
+type Props = {
+  snapshots: SnapshotRow[];
+  baseCurrency: string;
+};
+
+export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
+  const format = useFormatter();
+  const { privacyMode } = usePrivacyMode();
+
+  const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow } = useMemo(() => {
+    // 1. Create a lookup map of snapshot dates
+    const snapshotMap = new Map<string, SnapshotRow>();
+    for (const snap of snapshots) {
+      snapshotMap.set(snap.date, snap);
+    }
+
+    // 2. Determine end date (Saturday on or after Dec 31st of current year)
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const currentYear = today.getFullYear();
+    const dec31 = new Date(currentYear, 11, 31);
+    const dayOfWeekEnd = dec31.getDay(); // 0 = Sunday, 6 = Saturday
+    const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
+    const endDate = new Date(dec31);
+    endDate.setDate(dec31.getDate() + daysToAddToReachSaturday);
+
+    // 3. Determine start date (Sunday on or before Jan 1st of current year)
+    const jan1 = new Date(currentYear, 0, 1);
+    const dayOfWeekStart = jan1.getDay();
+    const startDate = new Date(jan1);
+    startDate.setDate(jan1.getDate() - dayOfWeekStart);
+
+    // 4. Calculate total days to show
+    const daysToShow = Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    const weeksToShow = daysToShow / 7;
+
+    const days = [];
+    const mLabels: { col: number; label: string }[] = [];
+    let currentMonth = -1;
+    let maxPositiveChange = 0;
+    let maxNegativeChange = 0;
+
+    for (let i = 0; i < daysToShow; i++) {
+      const current = new Date(startDate);
+      current.setDate(startDate.getDate() + i);
+      
+      const year = current.getFullYear();
+      const month = String(current.getMonth() + 1).padStart(2, "0");
+      const day = String(current.getDate()).padStart(2, "0");
+      const dateString = `${year}-${month}-${day}`;
+
+      const snap = snapshotMap.get(dateString);
+
+      // Track month boundaries for labels (only if we are still in the current year)
+      if (year === currentYear && current.getMonth() !== currentMonth && current.getDate() < 15) {
+        currentMonth = current.getMonth();
+        mLabels.push({
+          col: Math.floor(i / 7),
+          label: format.dateTime(current, { month: "short" }),
+        });
+      }
+
+      // Calculate change
+      let change: number | null = null;
+      if (snap) {
+        const previousSnapshots = snapshots.filter(s => s.date < snap.date);
+        if (previousSnapshots.length > 0) {
+          previousSnapshots.sort((a, b) => b.date.localeCompare(a.date));
+          change = snap.netWorth - previousSnapshots[0].netWorth;
+          
+          if (change > maxPositiveChange) maxPositiveChange = change;
+          if (change < maxNegativeChange) maxNegativeChange = change;
+        }
+      }
+
+      days.push({
+        date: current,
+        dateString,
+        hasSnapshot: !!snap,
+        netWorth: snap?.netWorth,
+        change,
+        isFuture: current > today,
+        isNextYear: year > currentYear,
+      });
+    }
+
+    return { gridDays: days, monthLabels: mLabels, maxPos: maxPositiveChange, maxNeg: Math.abs(maxNegativeChange), weeksToShow };
+  }, [snapshots, format]);
+
+  // Transpose the 1D array into 7 rows (Sunday - Saturday)
+  const rows = [];
+  for (let i = 0; i < 7; i++) {
+    const row = [];
+    for (let j = 0; j < weeksToShow; j++) {
+      row.push(gridDays[j * 7 + i]);
+    }
+    rows.push(row);
+  }
+
+  const daysOfWeek = [
+    format.dateTime(new Date(2024, 0, 7), { weekday: "narrow" }), // Sun
+    "",
+    format.dateTime(new Date(2024, 0, 9), { weekday: "narrow" }), // Tue
+    "",
+    format.dateTime(new Date(2024, 0, 11), { weekday: "narrow" }), // Thu
+    "",
+    format.dateTime(new Date(2024, 0, 13), { weekday: "narrow" }), // Sat
+  ];
+
+  return (
+    <div className="w-full">
+      <div className="overflow-x-auto pb-4 custom-scrollbar">
+        <div className="inline-flex flex-col min-w-max">
+          {/* Month Labels */}
+          <div className="flex text-xs text-muted-foreground/70 mb-1 ml-6 relative h-4">
+            {monthLabels.map((m, i) => (
+              <span
+                key={i}
+                className="absolute"
+                style={{ left: `${m.col * 14}px` }}
+              >
+                {m.label}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex gap-2">
+            {/* Day Labels */}
+            <div className="flex flex-col justify-between text-[10px] text-muted-foreground/50 leading-[10px] py-[2px]">
+              {daysOfWeek.map((day, i) => (
+                <span key={i} className="h-[10px] w-4 text-right">
+                  {day}
+                </span>
+              ))}
+            </div>
+
+            {/* Grid */}
+            <div className="flex flex-col gap-1">
+              {rows.map((row, rIdx) => (
+                <div key={rIdx} className="flex gap-1">
+                  {row.map((day, cIdx) => {
+                    const title = day.isFuture
+                      ? undefined
+                      : day.hasSnapshot
+                        ? `${format.dateTime(day.date, { dateStyle: "medium" })}\n${
+                            privacyMode
+                              ? "***"
+                              : formatCurrency(day.netWorth!, baseCurrency)
+                          }${
+                            day.change !== null && !privacyMode
+                              ? ` (${day.change >= 0 ? "+" : ""}${formatCurrency(day.change, baseCurrency)})`
+                              : ""
+                          }`
+                        : format.dateTime(day.date, { dateStyle: "medium" });
+
+                    let bgClass = "bg-muted/40 dark:bg-muted/20";
+                    if (day.isNextYear) {
+                      bgClass = "bg-transparent";
+                    } else if (!day.isFuture && day.hasSnapshot) {
+                      if (day.change !== null && day.change < 0) {
+                        const intensity = maxNeg > 0 ? Math.abs(day.change) / maxNeg : 1;
+                        if (intensity < 0.25) bgClass = "bg-destructive/20";
+                        else if (intensity < 0.5) bgClass = "bg-destructive/40";
+                        else if (intensity < 0.75) bgClass = "bg-destructive/60";
+                        else if (intensity < 0.95) bgClass = "bg-destructive/80";
+                        else bgClass = "bg-destructive";
+                      } else {
+                        // Positive or zero change, or no previous snapshot
+                        const intensity = maxPos > 0 && day.change !== null ? day.change / maxPos : 1;
+                        if (intensity < 0.25) bgClass = "bg-primary/20";
+                        else if (intensity < 0.5) bgClass = "bg-primary/40";
+                        else if (intensity < 0.75) bgClass = "bg-primary/60";
+                        else if (intensity < 0.95) bgClass = "bg-primary/80";
+                        else bgClass = "bg-primary";
+                      }
+                    }
+
+                    return (
+                      <div
+                        key={cIdx}
+                        title={title}
+                        className={cn(
+                          "w-[10px] h-[10px] rounded-[2px]",
+                          bgClass
+                        )}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -24,23 +24,23 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
   const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow } = useMemo(() => {
     // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
     const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
-    
+
     let maxPositiveChange = 0;
     let maxNegativeChange = 0;
 
     // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
     const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
-    
+
     for (let i = 0; i < sortedSnapshots.length; i++) {
       const snap = sortedSnapshots[i]!;
       const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
       const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
-      
+
       if (change !== null) {
         if (change > maxPositiveChange) maxPositiveChange = change;
         if (change < maxNegativeChange) maxNegativeChange = change;
       }
-      
+
       snapshotMap.set(snap.date, { ...snap, change });
     }
 

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -45,7 +45,8 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
     startDate.setDate(jan1.getDate() - dayOfWeekStart);
 
     // 4. Calculate total days to show
-    const daysToShow = Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    const daysToShow =
+      Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
     const weeksToShow = daysToShow / 7;
 
     const days = [];
@@ -57,7 +58,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
     for (let i = 0; i < daysToShow; i++) {
       const current = new Date(startDate);
       current.setDate(startDate.getDate() + i);
-      
+
       const year = current.getFullYear();
       const month = String(current.getMonth() + 1).padStart(2, "0");
       const day = String(current.getDate()).padStart(2, "0");
@@ -77,11 +78,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
       // Calculate change
       let change: number | null = null;
       if (snap) {
-        const previousSnapshots = snapshots.filter(s => s.date < snap.date);
+        const previousSnapshots = snapshots.filter((s) => s.date < snap.date);
         if (previousSnapshots.length > 0) {
           previousSnapshots.sort((a, b) => b.date.localeCompare(a.date));
           change = snap.netWorth - previousSnapshots[0].netWorth;
-          
+
           if (change > maxPositiveChange) maxPositiveChange = change;
           if (change < maxNegativeChange) maxNegativeChange = change;
         }
@@ -98,7 +99,13 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
       });
     }
 
-    return { gridDays: days, monthLabels: mLabels, maxPos: maxPositiveChange, maxNeg: Math.abs(maxNegativeChange), weeksToShow };
+    return {
+      gridDays: days,
+      monthLabels: mLabels,
+      maxPos: maxPositiveChange,
+      maxNeg: Math.abs(maxNegativeChange),
+      weeksToShow,
+    };
   }, [snapshots, format]);
 
   // Transpose the 1D array into 7 rows (Sunday - Saturday)
@@ -128,11 +135,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
           {/* Month Labels */}
           <div className="flex text-xs text-muted-foreground/70 mb-1 ml-6 relative h-4">
             {monthLabels.map((m, i) => (
-              <span
-                key={i}
-                className="absolute"
-                style={{ left: `${m.col * 14}px` }}
-              >
+              <span key={i} className="absolute" style={{ left: `${m.col * 14}px` }}>
                 {m.label}
               </span>
             ))}
@@ -157,9 +160,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                       ? undefined
                       : day.hasSnapshot
                         ? `${format.dateTime(day.date, { dateStyle: "medium" })}\n${
-                            privacyMode
-                              ? "***"
-                              : formatCurrency(day.netWorth!, baseCurrency)
+                            privacyMode ? "***" : formatCurrency(day.netWorth!, baseCurrency)
                           }${
                             day.change !== null && !privacyMode
                               ? ` (${day.change >= 0 ? "+" : ""}${formatCurrency(day.change, baseCurrency)})`
@@ -180,7 +181,8 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                         else bgClass = "bg-destructive";
                       } else {
                         // Positive or zero change, or no previous snapshot
-                        const intensity = maxPos > 0 && day.change !== null ? day.change / maxPos : 1;
+                        const intensity =
+                          maxPos > 0 && day.change !== null ? day.change / maxPos : 1;
                         if (intensity < 0.25) bgClass = "bg-primary/20";
                         else if (intensity < 0.5) bgClass = "bg-primary/40";
                         else if (intensity < 0.75) bgClass = "bg-primary/60";
@@ -193,10 +195,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                       <div
                         key={cIdx}
                         title={title}
-                        className={cn(
-                          "w-[10px] h-[10px] rounded-[2px]",
-                          bgClass
-                        )}
+                        className={cn("w-[10px] h-[10px] rounded-[2px]", bgClass)}
                       />
                     );
                   })}

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { useTranslations, useFormatter } from "next-intl";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
@@ -52,149 +51,141 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
   }, [snapshots, format]);
 
   return (
-    <Card className="border-0 bg-transparent shadow-none">
-      <CardHeader className="pb-2 flex flex-row items-center justify-between gap-2 space-y-0">
-        <CardTitle className="text-base font-medium">{t("title")}</CardTitle>
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-base font-medium">{t("title")}</h2>
         <FreshnessBadge kind="snapshot" timestamp={latestSnapshotAt} />
-      </CardHeader>
-      <CardContent>
-        {monthGroups.length === 0 ? (
-          <div className="py-12 text-center text-muted-foreground text-sm">{t("noData")}</div>
-        ) : (
-          <div
-            role="table"
-            aria-label={t("title")}
-            tabIndex={0}
-            className="max-h-[min(480px,55vh)] overflow-y-auto space-y-4 pr-1"
-          >
-            <div role="rowgroup" className="sr-only">
-              <div role="row">
-                <span role="columnheader">{t("colDate")}</span>
-                <span role="columnheader">{`${t("colAssets")} / ${t("colLiabilities")}`}</span>
-                <span role="columnheader">{`${t("colNetWorth")} / ${t("colChange")}`}</span>
-              </div>
+      </div>
+      {monthGroups.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground text-sm">{t("noData")}</div>
+      ) : (
+        <div
+          role="table"
+          aria-label={t("title")}
+          tabIndex={0}
+          className="max-h-[min(480px,55vh)] overflow-y-auto space-y-4 pr-1"
+        >
+          <div role="rowgroup" className="sr-only">
+            <div role="row">
+              <span role="columnheader">{t("colDate")}</span>
+              <span role="columnheader">{`${t("colAssets")} / ${t("colLiabilities")}`}</span>
+              <span role="columnheader">{`${t("colNetWorth")} / ${t("colChange")}`}</span>
             </div>
+          </div>
 
-            {monthGroups.map(({ monthKey, label, items }) => (
-              <div key={monthKey} role="rowgroup">
-                <div
-                  role="row"
-                  className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm mb-2 px-1 py-1"
+          {monthGroups.map(({ monthKey, label, items }) => (
+            <div key={monthKey} role="rowgroup">
+              <div
+                role="row"
+                className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm mb-2 px-1 py-1"
+              >
+                <span
+                  role="columnheader"
+                  aria-colspan={3}
+                  className="text-xs font-semibold uppercase tracking-widest text-muted-foreground/70"
                 >
-                  <span
-                    role="columnheader"
-                    aria-colspan={3}
-                    className="text-xs font-semibold uppercase tracking-widest text-muted-foreground/70"
-                  >
-                    {label}
-                  </span>
+                  {label}
+                </span>
+              </div>
+              <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+                <div className="hidden md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 px-4 py-2 bg-muted/30 border-b border-border/40 text-xs font-medium text-muted-foreground">
+                  <div>{t("colDate")}</div>
+                  <div className="text-right">{t("colAssets")}</div>
+                  <div className="text-right">{t("colLiabilities")}</div>
+                  <div className="text-right">{`${t("colNetWorth")} / ${t("colChange")}`}</div>
                 </div>
-                <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
-                  {/* Desktop Column Headers (visible only on md+) */}
-                  <div className="hidden md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 px-4 py-2 bg-muted/30 border-b border-border/40 text-xs font-medium text-muted-foreground">
-                    <div>{t("colDate")}</div>
-                    <div className="text-right">{t("colAssets")}</div>
-                    <div className="text-right">{t("colLiabilities")}</div>
-                    <div className="text-right">{`${t("colNetWorth")} / ${t("colChange")}`}</div>
-                  </div>
 
-                  {items.map((row, index) => {
-                    const dayLabel = format.dateTime(new Date(row.date + "T00:00:00"), {
-                      month: "short",
-                      day: "numeric",
-                    });
-                    const changePositive = row.change !== null && row.change > 0;
-                    const changeNegative = row.change !== null && row.change < 0;
-                    return (
-                      <div key={row.id}>
-                        {index > 0 && <div aria-hidden="true" className="h-px bg-border/60 mx-4" />}
-                        <div
-                          role="row"
-                          className={cn(
-                            "flex flex-col gap-1 px-4 md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 md:items-center",
-                            isCompact ? "py-2" : "py-3.5",
-                          )}
-                        >
-                          {/* Mobile: Date and Net Worth row. Desktop: Column 1 and 4 */}
-                          <div className="flex items-baseline justify-between gap-3 md:contents">
-                            {/* Date */}
-                            <div role="rowheader" className="shrink-0">
-                              <p className="text-sm font-medium">{dayLabel}</p>
-                            </div>
-
-                            {/* Net Worth & Change (Mobile order is different than desktop DOM order, but visually similar. For grid, it stays at the end) */}
-                            <div
-                              role="cell"
-                              className="text-right md:order-last md:flex md:flex-col md:justify-center"
-                            >
-                              <p className="text-sm font-semibold tabular-nums">
-                                {privacyMode ? "***" : formatCurrency(row.netWorth, baseCurrency)}
-                              </p>
-                              <p
-                                className={cn(
-                                  "text-xs tabular-nums mt-0.5",
-                                  changePositive
-                                    ? "text-primary"
-                                    : changeNegative
-                                      ? "text-destructive"
-                                      : "text-muted-foreground",
-                                )}
-                              >
-                                {privacyMode ? (
-                                  "***"
-                                ) : row.change === null ? (
-                                  <span
-                                    title={t("noPreviousSnapshot")}
-                                    aria-label={t("noPreviousSnapshot")}
-                                    className="cursor-help"
-                                  >
-                                    —
-                                  </span>
-                                ) : (
-                                  (row.change >= 0 ? "+" : "") +
-                                  formatCurrency(row.change, baseCurrency)
-                                )}
-                              </p>
-                            </div>
+                {items.map((row, index) => {
+                  const dayLabel = format.dateTime(new Date(row.date + "T00:00:00"), {
+                    month: "short",
+                    day: "numeric",
+                  });
+                  const changePositive = row.change !== null && row.change > 0;
+                  const changeNegative = row.change !== null && row.change < 0;
+                  return (
+                    <div key={row.id}>
+                      {index > 0 && <div aria-hidden="true" className="h-px bg-border/60 mx-4" />}
+                      <div
+                        role="row"
+                        className={cn(
+                          "flex flex-col gap-1 px-4 md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 md:items-center",
+                          isCompact ? "py-2" : "py-3.5",
+                        )}
+                      >
+                        <div className="flex items-baseline justify-between gap-3 md:contents">
+                          <div role="rowheader" className="shrink-0">
+                            <p className="text-sm font-medium">{dayLabel}</p>
                           </div>
 
-                          {/* Assets and Liabilities */}
-                          <div role="cell" className="md:contents">
-                            <p className="text-xs text-muted-foreground tabular-nums leading-relaxed md:hidden">
+                          <div
+                            role="cell"
+                            className="text-right md:order-last md:flex md:flex-col md:justify-center"
+                          >
+                            <p className="text-sm font-semibold tabular-nums">
+                              {privacyMode ? "***" : formatCurrency(row.netWorth, baseCurrency)}
+                            </p>
+                            <p
+                              className={cn(
+                                "text-xs tabular-nums mt-0.5",
+                                changePositive
+                                  ? "text-primary"
+                                  : changeNegative
+                                    ? "text-destructive"
+                                    : "text-muted-foreground",
+                              )}
+                            >
                               {privacyMode ? (
                                 "***"
+                              ) : row.change === null ? (
+                                <span
+                                  title={t("noPreviousSnapshot")}
+                                  aria-label={t("noPreviousSnapshot")}
+                                  className="cursor-help"
+                                >
+                                  —
+                                </span>
                               ) : (
-                                <>
-                                  <span className="block">
-                                    {t("colAssets")} {formatCurrency(row.totalAssets, baseCurrency)}
-                                  </span>
-                                  <span className="block">
-                                    {t("colLiabilities")}{" "}
-                                    {formatCurrency(row.totalLiabilities, baseCurrency)}
-                                  </span>
-                                </>
+                                (row.change >= 0 ? "+" : "") +
+                                formatCurrency(row.change, baseCurrency)
                               )}
                             </p>
-                            {/* Desktop specific cells */}
-                            <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
-                              {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
-                            </div>
-                            <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
-                              {privacyMode
-                                ? "***"
-                                : formatCurrency(row.totalLiabilities, baseCurrency)}
-                            </div>
+                          </div>
+                        </div>
+
+                        <div role="cell" className="md:contents">
+                          <p className="text-xs text-muted-foreground tabular-nums leading-relaxed md:hidden">
+                            {privacyMode ? (
+                              "***"
+                            ) : (
+                              <>
+                                <span className="block">
+                                  {t("colAssets")} {formatCurrency(row.totalAssets, baseCurrency)}
+                                </span>
+                                <span className="block">
+                                  {t("colLiabilities")}{" "}
+                                  {formatCurrency(row.totalLiabilities, baseCurrency)}
+                                </span>
+                              </>
+                            )}
+                          </p>
+                          <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
+                            {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
+                          </div>
+                          <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
+                            {privacyMode
+                              ? "***"
+                              : formatCurrency(row.totalLiabilities, baseCurrency)}
                           </div>
                         </div>
                       </div>
-                    );
-                  })}
-                </div>
+                    </div>
+                  );
+                })}
               </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -112,7 +112,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                           role="row"
                           className={cn(
                             "flex flex-col gap-1 px-4 md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 md:items-center",
-                            isCompact ? "py-2" : "py-3.5"
+                            isCompact ? "py-2" : "py-3.5",
                           )}
                         >
                           {/* Mobile: Date and Net Worth row. Desktop: Column 1 and 4 */}
@@ -121,9 +121,12 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                             <div role="rowheader" className="shrink-0">
                               <p className="text-sm font-medium">{dayLabel}</p>
                             </div>
-                            
+
                             {/* Net Worth & Change (Mobile order is different than desktop DOM order, but visually similar. For grid, it stays at the end) */}
-                            <div role="cell" className="text-right md:order-last md:flex md:flex-col md:justify-center">
+                            <div
+                              role="cell"
+                              className="text-right md:order-last md:flex md:flex-col md:justify-center"
+                            >
                               <p className="text-sm font-semibold tabular-nums">
                                 {privacyMode ? "***" : formatCurrency(row.netWorth, baseCurrency)}
                               </p>
@@ -154,7 +157,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                               </p>
                             </div>
                           </div>
-                          
+
                           {/* Assets and Liabilities */}
                           <div role="cell" className="md:contents">
                             <p className="text-xs text-muted-foreground tabular-nums leading-relaxed md:hidden">
@@ -174,10 +177,12 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                             </p>
                             {/* Desktop specific cells */}
                             <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
-                               {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
+                              {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
                             </div>
                             <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
-                               {privacyMode ? "***" : formatCurrency(row.totalLiabilities, baseCurrency)}
+                              {privacyMode
+                                ? "***"
+                                : formatCurrency(row.totalLiabilities, baseCurrency)}
                             </div>
                           </div>
                         </div>

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useFormatter } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/currencies";
@@ -24,6 +24,7 @@ type Props = {
 
 export function HistoryTable({ snapshots, baseCurrency }: Props) {
   const t = useTranslations("history");
+  const format = useFormatter();
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const isCompact = density === "compact";
@@ -39,9 +40,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
     for (const row of rows) {
       const d = new Date(row.date + "T00:00:00");
       const monthKey = `${d.getFullYear()}-${d.getMonth()}`;
-      const label = d
-        .toLocaleDateString(undefined, { year: "numeric", month: "long" })
-        .toUpperCase();
+      const label = format.dateTime(d, { year: "numeric", month: "long" }).toUpperCase();
       const last = groups[groups.length - 1];
       if (last && last.monthKey === monthKey) {
         last.items.push(row);
@@ -50,7 +49,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
       }
     }
     return groups;
-  }, [snapshots]);
+  }, [snapshots, format]);
 
   return (
     <Card className="border-0 bg-transparent shadow-none">
@@ -91,14 +90,19 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                   </span>
                 </div>
                 <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+                  {/* Desktop Column Headers (visible only on md+) */}
+                  <div className="hidden md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 px-4 py-2 bg-muted/30 border-b border-border/40 text-xs font-medium text-muted-foreground">
+                    <div>{t("colDate")}</div>
+                    <div className="text-right">{t("colAssets")}</div>
+                    <div className="text-right">{t("colLiabilities")}</div>
+                    <div className="text-right">{`${t("colNetWorth")} / ${t("colChange")}`}</div>
+                  </div>
+
                   {items.map((row, index) => {
-                    const dayLabel = new Date(row.date + "T00:00:00").toLocaleDateString(
-                      undefined,
-                      {
-                        month: "short",
-                        day: "numeric",
-                      },
-                    );
+                    const dayLabel = format.dateTime(new Date(row.date + "T00:00:00"), {
+                      month: "short",
+                      day: "numeric",
+                    });
                     const changePositive = row.change !== null && row.change > 0;
                     const changeNegative = row.change !== null && row.change < 0;
                     return (
@@ -106,13 +110,20 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                         {index > 0 && <div aria-hidden="true" className="h-px bg-border/60 mx-4" />}
                         <div
                           role="row"
-                          className={`flex flex-col gap-1 px-4 ${isCompact ? "py-2" : "py-3.5"}`}
+                          className={cn(
+                            "flex flex-col gap-1 px-4 md:grid md:grid-cols-[100px_1fr_1fr_120px] md:gap-4 md:items-center",
+                            isCompact ? "py-2" : "py-3.5"
+                          )}
                         >
-                          <div className="flex items-baseline justify-between gap-3">
+                          {/* Mobile: Date and Net Worth row. Desktop: Column 1 and 4 */}
+                          <div className="flex items-baseline justify-between gap-3 md:contents">
+                            {/* Date */}
                             <div role="rowheader" className="shrink-0">
                               <p className="text-sm font-medium">{dayLabel}</p>
                             </div>
-                            <div role="cell" className="text-right">
+                            
+                            {/* Net Worth & Change (Mobile order is different than desktop DOM order, but visually similar. For grid, it stays at the end) */}
+                            <div role="cell" className="text-right md:order-last md:flex md:flex-col md:justify-center">
                               <p className="text-sm font-semibold tabular-nums">
                                 {privacyMode ? "***" : formatCurrency(row.netWorth, baseCurrency)}
                               </p>
@@ -143,8 +154,10 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                               </p>
                             </div>
                           </div>
-                          <div role="cell">
-                            <p className="text-xs text-muted-foreground tabular-nums leading-relaxed">
+                          
+                          {/* Assets and Liabilities */}
+                          <div role="cell" className="md:contents">
+                            <p className="text-xs text-muted-foreground tabular-nums leading-relaxed md:hidden">
                               {privacyMode ? (
                                 "***"
                               ) : (
@@ -159,6 +172,13 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                                 </>
                               )}
                             </p>
+                            {/* Desktop specific cells */}
+                            <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
+                               {privacyMode ? "***" : formatCurrency(row.totalAssets, baseCurrency)}
+                            </div>
+                            <div className="hidden md:block text-right text-sm tabular-nums text-muted-foreground">
+                               {privacyMode ? "***" : formatCurrency(row.totalLiabilities, baseCurrency)}
+                            </div>
                           </div>
                         </div>
                       </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -88,7 +88,7 @@ export function Sidebar({
   return (
     <aside
       className={cn(
-        "hidden md:flex flex-col border-r bg-sidebar/80 backdrop-blur-md text-sidebar-foreground glass z-10 shrink-0 transition-[width] motion-normal",
+        "hidden md:flex flex-col border-r bg-sidebar/80 backdrop-blur-md text-sidebar-foreground glass z-10 shrink-0",
         collapsed ? "w-[72px]" : "w-64",
       )}
     >


### PR DESCRIPTION
## Summary

- **Full-year activity heatmap** on the history page — shows all 365 days of the current year as a color-coded grid, green for positive net worth changes and red for negative. Tapping a cell reveals a callout strip with the exact value and day-over-day change.
- **Dashboard integration** — trend chart and heatmap are merged into a single card. The heatmap renders as a compact footer strip below the line chart, sharing the same `NormalizedSnapshot[]` data fetch with no extra API calls.
- **History table polish** — removed ghost `Card` wrapper; clean flat layout with sticky month group headers.
- **Sidebar perf** — removed `transition-[width]` to eliminate layout-property animation thrashing.

## Changes

### New
- `src/components/history/history-heatmap.tsx` — full-year heatmap client component with ARIA grid roles, scroll fade mask, auto-scroll to today, tap-to-reveal callout, and privacy mode support
- `TrendChartSkeleton` in `lazy-charts.tsx` — combined loading skeleton matching the new card shape (chart area + 7-row heatmap cell grid)

### Modified
- `trend-chart.tsx` — adds `footer?: ReactNode` slot rendered inside the card below the chart area
- `trend-chart-section.tsx` — forwards `footer` prop to `LazyTrendChart`
- `dashboard-content.tsx` — lifts `getNormalizedHistory` fetch to orchestrator level (shared by trend chart and heatmap with no duplicate queries); passes heatmap as footer to `TrendChartSection`; pie charts moved to their own 2-col grid section below
- `history-table.tsx` — removes nested Card wrapper, adds `FreshnessBadge`, responsive two-column layout on md+

### Perf
- Heatmap snapshot delta computation reduced from O(N²) to O(N) (single sorted pass builds the change map)
- `getNormalizedHistory` is `"use cache"` with `cacheLife("hours")` — warm requests cost zero extra DB queries

## Test plan
- [ ] Dashboard loads: combined trend+heatmap card renders, heatmap auto-scrolls to current week
- [ ] Tap a heatmap cell — callout strip appears below with date, net worth, and change; dismiss button clears it
- [ ] Privacy mode on — heatmap and trend chart both show `***` in aria-labels and callout
- [ ] History page — heatmap and table render correctly
- [ ] Loading skeletons match the new card shape on slow connections
- [ ] `npm run typecheck && npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)