### PR TITLE
fix(accounts,snapshots): close transaction race conditions and UTC-floor snapshot date

### DIFF
--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -5,6 +5,7 @@ import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-servic
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { parseOccSymbol, formatOptionLabel, OptionError } from "@/lib/options";
 import { log } from "@/lib/logger";
 
@@ -43,6 +44,9 @@ export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
 });
 
 export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "holdings-create" });
+  if (limited) return limited;
+
   const { id } = await params;
 
   const account = await prisma.account.findUnique({

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -40,18 +40,7 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
 
     const { id: _txId, ...data } = parsed.data;
 
-    if (data.quantity !== undefined) {
-      const diff = data.quantity - Number(holdingTx.quantity);
-      if (diff !== 0) {
-        const newHoldingQty = Number(holdingTx.holding.quantity) + diff;
-        await prisma.holding.update({
-          where: { id: holdingTx.holding.id },
-          data: { quantity: newHoldingQty },
-        });
-      }
-    }
-
-    const updatedTx = await prisma.holdingTransaction.update({
+    const txUpdate = prisma.holdingTransaction.update({
       where: { id: transactionId },
       data: {
         ...(data.quantity !== undefined && { quantity: data.quantity }),
@@ -60,6 +49,22 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
         ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
       },
     });
+
+    const diff = data.quantity !== undefined ? data.quantity - Number(holdingTx.quantity) : 0;
+
+    let updatedTx;
+    if (diff !== 0) {
+      const [, tx] = await prisma.$transaction([
+        prisma.holding.update({
+          where: { id: holdingTx.holding.id },
+          data: { quantity: { increment: diff } },
+        }),
+        txUpdate,
+      ]);
+      updatedTx = tx;
+    } else {
+      updatedTx = await txUpdate;
+    }
 
     invalidateAccountCaches(userId);
     return ok(updatedTx);
@@ -85,23 +90,7 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
 
     const { id: _txId, ...data } = parsed.data;
 
-    // Recompute balance delta whenever amount or type changes.
-    if (data.amount !== undefined || data.type !== undefined) {
-      const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
-      const newTx = {
-        type: data.type ?? cashTx.type,
-        amount: data.amount ?? Number(cashTx.amount),
-      };
-      const delta = calculateBalanceDelta(oldTx, newTx);
-      if (delta !== 0) {
-        await prisma.account.update({
-          where: { id: accountId },
-          data: { cashBalance: { increment: delta } },
-        });
-      }
-    }
-
-    const updatedTx = await prisma.cashTransaction.update({
+    const cashTxUpdate = prisma.cashTransaction.update({
       where: { id: transactionId },
       data: {
         ...(data.amount !== undefined && { amount: data.amount }),
@@ -110,6 +99,31 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
         ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
       },
     });
+
+    // Recompute balance delta whenever amount or type changes.
+    let delta = 0;
+    if (data.amount !== undefined || data.type !== undefined) {
+      const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
+      const newTx = {
+        type: data.type ?? cashTx.type,
+        amount: data.amount ?? Number(cashTx.amount),
+      };
+      delta = calculateBalanceDelta(oldTx, newTx);
+    }
+
+    let updatedTx;
+    if (delta !== 0) {
+      const [, tx] = await prisma.$transaction([
+        prisma.account.update({
+          where: { id: accountId },
+          data: { cashBalance: { increment: delta } },
+        }),
+        cashTxUpdate,
+      ]);
+      updatedTx = tx;
+    } else {
+      updatedTx = await cashTxUpdate;
+    }
 
     invalidateAccountCaches(userId);
     return ok(updatedTx);
@@ -137,13 +151,13 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
       return failure("Transaction not found", 404);
     }
 
-    const newHoldingQty = Number(holdingTx.holding.quantity) - Number(holdingTx.quantity);
-    await prisma.holding.update({
-      where: { id: holdingTx.holding.id },
-      data: { quantity: newHoldingQty },
-    });
-
-    await prisma.holdingTransaction.delete({ where: { id: transactionId } });
+    await prisma.$transaction([
+      prisma.holding.update({
+        where: { id: holdingTx.holding.id },
+        data: { quantity: { decrement: Number(holdingTx.quantity) } },
+      }),
+      prisma.holdingTransaction.delete({ where: { id: transactionId } }),
+    ]);
     invalidateAccountCaches(userId);
     return ok({ ok: true });
   }

--- a/src/app/api/accounts/reorder/route.ts
+++ b/src/app/api/accounts/reorder/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { reorderAccountsSchema } from "@/lib/validators";
 
 function invalidateUserCaches(userId: string) {
@@ -11,6 +12,9 @@ function invalidateUserCaches(userId: string) {
 }
 
 export const PATCH = withAuth(async (request, _ctx, userId) => {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "accounts-reorder" });
+  if (limited) return limited;
+
   const body = await request.json();
   const parsed = reorderAccountsSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -2,9 +2,13 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { withAuth } from "@/lib/api-handler";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { ok } from "@/lib/api-responses";
 
-export const POST = withAuth(async (_request, _ctx, userId) => {
+export const POST = withAuth(async (request, _ctx, userId) => {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "rates-refresh" });
+  if (limited) return limited;
+
   const settings = await prisma.setting.findUnique({ where: { userId } });
   const baseCurrency = settings?.baseCurrency ?? "USD";
 

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -2,11 +2,16 @@ import { revalidateTag } from "next/cache";
 import { withAuth } from "@/lib/api-handler";
 import { refreshPricesForUser } from "@/lib/services/price-service";
 import { ok } from "@/lib/api-responses";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 
-export const POST = withAuth(async (_request, _ctx, userId) => {
+export const POST = withAuth(async (request, _ctx, userId) => {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "prices-refresh" });
+  if (limited) return limited;
+
   const result = await refreshPricesForUser(userId);
   // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
   revalidateTag("net-worth", "max");
   revalidateTag("prices:crypto", "max");
+  revalidateTag(`accounts:${userId}`, "max");
   return ok(result);
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -44,7 +44,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   session: { strategy: "jwt" },
   callbacks: {
     session({ session, token }) {
-      if (session.user && token.sub) {
+      if (session.user) {
+        if (!token.sub) {
+          throw new Error("Token missing sub");
+        }
         session.user.id = token.sub;
       }
       return session;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -32,6 +32,10 @@ const store = new Map<string, WindowEntry>();
 function getClientIp(request: Request): string {
   const xff = request.headers.get("x-forwarded-for");
   if (xff) return xff.split(",")[0].trim();
+  const cf = request.headers.get("cf-connecting-ip");
+  if (cf) return cf.trim();
+  const real = request.headers.get("x-real-ip");
+  if (real) return real.trim();
   return "unknown";
 }
 

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -56,18 +56,31 @@ export function resolveRate(
 
 /**
  * Race a promise against a timeout. Returns fallback if the promise
- * doesn't resolve within `ms` milliseconds.
+ * doesn't resolve within `ms` milliseconds. The optional onTimeout
+ * callback fires exactly once when the timeout wins the race, so
+ * callers can distinguish "timed out" from "completed with no data".
  */
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  onTimeout?: () => void,
+): Promise<T> {
   return Promise.race([
     promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+    new Promise<T>((resolve) =>
+      setTimeout(() => {
+        onTimeout?.();
+        resolve(fallback);
+      }, ms),
+    ),
   ]);
 }
 
 /**
  * Fetch exchange rates from external APIs with a timeout guard.
- * Returns {} if all sources fail or timeout.
+ * Returns {} if all sources fail or timeout. Logs distinctly on
+ * timeout so the failure mode is visible in the logs.
  */
 export async function fetchExchangeRates(base: string): Promise<Record<string, number>> {
   const doFetch = async (): Promise<Record<string, number>> => {
@@ -115,21 +128,35 @@ export async function fetchExchangeRates(base: string): Promise<Record<string, n
     return {};
   };
 
-  return withTimeout(doFetch(), RATE_FETCH_TIMEOUT_MS, {});
+  return withTimeout(doFetch(), RATE_FETCH_TIMEOUT_MS, {}, () => {
+    log.warn("rates.fetch.timeout", { base, timeoutMs: RATE_FETCH_TIMEOUT_MS });
+  });
 }
 
 /**
- * Upsert a single exchange rate into the DB.
+ * Upsert a single exchange rate into the DB. Also persists the inverse
+ * direction so reads never depend on `1 / rate` at query time (which
+ * makes different conversion paths return different values).
  * Errors are caught and logged as warnings so callers are never blocked.
  */
 async function persistExchangeRate(from: string, to: string, rate: number): Promise<void> {
   const id = `${from}_${to}`;
+  const inverseId = `${to}_${from}`;
+  const inverseRate = 1 / rate;
+  const now = new Date();
   try {
-    await prisma.exchangeRate.upsert({
-      where: { id },
-      update: { rate, updatedAt: new Date() },
-      create: { id, fromCurrency: from, toCurrency: to, rate },
-    });
+    await prisma.$transaction([
+      prisma.exchangeRate.upsert({
+        where: { id },
+        update: { rate, updatedAt: now },
+        create: { id, fromCurrency: from, toCurrency: to, rate },
+      }),
+      prisma.exchangeRate.upsert({
+        where: { id: inverseId },
+        update: { rate: inverseRate, updatedAt: now },
+        create: { id: inverseId, fromCurrency: to, toCurrency: from, rate: inverseRate },
+      }),
+    ]);
   } catch (error) {
     log.warn("rates.persist.failed", { from, to, error: String(error) });
   }
@@ -145,13 +172,24 @@ export async function refreshExchangeRates(baseCurrency: string): Promise<number
 
   if (entries.length === 0) return 0;
 
+  // Persist both directions (FROM→TO and TO→FROM) so reads never need
+  // to compute `1 / rate` at query time. Two paths through the rate map
+  // then always agree.
   const params: unknown[] = [];
-  const placeholders = entries.map(([toCurrency, rate]) => {
+  const placeholders: string[] = [];
+  for (const [toCurrency, rate] of entries) {
     const id = `${baseCurrency}_${toCurrency}`;
     const base = params.length;
     params.push(id, baseCurrency, toCurrency, String(rate));
-    return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}::numeric, NOW())`;
-  });
+    placeholders.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}::numeric, NOW())`);
+
+    const inverseId = `${toCurrency}_${baseCurrency}`;
+    const inverseBase = params.length;
+    params.push(inverseId, toCurrency, baseCurrency, String(1 / rate));
+    placeholders.push(
+      `($${inverseBase + 1}, $${inverseBase + 2}, $${inverseBase + 3}, $${inverseBase + 4}::numeric, NOW())`,
+    );
+  }
   await prisma.$executeRawUnsafe(
     `INSERT INTO "ExchangeRate" (id, "fromCurrency", "toCurrency", rate, "updatedAt")
      VALUES ${placeholders.join(", ")}

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -24,40 +24,51 @@ interface SnapshotRow {
   totalAssets: Decimal;
   totalLiabilities: Decimal;
   baseCurrency: string;
+  createdAt: Date;
 }
 
 /**
  * Pure transformation: convert and dedupe raw snapshots into NormalizedSnapshot[].
- * If multiple snapshots exist for the same date (e.g. from a currency change),
- * prefers the one whose baseCurrency already matches the target, otherwise the latest seen.
+ * If multiple snapshots exist for the same date (e.g. a manual + cron snapshot),
+ * prefers the snapshot whose baseCurrency already matches the target; otherwise
+ * keeps the one with the greatest createdAt so dedupe is deterministic.
  */
 function normalizeSnapshots(
   snapshots: SnapshotRow[],
   allRatesMap: Map<string, number>,
   targetBaseCurrency: string,
 ): NormalizedSnapshot[] {
-  const normalizedMap = new Map<string, NormalizedSnapshot>();
+  const winnerMap = new Map<string, SnapshotRow>();
 
   for (const s of snapshots) {
     const dateStr = s.date.toISOString().split("T")[0];
-    const rate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
-
-    const normalized: NormalizedSnapshot = {
-      id: s.id,
-      date: dateStr,
-      netWorth: Number(s.netWorth) * rate,
-      totalAssets: Number(s.totalAssets) * rate,
-      totalLiabilities: Number(s.totalLiabilities) * rate,
-      baseCurrency: targetBaseCurrency,
-    };
-
-    const existing = normalizedMap.get(dateStr);
-    if (!existing || s.baseCurrency === targetBaseCurrency) {
-      normalizedMap.set(dateStr, normalized);
+    const existing = winnerMap.get(dateStr);
+    if (!existing) {
+      winnerMap.set(dateStr, s);
+      continue;
+    }
+    const existingMatches = existing.baseCurrency === targetBaseCurrency;
+    const candidateMatches = s.baseCurrency === targetBaseCurrency;
+    if (candidateMatches && !existingMatches) {
+      winnerMap.set(dateStr, s);
+    } else if (candidateMatches === existingMatches && s.createdAt > existing.createdAt) {
+      winnerMap.set(dateStr, s);
     }
   }
 
-  return Array.from(normalizedMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+  return Array.from(winnerMap.entries())
+    .map(([dateStr, s]) => {
+      const rate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
+      return {
+        id: s.id,
+        date: dateStr,
+        netWorth: Number(s.netWorth) * rate,
+        totalAssets: Number(s.totalAssets) * rate,
+        totalLiabilities: Number(s.totalLiabilities) * rate,
+        baseCurrency: targetBaseCurrency,
+      };
+    })
+    .sort((a, b) => a.date.localeCompare(b.date));
 }
 
 /**
@@ -89,6 +100,7 @@ export async function getNormalizedHistory(
         totalAssets: true,
         totalLiabilities: true,
         baseCurrency: true,
+        createdAt: true,
       },
       orderBy: { date: "asc" },
     }),
@@ -135,6 +147,7 @@ async function fetchFullHistoryCached(
         totalAssets: true,
         totalLiabilities: true,
         baseCurrency: true,
+        createdAt: true,
       },
       orderBy: { date: "asc" },
     }),
@@ -209,7 +222,7 @@ export async function getRawHistoryWithBreakdown(
   const [snapshotsRaw, accountsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId },
-      select: { date: true, breakdown: true, baseCurrency: true },
+      select: { date: true, breakdown: true, baseCurrency: true, createdAt: true },
       orderBy: { date: "asc" },
     }),
     prisma.account.findMany({
@@ -220,13 +233,33 @@ export async function getRawHistoryWithBreakdown(
   ]);
 
   // Dedupe by date (same pattern as normalizeSnapshots): prefer the snapshot
-  // whose baseCurrency matches the target; otherwise keep the last one seen.
-  const dedupedMap = new Map<string, { breakdown: unknown; baseCurrency: string }>();
+  // whose baseCurrency matches the target; otherwise keep the greatest createdAt.
+  const dedupedMap = new Map<
+    string,
+    { breakdown: unknown; baseCurrency: string; createdAt: Date }
+  >();
   for (const s of snapshotsRaw) {
     const dateStr = s.date.toISOString().split("T")[0];
     const existing = dedupedMap.get(dateStr);
-    if (!existing || s.baseCurrency === targetBaseCurrency) {
-      dedupedMap.set(dateStr, { breakdown: s.breakdown, baseCurrency: s.baseCurrency });
+    if (!existing) {
+      dedupedMap.set(dateStr, {
+        breakdown: s.breakdown,
+        baseCurrency: s.baseCurrency,
+        createdAt: s.createdAt,
+      });
+      continue;
+    }
+    const existingMatches = existing.baseCurrency === targetBaseCurrency;
+    const candidateMatches = s.baseCurrency === targetBaseCurrency;
+    if (
+      (candidateMatches && !existingMatches) ||
+      (candidateMatches === existingMatches && s.createdAt > existing.createdAt)
+    ) {
+      dedupedMap.set(dateStr, {
+        breakdown: s.breakdown,
+        baseCurrency: s.baseCurrency,
+        createdAt: s.createdAt,
+      });
     }
   }
 

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -91,7 +91,19 @@ async function computeNetWorthSummary(
       const cached = priceMap[h.symbol];
       const currentPrice = cached?.price ?? null;
       const quantity = h.quantity;
-      const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
+      let multiplier = 1;
+      if (h.assetType === "OPTION") {
+        if (h.contractMultiplier == null) {
+          log.warn("holdings.option.missing_multiplier", {
+            userId,
+            holdingId: h.id,
+            symbol: h.symbol,
+          });
+          multiplier = 100;
+        } else {
+          multiplier = h.contractMultiplier;
+        }
+      }
       const marketValue = currentPrice !== null ? currentPrice * quantity * multiplier : null;
       return {
         ...h,

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getNetWorthSummary } from "./net-worth-service";
 
@@ -35,6 +36,10 @@ export async function createSnapshot(userId: string, baseCurrency: string) {
       breakdown,
     },
   });
+
+  revalidateTag(`history:${userId}`, "max");
+  revalidateTag(`net-worth:${userId}`, "max");
+  revalidateTag(`accounts:${userId}`, "max");
 
   return snapshot;
 }

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -4,8 +4,8 @@ import { getNetWorthSummary } from "./net-worth-service";
 
 export async function createSnapshot(userId: string, baseCurrency: string) {
   const summary = await getNetWorthSummary(userId, baseCurrency);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 
   const breakdown = Object.fromEntries(
     summary.accounts.map((a) => [a.id, { value: a.totalValue, currency: a.currency }]),

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -85,8 +85,7 @@ export const updateHoldingSchema = z.object({
     .transform((s) => s.toUpperCase())
     .optional(),
   name: z.string().min(1).max(100).optional(),
-  quantity: z.number().nonnegative().optional(),
-  assetType: z.enum(HOLDING_ASSET_TYPES).optional(),
+  quantity: z.number().positive("Quantity must be positive").optional(),
 });
 
 export const updateSettingsSchema = z.object({
@@ -95,27 +94,37 @@ export const updateSettingsSchema = z.object({
   stockColorScheme: z.enum(["GREEN_UP", "RED_UP"]).optional(),
 });
 
-export const updateTransactionSchema = z.object({
-  id: z.string(),
-  quantity: z.number().optional(),
-  type: z.enum(HOLDING_TRANSACTION_TYPES).optional(),
-  note: z.string().optional().nullable(),
-  createdAt: z.string().optional(), // Using string for ISO dates
-});
+export const updateTransactionSchema = z
+  .object({
+    id: z.string(),
+    quantity: z.number().finite().optional(),
+    type: z.enum(HOLDING_TRANSACTION_TYPES).optional(),
+    note: z.string().optional().nullable(),
+    createdAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  .refine((d) => d.quantity === undefined || d.type === "EDIT" || d.quantity > 0, {
+    message: "quantity must be positive for BUY/SELL",
+    path: ["quantity"],
+  });
 
 export const createCashTransactionSchema = z.object({
   type: z.enum(CASH_TRANSACTION_TYPES),
-  amount: z.number(),
+  amount: z.number().finite(),
   note: z.string().optional().nullable(),
 });
 
-export const updateCashTransactionSchema = z.object({
-  id: z.string(),
-  type: z.enum(CASH_TRANSACTION_TYPES).optional(),
-  amount: z.number().optional(),
-  note: z.string().optional().nullable(),
-  createdAt: z.string().optional(),
-});
+export const updateCashTransactionSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(CASH_TRANSACTION_TYPES).optional(),
+    amount: z.number().finite().optional(),
+    note: z.string().optional().nullable(),
+    createdAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  .refine((d) => d.amount === undefined || d.type === "EDIT" || d.amount > 0, {
+    message: "amount must be positive for DEPOSIT/WITHDRAWAL",
+    path: ["amount"],
+  });
 
 export const createGoalSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),


### PR DESCRIPTION
## Summary

Fixes all **Critical** and **High** severity items from `docs/BUGS.md`.

**Critical (commit `8ead5c8`)**
- `accounts/[id]/transactions/[transactionId]/route.ts`: wrap holding/cash transaction PATCH and holding-transaction DELETE in `prisma.$transaction` with atomic `increment`/`decrement` so concurrent edits / mid-flight crashes no longer desync `holding.quantity` or `account.cashBalance`.
- `snapshot-service.ts`: floor the snapshot date in UTC so the `userId_date_baseCurrency` upsert key matches the cron caller and stops drifting per server timezone.

**High (commit `205f077`)**
- `snapshot-service.ts` revalidates `history:/net-worth:/accounts:${userId}` after upsert.
- `prices/refresh` also revalidates `accounts:${userId}`.
- `accounts/reorder`, `holdings` POST, `prices/refresh`, `exchange-rates/refresh`: wrap with `rateLimitCheckWithPrune` (60/min per IP).
- `auth.ts` throws `"Token missing sub"` instead of silently issuing broken sessions.
- `rate-limit.getClientIp` falls back to `cf-connecting-ip` / `x-real-ip` before `"unknown"`.
- `exchange-rate-service`: logs `rates.fetch.timeout` distinctly when the timeout race fires; `persistExchangeRate` + `refreshExchangeRates` now store both directions so reads never depend on `1/rate`.
- `history-service`: `normalizeSnapshots` + `getRawHistoryWithBreakdown` break dedupe ties by `max(createdAt)` (queries extended to select `createdAt`).
- `net-worth-service`: logs `holdings.option.missing_multiplier` before defaulting to `100×`.
- `validators`: `updateHoldingSchema` requires positive `quantity` and no longer accepts `assetType`; transaction update schemas require `finite()` amounts, ISO-8601 `createdAt`, and reject non-positive amounts for non-EDIT types.

## Test plan

### Automated
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] CI green on the PR (`build`, lint, typecheck workflows)

### Manual smoke (run against a preview deploy or local dev DB)

**Critical — transaction race fixes**
- [x] Holding PATCH: edit a `BUY` transaction's quantity from `10` → `25`; reload the holding and confirm `holding.quantity` increased by exactly `15` (no drift).
- [x] Holding DELETE: delete a `BUY` of `5` shares; confirm `holding.quantity` decreased by exactly `5` and the transaction row is gone.
- [x] Cash PATCH: edit a `DEPOSIT` amount from `100` → `150`; confirm `account.cashBalance` rose by `50`.
- [x] Concurrency check (optional): from two terminals, fire two PATCHes against different transactions of the same holding in parallel and confirm `holding.quantity` equals the sum of all transaction quantities.

**Critical — snapshot timezone**
- [ ] Manually invoke `createSnapshot(userId, baseCurrency)` near a UTC day boundary (e.g. with `TZ=America/Los_Angeles node ...`) and confirm the resulting `NetWorthSnapshot.date` matches the cron's UTC-floored date, not the local-midnight one.
- [ ] Hit `/api/cron/snapshot` (with the `Bearer ${CRON_SECRET}` header), then visit `/history` and `/` — the new snapshot should appear immediately (cache invalidated by the new `revalidateTag` calls).

**High — cache invalidation**
- [ ] Trigger `POST /api/prices/refresh`; visit an account page and confirm prices reflect the refresh without waiting for the hour-long TTL.

**High — rate limiting**
- [ ] In a loop, POST to `/api/prices/refresh` more than 60×/min from one IP; confirm a `429` with `Retry-After` header. Repeat for `/api/accounts/reorder`, `/api/accounts/[id]/holdings` POST, `/api/exchange-rates/refresh`.

**High — auth loudness**
- [ ] Force a JWT without `sub` (e.g. tamper with `next-auth.session-token` cookie); confirm the request surfaces a thrown error in server logs rather than a silent 401.

**High — exchange rates**
- [ ] Trigger `POST /api/exchange-rates/refresh`; query the `ExchangeRate` table and confirm both `USD_TWD` and `TWD_USD` rows exist with reciprocal rates.
- [ ] Block outbound network to `api.frankfurter.app` + `open.er-api.com` and trigger a refresh; confirm a single `rates.fetch.timeout` warning appears in logs (not one per pair).

**High — history dedupe**
- [ ] Insert two `NetWorthSnapshot` rows for the same `(userId, date)` with different `createdAt`; load `/history` and confirm the row with the greatest `createdAt` is rendered.

**High — validators**
- [ ] PATCH `/api/accounts/[id]/holdings` with `quantity: 0` → expect 400.
- [ ] PATCH `/api/accounts/[id]/holdings` with `assetType: "OPTION"` on a stock holding → field is silently stripped (no 400, no change to `assetType` in DB).
- [ ] PATCH a holding transaction with `quantity: NaN` or `createdAt: "tomorrow"` → expect 400.
- [ ] PATCH a `DEPOSIT` cash transaction with `amount: -50` → expect 400 ("amount must be positive for DEPOSIT/WITHDRAWAL").

https://claude.ai/code/session_01VWg9BSVEudPGiZB5Woh8ew