### PR TITLE
fix(settings): a11y, theming, and responsive polish pass

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -515,7 +515,8 @@
     "close": "Close",
     "parseError": "JSON Syntax Error: The file you uploaded is not a valid JSON. Please check the file content.",
     "importSuccessTitle": "Import Successful",
-    "importSuccessMessage": "Your data has been restored successfully. Please refresh the page to see the changes."
+    "importSuccessMessage": "Your data has been restored successfully. Please refresh the page to see the changes.",
+    "done": "Done"
   },
   "installApp": {
     "title": "Add to Home Screen",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -515,7 +515,8 @@
     "close": "關閉",
     "parseError": "JSON 語法錯誤：您上傳的檔案並非有效的 JSON 格式。請檢查檔案內容。",
     "importSuccessTitle": "匯入成功",
-    "importSuccessMessage": "您的資料已成功還原。請重新整理頁面以查看變更。"
+    "importSuccessMessage": "您的資料已成功還原。請重新整理頁面以查看變更。",
+    "done": "完成"
   },
   "installApp": {
     "title": "加入主畫面",

--- a/src/app/(main)/settings/loading.tsx
+++ b/src/app/(main)/settings/loading.tsx
@@ -1,15 +1,7 @@
 export default function SettingsLoading() {
   return (
     <div className="space-y-10 max-w-2xl pb-16">
-      {/* Title + app philosophy blurb */}
-      <div className="flex flex-col space-y-4">
-        <div className="h-10 md:h-9 w-28 rounded-lg skeleton-shimmer" />
-        <div className="bg-muted/50 p-4 rounded-lg border w-full space-y-2">
-          <div className="h-4 w-32 rounded skeleton-shimmer" />
-          <div className="h-3.5 w-full rounded skeleton-shimmer" />
-          <div className="h-3.5 w-5/6 rounded skeleton-shimmer" />
-        </div>
-      </div>
+      <div className="h-10 md:h-9 w-28 rounded-lg skeleton-shimmer" />
 
       {/* Preferences section */}
       <div className="space-y-3 w-full">
@@ -50,7 +42,7 @@ export default function SettingsLoading() {
             </div>
             <div className="flex flex-wrap items-center gap-2">
               {[...Array(6)].map((_, i) => (
-                <div key={i} className="w-10 h-10 rounded-full skeleton-shimmer" />
+                <div key={i} className="w-11 h-11 rounded-full skeleton-shimmer" />
               ))}
             </div>
           </div>
@@ -126,7 +118,7 @@ export default function SettingsLoading() {
       {/* Danger zone */}
       <section className="space-y-3 w-full border-t pt-10">
         <div className="h-6 w-28 rounded skeleton-shimmer" />
-        <div className="border border-red-500/20 bg-red-500/5 rounded-lg overflow-hidden">
+        <div className="border border-destructive/20 bg-destructive/5 rounded-lg overflow-hidden">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
             <div className="space-y-1.5">
               <div className="h-4 w-24 rounded skeleton-shimmer" />

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -28,26 +28,20 @@ async function SettingsContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <div className="space-y-10 max-w-2xl pb-16 animate-in fade-in duration-200">
-        <div className="flex flex-col space-y-4">
-          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
-          <div className="bg-muted/50 p-4 rounded-lg border w-full">
-            <h3 className="font-semibold text-sm mb-1">{t("appPhilosophy")}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{t("appDescription")}</p>
-          </div>
-        </div>
+        <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
         <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
         <DataManagement />
         <InstallAppCard />
 
         <section className="space-y-3 w-full border-t pt-10">
-          <h3 className="text-lg font-semibold text-red-500 dark:text-red-400 flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-destructive flex items-center gap-2">
             {t("dangerZone")}
           </h3>
-          <div className="border border-red-500/20 bg-red-500/5 rounded-lg overflow-hidden">
+          <div className="border border-destructive/20 bg-destructive/5 rounded-lg overflow-hidden">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
               <div className="space-y-1">
-                <p className="text-sm font-medium text-red-600 dark:text-red-400">{t("signOut")}</p>
+                <p className="text-sm font-medium text-destructive">{t("signOut")}</p>
                 <p className="text-sm text-muted-foreground">{t("signOutDesc")}</p>
               </div>
               <form

--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -244,7 +244,7 @@ export function DataManagement() {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-primary">
-              <CheckCircleIcon className="h-5 w-5 text-green-500 dark:text-green-400" />
+              <CheckCircleIcon className="h-5 w-5 text-primary" />
               {t("importSuccessTitle")}
             </DialogTitle>
             <DialogDescription className="py-2 text-foreground font-medium">
@@ -253,7 +253,7 @@ export function DataManagement() {
           </DialogHeader>
           <DialogFooter>
             <Button className="w-full" onClick={() => window.location.reload()}>
-              OK
+              {t("done")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -118,7 +118,7 @@ export function SettingsForm({
               </div>
               <div className="flex items-center gap-2 sm:w-auto w-full">
                 <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
-                  <SelectTrigger id="currency-select" className="w-[200px]">
+                  <SelectTrigger id="currency-select" className="flex-1 sm:flex-none sm:w-[200px]">
                     <SelectValue>
                       {(() => {
                         const c = CURRENCIES.find((c) => c.code === currency);
@@ -150,7 +150,7 @@ export function SettingsForm({
               </div>
               <div className="flex items-center gap-2 sm:w-auto w-full">
                 <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
-                  <SelectTrigger id="language-select" className="w-[200px]">
+                  <SelectTrigger id="language-select" className="flex-1 sm:flex-none sm:w-[200px]">
                     <SelectValue>{t(`languages.${locale}`)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
@@ -182,7 +182,7 @@ export function SettingsForm({
                     key={d}
                     type="button"
                     onClick={() => setDensity(d)}
-                    className={`px-3 py-1.5 rounded-md text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                    className={`px-3 py-1.5 min-h-[44px] md:min-h-0 flex items-center justify-center rounded-md text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                       density === d
                         ? "bg-background border border-border shadow-sm text-foreground font-semibold"
                         : "border border-transparent text-muted-foreground font-medium hover:text-foreground"
@@ -213,7 +213,8 @@ export function SettingsForm({
                     onClick={() => setColorSchema(schema.id)}
                     title={t(`settings.colorSchemas.${schema.id}`)}
                     aria-label={t(`settings.colorSchemas.${schema.id}`)}
-                    className={`relative w-10 h-10 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                    aria-pressed={colorSchema === schema.id}
+                    className={`relative w-11 h-11 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                       colorSchema === schema.id
                         ? "ring-2 ring-offset-2 ring-foreground scale-110"
                         : "opacity-70 hover:opacity-100 hover:scale-105"


### PR DESCRIPTION
## Summary

- **Touch targets**: density toggle buttons get `min-h-[44px]` on mobile (restores natural height on `md+`); color schema swatches bumped from 40px to 44px (`w-11 h-11`)
- **Accessibility**: `aria-pressed` added to color schema swatch buttons, matching the existing pattern on density buttons (WCAG 4.1.2)
- **Theming**: all hard-coded `text-red-*` / `text-green-*` / `border-red-*` / `bg-red-*` classes replaced with `text-destructive`, `border-destructive/*`, `bg-destructive/*`, and `text-primary` tokens across `page.tsx`, `loading.tsx`, and `data-management.tsx` — now responds to color schema changes
- **Responsive**: `SelectTrigger` for currency and language rows changed from `w-[200px]` to `flex-1 sm:flex-none sm:w-[200px]` to prevent overflow on ≤320px viewports
- **i18n**: hardcoded `OK` string in import success dialog replaced with `t("done")` (`"Done"` / `"完成"`)
- **Distill**: app philosophy blurb card removed from the settings page header; settings is a task surface, not an onboarding screen

## Test plan

- [x] Settings page loads without errors in light and dark mode
- [x] Danger zone heading and card use the active destructive token (verify by switching color schema — the red should track the token, not stay fixed)
- [x] Import success dialog shows "Done" in en-US and "完成" in zh-TW
- [x] Currency and language selects fill available width on narrow mobile (320px viewport) without overflowing
- [x] Color schema swatch buttons report `aria-pressed="true"` on the active swatch (verify with browser DevTools accessibility panel)
- [x] Density toggle buttons have at least 44px tap height on mobile (verify with DevTools device emulation)
- [x] Skeleton loading state matches the live page layout (no philosophy blurb shimmer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)