### PR TITLE
feat(accounts): adopt Tooltip, Collapsible, Progress primitives

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -364,6 +364,7 @@
     "manageOrderHint": "Drag accounts to reorder. Pinned accounts always stay above unpinned ones.",
     "manageOrderScopeHint": "Ordering is global within each type (Assets/Liabilities), not per category.",
     "dragHandleLabel": "Drag to reorder",
+    "accountOptions": "Account options",
     "pinnedGroup": "Pinned",
     "otherGroup": "Others",
     "pin": "Pin",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -364,6 +364,7 @@
     "manageOrderHint": "拖曳帳戶即可重新排序。已釘選帳戶會固定在未釘選帳戶上方。",
     "manageOrderScopeHint": "排序會在每個類型（資產／負債）內全域生效，不會依類別各自排序。",
     "dragHandleLabel": "拖曳以重新排序",
+    "accountOptions": "帳戶選項",
     "pinnedGroup": "已釘選",
     "otherGroup": "其他",
     "pin": "釘選",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -8,6 +8,7 @@ import { DensityProvider } from "@/components/layout/density-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { LazyCommandPalette } from "@/components/layout/lazy-command-palette";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { getSession } from "@/lib/auth-session";
 
 async function SidebarWithSession() {
@@ -28,16 +29,18 @@ export default async function MainLayout({
         <PrivacyModeProvider>
           <LargeTitleProvider>
             <PullToRefreshProvider>
-              <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
-                <SidebarWithSession />
-              </Suspense>
-              <PullToRefreshIndicator />
-              <MobileMainShell>
-                <MobileHeader />
-                <div className="mx-auto w-full max-w-7xl p-4 md:p-6">{children}</div>
-              </MobileMainShell>
-              <MobileNav />
-              <LazyCommandPalette />
+              <TooltipProvider>
+                <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+                  <SidebarWithSession />
+                </Suspense>
+                <PullToRefreshIndicator />
+                <MobileMainShell>
+                  <MobileHeader />
+                  <div className="mx-auto w-full max-w-7xl p-4 md:p-6">{children}</div>
+                </MobileMainShell>
+                <MobileNav />
+                <LazyCommandPalette />
+              </TooltipProvider>
             </PullToRefreshProvider>
           </LargeTitleProvider>
         </PrivacyModeProvider>

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -32,6 +32,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from "@/components/ui/collapsible";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { AllocationBar } from "./allocation-bar";
 import {
   Archive,
   ArchiveRestore,
@@ -649,12 +652,12 @@ export function AccountsList({
           </div>
 
           {archivedAccounts.length > 0 && (
-            <div className="rounded-xl border overflow-hidden">
-              <button
-                type="button"
-                onClick={() => setShowArchived((prev) => !prev)}
-                className="w-full px-4 py-3 flex items-center justify-between bg-muted/30 hover:bg-muted/50 transition-colors"
-              >
+            <Collapsible
+              open={showArchived}
+              onOpenChange={setShowArchived}
+              className="rounded-xl border overflow-hidden"
+            >
+              <CollapsibleTrigger className="w-full px-4 py-3 flex items-center justify-between bg-muted/30 hover:bg-muted/50 transition-colors">
                 <span className="text-sm font-semibold">{t("accountsList.archivedSection")}</span>
                 <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
                   {archivedAccounts.length}
@@ -662,8 +665,8 @@ export function AccountsList({
                     className={`h-4 w-4 transition-transform ${showArchived ? "rotate-180" : ""}`}
                   />
                 </span>
-              </button>
-              {showArchived && (
+              </CollapsibleTrigger>
+              <CollapsiblePanel>
                 <div className="divide-y">
                   {archivedAccounts.map((account) => (
                     <div
@@ -700,8 +703,8 @@ export function AccountsList({
                     </div>
                   ))}
                 </div>
-              )}
-            </div>
+              </CollapsiblePanel>
+            </Collapsible>
           )}
         </>
       )}
@@ -998,23 +1001,26 @@ function DesktopAccountRow({
             {privacyMode ? "—" : pct !== null ? `${pct.toFixed(1)}%` : "—"}
           </span>
           {!privacyMode && pct !== null && (
-            <div className="w-14 h-1 bg-muted rounded-full overflow-hidden">
-              <div
-                className="h-full bg-primary rounded-full"
-                style={{ width: `${Math.min(pct, 100)}%` }}
-              />
-            </div>
+            <AllocationBar value={pct} label={`${pct.toFixed(1)}%`} />
           )}
         </div>
       </td>
       <td className="px-2 py-3.5 w-10 text-center" onClick={(e) => e.stopPropagation()}>
         <DropdownMenu>
-          <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
-            disabled={isDeleting || isUpdating}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+                  disabled={isDeleting || isUpdating}
+                  aria-label={t("accountsList.accountOptions")}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </DropdownMenuTrigger>
+              }
+            />
+            <TooltipContent>{t("accountsList.accountOptions")}</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={() => onTogglePin(account)}>
               {account.isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
@@ -1125,11 +1131,12 @@ function CategorySection({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div
+    <Collapsible
+      open={isExpanded}
+      onOpenChange={onToggleExpand}
       className={`rounded-xl border overflow-hidden transition-all motion-normal ${colors.border} ${isExpanded ? "shadow-md" : "shadow-sm hover:shadow-md"}`}
     >
-      <button
-        onClick={onToggleExpand}
+      <CollapsibleTrigger
         className={`w-full text-left ${isCompact ? "px-4 py-2.5" : "px-5 py-4"} flex items-center justify-between transition-colors ${colors.bg} hover:brightness-95 dark:hover:brightness-110`}
       >
         <div className="flex items-center gap-3 min-w-0">
@@ -1157,43 +1164,39 @@ function CategorySection({
             className={`w-5 h-5 text-muted-foreground transition-transform motion-normal ${isExpanded ? "rotate-180" : ""}`}
           />
         </div>
-      </button>
+      </CollapsibleTrigger>
 
-      <div
-        className={`grid transition-all motion-normal ${isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"}`}
-      >
-        <div className="overflow-hidden">
-          <div
-            className={`${isCompact ? "px-3 py-2.5 space-y-2" : "px-4 py-4 space-y-3"} bg-background/50`}
-          >
-            <AnimatePresence initial={false}>
-              {accounts.map((account) => (
-                <motion.div
-                  key={account.id}
-                  layout={shouldReduceMotion ? false : "position"}
-                  initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
-                  transition={shouldReduceMotion ? { duration: 0 } : springConfig}
-                >
-                  <AccountCardWithHoldings
-                    account={account}
-                    priceMap={priceMap}
-                    ratesMap={ratesMap}
-                    baseCurrency={baseCurrency}
-                    onDelete={onDelete}
-                    onTogglePin={onTogglePin}
-                    onArchive={onArchive}
-                    isDeleting={deletingId === account.id}
-                    isUpdating={updatingId === account.id}
-                  />
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          </div>
+      <CollapsiblePanel>
+        <div
+          className={`${isCompact ? "px-3 py-2.5 space-y-2" : "px-4 py-4 space-y-3"} bg-background/50`}
+        >
+          <AnimatePresence initial={false}>
+            {accounts.map((account) => (
+              <motion.div
+                key={account.id}
+                layout={shouldReduceMotion ? false : "position"}
+                initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+                transition={shouldReduceMotion ? { duration: 0 } : springConfig}
+              >
+                <AccountCardWithHoldings
+                  account={account}
+                  priceMap={priceMap}
+                  ratesMap={ratesMap}
+                  baseCurrency={baseCurrency}
+                  onDelete={onDelete}
+                  onTogglePin={onTogglePin}
+                  onArchive={onArchive}
+                  isDeleting={deletingId === account.id}
+                  isUpdating={updatingId === account.id}
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </div>
-      </div>
-    </div>
+      </CollapsiblePanel>
+    </Collapsible>
   );
 }
 
@@ -1313,12 +1316,20 @@ function AccountCardWithHoldings({
       </Link>
       <div className="absolute top-2 right-2 z-10" onClick={(e) => e.preventDefault()}>
         <DropdownMenu>
-          <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
-            disabled={isDeleting || isUpdating}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+                  disabled={isDeleting || isUpdating}
+                  aria-label={t("accountsList.accountOptions")}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </DropdownMenuTrigger>
+              }
+            />
+            <TooltipContent>{t("accountsList.accountOptions")}</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={() => onTogglePin(account)}>
               {account.isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}

--- a/src/components/accounts/allocation-bar.tsx
+++ b/src/components/accounts/allocation-bar.tsx
@@ -1,0 +1,9 @@
+import { Progress } from "@/components/ui/progress";
+
+/**
+ * Small fixed-width allocation/weight bar used in the accounts list and holdings
+ * table. Wraps the Progress primitive so both surfaces share one accessible bar.
+ */
+export function AllocationBar({ value, label }: { value: number; label?: string }) {
+  return <Progress value={Math.min(value, 100)} aria-label={label} className="h-1 w-14" />;
+}

--- a/src/components/accounts/holdings-table.tsx
+++ b/src/components/accounts/holdings-table.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
+import { AllocationBar } from "./allocation-bar";
 import { MoreHorizontal } from "lucide-react";
 import { formatCurrency, formatQuantity } from "@/lib/currencies";
 import { getOptionDisplay } from "@/lib/options";
@@ -145,12 +146,7 @@ export function HoldingsTable({
                       {privacyMode ? "—" : weight !== null ? `${weight.toFixed(1)}%` : "—"}
                     </span>
                     {!privacyMode && weight !== null && (
-                      <div className="w-14 h-1 bg-muted rounded-full overflow-hidden">
-                        <div
-                          className="h-full bg-primary rounded-full"
-                          style={{ width: `${Math.min(weight, 100)}%` }}
-                        />
-                      </div>
+                      <AllocationBar value={weight} label={`${weight.toFixed(1)}%`} />
                     )}
                   </div>
                 </td>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
+
+import { cn } from "@/lib/utils";
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />;
+}
+
+function CollapsiblePanel({ className, ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel
+      data-slot="collapsible-panel"
+      className={cn(
+        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height] duration-200 ease-out data-[ending-style]:h-0 data-[starting-style]:h-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsiblePanel };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
+
+import { cn } from "@/lib/utils";
+
+function Progress({ className, ...props }: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root data-slot="progress" {...props}>
+      <ProgressPrimitive.Track
+        className={cn("relative h-1.5 w-full overflow-hidden rounded-full bg-muted", className)}
+      >
+        <ProgressPrimitive.Indicator className="h-full rounded-full bg-primary transition-all" />
+      </ProgressPrimitive.Track>
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({ delay = 200, ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider delay={delay} {...props} />;
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props & { sideOffset?: number }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 origin-[var(--transform-origin)] rounded-md bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION
## Context

Tier A of a direct UI/UX audit of the **accounts tab** (follow-up to #347). Three patterns were hand-rolled where a shadcn/ui primitive fits better — and one was a real accessibility gap. All three components are native to the project's `@base-ui/react` (base-nova) stack, so each is a thin wrapper mirroring the `alert-dialog.tsx` added in #347.

## Changes

**New primitives**
- `src/components/ui/tooltip.tsx`, `collapsible.tsx`, `progress.tsx`
- `src/components/accounts/allocation-bar.tsx` — shared `<AllocationBar>` over Progress.

**Wired into the accounts tab**
1. **Tooltip** — the icon-only `MoreHorizontal` row-action triggers (desktop table + mobile card) previously had **no accessible name**. They now have an `aria-label` plus a hover/focus tooltip ("Account options"), composed via base-ui's `render` so the dropdown still opens normally. A single `TooltipProvider` (200ms delay) added in `(main)/layout.tsx`.
2. **Collapsible** — replaces the hand-rolled `grid-rows-[0fr]/[1fr]` collapse in the **category sections** and the **archived-accounts section**. Gains `aria-expanded` + keyboard toggle; the panel height resolves to `auto` when open, so accounts added/removed inside (framer-motion) resize without clipping.
3. **Progress** — replaces the two identical bare-`div` allocation bars in `accounts-list.tsx` and `holdings-table.tsx` with one `<AllocationBar value label />`, adding `role="progressbar"` + value ARIA.

**i18n:** new `accountsList.accountOptions` key (en-US + zh-TW).

Net: the consumers shrank (hand-rolled markup collapsed into primitives) even though behavior/a11y improved.

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run format:check` ✅
- Suggested manual checks: keyboard-toggle a category and the archived section (Space/Enter) and confirm `aria-expanded` flips; tab to a row's "⋯" button and confirm the tooltip/label; confirm allocation bars expose `role="progressbar"`.

## Notes
- Switch/Toggle, Pagination/ScrollArea, and the react-hook-form migration were deliberately left out (Tier B/deferred) — see the audit notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)