### PR TITLE
[codex] Share history and projection mobile surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ git worktree remove ../asset_tracker-<task-name>
 > [!WARNING]
 > A worktree's `node_modules` is a **symlink into the shared cache**. Don't run `npm install <pkg>` directly in a worktree — that mutates the cache and contaminates other worktrees. Instead, edit `package.json` + `package-lock.json` (or use a temporary `node_modules` outside the cache), then re-run `npm run setup:worktree` to populate a fresh hash bucket.
 
-
 ## 🔁 GitHub Actions policy (to control free-plan minutes)
 
 This repository uses a **light-vs-heavy CI split**:
@@ -137,6 +136,7 @@ This repository uses a **light-vs-heavy CI split**:
 - Add `[skip ci]` to PR title/body to skip PR lint/typecheck jobs.
 
 Workflow files:
+
 - `.github/workflows/ci.yml`
 - `.github/workflows/e2e.yml`
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -279,8 +279,11 @@
     "colAssets": "Assets",
     "colLiabilities": "Liabilities",
     "colChange": "Change",
+    "dailyChange30": "Daily Change, 30 Days",
+    "dailyChangeNoData": "Not enough recent snapshots to show daily changes.",
     "noData": "No snapshots yet. Take a snapshot from the dashboard to start tracking.",
     "noDataForRange": "No data for this range.",
+    "noSnapshot": "No snapshot",
     "noPreviousSnapshot": "No previous snapshot to compare"
   },
   "netWorthCard": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -279,8 +279,11 @@
     "colAssets": "總資產",
     "colLiabilities": "總負債",
     "colChange": "變化",
+    "dailyChange30": "近 30 日每日變化",
+    "dailyChangeNoData": "近期快照不足，無法顯示每日變化。",
     "noData": "尚無快照。請從儀表板建立快照以開始追蹤歷史。",
     "noDataForRange": "此範圍內無資料。",
