### PR TITLE
fix: apply privacy blur to heatmap grid

### DIFF
--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -185,7 +185,13 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   };
 
   return (
-    <div className="w-full">
+    <div
+      className={cn(
+        "w-full transition-[filter] duration-300",
+        privacyMode && "blur-sm pointer-events-none select-none",
+      )}
+      aria-hidden={privacyMode || undefined}
+    >
       {/*
         Relative wrapper lets the fade overlay sit on top of the scroll container
         without affecting layout. The fade uses mask-image on the scroll div itself


### PR DESCRIPTION
The HistoryHeatmap component was masking tooltip and aria-label text in
privacy mode but the heatmap grid itself remained fully visible, exposing
gain/loss patterns. Apply the standard blur pattern (blur-sm,
pointer-events-none, select-none, transition-[filter]) to the outermost
container, matching the approach used in daily-change-chart, projection-chart,
and attribution-chart.

https://claude.ai/code/session_01GG2E2a9SWkcwX8MYP7uosw