### PR TITLE
[codex] Fix duplicate loading sketches

### DIFF
--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { AccountDetail } from "@/components/accounts/account-detail";
 import { AccountsNavPanel } from "@/components/accounts/accounts-nav-panel";
@@ -10,7 +9,6 @@ import { log } from "@/lib/logger";
 import { getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
-import AccountDetailLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["accountDetail", "common", "categories", "transactionHistory"];
 
@@ -72,9 +70,5 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
 }
 
 export default function AccountDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  return (
-    <Suspense fallback={<AccountDetailLoading />}>
-      <AccountDetailContent params={params} />
-    </Suspense>
-  );
+  return <AccountDetailContent params={params} />;
 }

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
@@ -13,7 +12,6 @@ import {
 } from "@/lib/services/net-worth-service";
 import { getCachedPricesForSymbols } from "@/lib/services/price-service";
 import { log } from "@/lib/logger";
-import AccountsLoading from "./loading";
 
 const CLIENT_NAMESPACES = [
   "accountsList",
@@ -95,9 +93,5 @@ async function AccountsContent() {
 }
 
 export default function AccountsPage() {
-  return (
-    <Suspense fallback={<AccountsLoading />}>
-      <AccountsContent />
-    </Suspense>
-  );
+  return <AccountsContent />;
 }

--- a/src/app/(main)/analysis/loading.tsx
+++ b/src/app/(main)/analysis/loading.tsx
@@ -1,48 +1,88 @@
 export default function AnalysisLoading() {
+  const chartHeights = [280, 280, 280, 200, 280];
+
   return (
     <div className="space-y-4 md:space-y-8">
       {/* Title — matches LargeTitleHeading (text-4xl md:text-3xl) */}
       <div className="h-10 md:h-9 w-32 rounded-lg skeleton-shimmer" />
 
-      {/* Range / density toolbar */}
-      <div className="flex items-center justify-between">
-        <div className="h-4 w-40 rounded skeleton-shimmer" />
-        <div className="flex gap-1">
-          {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-7 w-10 rounded-md skeleton-shimmer" />
-          ))}
+      <div className="space-y-4">
+        {/* Mobile-only tab switcher */}
+        <div className="md:hidden flex border-b">
+          <div className="h-8 w-24 border-b-2 border-primary px-4 pb-2">
+            <div className="h-4 w-16 rounded skeleton-shimmer" />
+          </div>
+          <div className="h-8 w-24 px-4 pb-2">
+            <div className="h-4 w-14 rounded skeleton-shimmer" />
+          </div>
         </div>
-      </div>
 
-      {/* KPI tiles */}
-      <div className="grid gap-3 sm:gap-4 grid-cols-2 sm:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-24 rounded-xl skeleton-shimmer" />
-        ))}
-      </div>
-
-      {/* Charts stack — 5 chart panels matching analysis-view */}
-      {[...Array(5)].map((_, i) => (
-        <div key={i} className="rounded-xl border border-border/50 bg-card p-6">
-          <div className="h-5 w-40 rounded mb-4 skeleton-shimmer" />
-          <div className="h-[280px] rounded-lg skeleton-shimmer" />
+        {/* Sticky freshness + range selector */}
+        <div className="sticky top-[env(safe-area-inset-top)] md:top-0 z-40 flex items-center justify-between gap-2 py-2">
+          <div className="h-5 w-24 rounded-full skeleton-shimmer" />
+          <div className="inline-flex gap-1 rounded-full p-1">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-8 w-10 rounded-md skeleton-shimmer sm:h-6 sm:w-9" />
+            ))}
+          </div>
         </div>
-      ))}
 
