### PR TITLE
feat(history): desktop bento layout with summary rail

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -320,7 +320,20 @@
     "noData": "No snapshots yet. Take a snapshot from the dashboard to start tracking.",
     "noDataForRange": "No data for this range.",
     "noSnapshot": "No snapshot",
-    "noPreviousSnapshot": "No previous snapshot to compare"
+    "noPreviousSnapshot": "No previous snapshot to compare",
+    "tableTitle": "All Snapshots",
+    "summaryTitle": "Summary",
+    "allTimeHigh": "All-time high",
+    "allTimeLow": "All-time low",
+    "sinceFirst": "Since first snapshot",
+    "last30Days": "Last 30 days",
+    "bestDay": "Best day",
+    "worstDay": "Worst day",
+    "upDownDays": "Up / down days",
+    "fromHigh": "From all-time high",
+    "atHigh": "At all-time high",
+    "trackingSince": "Tracking since {date}",
+    "snapshotsCount": "{count, plural, one {# snapshot} other {# snapshots}}"
   },
   "netWorthCard": {
     "netWorth": "Net Worth",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -320,7 +320,20 @@
     "noData": "尚無快照。請從儀表板建立快照以開始追蹤歷史。",
     "noDataForRange": "此範圍內無資料。",
     "noSnapshot": "無快照",
-    "noPreviousSnapshot": "無前一筆快照可比較"
+    "noPreviousSnapshot": "無前一筆快照可比較",
+    "tableTitle": "所有快照",
+    "summaryTitle": "摘要",
+    "allTimeHigh": "歷史新高",
+    "allTimeLow": "歷史新低",
+    "sinceFirst": "自首次快照以來",
+    "last30Days": "近 30 日",
+    "bestDay": "最佳單日",
+    "worstDay": "最差單日",
+    "upDownDays": "上漲 / 下跌天數",
+    "fromHigh": "距歷史新高",
+    "atHigh": "正處於歷史新高",
+    "trackingSince": "自 {date} 起追蹤",
+    "snapshotsCount": "{count} 筆快照"
   },
   "netWorthCard": {
     "netWorth": "淨資產",

--- a/src/app/(main)/history/loading.tsx
+++ b/src/app/(main)/history/loading.tsx
@@ -3,14 +3,42 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function HistoryLoading() {
   return (
     <div className="space-y-4 md:space-y-8">
-      {/* Title — matches LargeTitleHeading (text-4xl md:text-3xl) */}
-      <Skeleton className="h-10 md:h-9 w-28 rounded-lg" />
+      {/* Title row — matches LargeTitleHeading (text-4xl md:text-3xl) + meta */}
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <Skeleton className="h-10 md:h-9 w-44 rounded-lg" />
+        <Skeleton className="h-4 w-48 rounded" />
+      </div>
 
-      {/* Trend chart card — matches TrendChart's own Card (no outer wrapper) */}
-      <div className="bg-card border border-border/50 rounded-xl shadow-sm">
-        <div className="px-4 pt-4 pb-2 space-y-4">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="h-[240px] rounded-lg" />
+      {/* Hero row — trend (8) + rail (4): summary over daily change */}
+      <div className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-8 bg-card border border-border/50 rounded-xl shadow-sm">
+          <div className="px-4 pt-4 pb-2 space-y-4">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-[240px] rounded-lg" />
+            <Skeleton className="h-[88px] rounded-lg" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-3 sm:gap-6 lg:col-span-4">
+          <div className="bg-card border border-border/50 rounded-xl shadow-sm">
+            <div className="p-4 space-y-4">
+              <Skeleton className="h-5 w-24" />
+              <div className="grid grid-cols-2 gap-x-4 gap-y-5">
+                {[...Array(8)].map((_, i) => (
+                  <div key={i} className="space-y-1.5">
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-5 w-16" />
+                    <Skeleton className="h-3 w-12" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="flex-1 bg-card border border-border/50 rounded-xl shadow-sm">
+            <div className="px-4 pt-4 pb-4 space-y-4">
+              <Skeleton className="h-5 w-44" />
+              <Skeleton className="h-[180px] rounded-lg" />
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -5,7 +5,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { HistoryView } from "@/components/history/history-view";
-import { getNormalizedHistory } from "@/lib/services/history-service";
+import { getFullNormalizedHistory } from "@/lib/services/history-service";
 
 const CLIENT_NAMESPACES = ["trendChart", "history", "freshness"];
 
@@ -16,7 +16,7 @@ async function HistoryContent() {
   const settingsP = getOrCreateSettings(userId);
   const [allMessages, snapshots, settings] = await Promise.all([
     getMessages(),
-    settingsP.then((s) => getNormalizedHistory(userId, s.baseCurrency)),
+    settingsP.then((s) => getFullNormalizedHistory(userId, s.baseCurrency)),
     settingsP,
   ]);
 
@@ -27,7 +27,6 @@ async function HistoryContent() {
           snapshots={snapshots}
           baseCurrency={settings.baseCurrency}
           showTitle
-          hideTrendRangeFilter
           className="animate-in fade-in duration-200"
         />
       </HistoryPullRefresh>

--- a/src/components/history/daily-change-chart.tsx
+++ b/src/components/history/daily-change-chart.tsx
@@ -42,6 +42,7 @@ type DailyChangePoint = {
 type Props = {
   snapshots: SnapshotRow[];
   baseCurrency: string;
+  className?: string;
 };
 
 type TooltipPayload = {
@@ -100,7 +101,7 @@ function DailyChangeTooltip({
   );
 }
 
-export function DailyChangeChart({ snapshots, baseCurrency }: Props) {
+export function DailyChangeChart({ snapshots, baseCurrency, className }: Props) {
   const t = useTranslations("history");
   const format = useFormatter();
   const { privacyMode } = usePrivacyMode();
@@ -147,32 +148,32 @@ export function DailyChangeChart({ snapshots, baseCurrency }: Props) {
   const hasAnyChange = data.some((point) => point.hasSnapshot && point.hasPreviousSnapshot);
 
   return (
-    <Card>
+    <Card className={cn("flex h-full flex-col", className)}>
       <CardHeader className="pb-2 px-4">
         <CardTitle className="text-base font-medium text-foreground">
           {t("dailyChange30")}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-4 pb-4">
+      <CardContent className="flex flex-1 flex-col px-4 pb-4">
         {!hasAnyChange ? (
-          <div className="h-[180px] flex items-center justify-center text-center text-sm text-muted-foreground">
+          <div className="flex flex-1 min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
             {t("dailyChangeNoData")}
           </div>
         ) : !mounted ? (
-          <div className="h-[180px]" />
+          <div className="flex-1 min-h-[180px]" />
         ) : (
           <div
             role="img"
             aria-label={t("dailyChange30")}
             aria-hidden={privacyMode || undefined}
             className={cn(
-              "relative h-[180px] transition-[filter] duration-300",
+              "relative flex-1 min-h-[180px] transition-[filter] duration-300",
               privacyMode && "blur-sm pointer-events-none select-none",
             )}
           >
             <ResponsiveContainer
               width="100%"
-              height={180}
+              height="100%"
               minWidth={0}
               initialDimension={{ width: 1, height: 180 }}
             >

--- a/src/components/history/history-summary.tsx
+++ b/src/components/history/history-summary.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import { useFormatter, useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { formatCurrency } from "@/lib/currencies";
+import { cn } from "@/lib/utils";
+import type { NormalizedSnapshot } from "@/lib/services/history-service";
+
+type Props = {
+  snapshots: NormalizedSnapshot[];
+  baseCurrency: string;
+  className?: string;
+};
+
+type DayMove = { value: number; date: string };
+
+/**
+ * Summary rail for the desktop History page. Condenses the full snapshot
+ * series into a compact stat grid that answers "what changed / am I on
+ * track": the all-time range, the move since start and over the last 30
+ * days, the current drawdown, the single best/worst days, and how
+ * consistently net worth has risen. Sits beside the trend chart.
+ *
+ * Figures use compact currency (NT$27.3M) to stay scannable in the rail;
+ * the precise amounts live in the ledger below. Privacy mode masks
+ * absolute money but keeps percentages and counts, so the shape of
+ * performance stays legible without exposing wealth.
+ */
+export function HistorySummary({ snapshots, baseCurrency, className }: Props) {
+  const t = useTranslations("history");
+  const format = useFormatter();
+  const { privacyMode } = usePrivacyMode();
+
+  const stats = useMemo(() => {
+    if (snapshots.length === 0) return null;
+
+    const first = snapshots[0];
+    const last = snapshots[snapshots.length - 1];
+
+    let athValue = first.netWorth;
+    let athDate = first.date;
+    let atlValue = first.netWorth;
+    let atlDate = first.date;
+    for (const snap of snapshots) {
+      if (snap.netWorth > athValue) {
+        athValue = snap.netWorth;
+        athDate = snap.date;
+      }
+      if (snap.netWorth < atlValue) {
+        atlValue = snap.netWorth;
+        atlDate = snap.date;
+      }
+    }
+
+    const changeAbs = last.netWorth - first.netWorth;
+    const changePct = first.netWorth !== 0 ? (changeAbs / Math.abs(first.netWorth)) * 100 : null;
+
+    const drawdownAbs = last.netWorth - athValue;
+    const atHigh = drawdownAbs >= 0;
+    const drawdownPct = athValue > 0 ? (drawdownAbs / athValue) * 100 : null;
+
+    // Last 30 days: compare against the latest snapshot on or before (lastDate - 30d).
+    const cutoff = new Date(last.date + "T00:00:00");
+    cutoff.setDate(cutoff.getDate() - 30);
+    const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(
+      2,
+      "0",
+    )}-${String(cutoff.getDate()).padStart(2, "0")}`;
+    let baseline30: NormalizedSnapshot | null = null;
+    for (const snap of snapshots) {
+      if (snap.date <= cutoffStr) baseline30 = snap;
+      else break;
+    }
+    const recent30Abs = baseline30 ? last.netWorth - baseline30.netWorth : null;
+    const recent30Pct =
+      baseline30 && baseline30.netWorth !== 0
+        ? ((last.netWorth - baseline30.netWorth) / Math.abs(baseline30.netWorth)) * 100
+        : null;
+
+    // Single best / worst inter-snapshot moves, and the up vs down tally.
+    let best: DayMove | null = null;
+    let worst: DayMove | null = null;
+    let upDays = 0;
+    let downDays = 0;
+    for (let i = 1; i < snapshots.length; i++) {
+      const delta = snapshots[i].netWorth - snapshots[i - 1].netWorth;
+      if (delta > 0) upDays++;
+      else if (delta < 0) downDays++;
+      if (best === null || delta > best.value) best = { value: delta, date: snapshots[i].date };
+      if (worst === null || delta < worst.value) worst = { value: delta, date: snapshots[i].date };
+    }
+    // Only surface best/worst when they actually represent gains/losses.
+    const bestGain: DayMove | null = best && best.value > 0 ? best : null;
+    const worstLoss: DayMove | null = worst && worst.value < 0 ? worst : null;
+
+    return {
+      athValue,
+      athDate,
+      atlValue,
+      atlDate,
+      changeAbs,
+      changePct,
+      recent30Abs,
+      recent30Pct,
+      drawdownAbs,
+      drawdownPct,
+      atHigh,
+      best: bestGain,
+      worst: worstLoss,
+      upDays,
+      downDays,
+      hasSpan: snapshots.length >= 2,
+    };
+  }, [snapshots]);
+
+  if (!stats) return null;
+
+  const money = (value: number) =>
+    privacyMode ? "***" : formatCurrency(value, baseCurrency, true);
+  const signedMoney = (value: number) =>
+    privacyMode ? "***" : `${value >= 0 ? "+" : ""}${formatCurrency(value, baseCurrency, true)}`;
+  const signedPct = (value: number) => `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+  const shortDate = (dateStr: string) =>
+    format.dateTime(new Date(dateStr + "T00:00:00"), { month: "short", day: "numeric" });
+
+  const tone = (value: number) =>
+    value > 0 ? "text-[var(--gain)]" : value < 0 ? "text-[var(--loss)]" : "text-foreground";
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader className="px-4 pb-3">
+        <CardTitle className="text-base font-medium text-foreground">{t("summaryTitle")}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-x-4 gap-y-5 px-4 pb-4">
+        <Stat
+          label={t("allTimeHigh")}
+          value={money(stats.athValue)}
+          sub={shortDate(stats.athDate)}
+        />
+        <Stat
+          label={t("allTimeLow")}
+          value={money(stats.atlValue)}
+          sub={shortDate(stats.atlDate)}
+        />
+
+        <Stat
+          label={t("sinceFirst")}
+          value={stats.hasSpan ? signedMoney(stats.changeAbs) : "—"}
+          valueClass={stats.hasSpan ? tone(stats.changeAbs) : "text-muted-foreground"}
+          sub={stats.hasSpan && stats.changePct !== null ? signedPct(stats.changePct) : undefined}
+          subClass={tone(stats.changeAbs)}
+        />
+        <Stat
+          label={t("last30Days")}
+          value={stats.recent30Abs !== null ? signedMoney(stats.recent30Abs) : "—"}
+          valueClass={
+            stats.recent30Abs !== null ? tone(stats.recent30Abs) : "text-muted-foreground"
+          }
+          sub={stats.recent30Pct !== null ? signedPct(stats.recent30Pct) : undefined}
+          subClass={stats.recent30Abs !== null ? tone(stats.recent30Abs) : undefined}
+        />
+
+        <Stat
+          label={t("bestDay")}
+          value={stats.best ? signedMoney(stats.best.value) : "—"}
+          valueClass={stats.best ? "text-[var(--gain)]" : "text-muted-foreground"}
+          sub={stats.best ? shortDate(stats.best.date) : undefined}
+        />
+        <Stat
+          label={t("worstDay")}
+          value={stats.worst ? signedMoney(stats.worst.value) : "—"}
+          valueClass={stats.worst ? "text-[var(--loss)]" : "text-muted-foreground"}
+          sub={stats.worst ? shortDate(stats.worst.date) : undefined}
+        />
+
+        <Stat
+          label={t("fromHigh")}
+          value={
+            stats.atHigh
+              ? t("atHigh")
+              : stats.drawdownPct !== null
+                ? signedPct(stats.drawdownPct)
+                : signedMoney(stats.drawdownAbs)
+          }
+          valueClass={stats.atHigh ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+          sub={stats.atHigh ? undefined : signedMoney(stats.drawdownAbs)}
+        />
+        <Stat
+          label={t("upDownDays")}
+          value={
+            <>
+              <span className="text-[var(--gain)]">{stats.upDays}</span>
+              <span className="text-muted-foreground"> / </span>
+              <span className="text-[var(--loss)]">{stats.downDays}</span>
+            </>
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  valueClass,
+  sub,
+  subClass,
+}: {
+  label: string;
+  value: ReactNode;
+  valueClass?: string;
+  sub?: string;
+  subClass?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "text-base font-semibold leading-tight tabular-nums",
+          valueClass ?? "text-foreground",
+        )}
+      >
+        {value}
+      </span>
+      {sub !== undefined && (
+        <span
+          className={cn("text-[11px] leading-tight tabular-nums text-muted-foreground", subClass)}
+        >
+          {sub}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -54,7 +54,7 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
-        <h2 className="text-base font-medium">{t("title")}</h2>
+        <h2 className="text-base font-medium">{t("tableTitle")}</h2>
         <FreshnessBadge kind="snapshot" timestamp={latestSnapshotAt} />
       </div>
       {monthGroups.length === 0 ? (

--- a/src/components/history/history-view.tsx
+++ b/src/components/history/history-view.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
 import { TrendChart } from "@/components/dashboard/trend-chart";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
+import { FreshnessBadge } from "@/components/ui/freshness-badge";
 import { cn } from "@/lib/utils";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
 import { DailyChangeChart } from "./daily-change-chart";
 import { HistoryHeatmap } from "./history-heatmap";
+import { HistorySummary } from "./history-summary";
 import { HistoryTable } from "./history-table";
 
 type Props = {
@@ -25,24 +27,60 @@ export function HistoryView({
   className,
 }: Props) {
   const t = useTranslations("history");
+  const format = useFormatter();
+
+  const firstSnapshot = snapshots[0];
+  const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
 
   return (
     <div className={cn("space-y-4 md:space-y-8", className)}>
-      {showTitle && <LargeTitleHeading>{t("title")}</LargeTitleHeading>}
+      {showTitle && (
+        <div className="flex flex-wrap items-end justify-between gap-x-4 gap-y-1">
+          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
+          {firstSnapshot && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="tabular-nums">
+                {t("trackingSince", {
+                  date: format.dateTime(new Date(firstSnapshot.date + "T00:00:00"), {
+                    dateStyle: "medium",
+                  }),
+                })}
+              </span>
+              <span aria-hidden="true" className="text-border">
+                ·
+              </span>
+              <span className="tabular-nums">
+                {t("snapshotsCount", { count: snapshots.length })}
+              </span>
+              <FreshnessBadge kind="snapshot" timestamp={latestSnapshotAt} mobileShort />
+            </div>
+          )}
+        </div>
+      )}
 
-      <TrendChart
-        snapshots={snapshots}
-        baseCurrency={baseCurrency}
-        hideRangeFilter={hideTrendRangeFilter}
-        footer={
-          <HistoryHeatmap
+      {/* Hero row: trend + heatmap hold the width; the rail stacks the derived
+          summary over recent daily volatility, mirroring the dashboard's 8/4 split. */}
+      <div className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12">
+        <div className="min-w-0 lg:col-span-8">
+          <TrendChart
             snapshots={snapshots}
             baseCurrency={baseCurrency}
-            labels={{ netWorth: t("colNetWorth"), change: t("colChange") }}
+            hideRangeFilter={hideTrendRangeFilter}
+            footer={
+              <HistoryHeatmap
+                snapshots={snapshots}
+                baseCurrency={baseCurrency}
+                labels={{ netWorth: t("colNetWorth"), change: t("colChange") }}
+              />
+            }
           />
-        }
-      />
-      <DailyChangeChart snapshots={snapshots} baseCurrency={baseCurrency} />
+        </div>
+        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4">
+          <HistorySummary snapshots={snapshots} baseCurrency={baseCurrency} />
+          <DailyChangeChart snapshots={snapshots} baseCurrency={baseCurrency} className="flex-1" />
+        </div>
+      </div>
+
       <HistoryTable snapshots={snapshots} baseCurrency={baseCurrency} />
     </div>
   );


### PR DESCRIPTION
## Summary

Brings the **History page** into the dashboard's 12-column bento language (desktop-first), so a wide monitor composes the data instead of just stretching a single full-width column. Mobile stays the existing calm vertical stack.

### Layout
- **Hero row (`lg:grid-cols-12`)** — trend chart + year heatmap footer at `col-span-8`, with a `col-span-4` rail that stacks a new **Summary** card over the 30-day **Daily Change** chart (mirrors the dashboard's 8/4 split).
- This fixes two desktop weaknesses of the prior full-width stack: the Summary is no longer stretched into emptiness, and Daily Change is no longer a letterboxed full-width strip (it's now height-flexible to fill the rail).
- **Header meta line** — tracking-since date, snapshot count, and the snapshot freshness badge.

### Summary card
A compact 2-column stat grid answering "what changed / am I on track": all-time high & low (with dates), change since first snapshot and over the last 30 days (abs + %), single best/worst day, current drawdown from peak, and an up/down-day tally. Tabular-nums, gain/loss tokens, privacy-aware (masks money, keeps percentages).

### Data
Switched the page read to `getFullNormalizedHistory` and **enabled the trend range filter** here, so `1Y` / `All` and the all-time-high/low stats use the full series rather than the 90-day window. Renamed the table section to "All Snapshots" so it no longer duplicates the page title.

### Also
- `DailyChangeChart` is now height-flexible (`flex-1`) instead of a fixed 180px strip.
- Matching loading skeleton; new `en-US` / `zh-TW` strings.

## Test plan
- [x] `npm run format:check`, `lint`, `typecheck` pass (pre-push hook enforced)
- [x] Verified live on desktop (dark mode): hero grid, summary math, range filter, gain/loss colors, height alignment
- [ ] Reviewer: confirm mobile stack + the "All Snapshots" ledger below the fold

🤖 Generated with [Claude Code](https://claude.com/claude-code)