### PR TITLE
feat(ui): error boundaries + standardized destructive confirms

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -44,6 +44,17 @@
     "back": "Back",
     "actionsFor": "Actions for {name}"
   },
+  "errors": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred while loading this page. You can try again or head back to your dashboard.",
+    "retry": "Try again",
+    "backHome": "Back to dashboard",
+    "notFoundTitle": "Page not found",
+    "notFoundDescription": "The page you're looking for doesn't exist or may have moved.",
+    "globalTitle": "Something went wrong",
+    "globalDescription": "The app ran into an unexpected error. Please try reloading.",
+    "reload": "Reload"
+  },
   "categories": {
     "BANK": "Bank",
     "BROKERAGE": "Brokerage",
@@ -377,6 +388,8 @@
     "nAccounts": "{count, plural, one {# account} other {# accounts}}",
     "nHoldings": "{count, plural, one {# holding} other {# holdings}}",
     "deleteConfirm": "Delete this account? This cannot be undone.",
+    "deleteTitle": "Delete account?",
+    "deleteDescription": "{name} and all of its holdings will be permanently deleted. This cannot be undone.",
     "deleteSuccess": "Account deleted",
     "deleteFailed": "Failed to delete account",
     "colName": "Name",
@@ -496,6 +509,8 @@
     "colValue": "Value",
     "colPercentage": "%",
     "deleteConfirm": "Delete this account? This cannot be undone.",
+    "deleteTitle": "Delete account?",
+    "deleteDescription": "{name} and all of its holdings will be permanently deleted. This cannot be undone.",
     "balanceUpdated": "Balance updated",
     "accountDeleted": "Account deleted",
     "holdingRemoved": "Holding removed",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -44,6 +44,17 @@
     "back": "返回",
     "actionsFor": "{name} 的操作"
   },
