### PR TITLE
feat: demo mode toggle + onboarding intro cards

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -113,7 +113,17 @@
     },
     "signOut": "Sign Out",
     "signOutDesc": "Securely log out of your account on this device.",
-    "dangerZone": "Danger Zone"
+    "dangerZone": "Danger Zone",
+    "gettingStartedTitle": "Getting Started",
+    "demoMode": "Demo mode",
+    "demoModeDescription": "Explore the app with a sample portfolio. Your real data is untouched and returns the moment you turn it off.",
+    "demoModeOn": "On",
+    "demoModeOff": "Off",
+    "demoModeEnabled": "Demo mode on — showing sample data",
+    "demoModeDisabled": "Demo mode off — showing your data",
+    "appTour": "App tour",
+    "appTourDescription": "Replay the quick intro to the main features.",
+    "showAppTour": "Show tour"
   },
   "languages": {
     "en-US": "English",
@@ -636,5 +646,20 @@
     "deleteSuccess": "Transaction deleted",
     "deleteSuccessSymbol": "{symbol} transaction deleted",
     "deleteFailed": "Failed to delete transaction"
+  },
+  "onboarding": {
+    "title": "Welcome to Assets Tracker",
+    "slide1Title": "Track your net worth",
+    "slide1Description": "See your complete financial picture in one place — assets minus liabilities, in any currency you choose.",
+    "slide2Title": "Organize accounts & holdings",
+    "slide2Description": "Add bank, brokerage, crypto, property and loan accounts, then track the stocks, ETFs and coins inside them.",
+    "slide3Title": "Understand your history",
+    "slide3Description": "Daily snapshots power trend charts, a contribution-vs-market breakdown, and your biggest movers over time.",
+    "slide4Title": "Plan ahead — and try demo mode",
+    "slide4Description": "Project your path to financial goals. New here? Turn on Demo mode in Settings to explore with sample data.",
+    "back": "Back",
+    "next": "Next",
+    "skip": "Skip",
+    "done": "Get started"
   }
 }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -113,7 +113,17 @@
     },
     "signOut": "登出",
     "signOutDesc": "安全地登出此裝置上的帳戶。",
-    "dangerZone": "危險區域"
+    "dangerZone": "危險區域",
+    "gettingStartedTitle": "開始使用",
+    "demoMode": "示範模式",
+    "demoModeDescription": "使用範例投資組合探索應用程式。您的真實資料不會被更動，關閉後立即恢復。",
+    "demoModeOn": "開啟",
+    "demoModeOff": "關閉",
+    "demoModeEnabled": "示範模式已開啟 — 顯示範例資料",
+    "demoModeDisabled": "示範模式已關閉 — 顯示您的資料",
+    "appTour": "應用程式導覽",
+    "appTourDescription": "重新播放主要功能的快速介紹。",
+    "showAppTour": "顯示導覽"
   },
   "languages": {
     "en-US": "English",
@@ -636,5 +646,20 @@
     "deleteSuccess": "交易已刪除",
     "deleteSuccessSymbol": "{symbol} 交易已刪除",
     "deleteFailed": "刪除交易失敗"
+  },
+  "onboarding": {
+    "title": "歡迎使用 Assets Tracker",
+    "slide1Title": "追蹤您的淨資產",
+    "slide1Description": "在同一處掌握完整的財務全貌 — 以您選擇的任何貨幣計算資產減去負債。",
+    "slide2Title": "整理帳戶與持倉",
+    "slide2Description": "新增銀行、券商、加密貨幣、不動產與貸款帳戶，並追蹤其中的股票、ETF 與幣別。",
+    "slide3Title": "了解您的歷史變化",
+    "slide3Description": "每日快照可繪製趨勢圖、投入與市場表現的拆解，以及一段期間內變動最大的項目。",
+    "slide4Title": "提前規劃 — 並試用示範模式",
+    "slide4Description": "預測您達成財務目標的路徑。第一次使用嗎？到設定開啟示範模式，用範例資料探索。",
+    "back": "上一步",
+    "next": "下一步",
+    "skip": "略過",
+    "done": "開始使用"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1162,6 +1162,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1184,6 +1185,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1206,6 +1208,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1222,6 +1225,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1238,6 +1242,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1254,6 +1259,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1270,6 +1276,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1286,6 +1293,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1302,6 +1310,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1318,6 +1327,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1334,6 +1344,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1350,6 +1361,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1366,6 +1378,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1388,6 +1401,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1410,6 +1424,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1432,6 +1447,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1454,6 +1470,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1476,6 +1493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1498,6 +1516,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1520,6 +1539,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1542,6 +1562,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1561,6 +1582,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1580,6 +1602,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1599,6 +1622,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7361,6 +7385,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9804,6 +9829,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -1,10 +1,14 @@
 import { notFound } from "next/navigation";
 import { AccountDetail } from "@/components/accounts/account-detail";
 import { AccountsNavPanel } from "@/components/accounts/accounts-nav-panel";
-import { getAccountDetail, getAccountPriceMap } from "@/lib/services/account-service";
-import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
+import {
+  resolveAccountDetail,
+  resolveAccountPriceMap,
+  resolveAccountsWithHoldings,
+  resolveExchangeRatesMap,
+} from "@/lib/services/demo-service";
 import { getSession } from "@/lib/auth-session";
-import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
+import { resolveRate } from "@/lib/services/exchange-rate-service";
 import { log } from "@/lib/logger";
 import { getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
@@ -16,7 +20,7 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
   const { id } = await params;
 
   // Kick off independent queries before awaiting the account
-  const ratesP = getAllExchangeRates();
+  const ratesP = resolveExchangeRatesMap();
   const messagesP = getMessages();
   const sessionP = getSession();
 
@@ -26,13 +30,13 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
   if (!userId) notFound();
 
   const [serialized, allAccounts] = await Promise.all([
-    getAccountDetail(userId, id),
-    fetchUserAccountsWithHoldings(userId),
+    resolveAccountDetail(userId, id),
+    resolveAccountsWithHoldings(userId),
   ]);
   if (!serialized) notFound();
 
   const symbols = serialized.holdings.map((h) => h.symbol);
-  const priceMap = await getAccountPriceMap(symbols);
+  const priceMap = await resolveAccountPriceMap(symbols);
 
   // Build rates map from bulk-loaded data. Render path is read-only
   // against ExchangeRate — missing pairs fall back to 1 (rates are warmed

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -4,13 +4,14 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AccountsList } from "@/components/accounts/accounts-list";
-import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
+import { resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import {
-  fetchUserAccountsWithHoldings,
-  fetchUserArchivedAccountsWithHoldings,
-} from "@/lib/services/net-worth-service";
-import { getCachedPricesForSymbols } from "@/lib/services/price-service";
+  resolveAccountsWithHoldings,
+  resolveArchivedAccountsWithHoldings,
+  resolveCachedPricesForSymbols,
+  resolveExchangeRatesMap,
+} from "@/lib/services/demo-service";
 import { log } from "@/lib/logger";
 
 const CLIENT_NAMESPACES = [
@@ -29,17 +30,17 @@ async function AccountsContent() {
   const [t, messages, accounts, archivedAccounts, settings, allRatesMap] = await Promise.all([
     getTranslations("accounts"),
     getMessages(),
-    fetchUserAccountsWithHoldings(userId),
-    fetchUserArchivedAccountsWithHoldings(userId),
+    resolveAccountsWithHoldings(userId),
+    resolveArchivedAccountsWithHoldings(userId),
     getOrCreateSettings(userId),
-    getAllExchangeRates(),
+    resolveExchangeRatesMap(),
   ]);
 
   const baseCurrency = settings.baseCurrency;
 
   // Fetch cached prices for this user's holding symbols only
   const allSymbols = [...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol)))];
