### PR TITLE
feat(settings): migrate stock color scheme to localStorage

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -9,7 +9,6 @@ import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-conte
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { LazyCommandPalette } from "@/components/layout/lazy-command-palette";
 import { getSession } from "@/lib/auth-session";
-import { getOrCreateSettings } from "@/lib/services/settings-service";
 
 async function SidebarWithSession() {
   const session = await getSession();
@@ -23,12 +22,8 @@ export default async function MainLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await getSession();
-  const settings = session?.user?.id ? await getOrCreateSettings(session.user.id) : null;
-  const stockScheme = settings?.stockColorScheme === "RED_UP" ? "red-up" : undefined;
-
   return (
-    <div data-stock-color-scheme={stockScheme} className="contents">
+    <div className="contents">
       <DensityProvider>
         <PrivacyModeProvider>
           <LargeTitleProvider>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -31,7 +31,6 @@ async function SettingsContent() {
         <SettingsForm
           currentCurrency={settings.baseCurrency}
           currentLocale={settings.locale}
-          currentStockColorScheme={settings.stockColorScheme}
         />
         <DataManagement />
         <InstallAppCard />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { ColorSchemaProvider } from "@/components/layout/color-schema-context";
+import { StockColorSchemeProvider } from "@/components/layout/stock-color-scheme-context";
 import { LazyToaster } from "@/components/layout/lazy-toaster";
 import { CustomSpeedInsights } from "@/components/layout/speed-insights";
 import { HtmlLangSync } from "@/components/layout/html-lang-sync";
@@ -292,6 +293,7 @@ export default function RootLayout({
       <body className="h-full flex flex-col md:flex-row overflow-hidden bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <ColorSchemaProvider>
+            <StockColorSchemeProvider>
             {/*
              * LocaleProviders reads the NEXT_LOCALE cookie — a runtime API.
              * Suspense keeps this cookie read out of the prerender pass so
@@ -309,6 +311,7 @@ export default function RootLayout({
                 <CustomSpeedInsights />
               </>
             ) : null}
+            </StockColorSchemeProvider>
           </ColorSchemaProvider>
         </ThemeProvider>
       </body>

--- a/src/components/layout/stock-color-scheme-context.tsx
+++ b/src/components/layout/stock-color-scheme-context.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+} from "react";
+
+export type StockColorScheme = "GREEN_UP" | "RED_UP";
+
+const VALID_SCHEMES: StockColorScheme[] = ["GREEN_UP", "RED_UP"];
+const STORAGE_KEY = "asset-tracker:stock-color-scheme";
+
+interface StockColorSchemeContextType {
+  stockColorScheme: StockColorScheme;
+  setStockColorScheme: (scheme: StockColorScheme) => void;
+}
+
+const StockColorSchemeContext = createContext<StockColorSchemeContextType>({
+  stockColorScheme: "GREEN_UP",
+  setStockColorScheme: () => {},
+});
+
+function applyScheme(scheme: StockColorScheme) {
+  if (scheme === "GREEN_UP") {
+    delete document.documentElement.dataset.stockColorScheme;
+  } else {
+    document.documentElement.dataset.stockColorScheme = "red-up";
+  }
+}
+
+export function StockColorSchemeProvider({ children }: { children: React.ReactNode }) {
+  const [stockColorScheme, setStockColorSchemeState] = useState<StockColorScheme>("GREEN_UP");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as StockColorScheme | null;
+    const scheme = stored && VALID_SCHEMES.includes(stored) ? stored : "GREEN_UP";
+    applyScheme(scheme);
+    startTransition(() => {
+      setMounted(true);
+      setStockColorSchemeState(scheme);
+    });
+  }, []);
+
+  const setStockColorScheme = useCallback((next: StockColorScheme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    applyScheme(next);
+    startTransition(() => setStockColorSchemeState(next));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      stockColorScheme: mounted ? stockColorScheme : "GREEN_UP",
+      setStockColorScheme,
+    }),
+    [mounted, stockColorScheme, setStockColorScheme],
+  );
+
+  return (
+    <StockColorSchemeContext.Provider value={value}>{children}</StockColorSchemeContext.Provider>
+  );
+}
+
+export function useStockColorScheme() {
+  return useContext(StockColorSchemeContext);
+}

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -17,6 +17,10 @@ import { useLocale, useTranslations } from "next-intl";
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, type Locale } from "@/i18n/config";
 import { useDensity, type Density } from "@/components/layout/density-context";
 import { useColorSchema, type ColorSchema } from "@/components/layout/color-schema-context";
+import {
+  useStockColorScheme,
+  type StockColorScheme,
+} from "@/components/layout/stock-color-scheme-context";
 import { Check, TrendingUp, TrendingDown } from "lucide-react";
 
 const COLOR_SCHEMAS: Array<{ id: ColorSchema; light: string; dark: string }> = [
@@ -27,8 +31,6 @@ const COLOR_SCHEMAS: Array<{ id: ColorSchema; light: string; dark: string }> = [
   { id: "amber", light: "#f59e0b", dark: "#fbbf24" },
   { id: "rose", light: "#f43f5e", dark: "#fb7185" },
 ];
-
-type StockColorScheme = "GREEN_UP" | "RED_UP";
 
 const STOCK_COLOR_SCHEMES: Array<{
   id: StockColorScheme;
@@ -42,11 +44,9 @@ const STOCK_COLOR_SCHEMES: Array<{
 export function SettingsForm({
   currentCurrency,
   currentLocale,
-  currentStockColorScheme,
 }: {
   currentCurrency: string;
   currentLocale: string;
-  currentStockColorScheme: StockColorScheme;
 }) {
   const router = useRouter();
   const t = useTranslations();
@@ -58,13 +58,11 @@ export function SettingsForm({
       : DEFAULT_LOCALE;
   const [currency, setCurrency] = useState(currentCurrency);
   const [locale, setLocale] = useState<Locale>(resolvedActiveLocale);
-  const [stockColorScheme, setStockColorScheme] =
-    useState<StockColorScheme>(currentStockColorScheme);
   const { density, setDensity } = useDensity();
   const { colorSchema, setColorSchema } = useColorSchema();
+  const { stockColorScheme, setStockColorScheme } = useStockColorScheme();
   const [saving, setSaving] = useState(false);
   const [savingLocale, setSavingLocale] = useState(false);
-  const [savingStockColor, setSavingStockColor] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   async function saveCurrency() {
@@ -104,26 +102,10 @@ export function SettingsForm({
     }
   }
 
-  async function pickStockColorScheme(next: StockColorScheme) {
-    if (next === stockColorScheme || savingStockColor) return;
+  function pickStockColorScheme(next: StockColorScheme) {
+    if (next === stockColorScheme) return;
     setStockColorScheme(next);
-    setSavingStockColor(true);
-    try {
-      const res = await fetch("/api/settings", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ stockColorScheme: next }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      toast.success(t("toast.stockColorSchemeUpdated"));
-      // Reload so the (main)/layout server component re-reads the setting and
-      // Recharts SVGs (which inline fill colors at render time) repaint.
-      setTimeout(() => window.location.reload(), 800);
-    } catch {
-      setStockColorScheme(stockColorScheme);
-      toast.error(t("toast.stockColorSchemeFailed"));
-      setSavingStockColor(false);
-    }
+    toast.success(t("toast.stockColorSchemeUpdated"));
   }
 
   async function refreshPrices() {
@@ -236,7 +218,6 @@ export function SettingsForm({
                       key={scheme.id}
                       type="button"
                       onClick={() => pickStockColorScheme(scheme.id)}
-                      disabled={savingStockColor}
                       title={t(`settings.stockColorSchemes.${scheme.id}`)}
                       aria-label={t(`settings.stockColorSchemes.${scheme.id}`)}
                       aria-pressed={isSelected}


### PR DESCRIPTION
## Summary

- Moves the up/down (gain/loss) color preference from the database to `localStorage`, matching the existing `colorSchema` pattern
- Creates `StockColorSchemeProvider` context that reads/writes `localStorage` under `"asset-tracker:stock-color-scheme"` and applies `data-stock-color-scheme` directly to `document.documentElement`
- Removes the `getOrCreateSettings` DB call from `(main)/layout.tsx` — it was only there to seed the attribute server-side
- Selection is now instant (no API call, no page reload, no loading spinner)

## Test plan

- [ ] Go to Settings → toggle between GREEN_UP and RED_UP — gain/loss colors update immediately
- [ ] Refresh the page — preference is preserved from localStorage
- [ ] Verify the setting persists after navigating between pages
- [ ] Open a second browser tab — it picks up the stored preference on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)