### PR TITLE
fix(mobile): a11y and responsive polish for mobile surfaces

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -306,8 +306,17 @@
   animation: skeleton-shimmer 1.6s ease-in-out infinite;
 }
 
+/* Decorative, continuously-looping effects must not run when the user has
+   asked for reduced motion (WCAG 2.3.3) — the mesh stays as a static wash. */
 @media (prefers-reduced-motion: reduce) {
   .skeleton-shimmer {
+    animation: none;
+  }
+  .hero-mesh-positive,
+  .hero-mesh-negative {
+    animation: none;
+  }
+  .ios-tab-pop {
     animation: none;
   }
 }

--- a/src/components/accounts/holdings-table.tsx
+++ b/src/components/accounts/holdings-table.tsx
@@ -40,20 +40,21 @@ interface HoldingsTableProps {
 
 interface Column {
   field: HoldingSortField | null;
-  label: string;
+  /** Key under the `accountDetail` i18n namespace; null for the actions column. */
+  labelKey: string | null;
   align: "left" | "right";
   className?: string;
 }
 
 const COLUMNS: Column[] = [
-  { field: "symbol", label: "Symbol", align: "left" },
-  { field: "name", label: "Name", align: "left" },
-  { field: "assetType", label: "Type", align: "left", className: "hidden lg:table-cell" },
-  { field: "quantity", label: "Qty", align: "right", className: "hidden lg:table-cell" },
-  { field: "currentPrice", label: "Price", align: "right" },
-  { field: "marketValue", label: "Mkt Value", align: "right" },
-  { field: "percentage", label: "Weight", align: "right" },
-  { field: null, label: "", align: "right" },
+  { field: "symbol", labelKey: "colSymbol", align: "left" },
+  { field: "name", labelKey: "colName", align: "left" },
+  { field: "assetType", labelKey: "colType", align: "left", className: "hidden lg:table-cell" },
+  { field: "quantity", labelKey: "colQty", align: "right", className: "hidden lg:table-cell" },
+  { field: "currentPrice", labelKey: "colPrice", align: "right" },
+  { field: "marketValue", labelKey: "colValue", align: "right" },
+  { field: "percentage", labelKey: "colPercentage", align: "right" },
+  { field: null, labelKey: null, align: "right" },
 ];
 
 export function HoldingsTable({
@@ -77,20 +78,39 @@ export function HoldingsTable({
       <table className="w-full text-sm">
         <thead className="sticky top-0 bg-muted/70 backdrop-blur-sm border-b border-border/40">
           <tr>
-            {COLUMNS.map((col, i) => (
-              <th
-                key={i}
-                className={`px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap ${
-                  col.align === "right" ? "text-right" : "text-left"
-                } ${col.field ? "cursor-pointer select-none hover:text-foreground transition-colors" : ""} ${col.className ?? ""}`}
-                onClick={col.field ? () => onSort(col.field!) : undefined}
-              >
-                {col.label}
-                {col.field && sortField === col.field && (
-                  <span className="ml-1">{sortDirection === "asc" ? "↑" : "↓"}</span>
-                )}
-              </th>
-            ))}
+            {COLUMNS.map((col, i) => {
+              const isSorted = !!col.field && sortField === col.field;
+              const label = col.labelKey ? t(`accountDetail.${col.labelKey}`) : "";
+              return (
+                <th
+                  key={i}
+                  scope="col"
+                  aria-sort={
+                    isSorted ? (sortDirection === "asc" ? "ascending" : "descending") : undefined
+                  }
+                  className={`px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap ${
+                    col.align === "right" ? "text-right" : "text-left"
+                  } ${col.className ?? ""}`}
+                >
+                  {col.field ? (
+                    <button
+                      type="button"
+                      onClick={() => onSort(col.field!)}
+                      className={`inline-flex items-center gap-1 select-none rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                        col.align === "right" ? "flex-row-reverse" : ""
+                      } ${isSorted ? "text-foreground" : ""}`}
+                    >
+                      <span>{label}</span>
+                      {isSorted && (
+                        <span aria-hidden="true">{sortDirection === "asc" ? "↑" : "↓"}</span>
+                      )}
+                    </button>
+                  ) : (
+                    label
+                  )}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>
@@ -156,8 +176,11 @@ export function HoldingsTable({
                 </td>
                 <td className={`px-2 ${tdPy} text-right`}>
                   <DropdownMenu>
-                    <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                      <MoreHorizontal className="h-4 w-4" />
+                    <DropdownMenuTrigger
+                      aria-label={t("common.actionsFor", { name: symbolLabel })}
+                      className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:opacity-100"
+                    >
+                      <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem onClick={() => onEdit(h)}>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -59,14 +59,13 @@ export function NetWorthCard({
               {t("netWorth")}
             </p>
           </div>
-          <div className="overflow-x-auto scrollbar-none">
-            <p
-              className="text-2xl sm:text-3xl font-bold text-foreground mt-1 whitespace-nowrap tabular-nums"
-              style={{ letterSpacing: "-0.02em" }}
-            >
-              {privacyMode ? HIDDEN : formatCurrency(animatedNetWorth, baseCurrency)}
-            </p>
-          </div>
+          <p
+            className="text-2xl sm:text-3xl font-bold text-foreground mt-1 whitespace-nowrap tabular-nums truncate"
+            style={{ letterSpacing: "-0.02em" }}
+            title={privacyMode ? undefined : formatCurrency(netWorth, baseCurrency)}
+          >
+            {privacyMode ? HIDDEN : formatCurrency(animatedNetWorth, baseCurrency)}
+          </p>
           {!privacyMode && delta !== null && pct !== null && (
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <div
@@ -102,11 +101,12 @@ export function NetWorthCard({
               {t("totalAssets")}
             </p>
           </div>
-          <div className="overflow-x-auto scrollbar-none">
-            <p className="text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums">
-              {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency)}
-            </p>
-          </div>
+          <p
+            className="text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums truncate"
+            title={privacyMode ? undefined : formatCurrency(totalAssets, baseCurrency)}
+          >
+            {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency, true)}
+          </p>
         </CardContent>
       </Card>
 
@@ -121,11 +121,12 @@ export function NetWorthCard({
               {t("totalLiabilities")}
             </p>
           </div>
-          <div className="overflow-x-auto scrollbar-none">
-            <p className="text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums">
-              {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency)}
-            </p>
-          </div>
+          <p
+            className="text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums truncate"
+            title={privacyMode ? undefined : formatCurrency(totalLiabilities, baseCurrency)}
+          >
+            {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency, true)}
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -56,7 +56,7 @@ export function MobileHeader() {
           type="button"
           onClick={handleBack}
           aria-label={t("common.back")}
-          className="absolute left-3 top-1/2 -translate-y-1/2 inline-flex items-center justify-center rounded-full h-10 w-10 text-foreground hover:bg-muted/60 active:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-normal"
+          className="absolute left-3 top-1/2 -translate-y-1/2 inline-flex items-center justify-center rounded-full h-11 w-11 text-foreground hover:bg-muted/60 active:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-normal"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -125,7 +125,7 @@ export function MobileHeader() {
           onClick={togglePrivacyMode}
           title={privacyMode ? "Show values" : "Hide values"}
           aria-label={privacyMode ? "Show values" : "Hide values"}
-          className="inline-flex items-center justify-center rounded-md h-10 w-10 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className="inline-flex items-center justify-center rounded-md h-11 w-11 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
         </button>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -264,7 +264,7 @@ export function MobileNav() {
   return (
     <nav
       className={cn(
-        "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 w-[calc(100%-1.5rem)] max-w-sm flex items-stretch gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.3)] dark:shadow-[0_10px_28px_-8px_rgba(0,0,0,0.65)] transition-transform motion-normal will-change-transform",
+        "md:hidden fixed left-1/2 -translate-x-1/2 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 w-[calc(100%-1.5rem)] max-w-sm flex items-stretch gap-1 px-2 py-1.5 rounded-full border border-border/60 bg-background/95 dark:bg-card/95 shadow-[0_-4px_24px_-4px_rgba(0,0,0,0.15),0_4px_12px_-4px_rgba(0,0,0,0.1)] dark:shadow-[0_-6px_28px_-4px_rgba(0,0,0,0.5),0_4px_12px_-4px_rgba(0,0,0,0.3)] transition-transform motion-normal will-change-transform",
         hidden && "translate-y-[calc(100%+1.75rem+env(safe-area-inset-bottom))]",
       )}
     >


### PR DESCRIPTION
## Summary

Addresses mobile UI audit findings (P1/P2) on mobile-size screens. No P0/P1 remain after this change; the one remaining P2 (dashboard sort chips) was intentionally reverted at the author's request and is not included here.

## Changes

- **Touch targets** (`mobile-header.tsx`): back and privacy buttons go from 40px to **44px** (`h-11 w-11`), meeting the native iOS / WCAG target-size expectation.
- **In-card horizontal scroll** (`net-worth-card.tsx`): removed the hidden `overflow-x-auto` wrappers around values, which could clip a figure and require a swipe inside the card with no scrollbar cue. The hero number keeps full precision with a `title` tooltip; the Assets/Liabilities cards use compact notation (`$1.2M`) with the full value in `title`.
- **Holdings table a11y + i18n** (`holdings-table.tsx`):
  - Column sorting was mouse-only (`<th onClick>`). Now real `<button>`s with focus rings, and `<th aria-sort>` exposes sort state to keyboard / screen-reader users (WCAG 2.1.1, 4.1.2).
  - Hard-coded English headers ("Symbol", "Qty"…) now route through i18n (`t("accountDetail.col…")`), so they localize under `zh-TW`.
  - Added an accessible name to the row actions (kebab) menu.
- **Reduced motion** (`globals.css`): the looping `hero-mesh` and `ios-tab-pop` animations now stop under `prefers-reduced-motion` (WCAG 2.3.3), merged alongside the skeleton shimmer guard from #354.
- **Tab bar shadow** (`sidebar.tsx`): the floating pill nav had a downward drop shadow that landed on the viewport floor, creating a visible color band below the tab bar. Shadow is now directed upward into the page content, matching native iOS dock behaviour.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass.
- `build` not run (DB-gated, per project CI convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)