### PR TITLE
fix(loading): align skeletons with final layout + add shimmer

### DIFF
--- a/src/app/(main)/analysis/loading.tsx
+++ b/src/app/(main)/analysis/loading.tsx
@@ -31,14 +31,14 @@ export default function AnalysisLoading() {
         </div>
 
         <div className="space-y-6">
-          {/* KPI tiles */}
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {/* KPI tiles — mirrors KpiTiles: 2-col on mobile, 4-col at md */}
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
             {[...Array(4)].map((_, i) => (
               <Card key={i} size="sm">
-                <div className="px-4 space-y-2">
+                <div className="px-3 space-y-1.5">
                   <Skeleton className="h-3 w-24" />
-                  <Skeleton className="h-7 w-36" />
-                  {i < 2 && <Skeleton className="h-3 w-20" />}
+                  <Skeleton className="h-7 w-36 max-w-full" />
+                  {i !== 2 && <Skeleton className="h-3 w-20" />}
                 </div>
               </Card>
             ))}

--- a/src/app/(main)/goals/loading.tsx
+++ b/src/app/(main)/goals/loading.tsx
@@ -1,3 +1,4 @@
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export default function GoalsLoading() {
@@ -7,39 +8,61 @@ export default function GoalsLoading() {
       <Skeleton className="h-10 md:h-9 w-24 rounded-lg" />
 
       <div className="space-y-4">
-        {/* Mobile-only tab switcher */}
-        <div className="md:hidden flex border-b gap-6 pb-2">
-          <Skeleton className="h-4 w-12" />
-          <Skeleton className="h-4 w-20" />
+        {/* Mobile-only tab switcher — mirrors GoalsView's underline tabs */}
+        <div className="md:hidden flex border-b">
+          <div className="px-4 pb-2 -mb-px border-b-2 border-primary">
+            <Skeleton className="h-4 w-12" />
+          </div>
+          <div className="px-4 pb-2">
+            <Skeleton className="h-4 w-20" />
+          </div>
         </div>
 
-        {/* Subtitle + Add button (from GoalsView) */}
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-4 w-48" />
-          <Skeleton className="h-9 w-28" />
-        </div>
+        <div className="space-y-6">
+          {/* Subtitle + Add button (size="sm" → h-7) */}
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-7 w-24 rounded-md" />
+          </div>
 
-        {/* Goal cards */}
-        <div className="grid gap-4">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="rounded-xl border border-border/50 bg-card p-6 space-y-4">
-              <div className="flex items-start justify-between">
-                <div className="space-y-2">
-                  <Skeleton className="h-5 w-48" />
-                  <Skeleton className="h-4 w-24" />
-                </div>
-                <div className="flex gap-2">
-                  <Skeleton className="h-8 w-16" />
-                  <Skeleton className="h-8 w-16" />
-                </div>
-              </div>
-              <Skeleton className="h-2.5 w-full rounded-full" />
-              <div className="flex justify-between">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-12" />
-              </div>
-            </div>
-          ))}
+          {/* Goal cards — mirror GoalCard (icon + title, square actions, progress, meta) */}
+          <div className="grid gap-4">
+            {[...Array(3)].map((_, i) => (
+              <Card key={i} className="border border-border/50 bg-card shadow-sm rounded-xl">
+                <CardContent className="p-5 space-y-4">
+                  {/* Header row */}
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Skeleton className="h-9 w-9 rounded-full shrink-0" />
+                      <div className="space-y-1.5 min-w-0">
+                        <Skeleton className="h-4 w-40 max-w-full" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Skeleton className="h-9 w-9 rounded-md" />
+                      <Skeleton className="h-9 w-9 rounded-md" />
+                    </div>
+                  </div>
+
+                  {/* Progress section */}
+                  <div className="space-y-1.5">
+                    <div className="flex justify-between">
+                      <Skeleton className="h-3 w-20" />
+                      <Skeleton className="h-3 w-10" />
+                    </div>
+                    <Skeleton className="h-2.5 w-full rounded-full" />
+                    <div className="flex justify-between">
+                      <Skeleton className="h-3 w-28" />
+                    </div>
+                  </div>
+
+                  {/* Metadata row */}
+                  <Skeleton className="h-3 w-32" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -281,6 +281,37 @@
   }
 }
 
+/* ─── Skeleton loading shimmer ───────────────────────────────────────────────
+   A highlight band sweeps across placeholders so the loading state is obvious
+   rather than reading as a static gray block. Applied via [data-slot="skeleton"]
+   in src/components/ui/skeleton.tsx. */
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.skeleton-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    transparent 20%,
+    color-mix(in oklab, var(--foreground) 12%, transparent) 50%,
+    transparent 80%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer {
+    animation: none;
+  }
+}
+
 /* ─── View-transition slide animations (item 10) ─────────────────────────── */
 
 @keyframes vt-slide-in-from-right {

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -36,25 +36,25 @@ function NetWorthSkeleton() {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
       {/* Primary: Net Worth */}
-      <Card className="col-span-2 lg:col-span-1 rounded-2xl h-[126px]">
+      <Card className="col-span-2 lg:col-span-1 rounded-2xl">
         <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
           <div className="flex items-center gap-2.5 mb-1.5">
             <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-3.5 sm:h-4 w-20" />
           </div>
-          <Skeleton className="h-8 w-40 max-w-full mt-1" />
+          <Skeleton className="h-7 sm:h-8 w-40 max-w-full mt-1" />
           <Skeleton className="h-6 w-28 rounded-full mt-3" />
         </CardContent>
       </Card>
       {/* Secondary: Assets + Liabilities */}
       {[0, 1].map((i) => (
-        <Card key={i} className="col-span-1 rounded-2xl h-[126px]">
+        <Card key={i} className="col-span-1 rounded-2xl">
           <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-            <div className="flex items-center gap-2 mb-1">
-              <Skeleton className="h-4 w-4 rounded-sm shrink-0" />
-              <Skeleton className="h-4 w-16" />
+            <div className="flex items-center gap-1.5 sm:gap-2 mb-1">
+              <Skeleton className="h-3.5 w-3.5 sm:h-4 sm:w-4 rounded-sm shrink-0" />
+              <Skeleton className="h-3.5 sm:h-4 w-16" />
             </div>
-            <Skeleton className="h-6 w-24 max-w-full mt-1" />
+            <Skeleton className="h-5 sm:h-6 w-24 max-w-full mt-1" />
           </CardContent>
         </Card>
       ))}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -19,6 +19,7 @@ import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card"
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { GoalWithProgress } from "@/lib/types";
 
 const fetchPreviousSnapshot = cache((userId: string) =>
@@ -33,16 +34,30 @@ const fetchPreviousSnapshot = cache((userId: string) =>
 
 function NetWorthSkeleton() {
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6 animate-pulse">
+    <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
+      {/* Primary: Net Worth */}
       <Card className="col-span-2 lg:col-span-1 rounded-2xl h-[126px]">
-        <CardContent className="h-full bg-muted/50 rounded-2xl" />
+        <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
+          <div className="flex items-center gap-2.5 mb-1.5">
+            <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <Skeleton className="h-8 w-40 max-w-full mt-1" />
+          <Skeleton className="h-6 w-28 rounded-full mt-3" />
+        </CardContent>
       </Card>
-      <Card className="col-span-1 rounded-2xl h-[126px]">
-        <CardContent className="h-full bg-muted/50 rounded-2xl" />
-      </Card>
-      <Card className="col-span-1 rounded-2xl h-[126px]">
-        <CardContent className="h-full bg-muted/50 rounded-2xl" />
-      </Card>
+      {/* Secondary: Assets + Liabilities */}
+      {[0, 1].map((i) => (
+        <Card key={i} className="col-span-1 rounded-2xl h-[126px]">
+          <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
+            <div className="flex items-center gap-2 mb-1">
+              <Skeleton className="h-4 w-4 rounded-sm shrink-0" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+            <Skeleton className="h-6 w-24 max-w-full mt-1" />
+          </CardContent>
+        </Card>
+      ))}
     </div>
   );
 }

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -13,23 +13,31 @@ export function DashboardSkeleton() {
       {/* Actions */}
       <Skeleton className="h-10 w-full rounded-lg" />
 
-      {/* Net Worth Cards — matches NetWorthSkeleton in dashboard-content.tsx */}
+      {/* Net Worth Cards — mirror NetWorthCard internals (icon + label + value) */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
+        {/* Primary: Net Worth */}
         <Card className="col-span-2 lg:col-span-1 rounded-2xl h-[126px]">
-          <CardContent className="h-full p-0">
-            <Skeleton className="h-full w-full rounded-2xl" />
+          <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
+            <div className="flex items-center gap-2.5 mb-1.5">
+              <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <Skeleton className="h-8 w-40 max-w-full mt-1" />
+            <Skeleton className="h-6 w-28 rounded-full mt-3" />
           </CardContent>
         </Card>
-        <Card className="col-span-1 rounded-2xl h-[126px]">
-          <CardContent className="h-full p-0">
-            <Skeleton className="h-full w-full rounded-2xl" />
-          </CardContent>
-        </Card>
-        <Card className="col-span-1 rounded-2xl h-[126px]">
-          <CardContent className="h-full p-0">
-            <Skeleton className="h-full w-full rounded-2xl" />
-          </CardContent>
-        </Card>
+        {/* Secondary: Assets + Liabilities */}
+        {[0, 1].map((i) => (
+          <Card key={i} className="col-span-1 rounded-2xl h-[126px]">
+            <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
+              <div className="flex items-center gap-2 mb-1">
+                <Skeleton className="h-4 w-4 rounded-sm shrink-0" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+              <Skeleton className="h-6 w-24 max-w-full mt-1" />
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       {/* Trend chart + heatmap footer */}

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -13,28 +13,30 @@ export function DashboardSkeleton() {
       {/* Actions */}
       <Skeleton className="h-10 w-full rounded-lg" />
 
-      {/* Net Worth Cards — mirror NetWorthCard internals (icon + label + value) */}
+      {/* Net Worth Cards — mirror NetWorthCard internals (icon + label + value).
+          No fixed height: content sizes the card just like the real card, so
+          the text-shaped lines never overflow the box on mobile. */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
         {/* Primary: Net Worth */}
-        <Card className="col-span-2 lg:col-span-1 rounded-2xl h-[126px]">
+        <Card className="col-span-2 lg:col-span-1 rounded-2xl">
           <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
             <div className="flex items-center gap-2.5 mb-1.5">
               <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-3.5 sm:h-4 w-20" />
             </div>
-            <Skeleton className="h-8 w-40 max-w-full mt-1" />
+            <Skeleton className="h-7 sm:h-8 w-40 max-w-full mt-1" />
             <Skeleton className="h-6 w-28 rounded-full mt-3" />
           </CardContent>
         </Card>
         {/* Secondary: Assets + Liabilities */}
         {[0, 1].map((i) => (
-          <Card key={i} className="col-span-1 rounded-2xl h-[126px]">
+          <Card key={i} className="col-span-1 rounded-2xl">
             <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-              <div className="flex items-center gap-2 mb-1">
-                <Skeleton className="h-4 w-4 rounded-sm shrink-0" />
-                <Skeleton className="h-4 w-16" />
+              <div className="flex items-center gap-1.5 sm:gap-2 mb-1">
+                <Skeleton className="h-3.5 w-3.5 sm:h-4 sm:w-4 rounded-sm shrink-0" />
+                <Skeleton className="h-3.5 sm:h-4 w-16" />
               </div>
-              <Skeleton className="h-6 w-24 max-w-full mt-1" />
+              <Skeleton className="h-5 sm:h-6 w-24 max-w-full mt-1" />
             </CardContent>
           </Card>
         ))}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Fixes loading-skeleton layouts that didn't match the final rendered content (causing a visible reflow when data arrived, especially on mobile) and makes loading states read more clearly with a subtle shimmer.

## Changes

- **Analysis** (`analysis/loading.tsx`): KPI tiles skeleton is now `grid-cols-2` on mobile (was a single column), matching `KpiTiles`' `grid-cols-2 md:grid-cols-4`. Also corrected card padding (`size="sm"` → `px-3`) and which tiles carry subtitles (best/worst/YTD).
- **Goals** (`goals/loading.tsx`): rebuilt the skeleton to mirror the real `GoalCard` — icon avatar, square `h-9 w-9` action buttons, progress label rows around the bar, metadata row, `p-5` padding, and a `size="sm"` (`h-7`) add button. Previously it had no icon and wide action buttons, which shifted the header on narrow screens.
- **Dashboard** (`dashboard-skeleton.tsx` + `dashboard-content.tsx` `NetWorthSkeleton`): net-worth cards now show text-shaped placeholders (icon + label + value) inside the card chrome instead of one solid block. Applied to both the route-level `loading.tsx` fallback and the streaming Suspense fallback.
  - **Mobile fix:** dropped the fixed `h-[126px]` (the real `NetWorthCard` sizes to content) and made value/label heights responsive (`h-7 sm:h-8` primary, `h-5 sm:h-6` secondary, `h-3.5 sm:h-4` labels). The flat heights overflowed the fixed box and clipped on mobile.
- **Skeleton** (`ui/skeleton.tsx` + `globals.css`): added a sweeping shimmer highlight on top of the existing pulse so placeholders clearly read as "loading." CSS-only, GPU-composited (no JS, no bundle/perf cost), and disabled under `prefers-reduced-motion`.

## Test plan

- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass.
- Manually verify `/`, `/analysis`, and `/goals` loading states at mobile width: skeletons line up with the loaded layout (no reflow / no clipped text) and the shimmer animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)