### PR TITLE
[codex] fix snapshot freshness timestamps

### DIFF
--- a/prisma/migrations/20260528000000_net_worth_snapshot_created_at_timestamptz/migration.sql
+++ b/prisma/migrations/20260528000000_net_worth_snapshot_created_at_timestamptz/migration.sql
@@ -1,0 +1,7 @@
+-- Store snapshot freshness timestamps as real instants.
+-- Existing values were written from JS Date values into TIMESTAMP columns,
+-- so interpret the stored wall-clock values as UTC while converting.
+
+ALTER TABLE "NetWorthSnapshot"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'UTC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,7 +161,7 @@ model NetWorthSnapshot {
   netWorth         Decimal  @db.Decimal(18, 2)
   baseCurrency     String
   breakdown        Json?
-  createdAt        DateTime @default(now())
+  createdAt        DateTime @default(now()) @db.Timestamptz(3)
 
   @@unique([userId, date, baseCurrency])
   @@index([userId, date(sort: Desc)])

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -178,7 +178,7 @@ export function AnalysisView({
   );
 
   const hasData = snapshots.length > 0;
-  const latestSnapshotAt = snapshots.length > 0 ? snapshots[snapshots.length - 1]!.date : null;
+  const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
 
   const [activeTab, setActiveTab] = useState<"analysis" | "history">("analysis");
 

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -11,6 +11,7 @@ import { FreshnessBadge } from "@/components/ui/freshness-badge";
 type SnapshotRow = {
   id: string;
   date: string;
+  createdAt: string;
   netWorth: number;
   totalAssets: number;
   totalLiabilities: number;
@@ -27,7 +28,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const isCompact = density === "compact";
-  const latestSnapshotAt = snapshots.length > 0 ? snapshots[snapshots.length - 1]!.date : null;
+  const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
 
   const monthGroups = useMemo(() => {
     const rows = [...snapshots].reverse().map((snap, idx, arr) => ({

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -8,6 +8,7 @@ import type { MonthlyContribution } from "./analysis-service";
 export interface NormalizedSnapshot {
   id: string;
   date: string;
+  createdAt: string;
   netWorth: number;
   totalAssets: number;
   totalLiabilities: number;
@@ -20,6 +21,7 @@ const DEFAULT_HISTORY_DAYS = 90;
 interface SnapshotRow {
   id: string;
   date: Date;
+  createdAt: Date;
   netWorth: Decimal;
   totalAssets: Decimal;
   totalLiabilities: Decimal;
@@ -45,6 +47,7 @@ function normalizeSnapshots(
     const normalized: NormalizedSnapshot = {
       id: s.id,
       date: dateStr,
+      createdAt: s.createdAt.toISOString(),
       netWorth: Number(s.netWorth) * rate,
       totalAssets: Number(s.totalAssets) * rate,
       totalLiabilities: Number(s.totalLiabilities) * rate,
@@ -85,6 +88,7 @@ export async function getNormalizedHistory(
       select: {
         id: true,
         date: true,
+        createdAt: true,
         netWorth: true,
         totalAssets: true,
         totalLiabilities: true,
@@ -131,6 +135,7 @@ async function fetchFullHistoryCached(
       select: {
         id: true,
         date: true,
+        createdAt: true,
         netWorth: true,
         totalAssets: true,
         totalLiabilities: true,

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -4,7 +4,8 @@ import { getNetWorthSummary } from "./net-worth-service";
 
 export async function createSnapshot(userId: string, baseCurrency: string) {
   const summary = await getNetWorthSummary(userId, baseCurrency);
-  const today = new Date();
+  const snapshotTakenAt = new Date();
+  const today = new Date(snapshotTakenAt);
   today.setHours(0, 0, 0, 0);
 
   const breakdown = Object.fromEntries(
@@ -24,6 +25,7 @@ export async function createSnapshot(userId: string, baseCurrency: string) {
       totalLiabilities: summary.totalLiabilities,
       netWorth: summary.netWorth,
       breakdown,
+      createdAt: snapshotTakenAt,
     },
     create: {
       userId,
@@ -33,6 +35,7 @@ export async function createSnapshot(userId: string, baseCurrency: string) {
       netWorth: summary.netWorth,
       baseCurrency,
       breakdown,
+      createdAt: snapshotTakenAt,
     },
   });
 


### PR DESCRIPTION
## Summary

- Thread `NetWorthSnapshot.createdAt` through normalized history data.
- Use the real snapshot creation timestamp for History and Analysis freshness badges.
- Update same-day snapshot upserts to refresh `createdAt`.
- Convert `NetWorthSnapshot.createdAt` to `TIMESTAMPTZ(3)` so snapshot freshness is stored as a real instant instead of a timezone-shifted wall-clock timestamp.

## Root Cause

History was displaying freshness from the date-only snapshot day, while the dashboard used `createdAt`. Same-day snapshot upserts also left `createdAt` unchanged. In addition, the snapshot `createdAt` column was a timezone-less timestamp, so newly written JS `Date` values could be read back with a local timezone offset.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx prisma migrate deploy` against the dev database
- Ran `/api/cron/snapshot` locally and confirmed latest snapshot `createdAt` reads back as the actual run time.