### PR TITLE
fix(search): restore holding symbol search broken by Yahoo schema validation

### DIFF
--- a/src/app/api/options/chain/route.ts
+++ b/src/app/api/options/chain/route.ts
@@ -1,5 +1,6 @@
 import { ok } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
+import { getYahooClient } from "@/lib/services/yahoo-client";
 import { log } from "@/lib/logger";
 
 type ChainContract = {
@@ -41,8 +42,7 @@ export async function GET(request: Request) {
   const dateParam = searchParams.get("date"); // YYYY-MM-DD
 
   try {
-    const YahooFinance = (await import("yahoo-finance2")).default;
-    const yf = new YahooFinance();
+    const yf = await getYahooClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const initial: any = await yf.options(symbol);
     const allDates: Date[] = initial.expirationDates ?? [];

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { unstable_cache } from "next/cache";
-import { ok } from "@/lib/api-responses";
+import { ok, failure } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
+import { getYahooClient } from "@/lib/services/yahoo-client";
 import { log } from "@/lib/logger";
 
 type SearchResult = {
@@ -73,42 +74,40 @@ function inferCurrency(symbol: string, exchange: string): string {
   return exchangeCurrencyMap[exchange] || "USD";
 }
 
+// NOTE: this intentionally does NOT swallow errors. A thrown error (Yahoo down,
+// network failure) must propagate so the handler can return a non-200 and the
+// caller can tell "search is broken" apart from "no matches". Errors also aren't
+// cached by unstable_cache, so a transient blip won't be pinned for an hour.
 const cachedYahooSearch = unstable_cache(
   async (query: string): Promise<SearchResult[]> => {
-    try {
-      const YahooFinance = (await import("yahoo-finance2")).default;
-      const yahooFinance = new YahooFinance();
-      // `validateResult: false` skips yahoo-finance2's strict schema validation.
-      // Yahoo periodically tweaks its search response shape (e.g. returning
-      // `typeDisp: "Equity"` where the lib's schema expects a lowercase const),
-      // which otherwise throws FailedYahooValidationError and makes search return
-      // zero results. The fields we read below are still present and coerced.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any = await yahooFinance.search(
-        query,
-        {
-          quotesCount: 10,
-          newsCount: 0,
-        },
-        { validateResult: false },
-      );
+    const yahooFinance = await getYahooClient();
+    // `validateResult: false` skips yahoo-finance2's strict schema validation.
+    // Yahoo periodically tweaks its search response shape (e.g. returning
+    // `typeDisp: "Equity"` where the lib's schema expects a lowercase const),
+    // which otherwise throws FailedYahooValidationError and makes search return
+    // zero results. The fields we read below are still present and coerced.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any = await yahooFinance.search(
+      query,
+      {
+        quotesCount: 10,
+        newsCount: 0,
+      },
+      { validateResult: false },
+    );
 
-      return (result.quotes || [])
-        .filter((q: Record<string, unknown>) => {
-          const qt = q.quoteType as string | undefined;
-          return qt && ["EQUITY", "ETF", "CRYPTOCURRENCY", "MUTUALFUND"].includes(qt);
-        })
-        .map((q: Record<string, unknown>) => ({
-          symbol: q.symbol as string,
-          name: (q.longname as string) || (q.shortname as string) || (q.symbol as string),
-          exchange: (q.exchDisp as string) || (q.exchange as string) || "",
-          type: mapQuoteType(q.quoteType as string),
-          currency: inferCurrency(q.symbol as string, (q.exchange as string) || ""),
-        }));
-    } catch (error) {
-      log.error("search.failed", { error: String(error) });
-      return [];
-    }
+    return (result.quotes || [])
+      .filter((q: Record<string, unknown>) => {
+        const qt = q.quoteType as string | undefined;
+        return qt && ["EQUITY", "ETF", "CRYPTOCURRENCY", "MUTUALFUND"].includes(qt);
+      })
+      .map((q: Record<string, unknown>) => ({
+        symbol: q.symbol as string,
+        name: (q.longname as string) || (q.shortname as string) || (q.symbol as string),
+        exchange: (q.exchDisp as string) || (q.exchange as string) || "",
+        type: mapQuoteType(q.quoteType as string),
+        currency: inferCurrency(q.symbol as string, (q.exchange as string) || ""),
+      }));
   },
   ["yahoo-search"],
   { revalidate: 3600 },
@@ -128,10 +127,17 @@ export async function GET(request: Request) {
     return ok([] as SearchResult[]);
   }
 
-  const results = await cachedYahooSearch(query);
-  return ok(results, {
-    headers: {
-      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
-    },
-  });
+  try {
+    const results = await cachedYahooSearch(query);
+    return ok(results, {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    // Distinct from an empty 200: signals an upstream failure so the client can
+    // show "search unavailable" instead of a misleading "no results".
+    log.error("search.failed", { query, error: String(error) });
+    return failure("Search is temporarily unavailable. Please try again.", 502);
+  }
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -78,11 +78,20 @@ const cachedYahooSearch = unstable_cache(
     try {
       const YahooFinance = (await import("yahoo-finance2")).default;
       const yahooFinance = new YahooFinance();
+      // `validateResult: false` skips yahoo-finance2's strict schema validation.
+      // Yahoo periodically tweaks its search response shape (e.g. returning
+      // `typeDisp: "Equity"` where the lib's schema expects a lowercase const),
+      // which otherwise throws FailedYahooValidationError and makes search return
+      // zero results. The fields we read below are still present and coerced.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any = await yahooFinance.search(query, {
-        quotesCount: 10,
-        newsCount: 0,
-      });
+      const result: any = await yahooFinance.search(
+        query,
+        {
+          quotesCount: 10,
+          newsCount: 0,
+        },
+        { validateResult: false },
+      );
 
       return (result.quotes || [])
         .filter((q: Record<string, unknown>) => {
@@ -110,7 +119,10 @@ export async function GET(request: Request) {
   if (limited) return limited;
 
   const { searchParams } = new URL(request.url);
-  const query = searchParams.get("q")?.trim();
+  // Normalize to lowercase so the cache key is case-insensitive: "AAPL", "aapl",
+  // and "Aapl" collapse to one cache entry. Yahoo's search is already
+  // case-insensitive, so this doesn't change which results come back.
+  const query = searchParams.get("q")?.trim().toLowerCase();
 
   if (!query || query.length < 1) {
     return ok([] as SearchResult[]);

--- a/src/components/accounts/holding-search.tsx
+++ b/src/components/accounts/holding-search.tsx
@@ -30,6 +30,7 @@ export function HoldingSearch({
   const [results, setResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
@@ -47,16 +48,27 @@ export function HoldingSearch({
     if (q.length < 1) {
       setResults([]);
       setShowResults(false);
+      setError(null);
       return;
     }
     setSearching(true);
+    setError(null);
     try {
       const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      if (!res.ok) {
+        // Upstream failure (e.g. Yahoo down) — distinct from an empty result set.
+        setResults([]);
+        setError("Search is temporarily unavailable. Please try again.");
+        setShowResults(true);
+        return;
+      }
       const { data }: { data: SearchResult[] } = await res.json();
       setResults(data);
       setShowResults(data.length > 0);
     } catch {
       setResults([]);
+      setError("Search is temporarily unavailable. Please try again.");
+      setShowResults(true);
     } finally {
       setSearching(false);
     }
@@ -94,30 +106,36 @@ export function HoldingSearch({
 
       {showResults && (
         <div className="absolute z-50 w-full mt-1 rounded-lg border bg-popover shadow-lg max-h-72 overflow-y-auto">
-          {results.map((r) => (
-            <button
-              key={r.symbol}
-              type="button"
-              className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
-              onClick={() => handleSelect(r)}
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-mono font-semibold text-sm">{r.symbol}</span>
-                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                    {r.type}
-                  </Badge>
+          {error && (
+            <p className="px-3 py-2.5 text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+          {!error &&
+            results.map((r) => (
+              <button
+                key={r.symbol}
+                type="button"
+                className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
+                onClick={() => handleSelect(r)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono font-semibold text-sm">{r.symbol}</span>
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                      {r.type}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate mt-0.5">{r.name}</p>
                 </div>
-                <p className="text-xs text-muted-foreground truncate mt-0.5">{r.name}</p>
-              </div>
-              <div className="text-right shrink-0">
-                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                  {r.currency}
-                </Badge>
-                <p className="text-[10px] text-muted-foreground mt-0.5">{r.exchange}</p>
-              </div>
-            </button>
-          ))}
+                <div className="text-right shrink-0">
+                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                    {r.currency}
+                  </Badge>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">{r.exchange}</p>
+                </div>
+              </button>
+            ))}
         </div>
       )}
     </div>

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { revalidateTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
+import { getYahooClient } from "@/lib/services/yahoo-client";
 import { log, withTiming } from "@/lib/logger";
 
 const FETCH_TIMEOUT_MS = 5_000;
@@ -70,8 +71,7 @@ async function fetchYahooQuotes(
   const results = new Map<string, { price: number; currency: string }>();
   if (symbols.length === 0) return results;
 
-  const YahooFinance = (await import("yahoo-finance2")).default;
-  const yahooFinance = new YahooFinance();
+  const yahooFinance = await getYahooClient();
 
   const fetchSymbols = async (syms: string[]) => {
     const quotes = await withRetry(() =>

--- a/src/lib/services/yahoo-client.ts
+++ b/src/lib/services/yahoo-client.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+// Single configured yahoo-finance2 client shared across every server call site
+// (search, price-service, options/chain). Centralizing instantiation keeps
+// client config in one place instead of being copy-pasted per route, and reuses
+// one instance across requests instead of constructing a fresh one each time.
+//
+// The dynamic import is deliberate: it keeps yahoo-finance2 (and its Node-only
+// deps) out of any module graph that doesn't actually call Yahoo.
+async function load() {
+  const YahooFinance = (await import("yahoo-finance2")).default;
+  return new YahooFinance({
+    // Informational console notices from the lib (not errors) — quiet them so
+    // server logs aren't polluted on every cron/price/search run.
+    suppressNotices: ["yahooSurvey", "ripHistorical"],
+  });
+}
+
+let clientPromise: ReturnType<typeof load> | null = null;
+
+/** Lazily instantiate (once) and return the shared YahooFinance client. */
+export function getYahooClient() {
+  return (clientPromise ??= load());
+}


### PR DESCRIPTION
## Problem

The **Add Holding** symbol search returned **zero results for every query** (name or ticker). Worse, the failure was *silent* — a total outage looked identical to "no matches found".

## Root cause

`GET /api/search` calls `yahooFinance.search()` from **yahoo-finance2 v3.14.0**, which runs strict schema validation on Yahoo's response. Yahoo changed their search payload (now returns `typeDisp: "Equity"` where the library's schema expects the lowercase const `"equity"`), so every call threw `FailedYahooValidationError`. The route's `try/catch` swallowed it and returned `[]`.

Reproduced directly against the live API:

```
The following result did not validate with schema: #/definitions/SearchResult
  typeDisp: "Equity"  (expected const "equity")
→ FailedYahooValidationError: Failed Yahoo Schema validation
```

## Changes

### Fix (commit 1)
- Pass `{ validateResult: false }` to `.search()` so the coerced result is returned without the strict schema gate. The fields the route reads (`symbol`, `longname`, `exchange`, `quoteType`, `currency`) are all still present.
- Lowercase-normalize the query before the cache lookup so different casings (`AAPL` / `aapl` / `Aapl`) share one `unstable_cache` entry. Yahoo search is already case-insensitive, so results are unchanged.

### Hardening (commit 2)
- **Centralized client** — new `src/lib/services/yahoo-client.ts` exports one lazily-instantiated, shared `YahooFinance` instance used by `search`, `price-service`, and `options/chain`. Config now lives in one place instead of three copy-pasted `new YahooFinance()` call sites.
- **Failures are no longer silent** — the cached search fetch lets errors propagate (so transient failures aren't cached for an hour), and the route returns **502** on failure, distinct from a **200 + []** for genuine no-matches. The client shows "Search is temporarily unavailable" instead of an empty dropdown, so an outage is visible to users and in error logs rather than masquerading as "no results".

## Verified post-fix (live API)

```
AAPL  => 6 quotes [AAPL:EQUITY, AAPB:ETF]
Apple => 5 quotes [AAPL:EQUITY, APLE:EQUITY]
2330  => 7 quotes [2330.TW:EQUITY, 2330.T:EQUITY]
BTC   => 5 quotes [BTC-USD:CRYPTOCURRENCY, ...]
```

## Notes

- `price-service`'s `quote()` validates fine today and already has per-symbol fallback isolation; it now just shares the centralized client.
- This class of break recurs whenever Yahoo shifts response shape; the durable complement is periodically bumping `yahoo-finance2` when upstream ships a schema fix.

## Checks

`format:check` · `lint` · `typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)