+    "noSnapshot": "無快照",
     "noPreviousSnapshot": "無前一筆快照可比較"
   },
   "netWorthCard": {

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -1,13 +1,10 @@
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { getTranslations, getMessages } from "next-intl/server";
+import { getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
-import { LargeTitleHeading } from "@/components/layout/large-title-heading";
-import { LazyTrendChart } from "@/components/dashboard/lazy-charts";
-import { HistoryTable } from "@/components/history/history-table";
-import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
+import { HistoryView } from "@/components/history/history-view";
 import { getNormalizedHistory } from "@/lib/services/history-service";
 
 const CLIENT_NAMESPACES = ["trendChart", "history", "freshness"];
@@ -17,8 +14,7 @@ async function HistoryContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   const settingsP = getOrCreateSettings(userId);
-  const [t, allMessages, snapshots, settings] = await Promise.all([
-    getTranslations("history"),
+  const [allMessages, snapshots, settings] = await Promise.all([
     getMessages(),
     settingsP.then((s) => getNormalizedHistory(userId, s.baseCurrency)),
     settingsP,
@@ -27,24 +23,13 @@ async function HistoryContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <HistoryPullRefresh>
-        <div className="space-y-4 md:space-y-8 animate-in fade-in duration-200">
-          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
-
-          <div className="h-[300px]">
-            <LazyTrendChart
-              baseCurrency={settings.baseCurrency}
-              snapshots={snapshots}
-              hideRangeFilter
-            />
-          </div>
-
-          <div className="bg-card border border-border/50 shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)] rounded-xl p-4 card-gradient transition-shadow hover:shadow-lg">
-            <div className="mb-4">
-              <HistoryHeatmap snapshots={snapshots} baseCurrency={settings.baseCurrency} />
-            </div>
-            <HistoryTable snapshots={snapshots} baseCurrency={settings.baseCurrency} />
-          </div>
-        </div>
+        <HistoryView
+          snapshots={snapshots}
+          baseCurrency={settings.baseCurrency}
+          showTitle
+          hideTrendRangeFilter
+          className="animate-in fade-in duration-200"
+        />
       </HistoryPullRefresh>
     </NextIntlClientProvider>
   );

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -9,6 +9,7 @@ import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 const CLIENT_NAMESPACES = [
   "dashboardActions",
   "freshness",
+  "history",
   "trendChart",
   "allocationChart",
   "currencyExposure",

--- a/src/app/(main)/projections/page.tsx
+++ b/src/app/(main)/projections/page.tsx
@@ -27,13 +27,7 @@ async function ProjectionsContent() {
       <div className="space-y-4 md:space-y-8 animate-in fade-in duration-200">
         <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
-        <ProjectionView
-          latestNetWorth={projectionData.latestNetWorth}
-          trailing12mSavings={projectionData.trailing12mSavings}
-          annualSnapshots={projectionData.annualSnapshots}
-          hasData={projectionData.hasData}
-          baseCurrency={settings.baseCurrency}
-        />
+        <ProjectionView projectionData={projectionData} baseCurrency={settings.baseCurrency} />
       </div>
     </NextIntlClientProvider>
   );

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -27,9 +27,9 @@ export const POST = withAuth(
       data: { cashBalance: { increment: delta } },
     });
 
-    revalidateTag(`accounts:${userId}`, "max");
-    revalidateTag(`net-worth:${userId}`, "max");
-    revalidateTag(`history:${userId}`, "max");
+    revalidateTag(`accounts:${userId}`, { expire: 0 });
+    revalidateTag(`net-worth:${userId}`, { expire: 0 });
+    revalidateTag(`history:${userId}`, { expire: 0 });
 
     return ok(transaction, { status: 201 });
   },

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -11,10 +11,9 @@ import { log } from "@/lib/logger";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, { expire: 0 });
+  revalidateTag(`net-worth:${userId}`, { expire: 0 });
+  revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
 async function maybeWarmExchangeRate(currency: string) {

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -7,10 +7,9 @@ import { withAuth } from "@/lib/api-handler";
 type IdCtx = { params: Promise<{ id: string }> };
 
 function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, { expire: 0 });
+  revalidateTag(`net-worth:${userId}`, { expire: 0 });
+  revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -8,9 +8,9 @@ import { withAuth } from "@/lib/api-handler";
 type TxCtx = { params: Promise<{ id: string; transactionId: string }> };
 
 function invalidateAccountCaches(userId: string) {
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, { expire: 0 });
+  revalidateTag(`net-worth:${userId}`, { expire: 0 });
+  revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
 export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {

--- a/src/app/api/accounts/reorder/route.ts
+++ b/src/app/api/accounts/reorder/route.ts
@@ -5,10 +5,9 @@ import { withAuth } from "@/lib/api-handler";
 import { reorderAccountsSchema } from "@/lib/validators";
 
 function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, { expire: 0 });
+  revalidateTag(`net-worth:${userId}`, { expire: 0 });
+  revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
 export const PATCH = withAuth(async (request, _ctx, userId) => {

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -7,9 +7,8 @@ import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { log } from "@/lib/logger";
 
 function invalidateUserCaches(userId: string) {
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`accounts:${userId}`, "max");
-  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, { expire: 0 });
+  revalidateTag(`net-worth:${userId}`, { expire: 0 });
 }
 
 // Fire-and-forget rate refresh for a currency that doesn't yet exist in

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -6,8 +6,7 @@ import { motion, useReducedMotion } from "framer-motion";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
 import { useDensity } from "@/components/layout/density-context";
 import { cn } from "@/lib/utils";
-import { TrendChart } from "@/components/dashboard/trend-chart";
-import { HistoryTable } from "@/components/history/history-table";
+import { HistoryView } from "@/components/history/history-view";
 import { FreshnessBadge } from "@/components/ui/freshness-badge";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
 import type {
@@ -297,10 +296,7 @@ export function AnalysisView({
 
       {/* History tab content — mobile only */}
       {activeTab === "history" && (
-        <div className="md:hidden space-y-4">
-          <TrendChart snapshots={snapshots} baseCurrency={baseCurrency} />
-          <HistoryTable snapshots={snapshots} baseCurrency={baseCurrency} />
-        </div>
+        <HistoryView snapshots={snapshots} baseCurrency={baseCurrency} className="md:hidden" />
       )}
     </div>
   );

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -111,7 +111,12 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
             aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
-            <ResponsiveContainer width="100%" height={280}>
+            <ResponsiveContainer
+              width="100%"
+              height={280}
+              minWidth={0}
+              initialDimension={{ width: 1, height: 280 }}
+            >
               <BarChart
                 data={data}
                 margin={{ top: 10, right: 4, left: 0, bottom: 20 }}

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -140,7 +140,12 @@ export function AttributionChart({ items, baseCurrency }: Props) {
             }`}
           >
             <div role="img" aria-label={`${t("attribution")}, ${t("attributionSubtitle")}`}>
-              <ResponsiveContainer width="100%" height={chartHeight}>
+              <ResponsiveContainer
+                width="100%"
+                height={chartHeight}
+                minWidth={0}
+                initialDimension={{ width: 1, height: chartHeight }}
+              >
                 <BarChart
                   layout="vertical"
                   data={chartData}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -134,7 +134,12 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
               </span>
             </div>
             <div role="img" aria-label={`${t("cashFlow")}, ${t("cashFlowSubtitle")}`}>
-              <ResponsiveContainer width="100%" height={280}>
+              <ResponsiveContainer
+                width="100%"
+                height={280}
+                minWidth={0}
+                initialDimension={{ width: 1, height: 280 }}
+              >
                 <BarChart
                   data={buckets}
                   margin={{ top: 10, right: 4, left: 0, bottom: 20 }}

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -129,7 +129,12 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
             aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
-            <ResponsiveContainer width="100%" height={280}>
+            <ResponsiveContainer
+              width="100%"
+              height={280}
+              minWidth={0}
+              initialDimension={{ width: 1, height: 280 }}
+            >
               <LineChart
                 data={chartData}
                 margin={{ top: 10, right: 4, left: 0, bottom: 20 }}

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -117,7 +117,12 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
             aria-hidden={privacyMode || undefined}
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
-            <ResponsiveContainer width="100%" height={280}>
+            <ResponsiveContainer
+              width="100%"
+              height={280}
+              minWidth={0}
+              initialDimension={{ width: 1, height: 280 }}
+            >
               <BarChart
                 data={data}
                 margin={{ top: 10, right: 4, left: 0, bottom: 20 }}

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -106,13 +106,7 @@ export function GoalsView({
       {/* Projections tab — mobile only */}
       {activeTab === "projections" && (
         <div role="tabpanel" className="md:hidden">
-          <ProjectionView
-            latestNetWorth={projectionData.latestNetWorth}
-            trailing12mSavings={projectionData.trailing12mSavings}
-            annualSnapshots={projectionData.annualSnapshots}
-            hasData={projectionData.hasData}
-            baseCurrency={baseCurrency}
-          />
+          <ProjectionView projectionData={projectionData} baseCurrency={baseCurrency} />
         </div>
       )}
     </div>

--- a/src/components/history/daily-change-chart.tsx
+++ b/src/components/history/daily-change-chart.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { startTransition, useEffect, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { useFormatter, useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useChartAnimation } from "@/hooks/use-chart-animation";
+import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
+import { formatChartTick } from "@/lib/chart-formatters";
+import { formatCurrency } from "@/lib/currencies";
+import { cn } from "@/lib/utils";
+
+const DAYS_TO_SHOW = 30;
+
+type SnapshotRow = {
+  id: string;
+  date: string;
+  netWorth: number;
+};
+
+type DailyChangePoint = {
+  date: string;
+  label: string;
+  longLabel: string;
+  change: number;
+  hasSnapshot: boolean;
+  hasPreviousSnapshot: boolean;
+};
+
+type Props = {
+  snapshots: SnapshotRow[];
+  baseCurrency: string;
+};
+
+type TooltipPayload = {
+  payload: DailyChangePoint;
+};
+
+function isoDate(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function DailyChangeTooltip({
+  active,
+  payload,
+  baseCurrency,
+  privacyMode,
+}: {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  baseCurrency: string;
+  privacyMode: boolean;
+}) {
+  const t = useTranslations("history");
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0].payload;
+  const isPositive = point.change >= 0;
+  const isZero = point.change === 0;
+
+  return (
+    <ChartTooltipContainer title={point.longLabel}>
+      {!point.hasSnapshot ? (
+        <div className="text-[11px] text-muted-foreground">{t("noSnapshot")}</div>
+      ) : !point.hasPreviousSnapshot ? (
+        <div className="text-[11px] text-muted-foreground">{t("noPreviousSnapshot")}</div>
+      ) : (
+        <ChartTooltipRow
+          label={t("colChange")}
+          value={
+            privacyMode
+              ? "***"
+              : `${isPositive ? "+" : ""}${formatCurrency(point.change, baseCurrency)}`
+          }
+          valueClassName={
+            isZero ? "text-muted-foreground" : isPositive ? "text-primary" : "text-destructive"
+          }
+        />
+      )}
+    </ChartTooltipContainer>
+  );
+}
+
+export function DailyChangeChart({ snapshots, baseCurrency }: Props) {
+  const t = useTranslations("history");
+  const format = useFormatter();
+  const { privacyMode } = usePrivacyMode();
+  const { handlers: crosshairHandlers } = useChartCrosshair();
+  const { isAnimationActive, onAnimationEnd } = useChartAnimation();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => startTransition(() => setMounted(true)), []);
+
+  const data = useMemo(() => {
+    const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
+    const changeByDate = new Map<string, { change: number; hasPreviousSnapshot: boolean }>();
+
+    sortedSnapshots.forEach((snapshot, index) => {
+      const previous = sortedSnapshots[index - 1];
+      changeByDate.set(snapshot.date, {
+        change: previous ? snapshot.netWorth - previous.netWorth : 0,
+        hasPreviousSnapshot: !!previous,
+      });
+    });
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const start = new Date(today);
+    start.setDate(today.getDate() - (DAYS_TO_SHOW - 1));
+
+    return Array.from({ length: DAYS_TO_SHOW }, (_, index): DailyChangePoint => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + index);
+      const dateString = isoDate(date);
+      const snapshotChange = changeByDate.get(dateString);
+
+      return {
+        date: dateString,
+        label: format.dateTime(date, { month: "numeric", day: "numeric" }),
+        longLabel: format.dateTime(date, { dateStyle: "medium" }),
+        change: snapshotChange?.change ?? 0,
+        hasSnapshot: !!snapshotChange,
+        hasPreviousSnapshot: snapshotChange?.hasPreviousSnapshot ?? false,
+      };
+    });
+  }, [snapshots, format]);
+
+  const hasAnyChange = data.some((point) => point.hasSnapshot && point.hasPreviousSnapshot);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2 px-4">
+        <CardTitle className="text-base font-medium text-foreground">
+          {t("dailyChange30")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4">
+        {!hasAnyChange ? (
+          <div className="h-[180px] flex items-center justify-center text-center text-sm text-muted-foreground">
+            {t("dailyChangeNoData")}
+          </div>
+        ) : !mounted ? (
+          <div className="h-[180px]" />
+        ) : (
+          <div
+            role="img"
+            aria-label={t("dailyChange30")}
+            aria-hidden={privacyMode || undefined}
+            className={cn(
+              "relative h-[180px] transition-[filter] duration-300",
+              privacyMode && "blur-sm pointer-events-none select-none",
+            )}
+          >
+            <ResponsiveContainer
+              width="100%"
+              height={180}
+              minWidth={0}
+              initialDimension={{ width: 1, height: 180 }}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 8, right: 2, left: 0, bottom: 8 }}
+                {...crosshairHandlers}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" vertical={false} />
+                <ReferenceLine y={0} stroke="var(--border)" strokeWidth={1} />
+                <XAxis
+                  dataKey="label"
+                  interval={6}
+                  tick={{ fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  width={42}
+                  tick={{ fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(value) => (privacyMode ? "" : formatChartTick(value))}
+                />
+                <Tooltip
+                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                  content={
+                    <DailyChangeTooltip baseCurrency={baseCurrency} privacyMode={privacyMode} />
+                  }
+                />
+                <Bar
+                  dataKey="change"
+                  radius={[3, 3, 3, 3]}
+                  isAnimationActive={isAnimationActive}
+                  onAnimationEnd={onAnimationEnd}
+                >
+                  {data.map((entry) => (
+                    <Cell
+                      key={entry.date}
+                      fill={
+                        !entry.hasSnapshot || !entry.hasPreviousSnapshot
+                          ? "var(--muted-foreground)"
+                          : entry.change === 0
+                            ? "var(--muted-foreground)"
+                            : entry.change > 0
+                              ? "var(--primary)"
+                              : "var(--destructive)"
+                      }
+                      opacity={
+                        !entry.hasSnapshot || !entry.hasPreviousSnapshot
+                          ? 0.18
+                          : entry.change === 0
+                            ? 0.35
+                            : 1
+                      }
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useFormatter } from "next-intl";
-import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
@@ -41,12 +41,17 @@ type GridDay = {
 type Props = {
   snapshots: SnapshotRow[];
   baseCurrency: string;
+  labels?: {
+    netWorth: string;
+    change: string;
+  };
 };
 
-export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
+export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   const format = useFormatter();
   const { privacyMode } = usePrivacyMode();
-  const [selectedDay, setSelectedDay] = useState<GridDay | null>(null);
+  const [tooltip, setTooltip] = useState<{ day: GridDay; x: number; y: number } | null>(null);
+  const tooltipLabels = labels ?? { netWorth: "Net Worth", change: "Change" };
 
   const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow, currentYear, todayColIndex } =
     useMemo(() => {
@@ -174,6 +179,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
     el.scrollLeft = Math.max(0, targetLeft);
   }, [todayColIndex]);
 
+  const showTooltipAtElement = (day: GridDay, element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
+    setTooltip({ day, x: rect.left + rect.width / 2, y: rect.top });
+  };
+
   return (
     <div className="w-full">
       {/*
@@ -232,7 +242,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                       );
                     }
 
-                    const isClickable = day.hasSnapshot && !day.isFuture;
+                    const canShowDetails = day.hasSnapshot && !day.isFuture;
 
                     const dateLabel = format.dateTime(day.date, { dateStyle: "medium" });
                     const cellLabel = day.isFuture
@@ -251,18 +261,6 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                               : ""
                           }`
                         : `${dateLabel}, no snapshot`;
-
-                    const title = day.isFuture
-                      ? undefined
-                      : day.hasSnapshot
-                        ? `${dateLabel}\n${
-                            privacyMode ? "***" : formatCurrency(day.netWorth!, baseCurrency)
-                          }${
-                            day.change !== null && !privacyMode
-                              ? ` (${day.change >= 0 ? "+" : ""}${formatCurrency(day.change, baseCurrency)})`
-                              : ""
-                          }`
-                        : dateLabel;
 
                     let bgClass = "bg-muted/40 dark:bg-muted/20";
                     if (!day.isFuture && day.hasSnapshot) {
@@ -290,24 +288,43 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
                         role="gridcell"
                         aria-colindex={cIdx + 1}
                         aria-label={cellLabel}
-                        aria-selected={selectedDay?.dateString === day.dateString}
-                        title={title}
-                        tabIndex={isClickable ? 0 : -1}
-                        onClick={isClickable ? () => setSelectedDay(day) : undefined}
-                        onKeyDown={
-                          isClickable
+                        aria-selected={tooltip?.day.dateString === day.dateString}
+                        tabIndex={canShowDetails ? 0 : -1}
+                        onPointerEnter={
+                          canShowDetails
                             ? (e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  e.preventDefault();
-                                  setSelectedDay(day);
+                                if (e.pointerType === "mouse") {
+                                  setTooltip({ day, x: e.clientX, y: e.clientY });
                                 }
                               }
                             : undefined
                         }
+                        onPointerMove={
+                          canShowDetails
+                            ? (e) => {
+                                if (e.pointerType === "mouse") {
+                                  setTooltip({ day, x: e.clientX, y: e.clientY });
+                                }
+                              }
+                            : undefined
+                        }
+                        onPointerLeave={
+                          canShowDetails
+                            ? (e) => {
+                                if (e.pointerType === "mouse") setTooltip(null);
+                              }
+                            : undefined
+                        }
+                        onFocus={
+                          canShowDetails
+                            ? (e) => showTooltipAtElement(day, e.currentTarget)
+                            : undefined
+                        }
+                        onBlur={canShowDetails ? () => setTooltip(null) : undefined}
                         className={cn(
                           "w-[10px] h-[10px] rounded-[2px]",
-                          isClickable &&
-                            "cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
+                          canShowDetails &&
+                            "cursor-pointer transition-transform hover:scale-125 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
                           bgClass,
                         )}
                       />
@@ -320,48 +337,52 @@ export function HistoryHeatmap({ snapshots, baseCurrency }: Props) {
         </div>
       </div>
 
-      {/* Tap-to-reveal callout — works on all devices, unlike title attribute */}
-      {selectedDay && (
-        <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 animate-in fade-in duration-150">
-          <div className="flex gap-6 min-w-0">
-            <div className="min-w-0">
-              <p className="text-xs text-muted-foreground">
-                {format.dateTime(selectedDay.date, { dateStyle: "medium" })}
-              </p>
-              <p className="text-sm font-semibold tabular-nums mt-0.5">
-                {privacyMode ? "***" : formatCurrency(selectedDay.netWorth!, baseCurrency)}
-              </p>
-            </div>
-            {selectedDay.change !== null && (
-              <div className="shrink-0">
-                <p className="text-xs text-muted-foreground">Change</p>
-                <p
-                  className={cn(
-                    "text-sm font-medium tabular-nums mt-0.5",
-                    selectedDay.change > 0
-                      ? "text-primary"
-                      : selectedDay.change < 0
-                        ? "text-destructive"
-                        : "text-muted-foreground",
-                  )}
-                >
-                  {privacyMode
-                    ? "***"
-                    : (selectedDay.change >= 0 ? "+" : "") +
-                      formatCurrency(selectedDay.change, baseCurrency)}
-                </p>
-              </div>
-            )}
-          </div>
-          <button
-            onClick={() => setSelectedDay(null)}
-            aria-label="Dismiss"
-            className="shrink-0 rounded-md p-1 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50 transition-colors"
+      {typeof document !== "undefined" &&
+        tooltip &&
+        createPortal(
+          <div
+            role="tooltip"
+            className="pointer-events-none fixed z-[60] min-w-[180px] -translate-x-1/2 -translate-y-[calc(100%+10px)] rounded-lg border border-border/60 bg-popover/95 px-3 py-2.5 shadow-xl ring-1 ring-black/5 backdrop-blur-md animate-in fade-in zoom-in-95 duration-100 dark:ring-white/5"
+            style={{ left: tooltip.x, top: tooltip.y }}
           >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
+            <p className="border-b border-border/40 pb-1 text-xs font-semibold text-foreground/90">
+              {format.dateTime(tooltip.day.date, { dateStyle: "medium" })}
+            </p>
+            <div className="mt-1.5 space-y-1">
+              <div className="flex items-center justify-between gap-6 text-[11px] leading-relaxed">
+                <span className="text-muted-foreground">{tooltipLabels.netWorth}</span>
+                <span className="font-medium tabular-nums whitespace-nowrap text-foreground">
+                  {privacyMode ? "***" : formatCurrency(tooltip.day.netWorth!, baseCurrency)}
+                </span>
+              </div>
+              {tooltip.day.change !== null && (
+                <div className="flex items-center justify-between gap-6 text-[11px] leading-relaxed">
+                  <span className="text-muted-foreground">{tooltipLabels.change}</span>
+                  <span
+                    className={cn(
+                      "font-medium tabular-nums whitespace-nowrap",
+                      tooltip.day.change > 0
+                        ? "text-primary"
+                        : tooltip.day.change < 0
+                          ? "text-destructive"
+                          : "text-muted-foreground",
+                    )}
+                  >
+                    {privacyMode
+                      ? "***"
+                      : (tooltip.day.change >= 0 ? "+" : "") +
+                        formatCurrency(tooltip.day.change, baseCurrency)}
+                  </span>
+                </div>
+              )}
+            </div>
+            <div
+              aria-hidden="true"
+              className="absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-r border-border/60 bg-popover/95"
+            />
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/history/history-view.tsx
+++ b/src/components/history/history-view.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { TrendChart } from "@/components/dashboard/trend-chart";
+import { LargeTitleHeading } from "@/components/layout/large-title-heading";
+import { cn } from "@/lib/utils";
+import type { NormalizedSnapshot } from "@/lib/services/history-service";
+import { DailyChangeChart } from "./daily-change-chart";
+import { HistoryHeatmap } from "./history-heatmap";
+import { HistoryTable } from "./history-table";
+
+type Props = {
+  snapshots: NormalizedSnapshot[];
+  baseCurrency: string;
+  showTitle?: boolean;
+  hideTrendRangeFilter?: boolean;
+  className?: string;
+};
+
+export function HistoryView({
+  snapshots,
+  baseCurrency,
+  showTitle = false,
+  hideTrendRangeFilter = false,
+  className,
+}: Props) {
+  const t = useTranslations("history");
+
+  return (
+    <div className={cn("space-y-4 md:space-y-8", className)}>
+      {showTitle && <LargeTitleHeading>{t("title")}</LargeTitleHeading>}
+
+      <TrendChart
+        snapshots={snapshots}
+        baseCurrency={baseCurrency}
+        hideRangeFilter={hideTrendRangeFilter}
+        footer={
+          <HistoryHeatmap
+            snapshots={snapshots}
+            baseCurrency={baseCurrency}
+            labels={{ netWorth: t("colNetWorth"), change: t("colChange") }}
+          />
+        }
+      />
+      <DailyChangeChart snapshots={snapshots} baseCurrency={baseCurrency} />
+      <HistoryTable snapshots={snapshots} baseCurrency={baseCurrency} />
+    </div>
+  );
+}

--- a/src/components/projections/projection-chart.tsx
+++ b/src/components/projections/projection-chart.tsx
@@ -105,7 +105,12 @@ export function ProjectionChart({ data, fireNumber, fireYear, baseCurrency }: Pr
           <div
             className={`relative transition-[filter] duration-300 ${privacyMode ? "blur-sm pointer-events-none select-none" : ""}`}
           >
-            <ResponsiveContainer width="100%" height={320}>
+            <ResponsiveContainer
+              width="100%"
+              height={320}
+              minWidth={0}
+              initialDimension={{ width: 1, height: 320 }}
+            >
               <ComposedChart data={data} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis dataKey="year" tick={{ fontSize: 12 }} interval="preserveStartEnd" />

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { formatCurrency, formatNumber, getCurrencySymbol } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
+import type { ProjectionData } from "@/lib/services/projection-service";
 import type { ChartPoint } from "./projection-chart";
 import { LazyProjectionChart } from "./lazy-projection-chart";
 
@@ -187,20 +188,12 @@ function NumberInput({
 }
 
 interface Props {
-  latestNetWorth: number;
-  trailing12mSavings: number;
-  annualSnapshots: { year: number; netWorth: number }[];
-  hasData: boolean;
+  projectionData: ProjectionData;
   baseCurrency: string;
 }
 
-export function ProjectionView({
-  latestNetWorth,
-  trailing12mSavings,
-  annualSnapshots,
-  hasData,
-  baseCurrency,
-}: Props) {
+export function ProjectionView({ projectionData, baseCurrency }: Props) {
+  const { latestNetWorth, trailing12mSavings, annualSnapshots, hasData } = projectionData;
   const t = useTranslations("projections");
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();


### PR DESCRIPTION
## Summary
- share the desktop History page and mobile Analysis > History subtab through a common HistoryView
- add a latest 30 days positive/negative daily change bar chart
- keep the heatmap in the shared net worth trend card, restore current-year Jan-Dec layout, and use hover/focus floating details
- share projection data plumbing between the Projections page and Goals mobile projection subpage
- fix Recharts zero-size warnings and immediate account cache invalidation for mutation-driven e2e consistency

## Validation
- npm run check
- PLAYWRIGHT_TEST_BASE_URL=http://localhost:3002 npm run test:e2e (7 passed, 1 skipped)