### PR TITLE
fix(accounts): include cash balance in brokerage total value

### DIFF
--- a/src/components/accounts/account-stat-cards.tsx
+++ b/src/components/accounts/account-stat-cards.tsx
@@ -40,34 +40,12 @@ export function AccountStatCards({
     );
   }
 
-  // BROKERAGE / CRYPTO: primary is market value; cash is the only secondary fact
-  // (holdings count lives in the Holdings section title below).
-  if (isBrokerage) {
-    return (
-      <section className="space-y-1">
-        <p
-          aria-live="polite"
-          className="text-4xl font-bold tracking-tight tabular-nums text-foreground"
-        >
-          {privacyMode ? HIDDEN : formatCurrency(totalHoldingsValue, account.currency)}
-        </p>
-        <p className="text-sm text-muted-foreground">{t("accountDetail.marketValue")}</p>
-        <div className="pt-2">
-          <InlineBalanceEditor
-            mode="inline"
-            inlineLabel={t("accountDetail.cashBalance")}
-            currentBalance={account.cashBalance}
-            currency={account.currency}
-            notePlaceholder={t("accountDetail.notePlaceholderDeposit")}
-            onSave={onSaveBalance}
-          />
-        </div>
-      </section>
-    );
-  }
-
-  // OTHER / INVESTMENT: primary is total value; secondary breaks it into cash + holdings value.
+  // BROKERAGE / CRYPTO / OTHER: primary is total value (cash + holdings);
+  // secondary breaks it into editable cash balance + holdings market value.
   const totalValue = account.cashBalance + totalHoldingsValue;
+  const notePlaceholder = isBrokerage
+    ? t("accountDetail.notePlaceholderDeposit")
+    : t("accountDetail.notePlaceholderSalary");
   return (
     <section className="space-y-1">
       <p
@@ -83,7 +61,7 @@ export function AccountStatCards({
           inlineLabel={t("accountDetail.cashBalance")}
           currentBalance={account.cashBalance}
           currency={account.currency}
-          notePlaceholder={t("accountDetail.notePlaceholderSalary")}
+          notePlaceholder={notePlaceholder}
           onSave={onSaveBalance}
         />
         <span className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- Brokerage and crypto-wallet account detail pages were showing only holdings market value as the headline, ignoring `cashBalance` — inconsistent with the accounts list (`accounts-list.tsx:136`) and the net-worth service (`net-worth-service.ts:163`), which already sum cash + holdings.
- Collapses the brokerage-only branch in `account-stat-cards.tsx` into the same layout as the OTHER branch: headline shows **Total Value = cash + holdings**, with the editable Cash Balance and read-only Holdings Value broken out underneath.
- Preserves the brokerage-specific deposit note placeholder when editing cash inline.

## Test plan
- [ ] Open a brokerage account detail page — headline should equal cash balance + sum of holdings market value, labeled "Total Value".
- [ ] Edit the inline cash balance — header total updates and matches the value shown on the accounts list / dashboard.
- [ ] Verify a crypto-wallet account behaves the same way.
- [ ] Bank account headline (still cash-only) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)