### PR TITLE
feat(dashboard): color-schema-aware donuts + state-conveying motion

### DIFF
--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
 import { ChevronRight } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
 import { useTranslations } from "next-intl";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
+import { springConfig } from "@/lib/motion";
 import type { NetWorthSummary } from "@/lib/types";
 
 const HIDDEN = "***";
@@ -22,6 +24,16 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const isCompact = density === "compact";
+  const reduceMotion = useReducedMotion();
+
+  // Allocation bars grow from 0 → their share once, the frame after mount, so
+  // proportion reads as a quick fill (the existing transition-[width] carries it).
+  // Skipped under reduced motion: bars render at full width immediately.
+  const [barsGrown, setBarsGrown] = useState(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setBarsGrown(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -114,13 +126,13 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
         </p>
         <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
           {accounts.map((account, index) => (
-            <div key={account.id}>
+            <motion.div key={account.id} layout={!reduceMotion} transition={springConfig}>
               {index > 0 && <div className="h-px bg-border/60 mx-4" />}
               <div className="relative overflow-hidden">
                 {!privacyMode && (
                   <div
-                    className={`absolute inset-y-0 left-0 ${isAsset ? "bg-[var(--gain)]/5" : "bg-[var(--loss)]/5"} transition-[width] duration-500`}
-                    style={{ width: `${getPercentage(account)}%` }}
+                    className={`absolute inset-y-0 left-0 ${isAsset ? "bg-[var(--gain)]/5" : "bg-[var(--loss)]/5"} transition-[width] duration-500 ease-out`}
+                    style={{ width: `${reduceMotion || barsGrown ? getPercentage(account) : 0}%` }}
                   />
                 )}
                 <Link
@@ -152,7 +164,7 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
                   </div>
                 </Link>
               </div>
-            </div>
+            </motion.div>
           ))}
           <div className="h-px bg-border/60" />
           <div className="flex items-center justify-between px-4 py-3 bg-muted/20">

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -11,16 +11,18 @@ import { formatCurrency } from "@/lib/currencies";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { NetWorthSummary } from "@/lib/types";
 
+// Schema-aware spectrum: --chart-1..5 re-tint with the selected color schema
+// (chart-1 is the accent), --chart-6..9 stay as the supplementary spectrum.
 const COLORS = [
-  "oklch(0.72 0.19 155)", // Emerald
-  "oklch(0.70 0.15 220)", // Sky blue
-  "oklch(0.65 0.18 270)", // Indigo
-  "oklch(0.72 0.17 310)", // Fuchsia
-  "oklch(0.78 0.16 65)", // Amber
-  "oklch(0.68 0.14 25)", // Coral
-  "oklch(0.75 0.12 180)", // Teal
-  "oklch(0.60 0.16 330)", // Rose
-  "oklch(0.80 0.14 100)", // Lime
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "var(--chart-9)",
 ];
 
 export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
@@ -123,8 +125,10 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                           x2="1"
                           y2="1"
                         >
-                          <stop offset="0%" stopColor={color} stopOpacity={0.95} />
-                          <stop offset="100%" stopColor={color} stopOpacity={0.65} />
+                          {/* var() resolves in the CSS `stop-color` property (style),
+                              not in the SVG presentation attribute. */}
+                          <stop offset="0%" style={{ stopColor: color, stopOpacity: 0.95 }} />
+                          <stop offset="100%" style={{ stopColor: color, stopOpacity: 0.65 }} />
                         </linearGradient>
                       ))}
                     </defs>

--- a/src/components/dashboard/currency-exposure-chart.tsx
+++ b/src/components/dashboard/currency-exposure-chart.tsx
@@ -10,16 +10,18 @@ import { formatCurrency } from "@/lib/currencies";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
 import type { NetWorthSummary } from "@/lib/types";
 
