### PR TITLE
fix: match dark theme-color to page background to remove iOS safe-area green tint

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,7 +174,10 @@
       radial-gradient(ellipse 60% 40% at 100% 80%, oklch(0.74 0.17 270 / 0.05), transparent);
   }
   html {
-    @apply font-sans scroll-smooth;
+    /* Paint the root element with the base background so the iOS safe-area
+       (status bar + home-indicator chin) blends with the page in standalone
+       PWA mode, where the chin is painted by <html>, not theme-color. */
+    @apply bg-background font-sans scroll-smooth;
   }
   .recharts-wrapper * {
     outline: none !important;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -247,7 +247,7 @@ export const viewport: Viewport = {
   viewportFit: "cover",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#f9fafb" },
-    { media: "(prefers-color-scheme: dark)", color: "#0d1f1e" },
+    { media: "(prefers-color-scheme: dark)", color: "#000d0e" },
   ],
 };
 


### PR DESCRIPTION
The dark themeColor (#0d1f1e, a teal-green) was painted by iOS Safari in
the home-indicator safe-area under viewportFit: cover, appearing as a
green block below the floating bottom nav. Update it to #000d0e, the
sRGB equivalent of the dark --background token (oklch(0.14 0.03 200)),
so the safe-area chin blends with the page.

https://claude.ai/code/session_01Bmj1MXH7JRbvs2p9ivJL4N