+  "errors": {
+    "title": "發生錯誤",
+    "description": "載入此頁面時發生未預期的錯誤。您可以重試，或返回儀表板。",
+    "retry": "重試",
+    "backHome": "返回儀表板",
+    "notFoundTitle": "找不到頁面",
+    "notFoundDescription": "您要找的頁面不存在，或已被移動。",
+    "globalTitle": "發生錯誤",
+    "globalDescription": "應用程式發生未預期的錯誤，請嘗試重新載入。",
+    "reload": "重新載入"
+  },
   "categories": {
     "BANK": "銀行",
     "BROKERAGE": "券商",
@@ -377,6 +388,8 @@
     "nAccounts": "{count} 個帳戶",
     "nHoldings": "{count} 個持倉",
     "deleteConfirm": "確定要刪除此帳戶？此操作無法復原。",
+    "deleteTitle": "刪除帳戶？",
+    "deleteDescription": "{name} 及其所有持倉將被永久刪除。此操作無法復原。",
     "deleteSuccess": "帳戶已刪除",
     "deleteFailed": "刪除帳戶失敗",
     "colName": "名稱",
@@ -496,6 +509,8 @@
     "colValue": "價值",
     "colPercentage": "%",
     "deleteConfirm": "確定要刪除此帳戶？此操作無法復原。",
+    "deleteTitle": "刪除帳戶？",
+    "deleteDescription": "{name} 及其所有持倉將被永久刪除。此操作無法復原。",
     "balanceUpdated": "餘額已更新",
     "accountDeleted": "帳戶已刪除",
     "holdingRemoved": "持倉已移除",

--- a/src/app/(main)/error.tsx
+++ b/src/app/(main)/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function MainError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("errors");
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12 text-center md:gap-6 md:py-24 animate-in fade-in zoom-in-95 motion-normal">
+      <div className="rounded-full bg-destructive/10 p-8 shadow-sm">
+        <AlertTriangle className="size-10 text-destructive" aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-2xl font-bold tracking-tight">{t("title")}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{t("description")}</p>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Button onClick={reset}>{t("retry")}</Button>
+        <Button variant="outline" render={<Link href="/" />}>
+          {t("backHome")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -28,10 +28,7 @@ async function SettingsContent() {
       <div className="space-y-10 max-w-2xl pb-16 animate-in fade-in duration-200">
         <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
-        <SettingsForm
-          currentCurrency={settings.baseCurrency}
-          currentLocale={settings.locale}
-        />
+        <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
         <DataManagement />
         <InstallAppCard />
 

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Renders when the root layout itself throws. It replaces the entire document,
+// so it must supply its own <html>/<body> and cannot rely on global styles,
+// providers, or i18n being available — keep it self-contained and in English.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          padding: "1.5rem",
+          textAlign: "center",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+          background: "#0d1f1e",
+          color: "#f4f4f5",
+        }}
+      >
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 700, margin: 0 }}>Something went wrong</h1>
+        <p style={{ maxWidth: "28rem", color: "#a1a1aa", margin: 0 }}>
+          The app ran into an unexpected error. Please try reloading.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            cursor: "pointer",
+            borderRadius: "0.5rem",
+            border: "none",
+            padding: "0.5rem 1.25rem",
+            fontSize: "0.875rem",
+            fontWeight: 600,
+            background: "#34d399",
+            color: "#0d1f1e",
+          }}
+        >
+          Reload
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -264,7 +264,7 @@ async function LocaleProviders({ children }: { children: React.ReactNode }) {
   const messages = await getMessages();
   return (
     <NextIntlClientProvider
-      messages={pickMessages(messages, ["app", "nav", "commandPalette", "common"])}
+      messages={pickMessages(messages, ["app", "nav", "commandPalette", "common", "errors"])}
     >
       <HtmlLangSync />
       {children}
@@ -294,23 +294,23 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <ColorSchemaProvider>
             <StockColorSchemeProvider>
-            {/*
-             * LocaleProviders reads the NEXT_LOCALE cookie — a runtime API.
-             * Suspense keeps this cookie read out of the prerender pass so
-             * static routes can produce a ◐ (Partial Prerender) shell.
-             * The fallback is a non-null element to avoid the Next.js
-             * "empty fallback above document body" anti-pattern.
-             */}
-            <Suspense fallback={<span />}>
-              <LocaleProviders>{children}</LocaleProviders>
-            </Suspense>
-            <LazyToaster />
-            {enableVercelInsights ? (
-              <>
-                <Analytics />
-                <CustomSpeedInsights />
-              </>
-            ) : null}
+              {/*
+               * LocaleProviders reads the NEXT_LOCALE cookie — a runtime API.
+               * Suspense keeps this cookie read out of the prerender pass so
+               * static routes can produce a ◐ (Partial Prerender) shell.
+               * The fallback is a non-null element to avoid the Next.js
+               * "empty fallback above document body" anti-pattern.
+               */}
+              <Suspense fallback={<span />}>
+                <LocaleProviders>{children}</LocaleProviders>
+              </Suspense>
+              <LazyToaster />
+              {enableVercelInsights ? (
+                <>
+                  <Analytics />
+                  <CustomSpeedInsights />
+                </>
+              ) : null}
             </StockColorSchemeProvider>
           </ColorSchemaProvider>
         </ThemeProvider>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default async function NotFound() {
+  const t = await getTranslations("errors");
+
+  return (
+    <div className="flex min-h-svh w-full flex-col items-center justify-center gap-6 p-6 text-center">
+      <div className="rounded-full bg-muted p-8 shadow-sm">
+        <FileQuestion className="size-10 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">404</h1>
+        <h2 className="text-xl font-semibold">{t("notFoundTitle")}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{t("notFoundDescription")}</p>
+      </div>
+      <Button render={<Link href="/" />}>{t("backHome")}</Button>
+    </div>
+  );
+}

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -8,6 +8,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Pencil } from "lucide-react";
 import { springConfig } from "@/lib/motion";
 
@@ -60,6 +70,7 @@ export function AccountDetail({
   const [isEditingName, setIsEditingName] = useState(false);
   const [tempName, setTempName] = useState(account.name);
   const [deleting, setDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [savingName, setSavingName] = useState(false);
   const [sortField, setSortField] = useState<HoldingSortField>("marketValue");
   const [sortDirection, setSortDirection] = useState<SortOrder>("desc");
@@ -193,24 +204,20 @@ export function AccountDetail({
     }
   }
 
-  function deleteAccount() {
+  async function confirmDeleteAccount() {
+    setShowDeleteConfirm(false);
     setDeleting(true);
-    showUndoDeleteToast({
-      message: t("accountDetail.accountDeleted"),
-      undoLabel: t("common.undo"),
-      onUndo: () => setDeleting(false),
-      onCommit: async () => {
-        try {
-          await fetch(`/api/accounts/${account.id}`, { method: "DELETE" });
-          startTransition(() => {
-            router.push("/accounts");
-          });
-        } catch {
-          toast.error(t("accountDetail.deleteFailed"));
-          setDeleting(false);
-        }
-      },
-    });
+    try {
+      const res = await fetch(`/api/accounts/${account.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error();
+      toast.success(t("accountDetail.accountDeleted"));
+      startTransition(() => {
+        router.push("/accounts");
+      });
+    } catch {
+      toast.error(t("accountDetail.deleteFailed"));
+      setDeleting(false);
+    }
   }
 
   function deleteHolding(holdingId: string) {
@@ -314,7 +321,12 @@ export function AccountDetail({
             </span>
           </div>
         </div>
-        <Button variant="destructive" size="sm" onClick={deleteAccount} disabled={deleting}>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => setShowDeleteConfirm(true)}
+          disabled={deleting}
+        >
           {deleting ? t("accountDetail.deleting") : t("accountDetail.deleteAccount")}
         </Button>
       </div>
@@ -480,6 +492,28 @@ export function AccountDetail({
           onSuccess={() => setRefreshTrigger((prev) => prev + 1)}
         />
       )}
+
+      <AlertDialog
+        open={showDeleteConfirm}
+        onOpenChange={(open) => {
+          if (!open) setShowDeleteConfirm(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("accountDetail.deleteTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("accountDetail.deleteDescription", { name: account.name })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={confirmDeleteAccount}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -23,6 +23,16 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   Archive,
   ArchiveRestore,
   ChevronDown,
@@ -193,6 +203,7 @@ export function AccountsList({
   const [showForm, setShowForm] = useState(false);
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [showArchived, setShowArchived] = useState(false);
   const [manageMode, setManageMode] = useState(false);
@@ -300,9 +311,15 @@ export function AccountsList({
     }
   }
 
-  async function deleteAccount(id: string) {
-    if (!confirm(t("accountsList.deleteConfirm"))) return;
+  function deleteAccount(id: string) {
+    const account = accounts.find((a) => a.id === id) ?? archivedAccounts.find((a) => a.id === id);
+    setPendingDelete({ id, name: account?.name ?? "" });
+  }
 
+  async function confirmDeleteAccount() {
+    if (!pendingDelete) return;
+    const id = pendingDelete.id;
+    setPendingDelete(null);
     setDeletingId(id);
     try {
       const res = await fetch("/api/accounts", {
@@ -704,6 +721,28 @@ export function AccountsList({
           defaultCurrency={baseCurrency}
         />
       )}
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("accountsList.deleteTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("accountsList.deleteDescription", { name: pendingDelete?.name ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={confirmDeleteAccount}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -4,11 +4,7 @@ import { useEffect, useState, startTransition } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ReferenceLine, XAxis, YAxis } from "recharts";
 import { useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  ChartContainer,
-  ChartTooltip,
-  type ChartConfig,
-} from "@/components/ui/chart";
+import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -4,11 +4,7 @@ import { useEffect, useState, startTransition } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
 import { useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  ChartContainer,
-  ChartTooltip,
-  type ChartConfig,
-} from "@/components/ui/chart";
+import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -4,11 +4,7 @@ import { useEffect, useState, startTransition } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
 import { useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  ChartContainer,
-  ChartTooltip,
-  type ChartConfig,
-} from "@/components/ui/chart";
+import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import type { VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Button, buttonVariants } from "@/components/ui/button";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({ className, ...props }: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("font-heading text-base leading-none font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props & {
+  variant?: VariantProps<typeof buttonVariants>["variant"];
+}) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      render={<Button variant={variant} className={cn(className)} />}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({ className, ...props }: AlertDialogPrimitive.Close.Props) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={<Button variant="outline" className={cn(className)} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({
   className,
@@ -13,11 +13,11 @@ function Card({
       data-size={size}
       className={cn(
         "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -26,11 +26,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -39,11 +39,11 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -53,20 +53,17 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -76,7 +73,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -85,19 +82,11 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-}
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,42 +1,42 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as RechartsPrimitive from "recharts"
-import type { TooltipValueType } from "recharts"
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+import type { TooltipValueType } from "recharts";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+const THEMES = { light: "", dark: ".dark" } as const;
 
-const INITIAL_DIMENSION = { width: 320, height: 200 } as const
-type TooltipNameType = number | string
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
+type TooltipNameType = number | string;
 
 export type ChartConfig = Record<
   string,
   {
-    label?: React.ReactNode
-    icon?: React.ComponentType
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
   )
->
+>;
 
 type ChartContextProps = {
-  config: ChartConfig
-}
+  config: ChartConfig;
+};
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.useContext(ChartContext);
 
   if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
+    throw new Error("useChart must be used within a <ChartContainer />");
   }
 
-  return context
+  return context;
 }
 
 function ChartContainer({
@@ -47,17 +47,15 @@ function ChartContainer({
   initialDimension = INITIAL_DIMENSION,
   ...props
 }: React.ComponentProps<"div"> & {
-  config: ChartConfig
-  children: React.ComponentProps<
-    typeof RechartsPrimitive.ResponsiveContainer
-  >["children"]
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
   initialDimension?: {
-    width: number
-    height: number
-  }
+    width: number;
+    height: number;
+  };
 }) {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`
+  const uniqueId = React.useId();
+  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`;
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -66,28 +64,24 @@ function ChartContainer({
         data-chart={chartId}
         className={cn(
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
-          className
+          className,
         )}
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer
-          initialDimension={initialDimension}
-        >
+        <RechartsPrimitive.ResponsiveContainer initialDimension={initialDimension}>
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>
-  )
+  );
 }
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme ?? config.color
-  )
+  const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color);
 
   if (!colorConfig.length) {
-    return null
+    return null;
   }
 
   return (
@@ -99,22 +93,20 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ?? itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
   })
   .join("\n")}
 }
-`
+`,
           )
           .join("\n"),
       }}
     />
-  )
-}
+  );
+};
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+const ChartTooltip = RechartsPrimitive.Tooltip;
 
 function ChartTooltipContent({
   active,
@@ -132,67 +124,52 @@ function ChartTooltipContent({
   labelKey,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<"div"> & {
-    hideLabel?: boolean
-    hideIndicator?: boolean
-    indicator?: "line" | "dot" | "dashed"
-    nameKey?: string
-    labelKey?: string
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
   } & Omit<
-    RechartsPrimitive.DefaultTooltipContentProps<
-      TooltipValueType,
-      TooltipNameType
-    >,
+    RechartsPrimitive.DefaultTooltipContentProps<TooltipValueType, TooltipNameType>,
     "accessibilityLayer"
   >) {
-  const { config } = useChart()
+  const { config } = useChart();
 
   const tooltipLabel = React.useMemo(() => {
     if (hideLabel || !payload?.length) {
-      return null
+      return null;
     }
 
-    const [item] = payload
-    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`
-    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const [item] = payload;
+    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
     const value =
-      !labelKey && typeof label === "string"
-        ? (config[label]?.label ?? label)
-        : itemConfig?.label
+      !labelKey && typeof label === "string" ? (config[label]?.label ?? label) : itemConfig?.label;
 
     if (labelFormatter) {
       return (
-        <div className={cn("font-medium", labelClassName)}>
-          {labelFormatter(value, payload)}
-        </div>
-      )
+        <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>
+      );
     }
 
     if (!value) {
-      return null
+      return null;
     }
 
-    return <div className={cn("font-medium", labelClassName)}>{value}</div>
-  }, [
-    label,
-    labelFormatter,
-    payload,
-    hideLabel,
-    labelClassName,
-    config,
-    labelKey,
-  ])
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
   if (!active || !payload?.length) {
-    return null
+    return null;
   }
 
-  const nestLabel = payload.length === 1 && indicator !== "dot"
+  const nestLabel = payload.length === 1 && indicator !== "dot";
 
   return (
     <div
       className={cn(
         "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
-        className
+        className,
       )}
     >
       {!nestLabel ? tooltipLabel : null}
@@ -200,16 +177,16 @@ function ChartTooltipContent({
         {payload
           .filter((item) => item.type !== "none")
           .map((item, index) => {
-            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`
-            const itemConfig = getPayloadConfigFromPayload(config, item, key)
-            const indicatorColor = color ?? item.payload?.fill ?? item.color
+            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color ?? item.payload?.fill ?? item.color;
 
             return (
               <div
                 key={index}
                 className={cn(
                   "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center"
+                  indicator === "dot" && "items-center",
                 )}
               >
                 {formatter && item?.value !== undefined && item.name ? (
@@ -229,7 +206,7 @@ function ChartTooltipContent({
                               "w-0 border-[1.5px] border-dashed bg-transparent":
                                 indicator === "dashed",
                               "my-0.5": nestLabel && indicator === "dashed",
-                            }
+                            },
                           )}
                           style={
                             {
@@ -243,7 +220,7 @@ function ChartTooltipContent({
                     <div
                       className={cn(
                         "flex flex-1 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center"
+                        nestLabel ? "items-end" : "items-center",
                       )}
                     >
                       <div className="grid gap-1.5">
@@ -263,14 +240,14 @@ function ChartTooltipContent({
                   </>
                 )}
               </div>
-            )
+            );
           })}
       </div>
     </div>
-  )
+  );
 }
 
-const ChartLegend = RechartsPrimitive.Legend
+const ChartLegend = RechartsPrimitive.Legend;
 
 function ChartLegendContent({
   className,
@@ -279,13 +256,13 @@ function ChartLegendContent({
   verticalAlign = "bottom",
   nameKey,
 }: React.ComponentProps<"div"> & {
-  hideIcon?: boolean
-  nameKey?: string
+  hideIcon?: boolean;
+  nameKey?: string;
 } & RechartsPrimitive.DefaultLegendContentProps) {
-  const { config } = useChart()
+  const { config } = useChart();
 
   if (!payload?.length) {
-    return null
+    return null;
   }
 
   return (
@@ -293,20 +270,20 @@ function ChartLegendContent({
       className={cn(
         "flex items-center justify-center gap-4",
         verticalAlign === "top" ? "pb-3" : "pt-3",
-        className
+        className,
       )}
     >
       {payload
         .filter((item) => item.type !== "none")
         .map((item, index) => {
-          const key = `${nameKey ?? item.dataKey ?? "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+          const key = `${nameKey ?? item.dataKey ?? "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
           return (
             <div
               key={index}
               className={cn(
-                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
               )}
             >
               {itemConfig?.icon && !hideIcon ? (
@@ -321,46 +298,35 @@ function ChartLegendContent({
               )}
               {itemConfig?.label}
             </div>
-          )
+          );
         })}
     </div>
-  )
+  );
 }
 
-function getPayloadConfigFromPayload(
-  config: ChartConfig,
-  payload: unknown,
-  key: string
-) {
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
   if (typeof payload !== "object" || payload === null) {
-    return undefined
+    return undefined;
   }
 
   const payloadPayload =
-    "payload" in payload &&
-    typeof payload.payload === "object" &&
-    payload.payload !== null
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
       ? payload.payload
-      : undefined
+      : undefined;
 
-  let configLabelKey: string = key
+  let configLabelKey: string = key;
 
-  if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
   } else if (
     payloadPayload &&
     key in payloadPayload &&
     typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
   ) {
-    configLabelKey = payloadPayload[
-      key as keyof typeof payloadPayload
-    ] as string
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
   }
 
-  return configLabelKey in config ? config[configLabelKey] : config[key]
+  return configLabelKey in config ? config[configLabelKey] : config[key];
 }
 
 export {
@@ -370,4 +336,4 @@ export {
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
-}
+};


### PR DESCRIPTION
## Context

A direct UI/UX audit of the app surfaced a small set of concrete gaps against an otherwise polished shell. This is the **Tier 1** slice: high-value, low-risk, self-contained.

## Changes

**Error & not-found boundaries** (none existed before)
- `src/app/(main)/error.tsx` — themed, in-shell error UI with a `reset()` "Try again" + "Back to dashboard".
- `src/app/not-found.tsx` — themed 404 (server component). The account detail page already calls `notFound()` but had no page to catch it.
- `src/app/global-error.tsx` — self-contained root fallback (own `<html>/<body>`, inline styles, English-only since it renders outside providers).
- New `errors` i18n namespace (en-US + zh-TW), wired into `pickMessages(...)` in the root layout.

**New `AlertDialog` primitive** — `src/components/ui/alert-dialog.tsx`, built on `@base-ui/react/alert-dialog` to match the project's base-ui / base-nova style (not Radix), mirroring `dialog.tsx`.

**Standardized destructive confirms**
- `accounts-list.tsx`: replaced the native `confirm()` with a controlled `AlertDialog` naming the account + cascading holdings.
- `account-detail.tsx`: account delete now shows a pre-confirm `AlertDialog` instead of the misleading "Deleting…"/undo-toast flow. Holdings/transactions keep their undo-toast.

The second commit is **formatting-only**: 6 files had pre-existing `prettier` drift on `master` that was blocking the pre-push hook. No behavioral changes.

## Verification
- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run format:check` ✅
- Suggested manual checks: throw in an RSC read → confirm `(main)/error.tsx` renders in-shell and "Try again" recovers; visit a bad URL → `not-found.tsx`; delete an account → `AlertDialog` names the account/holdings; delete a holding → undo-toast still works.

## Deferred (not in this PR)
Tier 2 (form a11y/validation, shared number-format util, loading-button spinners) and Tier 3 (mobile Drawer forms, skip-to-content, chart a11y, reorder guard, mobile-nav overflow) remain as backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)