-  const cachedPrices = await getCachedPricesForSymbols(allSymbols);
+  const cachedPrices = await resolveCachedPricesForSymbols(allSymbols);
   const priceMap: Record<string, number> = Object.fromEntries(
     cachedPrices.map((p) => [p.symbol, p.price]),
   );

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -2,7 +2,7 @@ import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { getCachedAnalysisPayload } from "@/lib/services/analysis-payload-service";
+import { resolveAnalysisPayload } from "@/lib/services/demo-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AnalysisView } from "@/components/analysis/analysis-view";
@@ -20,7 +20,7 @@ async function AnalysisContent() {
       getTranslations("analysis"),
       getMessages(),
       getLocale(),
-      settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency)),
+      settingsP.then((s) => resolveAnalysisPayload(userId, s.baseCurrency)),
       settingsP,
     ]);
 

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -5,7 +5,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { HistoryView } from "@/components/history/history-view";
-import { getNormalizedHistory } from "@/lib/services/history-service";
+import { resolveNormalizedHistory } from "@/lib/services/demo-service";
 
 const CLIENT_NAMESPACES = ["trendChart", "history", "freshness"];
 
@@ -16,7 +16,7 @@ async function HistoryContent() {
   const settingsP = getOrCreateSettings(userId);
   const [allMessages, snapshots, settings] = await Promise.all([
     getMessages(),
-    settingsP.then((s) => getNormalizedHistory(userId, s.baseCurrency)),
+    settingsP.then((s) => resolveNormalizedHistory(userId, s.baseCurrency)),
     settingsP,
   ]);
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -8,6 +8,11 @@ import { DensityProvider } from "@/components/layout/density-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { LazyCommandPalette } from "@/components/layout/lazy-command-palette";
+import { OnboardingProvider } from "@/components/onboarding/onboarding-context";
+import { OnboardingTour } from "@/components/onboarding/onboarding-tour";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
+import { pickMessages } from "@/lib/i18n-utils";
 import { getSession } from "@/lib/auth-session";
 
 async function SidebarWithSession() {
@@ -22,25 +27,31 @@ export default async function MainLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const messages = await getMessages();
   return (
     <div className="contents">
       <DensityProvider>
-        <PrivacyModeProvider>
-          <LargeTitleProvider>
-            <PullToRefreshProvider>
-              <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
-                <SidebarWithSession />
-              </Suspense>
-              <PullToRefreshIndicator />
-              <MobileMainShell>
-                <MobileHeader />
-                <div className="mx-auto w-full max-w-7xl p-4 md:p-6">{children}</div>
-              </MobileMainShell>
-              <MobileNav />
-              <LazyCommandPalette />
-            </PullToRefreshProvider>
-          </LargeTitleProvider>
-        </PrivacyModeProvider>
+        <NextIntlClientProvider messages={pickMessages(messages, ["onboarding", "common"])}>
+          <OnboardingProvider>
+            <OnboardingTour />
+            <PrivacyModeProvider>
+              <LargeTitleProvider>
+                <PullToRefreshProvider>
+                  <Suspense fallback={<Sidebar userImage={null} userName={null} />}>
+                    <SidebarWithSession />
+                  </Suspense>
+                  <PullToRefreshIndicator />
+                  <MobileMainShell>
+                    <MobileHeader />
+                    <div className="mx-auto w-full max-w-7xl p-4 md:p-6">{children}</div>
+                  </MobileMainShell>
+                  <MobileNav />
+                  <LazyCommandPalette />
+                </PullToRefreshProvider>
+              </LargeTitleProvider>
+            </PrivacyModeProvider>
+          </OnboardingProvider>
+        </NextIntlClientProvider>
       </DensityProvider>
     </div>
   );

--- a/src/app/(main)/projections/page.tsx
+++ b/src/app/(main)/projections/page.tsx
@@ -2,7 +2,7 @@ import { getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { getProjectionData } from "@/lib/services/projection-service";
+import { resolveProjectionData } from "@/lib/services/demo-service";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { ProjectionView } from "@/components/projections/projection-view";
@@ -18,7 +18,7 @@ async function ProjectionsContent() {
   const [t, messages, projectionData, settings] = await Promise.all([
     getTranslations("projections"),
     getMessages(),
-    settingsP.then((s) => getProjectionData(userId, s.baseCurrency)),
+    settingsP.then((s) => resolveProjectionData(userId, s.baseCurrency)),
     settingsP,
   ]);
 

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,34 +1,42 @@
+import { cookies } from "next/headers";
 import { SettingsForm } from "@/components/settings/settings-form";
 import { DataManagement } from "@/components/settings/data-management";
 import { InstallAppCard } from "@/components/settings/install-app-card";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { DEMO_COOKIE } from "@/lib/services/demo-service";
 import { Button } from "@/components/ui/button";
 import { getTranslations, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 
-const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement"];
+const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement", "onboarding"];
 
 async function SettingsContent() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   // Run all independent queries in parallel
-  const [t, allMessages, settings] = await Promise.all([
+  const [t, allMessages, settings, cookieStore] = await Promise.all([
     getTranslations("settings"),
     getMessages(),
     getOrCreateSettings(userId),
+    cookies(),
   ]);
+  const demoMode = cookieStore.get(DEMO_COOKIE)?.value === "1";
 
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <div className="space-y-10 max-w-2xl pb-16 animate-in fade-in duration-200">
         <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
-        <SettingsForm currentCurrency={settings.baseCurrency} currentLocale={settings.locale} />
+        <SettingsForm
+          currentCurrency={settings.baseCurrency}
+          currentLocale={settings.locale}
+          currentDemoMode={demoMode}
+        />
         <DataManagement />
         <InstallAppCard />
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -5,6 +5,7 @@ import { getOrCreateSettings } from "@/lib/services/settings-service";
 import { ok, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { DEMO_COOKIE } from "@/lib/services/demo-service";
 import { log } from "@/lib/logger";
 
 async function maybeWarmExchangeRate(currency: string) {
@@ -31,33 +32,44 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
   const parsed = updateSettingsSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
 
-  const settings = await prisma.setting.upsert({
-    where: { userId },
-    update: {
-      ...(parsed.data.baseCurrency !== undefined && { baseCurrency: parsed.data.baseCurrency }),
-      ...(parsed.data.locale !== undefined && { locale: parsed.data.locale }),
-      ...(parsed.data.stockColorScheme !== undefined && {
-        stockColorScheme: parsed.data.stockColorScheme,
-      }),
-    },
-    create: {
-      userId,
-      baseCurrency: parsed.data.baseCurrency ?? "USD",
-      locale: parsed.data.locale ?? "en-US",
-      stockColorScheme: parsed.data.stockColorScheme ?? "GREEN_UP",
-    },
-  });
+  const { demoMode } = parsed.data;
+  // Demo mode is the only field that doesn't persist to the Setting row — so
+  // a demo-only toggle must not write to the DB at all.
+  const hasPersistedFields =
+    parsed.data.baseCurrency !== undefined ||
+    parsed.data.locale !== undefined ||
+    parsed.data.stockColorScheme !== undefined;
 
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag(`settings:${userId}`, "max");
-  // If the base currency changed, the cached net-worth summary for this
-  // user is stale (values are denominated in the old currency).
-  if (parsed.data.baseCurrency !== undefined) {
-    revalidateTag(`net-worth:${userId}`, "max");
-    void maybeWarmExchangeRate(parsed.data.baseCurrency);
+  let settings: Awaited<ReturnType<typeof prisma.setting.upsert>> | null = null;
+  if (hasPersistedFields) {
+    settings = await prisma.setting.upsert({
+      where: { userId },
+      update: {
+        ...(parsed.data.baseCurrency !== undefined && { baseCurrency: parsed.data.baseCurrency }),
+        ...(parsed.data.locale !== undefined && { locale: parsed.data.locale }),
+        ...(parsed.data.stockColorScheme !== undefined && {
+          stockColorScheme: parsed.data.stockColorScheme,
+        }),
+      },
+      create: {
+        userId,
+        baseCurrency: parsed.data.baseCurrency ?? "USD",
+        locale: parsed.data.locale ?? "en-US",
+        stockColorScheme: parsed.data.stockColorScheme ?? "GREEN_UP",
+      },
+    });
+
+    // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+    revalidateTag(`settings:${userId}`, "max");
+    // If the base currency changed, the cached net-worth summary for this
+    // user is stale (values are denominated in the old currency).
+    if (parsed.data.baseCurrency !== undefined) {
+      revalidateTag(`net-worth:${userId}`, "max");
+      void maybeWarmExchangeRate(parsed.data.baseCurrency);
+    }
   }
 
-  const response = ok(settings);
+  const response = ok(settings ?? { demoMode: demoMode ?? false });
 
   // Set locale cookie so next-intl picks it up on the next request
   if (parsed.data.locale) {
@@ -66,6 +78,23 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
       maxAge: 60 * 60 * 24 * 365,
       sameSite: "lax",
     });
+  }
+
+  // Toggle the read-only demo overlay via cookie. Flip the per-user data tags
+  // so any prerendered RSC output is refreshed on the next navigation.
+  if (demoMode !== undefined) {
+    if (demoMode) {
+      response.cookies.set(DEMO_COOKIE, "1", {
+        path: "/",
+        maxAge: 60 * 60 * 24 * 30,
+        sameSite: "lax",
+      });
+    } else {
+      response.cookies.set(DEMO_COOKIE, "", { path: "/", maxAge: 0, sameSite: "lax" });
+    }
+    revalidateTag(`net-worth:${userId}`, "max");
+    revalidateTag(`accounts:${userId}`, "max");
+    revalidateTag(`history:${userId}`, "max");
   }
 
   return response;

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -5,13 +5,16 @@ import { LazyAllocationChart, LazyCurrencyExposureChart } from "@/components/das
 import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
 import { AccountsSummary } from "@/components/dashboard/accounts-summary";
 import { DashboardActions } from "@/components/dashboard/dashboard-actions";
-import {
-  getCachedNetWorthSummary,
-  fetchUserAccountsWithHoldings,
-} from "@/lib/services/net-worth-service";
+import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { getNormalizedHistory } from "@/lib/services/history-service";
+import {
+  isDemoMode,
+  resolveNetWorthSummary,
+  resolveNormalizedHistory,
+  resolveAccountCount,
+  getDemoPreviousSnapshot,
+} from "@/lib/services/demo-service";
 import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
@@ -86,10 +89,23 @@ function AccountsSummarySkeleton() {
 async function DashboardActionsSection({
   userId,
   baseCurrency,
+  demo,
 }: {
   userId: string;
   baseCurrency: string;
+  demo: boolean;
 }) {
+  if (demo) {
+    const nowIso = new Date().toISOString();
+    return (
+      <DashboardActions
+        baseCurrency={baseCurrency}
+        lastPriceUpdate={nowIso}
+        lastSnapshotDate={nowIso}
+      />
+    );
+  }
+
   const [previousSnapshot, latestPrice] = await Promise.all([
     fetchPreviousSnapshot(userId),
     prisma.priceCache.findFirst({
@@ -113,22 +129,31 @@ async function DashboardActionsSection({
  * Net worth cards — the LCP element on the dashboard.
  * Fetches the cached summary and recent snapshots for the delta display.
  */
-async function NetWorthSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
-  const [summary, previousSnapshot] = await Promise.all([
-    getCachedNetWorthSummary(userId, baseCurrency),
-    fetchPreviousSnapshot(userId),
-  ]);
-
+async function NetWorthSection({
+  userId,
+  baseCurrency,
+  demo,
+}: {
+  userId: string;
+  baseCurrency: string;
+  demo: boolean;
+}) {
+  const summary = await resolveNetWorthSummary(userId, baseCurrency);
   if (summary.accounts.length === 0) return null;
 
   let previousNetWorth: number | undefined;
-  if (previousSnapshot) {
-    if (previousSnapshot.baseCurrency === baseCurrency) {
-      previousNetWorth = Number(previousSnapshot.netWorth);
-    } else {
-      const rateMap = await getAllExchangeRates();
-      const rate = resolveRate(rateMap, previousSnapshot.baseCurrency, baseCurrency);
-      if (rate !== undefined) previousNetWorth = Number(previousSnapshot.netWorth) * rate;
+  if (demo) {
+    previousNetWorth = getDemoPreviousSnapshot(baseCurrency)?.netWorth;
+  } else {
+    const previousSnapshot = await fetchPreviousSnapshot(userId);
+    if (previousSnapshot) {
+      if (previousSnapshot.baseCurrency === baseCurrency) {
+        previousNetWorth = Number(previousSnapshot.netWorth);
+      } else {
+        const rateMap = await getAllExchangeRates();
+        const rate = resolveRate(rateMap, previousSnapshot.baseCurrency, baseCurrency);
+        if (rate !== undefined) previousNetWorth = Number(previousSnapshot.netWorth) * rate;
+      }
     }
   }
 
@@ -140,7 +165,7 @@ async function NetWorthSection({ userId, baseCurrency }: { userId: string; baseC
  * Shares the same cached summary as NetWorthSection (data-cache dedup).
  */
 async function ChartsSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
-  const summary = await getCachedNetWorthSummary(userId, baseCurrency);
+  const summary = await resolveNetWorthSummary(userId, baseCurrency);
   if (summary.accounts.length === 0) return null;
 
   return (
@@ -158,10 +183,15 @@ async function ChartsSection({ userId, baseCurrency }: { userId: string; baseCur
 async function GoalsMilestoneSection({
   userId,
   baseCurrency,
+  demo,
 }: {
   userId: string;
   baseCurrency: string;
+  demo: boolean;
 }) {
+  // Goals are real user data; suppress them under the read-only demo overlay
+  // so the demo dashboard stays self-consistent with its fixture net worth.
+  if (demo) return null;
   const goalsWithProgress = await computeGoalsWithProgress(userId, baseCurrency);
   if (goalsWithProgress.length === 0) return null;
 
@@ -198,7 +228,7 @@ async function AccountsSummarySection({
   userId: string;
   baseCurrency: string;
 }) {
-  const summary = await getCachedNetWorthSummary(userId, baseCurrency);
+  const summary = await resolveNetWorthSummary(userId, baseCurrency);
   if (summary.accounts.length === 0) return null;
 
   return <AccountsSummary summary={summary} />;
@@ -210,20 +240,20 @@ export async function DashboardContent({ userId }: { userId: string }) {
   // Settings are data-cached (30s TTL) — resolves near-instantly on cache hit
   const settings = await getOrCreateSettings(userId);
   const baseCurrency = settings.baseCurrency;
+  const demo = await isDemoMode();
 
-  // Pre-warm React caches for the inner sections
-  void fetchUserAccountsWithHoldings(userId);
-  void getAllExchangeRates();
+  // Pre-warm React caches for the inner sections (skip under the demo overlay,
+  // which never touches these DB-backed fetchers).
+  if (!demo) {
+    void fetchUserAccountsWithHoldings(userId);
+    void getAllExchangeRates();
+  }
 
   // Fetch snapshot history once — shared by TrendChartSection and HistoryHeatmap.
-  // getNormalizedHistory is "use cache" with cacheLife("hours"), so this is a
-  // cache read on warm requests. No extra DB query on repeat renders.
-  const snapshots = await getNormalizedHistory(userId, baseCurrency);
+  const snapshots = await resolveNormalizedHistory(userId, baseCurrency);
 
-  // Fast check: does this user have any active accounts?
-  const accountCount = await prisma.account.count({
-    where: { userId, isActive: true },
-  });
+  // Fast check: does this user have any active accounts (or demo data)?
+  const accountCount = await resolveAccountCount(userId);
 
   if (accountCount === 0) {
     const t = await getTranslations("dashboard");
@@ -263,17 +293,17 @@ export async function DashboardContent({ userId }: { userId: string }) {
     <>
       {/* Actions stream first — lightweight metadata, no summary needed */}
       <Suspense fallback={<div className="h-10 w-full bg-muted animate-pulse rounded-lg" />}>
-        <DashboardActionsSection userId={userId} baseCurrency={baseCurrency} />
+        <DashboardActionsSection userId={userId} baseCurrency={baseCurrency} demo={demo} />
       </Suspense>
 
       {/* Net worth card — the LCP element, streams as soon as summary resolves */}
       <Suspense fallback={<NetWorthSkeleton />}>
-        <NetWorthSection userId={userId} baseCurrency={baseCurrency} />
+        <NetWorthSection userId={userId} baseCurrency={baseCurrency} demo={demo} />
       </Suspense>
 
       {/* Goals milestone — next active goal, streams after net worth */}
       <Suspense fallback={null}>
-        <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
+        <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} demo={demo} />
       </Suspense>
 
       {/* Trend chart + activity heatmap footer — share the same card */}

--- a/src/components/onboarding/onboarding-carousel.tsx
+++ b/src/components/onboarding/onboarding-carousel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { springConfig } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface OnboardingSlide {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+interface OnboardingCarouselProps {
+  slides: OnboardingSlide[];
+  labels: { back: string; next: string; skip: string; done: string };
+  onDone: () => void;
+}
+
+const SWIPE_DISTANCE = 60;
+const SWIPE_VELOCITY = 300;
+
+export function OnboardingCarousel({ slides, labels, onDone }: OnboardingCarouselProps) {
+  const [[index, direction], setState] = useState<[number, number]>([0, 0]);
+  const isLast = index === slides.length - 1;
+  const isFirst = index === 0;
+
+  const paginate = useCallback(
+    (dir: number) => {
+      setState(([cur]) => {
+        const next = cur + dir;
+        if (next < 0 || next >= slides.length) return [cur, dir];
+        return [next, dir];
+      });
+    },
+    [slides.length],
+  );
+
+  // Arrow-key navigation.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "ArrowRight") paginate(1);
+      else if (e.key === "ArrowLeft") paginate(-1);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [paginate]);
+
+  const slide = slides[index];
+  const Icon = slide.icon;
+
+  return (
+    <div className="flex flex-col">
+      {/* Slide viewport */}
+      <div className="relative h-[230px] overflow-hidden px-6">
+        <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          <motion.div
+            key={index}
+            custom={direction}
+            variants={{
+              enter: (dir: number) => ({ x: dir > 0 ? 240 : -240, opacity: 0 }),
+              center: { x: 0, opacity: 1 },
+              exit: (dir: number) => ({ x: dir > 0 ? -240 : 240, opacity: 0 }),
+            }}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={springConfig}
+            drag="x"
+            dragConstraints={{ left: 0, right: 0 }}
+            dragElastic={0.2}
+            onDragEnd={(_, info) => {
+              if (info.offset.x < -SWIPE_DISTANCE || info.velocity.x < -SWIPE_VELOCITY) {
+                paginate(1);
+              } else if (info.offset.x > SWIPE_DISTANCE || info.velocity.x > SWIPE_VELOCITY) {
+                paginate(-1);
+              }
+            }}
+            className="absolute inset-0 flex cursor-grab flex-col items-center justify-center gap-4 px-2 text-center active:cursor-grabbing"
+          >
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <Icon className="h-8 w-8" aria-hidden="true" />
+            </div>
+            <h3 className="text-xl font-bold tracking-tight">{slide.title}</h3>
+            <p className="max-w-sm text-sm text-muted-foreground">{slide.description}</p>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Dot indicators */}
+      <div className="flex justify-center gap-2 py-4" role="tablist" aria-label="Onboarding slides">
+        {slides.map((_, i) => (
+          <button
+            key={i}
+            type="button"
+            aria-label={`Go to slide ${i + 1}`}
+            aria-selected={i === index}
+            role="tab"
+            onClick={() => setState(([cur]) => [i, i > cur ? 1 : -1])}
+            className={cn(
+              "h-2 rounded-full transition-all",
+              i === index
+                ? "w-6 bg-primary"
+                : "w-2 bg-muted-foreground/30 hover:bg-muted-foreground/50",
+            )}
+          />
+        ))}
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center justify-between gap-2 px-6 pb-6">
+        {isFirst ? (
+          <Button variant="ghost" onClick={onDone} className="text-muted-foreground">
+            {labels.skip}
+          </Button>
+        ) : (
+          <Button variant="ghost" onClick={() => paginate(-1)}>
+            <ChevronLeft className="h-4 w-4" />
+            {labels.back}
+          </Button>
+        )}
+
+        {isLast ? (
+          <Button onClick={onDone}>{labels.done}</Button>
+        ) : (
+          <Button onClick={() => paginate(1)}>
+            {labels.next}
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/onboarding-context.tsx
+++ b/src/components/onboarding/onboarding-context.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+} from "react";
+import { usePathname } from "next/navigation";
+
+interface OnboardingContextType {
+  open: boolean;
+  /** Open the tour on demand (e.g. the "Show app tour" button in settings). */
+  openTour: () => void;
+  /** Close the tour and remember that it has been seen. */
+  closeTour: () => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextType>({
+  open: false,
+  openTour: () => {},
+  closeTour: () => {},
+});
+
+const STORAGE_KEY = "asset-tracker:onboarding-seen";
+
+export function OnboardingProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const pathname = usePathname();
+
+  // Auto-show once, on the first dashboard visit, when never seen before.
+  // Guarded by `mounted` so the server render never opens the dialog (avoids
+  // hydration mismatch).
+  useEffect(() => {
+    let seen = false;
+    try {
+      seen = localStorage.getItem(STORAGE_KEY) === "1";
+    } catch {
+      seen = true; // storage unavailable → don't nag
+    }
+    const shouldOpen = !seen && pathname === "/";
+    startTransition(() => {
+      setMounted(true);
+      if (shouldOpen) setOpen(true);
+    });
+    // Only evaluate on first mount; replay is handled via openTour().
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const closeTour = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // ignore
+    }
+    startTransition(() => setOpen(false));
+  }, []);
+
+  const openTour = useCallback(() => {
+    startTransition(() => setOpen(true));
+  }, []);
+
+  const value = useMemo(
+    () => ({ open: mounted && open, openTour, closeTour }),
+    [mounted, open, openTour, closeTour],
+  );
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}
+
+export function useOnboarding() {
+  return useContext(OnboardingContext);
+}

--- a/src/components/onboarding/onboarding-tour.tsx
+++ b/src/components/onboarding/onboarding-tour.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Wallet, Landmark, LineChart, Sparkles } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useOnboarding } from "@/components/onboarding/onboarding-context";
+import {
+  OnboardingCarousel,
+  type OnboardingSlide,
+} from "@/components/onboarding/onboarding-carousel";
+
+export function OnboardingTour() {
+  const t = useTranslations("onboarding");
+  const isMobile = useIsMobile();
+  const { open, closeTour } = useOnboarding();
+
+  const slides: OnboardingSlide[] = [
+    { icon: Wallet, title: t("slide1Title"), description: t("slide1Description") },
+    { icon: Landmark, title: t("slide2Title"), description: t("slide2Description") },
+    { icon: LineChart, title: t("slide3Title"), description: t("slide3Description") },
+    { icon: Sparkles, title: t("slide4Title"), description: t("slide4Description") },
+  ];
+
+  const labels = {
+    back: t("back"),
+    next: t("next"),
+    skip: t("skip"),
+    done: t("done"),
+  };
+
+  const carousel = <OnboardingCarousel slides={slides} labels={labels} onDone={closeTour} />;
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={(o) => !o && closeTour()}>
+        <DrawerContent showCloseButton={false}>
+          <DrawerHeader className="items-center text-center">
+            <DrawerTitle>{t("title")}</DrawerTitle>
+          </DrawerHeader>
+          {carousel}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && closeTour()}>
+      <DialogContent className="sm:max-w-md p-0">
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle className="text-center">{t("title")}</DialogTitle>
+        </DialogHeader>
+        {carousel}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -21,6 +21,7 @@ import {
   useStockColorScheme,
   type StockColorScheme,
 } from "@/components/layout/stock-color-scheme-context";
+import { useOnboarding } from "@/components/onboarding/onboarding-context";
 import { Check, TrendingUp, TrendingDown } from "lucide-react";
 
 const COLOR_SCHEMAS: Array<{ id: ColorSchema; light: string; dark: string }> = [
@@ -44,12 +45,17 @@ const STOCK_COLOR_SCHEMES: Array<{
 export function SettingsForm({
   currentCurrency,
   currentLocale,
+  currentDemoMode,
 }: {
   currentCurrency: string;
   currentLocale: string;
+  currentDemoMode: boolean;
 }) {
   const router = useRouter();
   const t = useTranslations();
+  const { openTour } = useOnboarding();
+  const [demoMode, setDemoMode] = useState(currentDemoMode);
+  const [savingDemo, setSavingDemo] = useState(false);
   const activeLocale = useLocale();
   const resolvedActiveLocale: Locale = SUPPORTED_LOCALES.includes(activeLocale as Locale)
     ? (activeLocale as Locale)
@@ -99,6 +105,27 @@ export function SettingsForm({
       toast.error(t("toast.languageFailed"));
     } finally {
       setSavingLocale(false);
+    }
+  }
+
+  async function toggleDemoMode(next: boolean) {
+    if (next === demoMode || savingDemo) return;
+    setSavingDemo(true);
+    setDemoMode(next);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ demoMode: next }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success(next ? t("settings.demoModeEnabled") : t("settings.demoModeDisabled"));
+      router.refresh();
+    } catch {
+      setDemoMode(!next);
+      toast.error(t("toast.failed"));
+    } finally {
+      setSavingDemo(false);
     }
   }
 
@@ -303,6 +330,57 @@ export function SettingsForm({
                   </button>
                 ))}
               </div>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* GETTING STARTED SECTION */}
+      <section className="space-y-3">
+        <h3 className="text-lg font-semibold text-foreground">
+          {t("settings.gettingStartedTitle")}
+        </h3>
+        <Card className="overflow-hidden p-0">
+          <CardContent className="p-0">
+            {/* Demo Mode Row */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">{t("settings.demoMode")}</p>
+                <p className="text-sm text-muted-foreground">{t("settings.demoModeDescription")}</p>
+              </div>
+              <div className="w-fit flex items-center gap-1 rounded-lg border p-1 bg-muted/30">
+                {([false, true] as const).map((value) => (
+                  <button
+                    key={String(value)}
+                    type="button"
+                    onClick={() => toggleDemoMode(value)}
+                    disabled={savingDemo}
+                    className={`px-3 py-1.5 min-h-[44px] md:min-h-0 flex items-center justify-center rounded-md text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-60 ${
+                      demoMode === value
+                        ? "bg-background border border-border shadow-sm text-foreground font-semibold"
+                        : "border border-transparent text-muted-foreground font-medium hover:text-foreground"
+                    }`}
+                    aria-pressed={demoMode === value}
+                  >
+                    {value ? t("settings.demoModeOn") : t("settings.demoModeOff")}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* App Tour Row */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">{t("settings.appTour")}</p>
+                <p className="text-sm text-muted-foreground">{t("settings.appTourDescription")}</p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={openTour}
+                className="w-full sm:w-auto min-w-[150px]"
+              >
+                {t("settings.showAppTour")}
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/src/lib/demo/demo-data.ts
+++ b/src/lib/demo/demo-data.ts
@@ -1,0 +1,337 @@
+import "server-only";
+import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/types";
+import { resolveRate } from "@/lib/services/exchange-rate-service";
+
+/**
+ * Read-only demo fixture.
+ *
+ * Everything here is deterministic and offline — no live price/FX fetches — so
+ * the "demo mode" overlay (see `src/lib/services/demo-service.ts`) can paint a
+ * realistic, populated app for first-time users without writing a single row to
+ * the database. Monetary values are authored in a canonical currency (USD or
+ * TWD per account) and converted to the viewer's base currency at render time
+ * via {@link resolveRate} + {@link DEMO_EXCHANGE_RATES}.
+ *
+ * All account/holding fields are already serialized (plain numbers + ISO date
+ * strings) so they satisfy the Serialized* types directly and stream straight
+ * to client components without going through the Decimal/Date serializers.
+ */
+
+/** Stable synthetic user id, used only for cache-key shapes; never persisted. */
+export const DEMO_USER_ID = "demo-user";
+
+/** ISO timestamp used for all fixture createdAt/updatedAt fields. */
+const FIXED_TS = "2024-01-15T00:00:00.000Z";
+
+// ---------------------------------------------------------------------------
+// Static prices & exchange rates (deterministic, offline)
+// ---------------------------------------------------------------------------
+
+export const DEMO_PRICE_MAP: Record<string, { price: number; currency: string }> = {
+  // US equities / ETFs (USD)
+  AAPL: { price: 230, currency: "USD" },
+  MSFT: { price: 430, currency: "USD" },
+  NVDA: { price: 130, currency: "USD" },
+  GOOGL: { price: 175, currency: "USD" },
+  AMZN: { price: 200, currency: "USD" },
+  TSLA: { price: 250, currency: "USD" },
+  VOO: { price: 540, currency: "USD" },
+  VTI: { price: 280, currency: "USD" },
+  // Crypto (USD)
+  BTC: { price: 95000, currency: "USD" },
+  ETH: { price: 3400, currency: "USD" },
+  SOL: { price: 190, currency: "USD" },
+  // Taiwan equities (TWD)
+  "2330.TW": { price: 1050, currency: "TWD" },
+  "0050.TW": { price: 190, currency: "TWD" },
+};
+
+/**
+ * Rates keyed "FROM_TO" where amount_in_FROM * rate = amount_in_TO.
+ * Inverse pairs are derived by {@link resolveRate}, so only USD→X is stored.
+ */
+export const DEMO_EXCHANGE_RATES: Map<string, number> = new Map([
+  ["USD_TWD", 32],
+  ["USD_EUR", 0.92],
+  ["USD_GBP", 0.79],
+  ["USD_JPY", 150],
+  ["USD_CAD", 1.36],
+  ["USD_AUD", 1.52],
+  ["USD_HKD", 7.8],
+  ["USD_CNY", 7.2],
+  ["USD_SGD", 1.34],
+  ["USD_KRW", 1350],
+  ["USD_INR", 83],
+  ["USD_CHF", 0.88],
+]);
+
+// ---------------------------------------------------------------------------
+// Accounts + holdings fixture
+// ---------------------------------------------------------------------------
+
+function holding(
+  accountId: string,
+  symbol: string,
+  name: string,
+  quantity: number,
+  assetType: SerializedHolding["assetType"],
+  currency: string,
+): SerializedHolding {
+  // Cast mirrors serializeHolding(): the Serialized<> mapping types option-only
+  // fields (strike/expiration) as non-null, but they are genuinely null here.
+  return {
+    id: `demo-h-${accountId}-${symbol}`,
+    accountId,
+    symbol,
+    name,
+    quantity,
+    currency,
+    assetType,
+    underlyingSymbol: null,
+    optionType: null,
+    strike: null,
+    expiration: null,
+    contractMultiplier: null,
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  } as unknown as SerializedHolding;
+}
+
+function account(
+  id: string,
+  name: string,
+  type: "ASSET" | "LIABILITY",
+  category: SerializedAccountWithHoldings["category"],
+  currency: string,
+  cashBalance: number,
+  sortOrder: number,
+  holdings: SerializedHolding[] = [],
+  isPinned = false,
+): SerializedAccountWithHoldings {
+  return {
+    id,
+    userId: DEMO_USER_ID,
+    name,
+    type,
+    category,
+    currency,
+    cashBalance,
+    isActive: true,
+    isPinned,
+    sortOrder,
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+    holdings,
+  };
+}
+
+export const DEMO_ACCOUNTS: SerializedAccountWithHoldings[] = [
+  account("demo-acct-savings", "High-Yield Savings", "ASSET", "BANK", "USD", 60000, 0, [], true),
+  account("demo-acct-checking", "Everyday Checking", "ASSET", "BANK", "USD", 24500, 1),
+  account("demo-acct-brokerage", "Brokerage", "ASSET", "BROKERAGE", "USD", 3200, 2, [
+    holding("demo-acct-brokerage", "AAPL", "Apple Inc.", 50, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "MSFT", "Microsoft Corp.", 25, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "NVDA", "NVIDIA Corp.", 80, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "GOOGL", "Alphabet Inc.", 30, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "AMZN", "Amazon.com Inc.", 25, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "TSLA", "Tesla Inc.", 20, "STOCK", "USD"),
+    holding("demo-acct-brokerage", "VOO", "Vanguard S&P 500 ETF", 30, "ETF", "USD"),
+    holding("demo-acct-brokerage", "VTI", "Vanguard Total Market ETF", 40, "ETF", "USD"),
+  ]),
+  account("demo-acct-crypto", "Crypto Wallet", "ASSET", "CRYPTO_WALLET", "USD", 0, 3, [
+    holding("demo-acct-crypto", "BTC", "Bitcoin", 0.5, "CRYPTO", "USD"),
+    holding("demo-acct-crypto", "ETH", "Ethereum", 5, "CRYPTO", "USD"),
+    holding("demo-acct-crypto", "SOL", "Solana", 40, "CRYPTO", "USD"),
+  ]),
+  account("demo-acct-tw", "TW Brokerage", "ASSET", "BROKERAGE", "TWD", 150000, 4, [
+    holding("demo-acct-tw", "2330.TW", "TSMC", 200, "STOCK", "TWD"),
+    holding("demo-acct-tw", "0050.TW", "Yuanta Taiwan 50 ETF", 500, "ETF", "TWD"),
+  ]),
+  account("demo-acct-property", "Primary Residence", "ASSET", "PROPERTY", "USD", 450000, 5),
+  account("demo-acct-card", "Rewards Credit Card", "LIABILITY", "CREDIT_CARD", "USD", 4800, 6),
+  account("demo-acct-mortgage", "Home Mortgage", "LIABILITY", "MORTGAGE", "USD", 320000, 7),
+];
+
+// ---------------------------------------------------------------------------
+// Current per-account value (USD) — derived from the same prices/rates the
+// dashboard uses, so the latest snapshot matches the net-worth card exactly.
+// ---------------------------------------------------------------------------
+
+/** Returns each account's current total value in USD (positive magnitude). */
+function currentAccountValuesUSD(): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const acct of DEMO_ACCOUNTS) {
+    const cashRate = resolveRate(DEMO_EXCHANGE_RATES, acct.currency, "USD") ?? 1;
+    let valueUSD = acct.cashBalance * cashRate;
+    for (const h of acct.holdings) {
+      const px = DEMO_PRICE_MAP[h.symbol];
+      if (!px) continue;
+      const hRate = resolveRate(DEMO_EXCHANGE_RATES, px.currency, "USD") ?? 1;
+      valueUSD += px.price * h.quantity * hRate;
+    }
+    out[acct.id] = valueUSD;
+  }
+  return out;
+}
+
+export const DEMO_ACCOUNT_META = DEMO_ACCOUNTS.map((a) => ({
+  id: a.id,
+  name: a.name,
+  category: a.category,
+  type: a.type,
+}));
+
+// ---------------------------------------------------------------------------
+// Deterministic history generation
+// ---------------------------------------------------------------------------
+
+/** Tiny seeded LCG → stable pseudo-random sequence in [0, 1). */
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/** Number of daily history points generated (≈ 18 months). */
+const HISTORY_DAYS: number = 540;
+
+export interface DemoSnapshot {
+  /** "YYYY-MM-DD" */
+  date: string;
+  /** ISO timestamp */
+  createdAt: string;
+  /** Net worth in USD. */
+  netWorthUSD: number;
+  totalAssetsUSD: number;
+  totalLiabilitiesUSD: number;
+  /** accountId → value in USD (positive magnitude, matching snapshot breakdown). */
+  perAccountUSD: Record<string, number>;
+}
+
+/**
+ * Build the full daily history (oldest → newest) ending today. The newest point
+ * equals the current per-account values exactly, so the dashboard delta and the
+ * history chart's last point agree. Deterministic given the seed; the only
+ * non-constant input is "today", which keeps the demo perpetually fresh.
+ */
+function buildDemoHistory(): DemoSnapshot[] {
+  const current = currentAccountValuesUSD();
+  const snapshots: DemoSnapshot[] = [];
+
+  // Per-account growth profile: how much smaller the value was at the start of
+  // the window (startFrac), plus volatility amplitude. Liabilities amortize, so
+  // they were *larger* in the past (startFrac > 1).
+  const profile: Record<string, { startFrac: number; vol: number; seed: number }> = {
+    "demo-acct-savings": { startFrac: 0.6, vol: 0.01, seed: 11 },
+    "demo-acct-checking": { startFrac: 0.85, vol: 0.06, seed: 22 },
+    "demo-acct-brokerage": { startFrac: 0.68, vol: 0.05, seed: 33 },
+    "demo-acct-crypto": { startFrac: 0.45, vol: 0.14, seed: 44 },
+    "demo-acct-tw": { startFrac: 0.72, vol: 0.05, seed: 55 },
+    "demo-acct-property": { startFrac: 0.93, vol: 0.004, seed: 66 },
+    "demo-acct-card": { startFrac: 1.15, vol: 0.18, seed: 77 },
+    "demo-acct-mortgage": { startFrac: 1.08, vol: 0.001, seed: 88 },
+  };
+
+  const rngs: Record<string, () => number> = {};
+  for (const acct of DEMO_ACCOUNTS) {
+    rngs[acct.id] = makeRng(profile[acct.id]?.seed ?? 1);
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  for (let i = 0; i < HISTORY_DAYS; i++) {
+    const daysAgo = HISTORY_DAYS - 1 - i;
+    const d = new Date(today);
+    d.setDate(d.getDate() - daysAgo);
+    const dateStr = d.toISOString().split("T")[0];
+    const t = HISTORY_DAYS === 1 ? 1 : i / (HISTORY_DAYS - 1); // 0 → 1
+
+    const perAccountUSD: Record<string, number> = {};
+    let assets = 0;
+    let liabilities = 0;
+
+    for (const acct of DEMO_ACCOUNTS) {
+      const p = profile[acct.id] ?? { startFrac: 0.8, vol: 0.04, seed: 1 };
+      const isLast = i === HISTORY_DAYS - 1;
+      let factor: number;
+      if (isLast) {
+        factor = 1; // newest point lands exactly on current values
+      } else {
+        const trend = p.startFrac + (1 - p.startFrac) * t;
+        // Smooth wave + small jitter for organic-looking lines.
+        const wave = Math.sin(t * Math.PI * 3 + p.seed) * p.vol * 0.5;
+        const jitter = (rngs[acct.id]() - 0.5) * p.vol;
+        factor = trend + wave + jitter;
+      }
+      const value = Math.max(0, current[acct.id] * factor);
+      perAccountUSD[acct.id] = value;
+      if (acct.type === "ASSET") assets += value;
+      else liabilities += value;
+    }
+
+    snapshots.push({
+      date: dateStr,
+      createdAt: d.toISOString(),
+      netWorthUSD: assets - liabilities,
+      totalAssetsUSD: assets,
+      totalLiabilitiesUSD: liabilities,
+      perAccountUSD,
+    });
+  }
+
+  return snapshots;
+}
+
+/** Memoized full history (per server process). */
+let _history: DemoSnapshot[] | null = null;
+let _historyDay: string | null = null;
+export function getDemoHistory(): DemoSnapshot[] {
+  const todayKey = new Date().toISOString().split("T")[0];
+  if (!_history || _historyDay !== todayKey) {
+    _history = buildDemoHistory();
+    _historyDay = todayKey;
+  }
+  return _history;
+}
+
+// ---------------------------------------------------------------------------
+// Monthly cash-flow fixture (net deposits in USD), distributed per account.
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic per-(account, month) net cash contributions in USD. Only the
+ * "saver" accounts receive regular contributions; values are stable per month.
+ */
+export function getDemoAccountCashFlowUSD(): {
+  accountId: string;
+  monthKey: string;
+  contributions: number;
+}[] {
+  const contributors: Record<string, { base: number; seed: number }> = {
+    "demo-acct-savings": { base: 1500, seed: 101 },
+    "demo-acct-brokerage": { base: 2000, seed: 202 },
+    "demo-acct-crypto": { base: 400, seed: 303 },
+  };
+
+  // Walk the last 13 month keys ending this month.
+  const now = new Date();
+  const monthKeys: string[] = [];
+  for (let m = 12; m >= 0; m--) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - m, 1));
+    monthKeys.push(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`);
+  }
+
+  const out: { accountId: string; monthKey: string; contributions: number }[] = [];
+  for (const [accountId, cfg] of Object.entries(contributors)) {
+    const rng = makeRng(cfg.seed);
+    for (const monthKey of monthKeys) {
+      const jitter = (rng() - 0.3) * cfg.base * 0.8;
+      const amount = Math.round(cfg.base + jitter);
+      out.push({ accountId, monthKey, contributions: amount });
+    }
+  }
+  return out;
+}

--- a/src/lib/services/demo-service.ts
+++ b/src/lib/services/demo-service.ts
@@ -1,0 +1,271 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
+import {
+  computeSummaryFromData,
+  fetchUserAccountsWithHoldings,
+  fetchUserArchivedAccountsWithHoldings,
+  getCachedNetWorthSummary,
+} from "./net-worth-service";
+import { getAccountDetail, getAccountPriceMap } from "./account-service";
+import { getNormalizedHistory, getFullNormalizedHistory } from "./history-service";
+import { getCachedAnalysisPayload, type AnalysisPayload } from "./analysis-payload-service";
+import { getProjectionData, type ProjectionData } from "./projection-service";
+import { getCachedPricesForSymbols } from "./price-service";
+import {
+  DEMO_ACCOUNTS,
+  DEMO_ACCOUNT_META,
+  DEMO_EXCHANGE_RATES,
+  DEMO_PRICE_MAP,
+  getDemoAccountCashFlowUSD,
+  getDemoHistory,
+} from "@/lib/demo/demo-data";
+import type { NetWorthSummary, SerializedAccountWithHoldings } from "@/lib/types";
+import type {
+  NormalizedSnapshot,
+  RawHistoryData,
+  SnapshotBreakdown,
+  AccountMeta,
+  AccountMonthlyContribution,
+} from "./history-service";
+import type { MonthlyContribution } from "./analysis-service";
+
+/** Cookie name for the read-only demo overlay. Presence (= "1") enables it. */
+export const DEMO_COOKIE = "demo_mode";
+
+/**
+ * Whether the current request is in demo mode. Reads a cookie, so it MUST be
+ * called outside any `"use cache"` scope (cacheComponents forbids cookie reads
+ * inside cached functions). All `resolve*` helpers below branch on this before
+ * touching the cached, DB-backed fetchers.
+ */
+export async function isDemoMode(): Promise<boolean> {
+  const store = await cookies();
+  return store.get(DEMO_COOKIE)?.value === "1";
+}
+
+// ---------------------------------------------------------------------------
+// Demo data builders (pure; convert canonical USD fixtures → base currency)
+// ---------------------------------------------------------------------------
+
+function usdToBase(baseCurrency: string): number {
+  return resolveRate(DEMO_EXCHANGE_RATES, "USD", baseCurrency) ?? 1;
+}
+
+function getDemoNetWorthSummary(baseCurrency: string): NetWorthSummary {
+  return computeSummaryFromData(DEMO_ACCOUNTS, DEMO_EXCHANGE_RATES, DEMO_PRICE_MAP, baseCurrency);
+}
+
+function getDemoNormalizedHistory(baseCurrency: string, days?: number): NormalizedSnapshot[] {
+  const rate = usdToBase(baseCurrency);
+  let history = getDemoHistory();
+  if (days !== undefined) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffStr = cutoff.toISOString().split("T")[0];
+    history = history.filter((s) => s.date >= cutoffStr);
+  }
+  return history.map((s) => ({
+    id: `demo-snap-${s.date}`,
+    date: s.date,
+    createdAt: s.createdAt,
+    netWorth: s.netWorthUSD * rate,
+    totalAssets: s.totalAssetsUSD * rate,
+    totalLiabilities: s.totalLiabilitiesUSD * rate,
+    baseCurrency,
+  }));
+}
+
+function getDemoRawHistory(baseCurrency: string): RawHistoryData {
+  const rate = usdToBase(baseCurrency);
+  const snapshots: SnapshotBreakdown[] = getDemoHistory().map((s) => {
+    const accountValues: Record<string, number> = {};
+    for (const [id, v] of Object.entries(s.perAccountUSD)) {
+      accountValues[id] = v * rate;
+    }
+    return { date: s.date, accountValues };
+  });
+  const accounts: AccountMeta[] = DEMO_ACCOUNT_META.map((a) => ({
+    id: a.id,
+    name: a.name,
+    category: a.category,
+  }));
+  return { snapshots, accounts };
+}
+
+function getDemoAccountMonthlyCashFlow(baseCurrency: string): AccountMonthlyContribution[] {
+  const rate = usdToBase(baseCurrency);
+  return getDemoAccountCashFlowUSD().map((c) => ({
+    accountId: c.accountId,
+    monthKey: c.monthKey,
+    contributions: c.contributions * rate,
+  }));
+}
+
+function getDemoMonthlyCashFlow(baseCurrency: string): MonthlyContribution[] {
+  const byMonth = new Map<string, number>();
+  for (const c of getDemoAccountMonthlyCashFlow(baseCurrency)) {
+    byMonth.set(c.monthKey, (byMonth.get(c.monthKey) ?? 0) + c.contributions);
+  }
+  return Array.from(byMonth.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([monthKey, contributions]) => ({ monthKey, contributions }));
+}
+
+function getDemoAnalysisPayload(baseCurrency: string): AnalysisPayload {
+  return {
+    snapshots: getDemoNormalizedHistory(baseCurrency),
+    cashFlowData: getDemoMonthlyCashFlow(baseCurrency),
+    rawHistory: getDemoRawHistory(baseCurrency),
+    accountCashFlow: getDemoAccountMonthlyCashFlow(baseCurrency),
+  };
+}
+
+function getDemoProjectionData(baseCurrency: string): ProjectionData {
+  const history = getDemoNormalizedHistory(baseCurrency);
+  if (history.length === 0) {
+    return { latestNetWorth: 0, trailing12mSavings: 0, annualSnapshots: [], hasData: false };
+  }
+  const latestNetWorth = history[history.length - 1].netWorth;
+  const byYear = new Map<number, number>();
+  for (const s of history) {
+    byYear.set(Number(s.date.slice(0, 4)), s.netWorth);
+  }
+  const annualSnapshots = Array.from(byYear.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([year, netWorth]) => ({ year, netWorth }));
+
+  const trailing12mSavings = getDemoMonthlyCashFlow(baseCurrency).reduce(
+    (sum, c) => sum + c.contributions,
+    0,
+  );
+
+  return { latestNetWorth, trailing12mSavings, annualSnapshots, hasData: true };
+}
+
+/** Demo equivalent of the dashboard's "previous snapshot" delta source. */
+export interface DemoPreviousSnapshot {
+  date: string;
+  createdAt: string;
+  netWorth: number;
+  baseCurrency: string;
+}
+
+// ---------------------------------------------------------------------------
+// Resolvers — call these from pages instead of the raw fetchers. Each one
+// returns demo data when the cookie is set, otherwise delegates to the real
+// (cached, DB-backed) read.
+// ---------------------------------------------------------------------------
+
+export async function resolveNetWorthSummary(
+  userId: string,
+  baseCurrency: string,
+): Promise<NetWorthSummary> {
+  if (await isDemoMode()) return getDemoNetWorthSummary(baseCurrency);
+  return getCachedNetWorthSummary(userId, baseCurrency);
+}
+
+export async function resolveAccountsWithHoldings(
+  userId: string,
+): Promise<SerializedAccountWithHoldings[]> {
+  if (await isDemoMode()) return DEMO_ACCOUNTS;
+  return fetchUserAccountsWithHoldings(userId);
+}
+
+export async function resolveArchivedAccountsWithHoldings(
+  userId: string,
+): Promise<SerializedAccountWithHoldings[]> {
+  if (await isDemoMode()) return [];
+  return fetchUserArchivedAccountsWithHoldings(userId);
+}
+
+export async function resolveNormalizedHistory(
+  userId: string,
+  baseCurrency: string,
+): Promise<NormalizedSnapshot[]> {
+  if (await isDemoMode()) return getDemoNormalizedHistory(baseCurrency, 90);
+  return getNormalizedHistory(userId, baseCurrency);
+}
+
+export async function resolveFullNormalizedHistory(
+  userId: string,
+  baseCurrency: string,
+): Promise<NormalizedSnapshot[]> {
+  if (await isDemoMode()) return getDemoNormalizedHistory(baseCurrency);
+  return getFullNormalizedHistory(userId, baseCurrency);
+}
+
+export async function resolveAccountCount(userId: string): Promise<number> {
+  if (await isDemoMode()) return DEMO_ACCOUNTS.length;
+  const { prisma } = await import("@/lib/prisma");
+  return prisma.account.count({ where: { userId, isActive: true } });
+}
+
+export async function resolveAccountDetail(
+  userId: string,
+  accountId: string,
+): Promise<SerializedAccountWithHoldings | null> {
+  if (await isDemoMode()) return DEMO_ACCOUNTS.find((a) => a.id === accountId) ?? null;
+  return getAccountDetail(userId, accountId);
+}
+
+export async function resolveAccountPriceMap(symbols: string[]): Promise<Record<string, number>> {
+  if (await isDemoMode()) {
+    const out: Record<string, number> = {};
+    for (const s of symbols) {
+      const px = DEMO_PRICE_MAP[s];
+      if (px) out[s] = px.price;
+    }
+    return out;
+  }
+  return getAccountPriceMap(symbols);
+}
+
+export async function resolveCachedPricesForSymbols(
+  symbols: string[],
+): Promise<{ symbol: string; price: number; currency: string }[]> {
+  if (await isDemoMode()) {
+    return symbols
+      .filter((s) => DEMO_PRICE_MAP[s])
+      .map((s) => ({
+        symbol: s,
+        price: DEMO_PRICE_MAP[s].price,
+        currency: DEMO_PRICE_MAP[s].currency,
+      }));
+  }
+  return getCachedPricesForSymbols(symbols);
+}
+
+export async function resolveExchangeRatesMap(): Promise<Map<string, number>> {
+  if (await isDemoMode()) return DEMO_EXCHANGE_RATES;
+  return getAllExchangeRates();
+}
+
+export async function resolveAnalysisPayload(
+  userId: string,
+  baseCurrency: string,
+): Promise<AnalysisPayload> {
+  if (await isDemoMode()) return getDemoAnalysisPayload(baseCurrency);
+  return getCachedAnalysisPayload(userId, baseCurrency);
+}
+
+export async function resolveProjectionData(
+  userId: string,
+  baseCurrency: string,
+): Promise<ProjectionData> {
+  if (await isDemoMode()) return getDemoProjectionData(baseCurrency);
+  return getProjectionData(userId, baseCurrency);
+}
+
+/** Demo previous-snapshot meta (2nd-to-last point) for the dashboard delta. */
+export function getDemoPreviousSnapshot(baseCurrency: string): DemoPreviousSnapshot | null {
+  const history = getDemoNormalizedHistory(baseCurrency);
+  if (history.length < 2) return null;
+  const prev = history[history.length - 2];
+  return {
+    date: prev.date,
+    createdAt: prev.createdAt,
+    netWorth: prev.netWorth,
+    baseCurrency,
+  };
+}

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -80,6 +80,24 @@ async function computeNetWorthSummary(
     prices.map((p) => [p.symbol, { price: Number(p.price), currency: p.currency }]),
   );
 
+  return computeSummaryFromData(accounts, allRatesMap, priceMap, baseCurrency, userId);
+}
+
+/**
+ * Pure net-worth computation: given already-fetched accounts, an exchange-rate
+ * map, and a price map, derive the full {@link NetWorthSummary}. Separated from
+ * {@link computeNetWorthSummary} so callers that already hold the inputs — most
+ * notably the read-only **demo overlay** (`src/lib/services/demo-service.ts`),
+ * which feeds a static fixture — can reuse the exact same math without touching
+ * the database.
+ */
+export function computeSummaryFromData(
+  accounts: SerializedAccountWithHoldings[],
+  allRatesMap: Map<string, number>,
+  priceMap: Record<string, { price: number; currency: string }>,
+  baseCurrency: string,
+  userId?: string,
+): NetWorthSummary {
   let totalAssets = 0;
   let totalLiabilities = 0;
   const accountsWithValue: AccountWithValue[] = [];

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -93,6 +93,9 @@ export const updateSettingsSchema = z.object({
   baseCurrency: z.string().length(3).optional(),
   locale: z.enum(["en-US", "zh-TW"]).optional(),
   stockColorScheme: z.enum(["GREEN_UP", "RED_UP"]).optional(),
+  // Read-only demo overlay. Persisted as a cookie, not a DB column — toggling
+  // it writes zero rows for the user's real data.
+  demoMode: z.boolean().optional(),
 });
 
 export const updateTransactionSchema = z.object({


### PR DESCRIPTION
## Overview

Two onboarding aids for first-time users, both requested in the original ask:

1. **Demo mode** — a Settings toggle that paints the whole app with a built-in sample portfolio (read-only overlay, **zero DB writes**, fully reversible).
2. **Onboarding intro cards** — a few responsive, swipeable cards explaining the main features; auto-shown on first visit and re-openable from Settings.

## Demo mode (read-only sample overlay)

- New **Demo mode** toggle in Settings → *Getting Started*. When on, the dashboard, accounts list/detail, history, analysis, and projections all render a deterministic, offline sample portfolio. Turning it off instantly restores real data.
- **Persistence via a `demo_mode` cookie** (mirrors the existing `NEXT_LOCALE` idiom) — no Prisma migration, no rows written for the user's real data. The cookie is read **only in uncached resolvers**, never inside a `"use cache"` scope, so it's `cacheComponents`-safe.
- **No duplicated math:** extracted a pure `computeSummaryFromData()` from `net-worth-service.ts` so the fixture flows through the *exact* net-worth computation. `demo-service.ts` exposes `isDemoMode()` + `resolve*` wrappers that each page calls instead of the raw fetcher.
- **Fixture** (`src/lib/demo/demo-data.ts`): ~6 accounts across categories (bank, brokerage, crypto, TWD foreign brokerage, property, credit card, mortgage), ~14 holdings (USD + TWD), static prices/FX, and 18 months of seeded daily snapshots. The newest point lands exactly on the current net worth, so the dashboard delta and history agree.
- Toggling flips the per-user cache tags + `router.refresh()`.

## Onboarding intro cards (auto + replay)

- Lightweight **framer-motion** swipeable carousel (drag, dot indicators, back/next/skip/done, arrow keys) — no new dependency.
- **Responsive:** Drawer on mobile, Dialog on desktop (reuses `useIsMobile()` + the `goal-form-dialog` pattern).
- **Auto-shows on first dashboard visit** (remembered in `localStorage` with a `mounted` guard against hydration mismatch) and is **re-openable** via a "Show tour" button in Settings, wired through a shared `OnboardingProvider` in the `(main)` layout.

## i18n

New `onboarding` namespace + `settings` keys in both `en-US` and `zh-TW`.

## Files of note

- `src/lib/demo/demo-data.ts` (new) — fixture
- `src/lib/services/demo-service.ts` (new) — `isDemoMode()` + `resolve*` wrappers
- `src/lib/services/net-worth-service.ts` — extracted pure `computeSummaryFromData()`
- `src/components/onboarding/*` (new) — context, carousel, responsive tour
- `src/app/api/settings/route.ts` — demo cookie set/clear (no DB write for demo-only toggle)
- page wiring: dashboard, accounts, accounts/[id], history, analysis, projections, settings

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format:check` — all clean (also enforced by the pre-push hook).
- **`npm run build` succeeds** — all pages prerender with PPR, confirming no `cacheComponents`/cookie violations.
- Not yet exercised at runtime here (no DB/auth in the build env). To verify locally: toggle demo on in Settings and walk the pages; clear `localStorage` key `asset-tracker:onboarding-seen` to re-trigger the auto-show; check Drawer (mobile) vs Dialog (desktop).

https://claude.ai/code/session_01LYHsEtBUQfKL8egvzfiyCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYHsEtBUQfKL8egvzfiyCr)_