### PR TITLE
feat(dashboard): redesign dashboard into desktop bento grid

### DIFF
--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -258,7 +258,7 @@ export function AnalysisView({
             className={isCompact ? "space-y-3" : "space-y-6"}
           >
             <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
-            <PortfolioHeatmap summary={summary} />
+            <PortfolioHeatmap summary={summary} fillHeight />
             <Card size={isCompact ? "sm" : "default"}>
               <LazyMonthlyChangeChart
                 buckets={buckets}

--- a/src/components/analysis/portfolio-heatmap.tsx
+++ b/src/components/analysis/portfolio-heatmap.tsx
@@ -8,7 +8,7 @@ import { Treemap, type TreemapNode } from "recharts";
 import { useDensity } from "@/components/layout/density-context";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useContainerWidth } from "@/hooks/use-container-size";
+import { useContainerSize } from "@/hooks/use-container-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { formatCurrency } from "@/lib/currencies";
 import { cn } from "@/lib/utils";
@@ -208,7 +208,14 @@ function accountChildren(account: NetWorthSummary["accounts"][number], cashLabel
   ];
 }
 
-export function PortfolioHeatmap({ summary }: { summary: NetWorthSummary }) {
+export function PortfolioHeatmap({
+  summary,
+  fillHeight = false,
+}: {
+  summary: NetWorthSummary;
+  /** Grow the treemap to fill the side-panel height (for fixed-height slots like the dashboard grid). */
+  fillHeight?: boolean;
+}) {
   const t = useTranslations("analysis");
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
@@ -217,13 +224,17 @@ export function PortfolioHeatmap({ summary }: { summary: NetWorthSummary }) {
   const shouldReduceMotion = useReducedMotion();
   const chartSummaryId = useId();
   const chartRef = useRef<HTMLDivElement>(null);
-  const chartWidth = useContainerWidth(chartRef);
-  const chartHeight = useMemo(() => {
+  const { width: chartWidth, height: chartContainerHeight } = useContainerSize(chartRef);
+  const baseChartHeight = useMemo(() => {
     if (chartWidth === 0) return isCompact ? 220 : 280;
     if (chartWidth < 420) return Math.max(190, Math.round(chartWidth * 0.62));
     if (chartWidth < 760) return Math.max(240, Math.round(chartWidth * 0.55));
     return isCompact ? 220 : 280;
   }, [chartWidth, isCompact]);
+  // In fillHeight mode the container stretches to the taller side panel; render the
+  // treemap at that measured height so it consumes the gap instead of leaving it blank.
+  const chartHeight =
+    fillHeight && chartContainerHeight > baseChartHeight ? chartContainerHeight : baseChartHeight;
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
   const [activeNode, setActiveNode] = useState<HeatmapNode | null>(null);
 
@@ -425,7 +436,7 @@ export function PortfolioHeatmap({ summary }: { summary: NetWorthSummary }) {
         ) : (
           <>
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
-              <div className="min-w-0">
+              <div className={cn("min-w-0", fillHeight && "lg:flex lg:flex-col")}>
                 <div className="mb-2 flex min-h-8 items-center gap-2 overflow-hidden">
                   {selectedAccount && (
                     <button
@@ -448,9 +459,11 @@ export function PortfolioHeatmap({ summary }: { summary: NetWorthSummary }) {
                 <div
                   ref={chartRef}
                   className={cn(
-                    "relative min-h-[190px] overflow-hidden bg-[color-mix(in_oklch,var(--muted)_24%,var(--card))] ring-1 ring-border/60 transition-[filter] duration-300 sm:min-h-[240px] lg:min-h-0",
+                    "relative min-h-[190px] overflow-hidden bg-[color-mix(in_oklch,var(--muted)_24%,var(--card))] ring-1 ring-border/60 transition-[filter] duration-300 sm:min-h-[240px]",
+                    fillHeight ? "lg:flex-1" : "lg:min-h-0",
                     privacyMode && "blur-sm pointer-events-none select-none",
                   )}
+                  style={fillHeight ? { minHeight: baseChartHeight } : undefined}
                   role={privacyMode ? undefined : "img"}
                   aria-label={privacyMode ? undefined : chartLabel}
                   aria-describedby={privacyMode ? undefined : chartSummaryId}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -63,20 +63,16 @@ function NetWorthSkeleton() {
   );
 }
 
-function ChartsSkeleton() {
+function ChartCardSkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
-      {[...Array(2)].map((_, i) => (
-        <Card key={i}>
-          <CardHeader className="pb-2">
-            <div className="h-5 w-32 bg-muted animate-pulse rounded" />
-          </CardHeader>
-          <CardContent>
-            <div className="h-[250px] bg-muted animate-pulse rounded" />
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+    <Card>
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-[250px]" />
+      </CardContent>
+    </Card>
   );
 }
 
@@ -176,19 +172,31 @@ async function NetWorthSection({ userId, baseCurrency }: { userId: string; baseC
 }
 
 /**
- * Allocation + currency exposure charts.
- * Shares the same cached summary as NetWorthSection (data-cache dedup).
+ * Allocation donut — asset composition by category.
+ * Lives in the trend-row rail. Shares the cached summary (data-cache dedup).
  */
-async function ChartsSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
+async function AllocationSection({
+  userId,
+  baseCurrency,
+}: {
+  userId: string;
+  baseCurrency: string;
+}) {
   const summary = await getCachedNetWorthSummary(userId, baseCurrency);
   if (summary.accounts.length === 0) return null;
 
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
-      <LazyAllocationChart summary={summary} />
-      <LazyCurrencyExposureChart summary={summary} />
-    </div>
-  );
+  return <LazyAllocationChart summary={summary} />;
+}
+
+/**
+ * Currency exposure donut — value split by currency.
+ * Pairs with the portfolio heatmap row. Shares the cached summary (data-cache dedup).
+ */
+async function CurrencySection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
+  const summary = await getCachedNetWorthSummary(userId, baseCurrency);
+  if (summary.accounts.length === 0) return null;
+
+  return <LazyCurrencyExposureChart summary={summary} />;
 }
 
 /**
@@ -261,7 +269,7 @@ async function PortfolioHeatmapSection({
   );
   if (!hasAssets) return null;
 
-  return <PortfolioHeatmap summary={summary} />;
+  return <PortfolioHeatmap summary={summary} fillHeight />;
 }
 
 /* ---------- Orchestrator ---------- */
@@ -326,42 +334,61 @@ export async function DashboardContent({ userId }: { userId: string }) {
         <DashboardActionsSection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
 
-      {/* Net worth card — the LCP element, streams as soon as summary resolves */}
+      {/* Net worth card — the LCP element, full-bleed headline above the grid */}
       <Suspense fallback={<NetWorthSkeleton />}>
         <NetWorthSection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
 
-      {/* Goals milestone — next active goal, streams after net worth */}
-      <Suspense fallback={null}>
-        <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
-      </Suspense>
+      {/* Tier 2 — "what changed": trend chart (8) + goals/allocation rail (4) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
+        <div className="min-w-0 lg:col-span-8">
+          <Suspense fallback={<TrendChartSkeleton />}>
+            <TrendChartSection
+              baseCurrency={baseCurrency}
+              snapshots={snapshots}
+              footer={<HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />}
+            />
+          </Suspense>
+        </div>
+        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4">
+          <Suspense fallback={null}>
+            <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+          {/* Allocation lives in the desktop rail; on mobile it joins the donut pair below */}
+          <div className="hidden lg:block">
+            <Suspense fallback={<ChartCardSkeleton />}>
+              <AllocationSection userId={userId} baseCurrency={baseCurrency} />
+            </Suspense>
+          </div>
+        </div>
+      </div>
 
-      {/* Trend chart + activity heatmap footer — share the same card */}
-      <div className="animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
-        <Suspense fallback={<TrendChartSkeleton />}>
-          <TrendChartSection
-            baseCurrency={baseCurrency}
-            snapshots={snapshots}
-            footer={<HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />}
-          />
+      {/* Mobile-only — keep the two donuts side by side below the desktop breakpoint */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 lg:hidden animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
+        <Suspense fallback={<ChartCardSkeleton />}>
+          <AllocationSection userId={userId} baseCurrency={baseCurrency} />
+        </Suspense>
+        <Suspense fallback={<ChartCardSkeleton />}>
+          <CurrencySection userId={userId} baseCurrency={baseCurrency} />
         </Suspense>
       </div>
 
-      {/* Allocation + currency exposure charts */}
-      <div className="animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
-        <Suspense fallback={<ChartsSkeleton />}>
-          <ChartsSection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
+      {/* Tier 3 — "what it's made of": portfolio heatmap (8) + currency donut (4) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
+        <div className="min-w-0 lg:col-span-8">
+          <Suspense fallback={<PortfolioHeatmapSkeleton />}>
+            <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+        </div>
+        {/* Currency lives in the desktop rail; on mobile it joins the donut pair above */}
+        <div className="hidden min-w-0 lg:col-span-4 lg:block">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <CurrencySection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+        </div>
       </div>
 
-      {/* Account heatmap — bridges exposure charts and the detailed account list */}
-      <div className="animate-in fade-in slide-in-from-bottom-12 motion-slow fill-mode-both delay-150">
-        <Suspense fallback={<PortfolioHeatmapSkeleton />}>
-          <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
-      </div>
-
-      {/* Accounts summary table */}
+      {/* Tier 4 — drill-in detail: full-width accounts summary */}
       <div className="animate-in fade-in slide-in-from-bottom-12 motion-slow fill-mode-both delay-150">
         <Suspense fallback={<AccountsSummarySkeleton />}>
           <AccountsSummarySection userId={userId} baseCurrency={baseCurrency} />

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -2,6 +2,19 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
 
+function ChartCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-[250px]" />
+      </CardContent>
+    </Card>
+  );
+}
+
 export function DashboardSkeleton() {
   return (
     <div className="space-y-4 md:space-y-8">
@@ -13,9 +26,9 @@ export function DashboardSkeleton() {
       {/* Actions */}
       <Skeleton className="h-10 w-full rounded-lg" />
 
-      {/* Net Worth Cards — mirror NetWorthCard internals (icon + label + value).
-          No fixed height: content sizes the card just like the real card, so
-          the text-shaped lines never overflow the box on mobile. */}
+      {/* Net Worth Cards — full-bleed headline; mirror NetWorthCard internals
+          (icon + label + value). No fixed height: content sizes the card like
+          the real card so the text-shaped lines never overflow on mobile. */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
         {/* Primary: Net Worth */}
         <Card className="col-span-2 lg:col-span-1 rounded-2xl">
@@ -42,45 +55,55 @@ export function DashboardSkeleton() {
         ))}
       </div>
 
-      {/* Trend chart + heatmap footer */}
-      <TrendChartSkeleton />
-
-      {/* Allocation + currency exposure charts */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
-        {[0, 1].map((i) => (
-          <Card key={i}>
-            <CardHeader className="pb-2">
-              <Skeleton className="h-5 w-32" />
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-[250px]" />
-            </CardContent>
-          </Card>
-        ))}
+      {/* Tier 2 — trend chart + heatmap footer (8) alongside the allocation rail (4) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6">
+        <div className="min-w-0 lg:col-span-8">
+          <TrendChartSkeleton />
+        </div>
+        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4">
+          {/* Allocation donut lives in the desktop rail only */}
+          <div className="hidden lg:block">
+            <ChartCardSkeleton />
+          </div>
+        </div>
       </div>
 
-      {/* Account heatmap */}
-      <Card>
-        <CardHeader className="pb-2">
-          <Skeleton className="h-5 w-36" />
-          <Skeleton className="h-4 w-64 max-w-full" />
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
-            <Skeleton className="h-[240px] sm:h-[280px]" />
-            <div className="hidden space-y-3 lg:block">
-              <Skeleton className="h-24" />
-              <div className="space-y-2">
-                {[...Array(4)].map((_, i) => (
-                  <Skeleton key={i} className="h-10" />
-                ))}
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Mobile-only — the two donuts sit together below the lg breakpoint */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 lg:hidden">
+        <ChartCardSkeleton />
+        <ChartCardSkeleton />
+      </div>
 
-      {/* Accounts summary — matches AccountsSummarySkeleton */}
+      {/* Tier 3 — portfolio heatmap (8) alongside the currency donut (4) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6">
+        <div className="min-w-0 lg:col-span-8">
+          <Card>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-5 w-36" />
+              <Skeleton className="h-4 w-64 max-w-full" />
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
+                <Skeleton className="h-[240px] sm:h-[280px]" />
+                <div className="hidden space-y-3 lg:block">
+                  <Skeleton className="h-24" />
+                  <div className="space-y-2">
+                    {[...Array(4)].map((_, i) => (
+                      <Skeleton key={i} className="h-10" />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        {/* Currency donut lives in the desktop rail only */}
+        <div className="hidden min-w-0 lg:col-span-4 lg:block">
+          <ChartCardSkeleton />
+        </div>
+      </div>
+
+      {/* Tier 4 — accounts summary (matches AccountsSummarySkeleton) */}
       <div className="space-y-3">
         <Skeleton className="h-5 w-40" />
         <div className="space-y-3">

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
@@ -10,6 +11,56 @@ import type { NetWorthSummary } from "@/lib/types";
 import { TrendingUp, TrendingDown, Layers, Wallet } from "lucide-react";
 
 const HIDDEN = "***";
+
+/**
+ * Currency value that prefers the full number but falls back to the compact
+ * form (e.g. $1.2M) when the full digits would overflow the available width.
+ * An invisible, out-of-flow sibling holds the full string so its natural width
+ * can be compared against the container without affecting layout.
+ */
+function FitCurrency({
+  amount,
+  currency,
+  privacy,
+  className,
+}: {
+  amount: number;
+  currency: string;
+  privacy: boolean;
+  className?: string;
+}) {
+  const full = formatCurrency(amount, currency);
+  const containerRef = useRef<HTMLParagraphElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const [fits, setFits] = useState(true);
+
+  useLayoutEffect(() => {
+    if (privacy) return;
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) return;
+    const check = () => setFits(measure.offsetWidth <= container.clientWidth);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [full, privacy]);
+
+  return (
+    <p ref={containerRef} className={className} title={privacy ? undefined : full}>
+      {privacy ? HIDDEN : fits ? full : formatCurrency(amount, currency, true)}
+      {!privacy && (
+        <span
+          ref={measureRef}
+          aria-hidden
+          className="pointer-events-none invisible absolute left-0 top-0 whitespace-nowrap"
+        >
+          {full}
+        </span>
+      )}
+    </p>
+  );
+}
 
 export function NetWorthCard({
   summary,
@@ -101,12 +152,12 @@ export function NetWorthCard({
               {t("totalAssets")}
             </p>
           </div>
-          <p
-            className="text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums truncate"
-            title={privacyMode ? undefined : formatCurrency(totalAssets, baseCurrency)}
-          >
-            {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency, true)}
-          </p>
+          <FitCurrency
+            amount={totalAssets}
+            currency={baseCurrency}
+            privacy={privacyMode}
+            className="relative text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums truncate"
+          />
         </CardContent>
       </Card>
 
@@ -121,12 +172,12 @@ export function NetWorthCard({
               {t("totalLiabilities")}
             </p>
           </div>
-          <p
-            className="text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums truncate"
-            title={privacyMode ? undefined : formatCurrency(totalLiabilities, baseCurrency)}
-          >
-            {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency, true)}
-          </p>
+          <FitCurrency
+            amount={totalLiabilities}
+            currency={baseCurrency}
+            privacy={privacyMode}
+            className="relative text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums truncate"
+          />
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

Redesigns the dashboard tab from a single-column stack (a mobile layout scaled up) into a deliberate desktop **bento grid**, while preserving the native mobile stack. Reuses every existing component; the changes are layout, one heatmap sizing prop, a fit-to-width metric value, and a realigned loading skeleton.

## What changed

**Desktop layout (`lg+`), `dashboard-content.tsx`:**
- **Hero:** net-worth cards stay full-bleed.
- **Tier 2:** trend chart + activity heatmap `[8]` alongside a goals + allocation-donut rail `[4]`.
- **Tier 3:** portfolio heatmap `[8]` alongside the currency-exposure donut `[4]`.
- **Tier 4:** accounts summary full-width (the % bar-fill rows read well wide).
- Below `lg` everything collapses to the existing single-column order, and the two donuts are kept **together on mobile** via a `lg:hidden` paired block (the desktop donuts are `hidden lg:block`).

**Heatmap fills its slot, `portfolio-heatmap.tsx`:**
- New `fillHeight?: boolean` prop (default `false`). When on, the treemap grows to the measured container height so it consumes the space the side panel creates instead of leaving a gap below it. A `minHeight` floor prevents clipping/squishing when the account list is short.
- Wired on both the dashboard and `/analysis`. Call sites that don't pass the prop are unaffected.

**Fit-to-width metric values, `net-worth-card.tsx`:**
- Total assets / liabilities now show the **full** figure when it fits the card and fall back to the **compact** form (e.g. `$1.2M`) only when it would overflow. Width is measured against an invisible out-of-flow sibling (checked in `useLayoutEffect` + `ResizeObserver`, so no flash and correct across density/resize). Privacy mode and the hover title are preserved.

**Loading skeleton realigned, `dashboard-skeleton.tsx`:**
- The route-level skeleton now mirrors the bento grid tier-for-tier (including the desktop rails and the mobile donut pair) and matches the streaming Suspense fallbacks, so the loading → streaming → content hand-off doesn't shift.

## Notes
- All streaming Suspense boundaries, skeletons, and the empty/zero-account state are preserved; data flow is unchanged.
- `format:check`, `lint`, and `typecheck` pass locally (and via the pre-push hook).

## Test plan
- [ ] Desktop `≥1024px`: tiers pair side by side; heatmap treemap fills under the account list with no dead space.
- [ ] Mobile `<1024px`: single-column stack; allocation + currency donuts sit together.
- [ ] `/analysis`: heatmap matches the dashboard fill behavior.
- [ ] Total assets/liabilities show full digits on a wide card and collapse to compact when narrow.
- [ ] Loading skeleton matches the final grid at mobile + desktop with no layout shift into the streamed content.
- [ ] Privacy mode, compact density, and reduced motion still behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)