### PR TITLE
Add explicit selected marker to stock color scheme options

### DIFF
--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -237,6 +237,12 @@ export function SettingsForm({
                         background: `linear-gradient(135deg, ${scheme.upColor} 50%, ${scheme.downColor} 50%)`,
                       }}
                     >
+                      {isSelected ? (
+                        <span className="absolute -top-1 -right-1 inline-flex items-center gap-1 rounded-full border border-border bg-background/95 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85">
+                          <Check aria-hidden className="h-2.5 w-2.5" />
+                          <span aria-hidden>Selected</span>
+                        </span>
+                      ) : null}
                       <TrendingUp
                         aria-hidden
                         className="absolute top-2 left-2 w-3 h-3 text-white drop-shadow"
@@ -245,6 +251,7 @@ export function SettingsForm({
                         aria-hidden
                         className="absolute bottom-2 right-2 w-3 h-3 text-white drop-shadow"
                       />
+                      {isSelected ? <span className="sr-only">Selected</span> : null}
                     </button>
                   );
                 })}


### PR DESCRIPTION
### Motivation
- Make the active stock up/down color option visibly and programmatically distinguishable beyond the existing ring/scale and color cues so selection is understandable without relying on color perception. 
- Ensure the selected indicator remains legible on both light and dark themes and over either half of the gradient swatch.

### Description
- Updated `src/components/settings/settings-form.tsx` to render a conditional selected badge on the active stock color button that contains a `Check` icon and the text `Selected` for clear visual affordance. 
- The badge uses a bordered, high-contrast background (`border`, `bg-background/95`, `text-foreground`, shadow and `backdrop-blur` fallback) and is positioned `absolute -top-1 -right-1` so it remains visible over the gradient. 
- Kept `aria-pressed` semantics intact and added an additional `sr-only` `Selected` span so assistive technologies receive explicit state information independent of color.

### Testing
- Ran `npm run lint -- src/components/settings/settings-form.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15872e01b08321a5517eaded2db0bc)