### PR TITLE
Adjust Analysis density behavior on mobile

### DIFF
--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -254,27 +254,27 @@ export function AnalysisView({
             className={isCompact ? "space-y-3" : "space-y-6"}
           >
             <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
-            <Card>
+            <Card size={isCompact ? "sm" : "default"}>
               <LazyMonthlyChangeChart
                 buckets={buckets}
                 baseCurrency={baseCurrency}
                 locale={locale}
               />
             </Card>
-            <Card>
+            <Card size={isCompact ? "sm" : "default"}>
               <LazyAssetsLiabilitiesChart
                 buckets={buckets}
                 baseCurrency={baseCurrency}
                 locale={locale}
               />
             </Card>
-            <Card>
+            <Card size={isCompact ? "sm" : "default"}>
               <LazyCashFlowChart buckets={cashFlowBuckets} baseCurrency={baseCurrency} />
             </Card>
-            <Card>
+            <Card size={isCompact ? "sm" : "default"}>
               <LazyAttributionChart items={attributionItems} baseCurrency={baseCurrency} />
             </Card>
-            <Card>
+            <Card size={isCompact ? "sm" : "default"}>
               <LazyCategoryTrendChart
                 data={categoryHistory}
                 baseCurrency={baseCurrency}

--- a/src/components/analysis/assets-liabilities-chart.tsx
+++ b/src/components/analysis/assets-liabilities-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
@@ -76,6 +77,8 @@ function AssetsTooltip({
 export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const chartHeight = density === "compact" ? 240 : 280;
   const [mounted, setMounted] = useState(false);
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   const { handlers: crosshairHandlers } = useChartCrosshair();
@@ -102,11 +105,14 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
         {data.length === 0 ? (
-          <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+          <div
+            className="flex items-center justify-center text-muted-foreground text-sm"
+            style={{ height: chartHeight }}
+          >
             {t("noData")}
           </div>
         ) : !mounted ? (
-          <div className="h-[280px]" />
+          <div style={{ height: chartHeight }} />
         ) : (
           <div
             role="img"
@@ -116,8 +122,9 @@ export function AssetsLiabilitiesChart({ buckets, baseCurrency, locale }: Props)
           >
             <ChartContainer
               config={config}
-              className="h-[280px] w-full"
-              initialDimension={{ width: 1, height: 280 }}
+              className="w-full"
+              style={{ height: chartHeight }}
+              initialDimension={{ width: 1, height: chartHeight }}
             >
               <BarChart
                 data={data}

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -7,6 +7,7 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
 import type { AttributionItem } from "@/lib/services/analysis-service";
@@ -95,6 +96,8 @@ export function AttributionChart({ items, baseCurrency }: Props) {
   const t = useTranslations("analysis");
   const tCat = useTranslations("categories");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const isCompact = density === "compact";
   const [mounted, setMounted] = useState(false);
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
@@ -110,7 +113,10 @@ export function AttributionChart({ items, baseCurrency }: Props) {
   // largest bar at the top of the chart.
   const chartData = [...items].reverse();
 
-  const chartHeight = Math.max(200, chartData.length * 36 + 40);
+  const chartHeight = Math.max(
+    isCompact ? 180 : 200,
+    chartData.length * (isCompact ? 30 : 36) + 40,
+  );
 
   return (
     <>
@@ -128,7 +134,7 @@ export function AttributionChart({ items, baseCurrency }: Props) {
         ) : (
           <div
             aria-hidden={privacyMode || undefined}
-            className={`space-y-4 transition-[filter] duration-300 ${
+            className={`${isCompact ? "space-y-3" : "space-y-4"} transition-[filter] duration-300 ${
               privacyMode ? "blur-sm pointer-events-none select-none" : ""
             }`}
           >
@@ -191,7 +197,11 @@ export function AttributionChart({ items, baseCurrency }: Props) {
             </div>
 
             {/* Summary row */}
-            <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs">
+            <div
+              className={`grid grid-cols-3 gap-2 rounded-lg bg-muted/40 text-xs ${
+                isCompact ? "px-2.5 py-1.5" : "px-3 py-2"
+              }`}
+            >
               <div>
                 <div className="text-muted-foreground">{t("attrCash")}</div>
                 <div className="tabular-nums font-medium mt-0.5">

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -8,6 +8,7 @@ import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { CashFlowBucket } from "@/lib/services/analysis-service";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
@@ -86,6 +87,8 @@ const cashflowConfig = {} satisfies ChartConfig;
 export function CashFlowChart({ buckets, baseCurrency }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const chartHeight = density === "compact" ? 240 : 280;
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
@@ -99,11 +102,14 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
         {buckets.length === 0 ? (
-          <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+          <div
+            className="flex items-center justify-center text-muted-foreground text-sm"
+            style={{ height: chartHeight }}
+          >
             {t("noData")}
           </div>
         ) : !mounted ? (
-          <div className="h-[280px]" />
+          <div style={{ height: chartHeight }} />
         ) : (
           <div
             aria-hidden={privacyMode || undefined}
@@ -130,8 +136,9 @@ export function CashFlowChart({ buckets, baseCurrency }: Props) {
             <div role="img" aria-label={`${t("cashFlow")}, ${t("cashFlowSubtitle")}`}>
               <ChartContainer
                 config={cashflowConfig}
-                className="h-[280px] w-full"
-                initialDimension={{ width: 1, height: 280 }}
+                className="w-full"
+                style={{ height: chartHeight }}
+                initialDimension={{ width: 1, height: chartHeight }}
               >
                 <BarChart
                   data={buckets}

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -17,6 +17,7 @@ import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import { ChartTooltipContainer, ChartTooltipRow } from "@/components/ui/chart-tooltip";
@@ -80,6 +81,8 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const tCat = useTranslations("categories");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const chartHeight = density === "compact" ? 240 : 280;
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
@@ -117,11 +120,14 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
         {data.length === 0 ? (
-          <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+          <div
+            className="flex items-center justify-center text-muted-foreground text-sm"
+            style={{ height: chartHeight }}
+          >
             {t("noData")}
           </div>
         ) : !mounted ? (
-          <div className="h-[280px]" />
+          <div style={{ height: chartHeight }} />
         ) : (
           <div
             role="img"
@@ -131,9 +137,9 @@ export function CategoryTrendChart({ data, baseCurrency, locale }: Props) {
           >
             <ResponsiveContainer
               width="100%"
-              height={280}
+              height={chartHeight}
               minWidth={0}
-              initialDimension={{ width: 1, height: 280 }}
+              initialDimension={{ width: 1, height: chartHeight }}
             >
               <LineChart
                 data={chartData}

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -34,8 +34,8 @@ function Tile({
         ? "text-[var(--loss)]"
         : "text-foreground";
   return (
-    <Card size="sm" className="min-w-0">
-      <CardContent className={isCompact ? "space-y-1 p-3 min-w-0" : "space-y-1.5 min-w-0"}>
+    <Card size={isCompact ? "sm" : "default"} className="min-w-0">
+      <CardContent className={isCompact ? "space-y-1 min-w-0" : "space-y-1.5 min-w-0"}>
         <div className="text-xs text-muted-foreground font-medium truncate">{title}</div>
         <div className="overflow-x-auto scrollbar-none">
           <div

--- a/src/components/analysis/lazy-analysis-charts.tsx
+++ b/src/components/analysis/lazy-analysis-charts.tsx
@@ -3,15 +3,19 @@
 import dynamic from "next/dynamic";
 import { CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDensity } from "@/components/layout/density-context";
 
 function ChartSkeleton({ height = 280 }: { height?: number }) {
+  const { density } = useDensity();
+  const skeletonHeight = density === "compact" ? Math.max(180, height - 40) : height;
+
   return (
     <>
       <CardHeader className="pb-2 px-2 sm:px-4">
         <Skeleton className="h-5 w-40" />
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
-        <Skeleton style={{ height }} />
+        <Skeleton style={{ height: skeletonHeight }} />
       </CardContent>
     </>
   );

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -8,6 +8,7 @@ import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick } from "@/lib/chart-formatters";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { useDensity } from "@/components/layout/density-context";
 import type { MonthlyBucket } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
@@ -83,6 +84,8 @@ const monthlyChangeConfig = {} satisfies ChartConfig;
 export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
+  const { density } = useDensity();
+  const chartHeight = density === "compact" ? 240 : 280;
   const [mounted, setMounted] = useState(false);
   const { handlers: crosshairHandlers } = useChartCrosshair();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
@@ -99,11 +102,14 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
       </CardHeader>
       <CardContent className="px-2 sm:px-4 pb-4">
         {data.length === 0 ? (
-          <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+          <div
+            className="flex items-center justify-center text-muted-foreground text-sm"
+            style={{ height: chartHeight }}
+          >
             {t("noData")}
           </div>
         ) : !mounted ? (
-          <div className="h-[280px]" />
+          <div style={{ height: chartHeight }} />
         ) : (
           <div
             role="img"
@@ -113,8 +119,9 @@ export function MonthlyChangeChart({ buckets, baseCurrency, locale }: Props) {
           >
             <ChartContainer
               config={monthlyChangeConfig}
-              className="h-[280px] w-full"
-              initialDimension={{ width: 1, height: 280 }}
+              className="w-full"
+              style={{ height: chartHeight }}
+              initialDimension={{ width: 1, height: chartHeight }}
             >
               <BarChart
                 data={data}


### PR DESCRIPTION
## Summary
- Make the Analysis tab actually reflect the `Display Density` setting on mobile.
- Apply compact sizing to the KPI tiles, chart card wrappers, chart heights, and attribution summary spacing.
- Keep the existing density control and chart structure intact, just make the compact mode visibly tighter.

## Testing
- `npx eslint` on the touched Analysis components passed.
- `npx tsc --noEmit --pretty false` passed.
- Performed a local browser smoke check; the app loaded, and the authenticated Analysis surface was not available from that session because it redirected to login.