+// Schema-aware spectrum (see allocation-chart). Rotated to start at --chart-3
+// so this donut stays visually distinct from the allocation donut beside it.
 const COLORS = [
-  "oklch(0.65 0.18 270)", // Indigo
-  "oklch(0.72 0.17 310)", // Fuchsia
-  "oklch(0.78 0.16 65)", // Amber
-  "oklch(0.72 0.19 155)", // Emerald
-  "oklch(0.70 0.15 220)", // Sky blue
-  "oklch(0.68 0.14 25)", // Coral
-  "oklch(0.75 0.12 180)", // Teal
-  "oklch(0.60 0.16 330)", // Rose
-  "oklch(0.80 0.14 100)", // Lime
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "var(--chart-9)",
 ];
 
 export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary }) {
@@ -111,8 +113,10 @@ export function CurrencyExposureChart({ summary }: { summary: NetWorthSummary })
                           x2="1"
                           y2="1"
                         >
-                          <stop offset="0%" stopColor={color} stopOpacity={0.95} />
-                          <stop offset="100%" stopColor={color} stopOpacity={0.65} />
+                          {/* var() resolves in the CSS `stop-color` property (style),
+                              not in the SVG presentation attribute. */}
+                          <stop offset="0%" style={{ stopColor: color, stopOpacity: 0.95 }} />
+                          <stop offset="100%" style={{ stopColor: color, stopOpacity: 0.65 }} />
                         </linearGradient>
                       ))}
                     </defs>

--- a/src/components/dashboard/goals-milestone-card.tsx
+++ b/src/components/dashboard/goals-milestone-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useReducedMotion } from "framer-motion";
 import { useLocale, useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
@@ -24,6 +26,15 @@ export function GoalsMilestoneCard({
   const t = useTranslations("goalsMilestone");
   const locale = useLocale();
   const { privacyMode } = usePrivacyMode();
+  const reduceMotion = useReducedMotion();
+
+  // Fill the progress bar from 0 → its value the frame after mount so the
+  // milestone reads as advancing. Reduced motion lands at the final width.
+  const [filled, setFilled] = useState(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setFilled(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   if (totalGoals === 0) return null;
 
@@ -68,8 +79,8 @@ export function GoalsMilestoneCard({
               className="h-2 w-full rounded-full bg-muted/60 overflow-hidden"
             >
               <div
-                className="h-full rounded-full bg-primary/80 transition-all motion-normal"
-                style={{ width: `${progressClamped}%` }}
+                className="h-full rounded-full bg-primary/80 transition-[width] duration-700 ease-out"
+                style={{ width: `${reduceMotion || filled ? progressClamped : 0}%` }}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Two dashboard refinements on the color-design branch:

1. **Donut charts now follow the accent color schema.** The allocation and currency-exposure donuts hardcoded their own `oklch` palettes, so picking a non-emerald schema (ocean, violet, etc.) left them stuck. Both now read the schema-aware `--chart-*` tokens, so slices and legend dots re-tint with the accent. The currency donut starts at `--chart-3` to stay visually distinct from the allocation donut beside it on mobile.

2. **State-conveying motion** in three spots that previously snapped:
   - Account allocation bars grow from 0 to their share on mount.
   - Sorting the accounts list animates a FLIP reorder (Framer Motion `layout`) instead of jumping, so you can track where an account moved.
   - The goal milestone progress bar advances from 0 on mount.

## Implementation notes

- **SVG `var()` gotcha:** gradient stops moved from the `stopColor` attribute to inline `style`, because `var()` resolves in the CSS `stop-color` property but not in the SVG presentation attribute. Without this the slices would render black.
- **Gain/loss stays semantic:** the net-worth mesh glow and asset/liability icons still follow the up/down (green-up / red-up) scheme, not the accent. Money direction colors are intentionally untouched.
- **Reduced motion:** all three animations are gated on `prefers-reduced-motion` (globals.css has no universal override), landing at final state immediately. Motion is transform/width only.

## Test plan

- [x] `npm run format:check`, `npm run lint`, `npm run typecheck` all pass
- [ ] Switch color schema in Settings (ocean / violet / rose) and confirm both donuts re-tint
- [ ] Sort the accounts summary and confirm rows glide to new positions
- [ ] Toggle OS reduced-motion and confirm bars/reorder land instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)