-      {/* Top movers list — card with table-like rows */}
-      <div className="rounded-xl border border-border/50 bg-card p-6">
-        <div className="h-5 w-32 rounded mb-2 skeleton-shimmer" />
-        <div className="h-3 w-56 rounded mb-4 skeleton-shimmer" />
-        <div className="space-y-3">
-          {[...Array(4)].map((_, i) => (
-            <div key={i} className="flex items-center justify-between gap-3">
-              <div className="flex-1 space-y-1.5">
-                <div className="h-4 w-32 rounded skeleton-shimmer" />
-                <div className="h-3 w-20 rounded skeleton-shimmer" />
+        <div className="space-y-6">
+          {/* KPI tiles */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="rounded-xl border border-border/50 bg-card p-4 space-y-2">
+                <div className="h-3 w-24 rounded skeleton-shimmer" />
+                <div className="h-7 w-36 rounded skeleton-shimmer" />
+                {i < 2 && <div className="h-3 w-20 rounded skeleton-shimmer" />}
               </div>
-              <div className="h-6 w-24 rounded-md skeleton-shimmer" />
+            ))}
+          </div>
+
+          {/* Charts stack — mirrors premium-card + lazy chart skeletons */}
+          {chartHeights.map((height, i) => (
+            <div key={i} className="premium-card">
+              <div className="border-0 bg-transparent shadow-none">
+                <div className="pb-2 px-2 sm:px-4 pt-4">
+                  <div className="h-5 w-40 rounded skeleton-shimmer" />
+                </div>
+                <div className="px-2 sm:px-4 pb-4">
+                  <div className="rounded skeleton-shimmer" style={{ height }} />
+                </div>
+              </div>
             </div>
           ))}
+
+          {/* Top movers list — card with horizontally scrollable table rows */}
+          <div className="rounded-xl border border-border/50 bg-card">
+            <div className="px-6 pt-6 pb-2">
+              <div className="h-5 w-32 rounded mb-2 skeleton-shimmer" />
+              <div className="h-3 w-56 max-w-full rounded skeleton-shimmer" />
+            </div>
+            <div className="px-6 pb-6 overflow-hidden">
+              <div className="min-w-[520px] space-y-3">
+                <div className="grid grid-cols-[1fr_5rem_5rem_6rem] gap-4 border-b border-border/60 pb-2">
+                  {[...Array(4)].map((_, i) => (
+                    <div key={i} className="h-3 rounded skeleton-shimmer" />
+                  ))}
+                </div>
+                {[...Array(4)].map((_, i) => (
+                  <div
+                    key={i}
+                    className="grid grid-cols-[1fr_5rem_5rem_6rem] items-center gap-4 border-b border-border/40 pb-3 last:border-0"
+                  >
+                    <div className="space-y-1.5">
+                      <div className="h-4 w-32 rounded skeleton-shimmer" />
+                      <div className="h-3 w-20 rounded skeleton-shimmer" />
+                    </div>
+                    <div className="h-4 rounded skeleton-shimmer" />
+                    <div className="h-4 rounded skeleton-shimmer" />
+                    <div className="ml-auto h-6 w-24 rounded-md skeleton-shimmer" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getSession } from "@/lib/auth-session";
@@ -7,7 +6,6 @@ import { getCachedAnalysisPayload } from "@/lib/services/analysis-payload-servic
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AnalysisView } from "@/components/analysis/analysis-view";
-import AnalysisLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["analysis", "categories", "nav", "trendChart", "history", "freshness"];
 
@@ -45,9 +43,5 @@ async function AnalysisContent() {
 }
 
 export default function AnalysisPage() {
-  return (
-    <Suspense fallback={<AnalysisLoading />}>
-      <AnalysisContent />
-    </Suspense>
-  );
+  return <AnalysisContent />;
 }

--- a/src/app/(main)/goals/page.tsx
+++ b/src/app/(main)/goals/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
@@ -9,7 +8,6 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { GoalsView } from "@/components/goals/goals-view";
-import GoalsLoading from "./loading";
 import type { SerializedAccount } from "@/lib/types";
 
 const CLIENT_NAMESPACES = ["goals", "common", "nav", "projections"];
@@ -49,9 +47,5 @@ async function GoalsContent() {
 }
 
 export default function GoalsPage() {
-  return (
-    <Suspense fallback={<GoalsLoading />}>
-      <GoalsContent />
-    </Suspense>
-  );
+  return <GoalsContent />;
 }

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { getTranslations, getMessages } from "next-intl/server";
@@ -10,7 +9,6 @@ import { HistoryTable } from "@/components/history/history-table";
 import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { getNormalizedHistory } from "@/lib/services/history-service";
-import HistoryLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["trendChart", "history", "freshness"];
 
@@ -53,9 +51,5 @@ async function HistoryContent() {
 }
 
 export default function HistoryPage() {
-  return (
-    <Suspense fallback={<HistoryLoading />}>
-      <HistoryContent />
-    </Suspense>
-  );
+  return <HistoryContent />;
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,5 @@
-import { Suspense } from "react";
 import { getSession } from "@/lib/auth-session";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
-import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
 import { DashboardPullRefresh } from "@/components/dashboard/dashboard-pull-refresh";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
@@ -43,9 +41,5 @@ async function DashboardPageContent() {
 }
 
 export default function DashboardPage() {
-  return (
-    <Suspense fallback={<DashboardSkeleton />}>
-      <DashboardPageContent />
-    </Suspense>
-  );
+  return <DashboardPageContent />;
 }

--- a/src/app/(main)/projections/page.tsx
+++ b/src/app/(main)/projections/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getSession } from "@/lib/auth-session";
@@ -7,7 +6,6 @@ import { getProjectionData } from "@/lib/services/projection-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { ProjectionView } from "@/components/projections/projection-view";
-import ProjectionsLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["projections"];
 
@@ -42,9 +40,5 @@ async function ProjectionsContent() {
 }
 
 export default function ProjectionsPage() {
-  return (
-    <Suspense fallback={<ProjectionsLoading />}>
-      <ProjectionsContent />
-    </Suspense>
-  );
+  return <ProjectionsContent />;
 }

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { SettingsForm } from "@/components/settings/settings-form";
 import { DataManagement } from "@/components/settings/data-management";
 import { InstallAppCard } from "@/components/settings/install-app-card";
@@ -10,7 +9,6 @@ import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
-import SettingsLoading from "./loading";
 
 const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement"];
 
@@ -64,9 +62,5 @@ async function SettingsContent() {
 }
 
 export default function SettingsPage() {
-  return (
-    <Suspense fallback={<SettingsLoading />}>
-      <SettingsContent />
-    </Suspense>
-  );
+  return <SettingsContent />;
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,7 +1,8 @@
 import { Suspense, cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { NetWorthCard } from "@/components/dashboard/net-worth-card";
-import { LazyAllocationChart, LazyCurrencyExposureChart, TrendChartSkeleton } from "@/components/dashboard/lazy-charts";
+import { LazyAllocationChart, LazyCurrencyExposureChart } from "@/components/dashboard/lazy-charts";
+import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
 import { AccountsSummary } from "@/components/dashboard/accounts-summary";
 import { DashboardActions } from "@/components/dashboard/dashboard-actions";
 import {

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
 
 export function DashboardSkeleton() {
   return (
@@ -24,16 +25,11 @@ export function DashboardSkeleton() {
         </Card>
       </div>
 
-      {/* Charts — 1st = trend (taller, lg col-span-2 xl col-span-1), 2nd + 3rd = h-250 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-6 items-stretch">
-        <Card className="lg:col-span-2 xl:col-span-1">
-          <CardHeader className="pb-2">
-            <div className="h-5 w-32 rounded skeleton-shimmer" />
-          </CardHeader>
-          <CardContent>
-            <div className="h-[350px] rounded skeleton-shimmer" />
-          </CardContent>
-        </Card>
+      {/* Trend chart + heatmap footer */}
+      <TrendChartSkeleton />
+
+      {/* Allocation + currency exposure charts */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
         {[0, 1].map((i) => (
           <Card key={i}>
             <CardHeader className="pb-2">

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
 
 function ChartSkeleton() {
   return (
@@ -16,41 +17,7 @@ function ChartSkeleton() {
   );
 }
 
-export function TrendChartSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="h-5 w-32 skeleton-shimmer rounded" />
-      </CardHeader>
-      <CardContent>
-        <div className="h-[250px] skeleton-shimmer rounded" />
-      </CardContent>
-      {/* Heatmap footer skeleton */}
-      <div className="border-t border-border/40 px-4 pt-3 pb-4">
-        <div className="h-3 w-48 skeleton-shimmer rounded mb-2 ml-6" />
-        <div className="flex gap-2">
-          <div className="flex flex-col gap-1">
-            {[...Array(7)].map((_, i) => (
-              <div key={i} className="w-4 h-[10px] skeleton-shimmer rounded-sm" />
-            ))}
-          </div>
-          <div className="flex flex-col gap-1 overflow-hidden">
-            {[...Array(7)].map((_, row) => (
-              <div key={row} className="flex gap-1">
-                {[...Array(44)].map((_, col) => (
-                  <div key={col} className="w-[10px] h-[10px] shrink-0 skeleton-shimmer rounded-[2px]" />
-                ))}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </Card>
-  );
-}
-
 export const LazyTrendChart = dynamic(() => import("./trend-chart").then((m) => m.TrendChart), {
-  ssr: false,
   loading: () => <TrendChartSkeleton />,
 });
 

--- a/src/components/dashboard/trend-chart-skeleton.tsx
+++ b/src/components/dashboard/trend-chart-skeleton.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export function TrendChartSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="h-5 w-32 skeleton-shimmer rounded" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-[250px] skeleton-shimmer rounded" />
+      </CardContent>
+      {/* Heatmap footer skeleton */}
+      <div className="border-t border-border/40 px-4 pt-3 pb-4">
+        <div className="h-3 w-48 skeleton-shimmer rounded mb-2 ml-6" />
+        <div className="flex gap-2">
+          <div className="flex flex-col gap-1">
+            {[...Array(7)].map((_, i) => (
+              <div key={i} className="w-4 h-[10px] skeleton-shimmer rounded-sm" />
+            ))}
+          </div>
+          <div className="flex flex-col gap-1 overflow-hidden">
+            {[...Array(7)].map((_, row) => (
+              <div key={row} className="flex gap-1">
+                {[...Array(44)].map((_, col) => (
+                  <div
+                    key={col}
+                    className="w-[10px] h-[10px] shrink-0 skeleton-shimmer rounded-[2px]"
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -332,11 +332,7 @@ export function TrendChart({
           </div>
         )}
       </CardContent>
-      {footer && (
-        <div className="border-t border-border/40 px-4 pt-3 pb-4">
-          {footer}
-        </div>
-      )}
+      {footer && <div className="border-t border-border/40 px-4 pt-3 pb-4">{footer}</div>}
     </Card>
   );
 }

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -50,100 +50,100 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
 
   const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow, currentYear, todayColIndex } =
     useMemo(() => {
-    // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
-    const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
+      // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
+      const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
 
-    let maxPositiveChange = 0;
-    let maxNegativeChange = 0;
+      let maxPositiveChange = 0;
+      let maxNegativeChange = 0;
 
-    // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
-    const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
+      // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
+      const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
 
-    for (let i = 0; i < sortedSnapshots.length; i++) {
-      const snap = sortedSnapshots[i]!;
-      const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
-      const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
+      for (let i = 0; i < sortedSnapshots.length; i++) {
+        const snap = sortedSnapshots[i]!;
+        const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
+        const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
 
-      if (change !== null) {
-        if (change > maxPositiveChange) maxPositiveChange = change;
-        if (change < maxNegativeChange) maxNegativeChange = change;
+        if (change !== null) {
+          if (change > maxPositiveChange) maxPositiveChange = change;
+          if (change < maxNegativeChange) maxNegativeChange = change;
+        }
+
+        snapshotMap.set(snap.date, { ...snap, change });
       }
 
-      snapshotMap.set(snap.date, { ...snap, change });
-    }
+      // 3. Determine end date (Saturday on or after Dec 31st of current year)
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const currentYear = today.getFullYear();
+      const dec31 = new Date(currentYear, 11, 31);
+      const dayOfWeekEnd = dec31.getDay(); // 0 = Sunday, 6 = Saturday
+      const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
+      const endDate = new Date(dec31);
+      endDate.setDate(dec31.getDate() + daysToAddToReachSaturday);
 
-    // 3. Determine end date (Saturday on or after Dec 31st of current year)
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const currentYear = today.getFullYear();
-    const dec31 = new Date(currentYear, 11, 31);
-    const dayOfWeekEnd = dec31.getDay(); // 0 = Sunday, 6 = Saturday
-    const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
-    const endDate = new Date(dec31);
-    endDate.setDate(dec31.getDate() + daysToAddToReachSaturday);
+      // 4. Determine start date (Sunday on or before Jan 1st of current year)
+      const jan1 = new Date(currentYear, 0, 1);
+      const dayOfWeekStart = jan1.getDay();
+      const startDate = new Date(jan1);
+      startDate.setDate(jan1.getDate() - dayOfWeekStart);
 
-    // 4. Determine start date (Sunday on or before Jan 1st of current year)
-    const jan1 = new Date(currentYear, 0, 1);
-    const dayOfWeekStart = jan1.getDay();
-    const startDate = new Date(jan1);
-    startDate.setDate(jan1.getDate() - dayOfWeekStart);
+      // 5. Calculate total days to show
+      const daysToShow =
+        Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+      const weeksToShow = daysToShow / 7;
 
-    // 5. Calculate total days to show
-    const daysToShow =
-      Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-    const weeksToShow = daysToShow / 7;
+      const days: GridDay[] = [];
+      const mLabels: { col: number; label: string }[] = [];
+      let currentMonth = -1;
 
-    const days: GridDay[] = [];
-    const mLabels: { col: number; label: string }[] = [];
-    let currentMonth = -1;
+      for (let i = 0; i < daysToShow; i++) {
+        const current = new Date(startDate);
+        current.setDate(startDate.getDate() + i);
 
-    for (let i = 0; i < daysToShow; i++) {
-      const current = new Date(startDate);
-      current.setDate(startDate.getDate() + i);
+        const year = current.getFullYear();
+        const month = String(current.getMonth() + 1).padStart(2, "0");
+        const day = String(current.getDate()).padStart(2, "0");
+        const dateString = `${year}-${month}-${day}`;
 
-      const year = current.getFullYear();
-      const month = String(current.getMonth() + 1).padStart(2, "0");
-      const day = String(current.getDate()).padStart(2, "0");
-      const dateString = `${year}-${month}-${day}`;
+        const snapData = snapshotMap.get(dateString);
 
-      const snapData = snapshotMap.get(dateString);
+        // Track month boundaries for labels (only if we are still in the current year)
+        if (year === currentYear && current.getMonth() !== currentMonth && current.getDate() < 15) {
+          currentMonth = current.getMonth();
+          mLabels.push({
+            col: Math.floor(i / 7),
+            label: format.dateTime(current, { month: "short" }),
+          });
+        }
 
-      // Track month boundaries for labels (only if we are still in the current year)
-      if (year === currentYear && current.getMonth() !== currentMonth && current.getDate() < 15) {
-        currentMonth = current.getMonth();
-        mLabels.push({
-          col: Math.floor(i / 7),
-          label: format.dateTime(current, { month: "short" }),
+        days.push({
+          date: current,
+          dateString,
+          hasSnapshot: !!snapData,
+          netWorth: snapData?.netWorth,
+          change: snapData?.change ?? null,
+          isFuture: current > today,
+          isNextYear: year > currentYear,
         });
       }
 
-      days.push({
-        date: current,
-        dateString,
-        hasSnapshot: !!snapData,
-        netWorth: snapData?.netWorth,
-        change: snapData?.change ?? null,
-        isFuture: current > today,
-        isNextYear: year > currentYear,
-      });
-    }
+      // Column index of the current week, used to seed the initial scroll position
+      const todayDayOffset = Math.round(
+        (today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      const todayColIndex = Math.floor(todayDayOffset / 7);
 
-    // Column index of the current week, used to seed the initial scroll position
-    const todayDayOffset = Math.round(
-      (today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
-    );
-    const todayColIndex = Math.floor(todayDayOffset / 7);
-
-    return {
-      gridDays: days,
-      monthLabels: mLabels,
-      maxPos: maxPositiveChange,
-      maxNeg: Math.abs(maxNegativeChange),
-      weeksToShow,
-      currentYear,
-      todayColIndex,
-    };
-  }, [snapshots, format]);
+      return {
+        gridDays: days,
+        monthLabels: mLabels,
+        maxPos: maxPositiveChange,
+        maxNeg: Math.abs(maxNegativeChange),
+        weeksToShow,
+        currentYear,
+        todayColIndex,
+      };
+    }, [snapshots, format]);
 
   // Transpose the flat array into 7 rows (Sunday–Saturday)
   const rows = useMemo(() => {
@@ -239,9 +239,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                       ? `${dateLabel}, no data yet`
                       : day.hasSnapshot
                         ? `${dateLabel}, net worth ${
-                            privacyMode
-                              ? "hidden"
-                              : formatCurrency(day.netWorth!, baseCurrency)
+                            privacyMode ? "hidden" : formatCurrency(day.netWorth!, baseCurrency)
                           }${
                             day.change !== null
                               ? `, change ${
@@ -308,7 +306,8 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                         }
                         className={cn(
                           "w-[10px] h-[10px] rounded-[2px]",
-                          isClickable && "cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
+                          isClickable &&
+                            "cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
                           bgClass,
                         )}
                       />


### PR DESCRIPTION
## Summary

- remove duplicate full-page Suspense loading wrappers from main tab pages that already have route-level `loading.tsx` fallbacks
- align the dashboard route skeleton with the current dashboard layout, including the trend chart heatmap footer
- share the trend chart skeleton between the route fallback and lazy chart fallback, and allow the trend chart shell to prerender instead of forcing a second client-only sketch
- run Prettier on the chart/heatmap files flagged by the repo check

## Root Cause

Next.js route `loading.tsx` already wraps each route with a Suspense fallback. The affected pages also wrapped their whole page content in another Suspense boundary using the same route loading component. On dashboard, the first route skeleton was also stale: it sketched the old chart layout without the heatmap, then the lazy trend chart fallback drew a second heatmap-aware sketch.

## Validation

- `npm run check`
- push hook: `format:check`, `lint`, `typecheck`
