### PR TITLE
feat: add local postgres database for development via docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,16 @@
+# ==========================================
+# 1. LOCAL DEVELOPMENT (Docker)
+# ==========================================
+# Use this when running the local Docker database (npm run db:up)
+# DATABASE_URL="postgresql://postgres:postgres@localhost:5432/asset_app?sslmode=disable"
+# DIRECT_URL="postgresql://postgres:postgres@localhost:5432/asset_app?sslmode=disable"
+
+# ==========================================
+# 2. NEON PRODUCTION/PREVIEW 
+# ==========================================
 # PostgreSQL connection string — pooled connection (PgBouncer / Neon pooler).
 # Used by the app at runtime via the Neon WebSocket adapter.
 DATABASE_URL="postgresql://USER:PASSWORD@HOST-pooler.HOST:5432/DATABASE?sslmode=require"
-
 # Direct (non-pooled) connection — used only by `prisma migrate` / `prisma db push`.
 # For Neon, this is the same URL with the "-pooler" suffix removed from the host.
 # Optional: when unset, migrations fall back to DATABASE_URL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ npx prisma migrate dev --name <description>        # Author a new migration loca
 npx prisma migrate deploy                          # Apply pending migrations against $DATABASE_URL (run by build:vercel on Vercel)
 npx prisma migrate resolve --applied <migration>   # One-shot baseline: mark a migration as already-applied (e.g. when adopting migrations on a DB seeded via db push)
 npx prisma db push                                 # Quick prototype-only schema sync — bypasses migration history; commit a migrate dev before merging
+npx prisma db push --force-reset                    # Reset local DB (drops all tables, recreates schema directly, bypassing migration history)
 npx prisma studio                                  # Open Prisma Studio GUI
 
 # E2E tests (Playwright)

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ npx prisma migrate deploy   # apply committed migrations to your database
 We recommend using a local PostgreSQL database via Docker for development to avoid incurring Neon compute costs.
 
 1. **Start the local database:**
+
    ```bash
    npm run db:up
    ```
 
 2. **Push the schema to your local DB:**
+
    ```bash
    npx prisma db push
    ```
@@ -93,6 +95,9 @@ We recommend using a local PostgreSQL database via Docker for development to avo
 Open [http://localhost:3000](http://localhost:3000) to see your dashboard.
 
 When you are done developing for the day, you can stop the database with `npm run db:down`.
+
+> [!TIP]
+> **Resetting the Local Database**: If you need to clear all data and rebuild the database schema from scratch, run `npx prisma db push --force-reset`. Avoid using `npx prisma migrate reset` locally, as the repository does not have a baseline migration file (it relies on `db push` for schema sync) and the command will fail.
 
 ### 5. End-to-End Tests
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,26 @@ npx prisma migrate deploy   # apply committed migrations to your database
 
 ### 4. Running Locally
 
-```bash
-npm run dev
-```
+We recommend using a local PostgreSQL database via Docker for development to avoid incurring Neon compute costs.
+
+1. **Start the local database:**
+   ```bash
+   npm run db:up
+   ```
+
+2. **Push the schema to your local DB:**
+   ```bash
+   npx prisma db push
+   ```
+
+3. **Start the development server:**
+   ```bash
+   npm run dev
+   ```
 
 Open [http://localhost:3000](http://localhost:3000) to see your dashboard.
+
+When you are done developing for the day, you can stop the database with `npm run db:down`.
 
 ### 5. End-to-End Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   db:
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: asset_app
     ports:
-      - '5432:5432'
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: asset_app
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/next.config.ts
+++ b/next.config.ts
@@ -52,7 +52,7 @@ const nextConfig: NextConfig = {
       "@base-ui/react",
     ],
   },
-  serverExternalPackages: ["ws", "@neondatabase/serverless"],
+  serverExternalPackages: ["ws", "@neondatabase/serverless", "pg"],
   headers: async () => [
     {
       source: "/:path*",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "prepare": "husky",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "db:up": "docker-compose up -d",
+    "db:down": "docker-compose down"
   },
   "lint-staged": {
     "**/*.{ts,tsx,mjs,js}": [

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,7 +32,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               const user = await prisma.user.upsert({
                 where: { email: E2E_TEST_EMAIL },
                 update: {},
-                create: { email: E2E_TEST_EMAIL, name: "E2E Test User" },
+                create: {
+                  email: E2E_TEST_EMAIL,
+                  name: "E2E Test User",
+                  appSettings: {
+                    create: {
+                      locale: "en-US",
+                      baseCurrency: "USD",
+                    },
+                  },
+                },
               });
               if (!user) return null;
               return { id: user.id, name: user.name, email: user.email, image: user.image };

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -10,6 +10,19 @@ type AnyRecord = Record<string, unknown> & { [key: string]: any };
 export const customPrismaAdapter = {
   ...PrismaAdapter(prisma),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createUser: async (data: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const user = await prisma.user.create({ data: data as any });
+    await prisma.setting.create({
+      data: {
+        userId: user.id,
+        locale: "en-US",
+        baseCurrency: "USD",
+      },
+    });
+    return user;
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   linkAccount: (data: AnyRecord) => prisma.authAccount.create({ data: data as any }) as any,
   unlinkAccount: (provider_providerAccountId: ProviderAccountId) =>
     prisma.authAccount.delete({

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,17 +1,27 @@
 import "server-only";
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { neonConfig } from "@neondatabase/serverless";
 import ws from "ws";
+import pg from "pg";
 import { DATABASE_URL } from "@/lib/env";
-
-// Enable WebSocket connections for non-edge environments (Node.js)
-neonConfig.webSocketConstructor = ws;
 
 function createPrismaClient() {
   const connectionString = DATABASE_URL;
-  // PrismaNeon takes a PoolConfig and manages the pool internally
-  const adapter = new PrismaNeon({ connectionString });
+  const isNeon = connectionString.includes("neon.tech");
+
+  let adapter;
+  if (isNeon) {
+    // Enable WebSocket connections for non-edge environments (Node.js)
+    neonConfig.webSocketConstructor = ws;
+    adapter = new PrismaNeon({ connectionString });
+  } else {
+    // Standard PostgreSQL database (e.g. local Docker PG)
+    const pool = new pg.Pool({ connectionString });
+    adapter = new PrismaPg(pool);
+  }
+
   const client = new PrismaClient({ adapter });
 
   return client.$extends({

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -30,13 +30,24 @@ async function getOrCreateSettingsInner(userId: string) {
   const locale = await getLocale();
   const baseCurrency = getLocaleDefaultCurrency(locale);
 
-  return prisma.setting.create({
-    data: {
-      userId,
-      locale,
-      baseCurrency,
-    },
-  });
+  try {
+    const created = await prisma.setting.create({
+      data: {
+        userId,
+        locale,
+        baseCurrency,
+      },
+    });
+    return created;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
+      // If a concurrent request successfully created the settings first,
+      // load it directly from the database
+      const directSettings = await prisma.setting.findUnique({ where: { userId } });
+      if (directSettings) return directSettings;
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview

This pull request resolves database connectivity issues on local development and fixes cache-related rendering warnings/exceptions on user login/first-visit.

---

## Key Changes

### 1. 🔌 Local PostgreSQL Database Connectivity
* **The Problem**: `src/lib/prisma.ts` was hardcoded to use the Neon Serverless driver adapter (`PrismaNeon`) over WebSockets. This caused connection failures (e.g. during authentication queries) when running the application locally against a standard PostgreSQL container on `localhost:5432` which only accepts TCP connections.
* **The Solution**: 
  * Updated `src/lib/prisma.ts` to dynamically switch adapters:
    * If `DATABASE_URL` contains `neon.tech`, it uses `PrismaNeon` (WebSockets + serverless configuration).
    * If it is a standard TCP host (e.g. `localhost`), it falls back to standard PostgreSQL driver `@prisma/adapter-pg` (`PrismaPg`) coupled with `pg.Pool`.
  * Updated `next.config.ts` to add `"pg"` to the `serverExternalPackages` array, preventing webpack/turbopack bundling issues with the native drivers.

### 2. ⚡ RSC Cache Validation Warning (`revalidateTag` during render)
* **The Problem**: The app uses Next.js 16 `"use cache"` to speed up settings loading. On first login, settings do not exist. `getOrCreateSettings` would dynamically insert the record and call `revalidateTag` to purge the cached `null` result. However, Next.js throws an error/warning when `revalidateTag` is called during the rendering pass of a React Server Component (RSC).
* **The Solution**:
  * Moved the settings record creation to **user registration lifecycle events** (mutations outside the rendering pipeline):
    * **Google OAuth**: Created via the custom `createUser` function inside the custom adapter in `src/lib/auth-adapter.ts`.
    * **Credentials / E2E users**: Created via a nested `appSettings: { create: ... }` relation during user upsert in `src/auth.ts`.
  * Removed the unsupported `revalidateTag` calls from the rendering fallback inside `src/lib/services/settings-service.ts`.
  * Ensured the settings-service creation fallback is type-safe (avoided forbidden `any` catches, checked Prisma constraint error code `P2002` correctly for concurrent page loads).

### 3. 📝 Local Database Reset Documentation
* **The Problem**: Standard `prisma migrate reset` fails locally because the repository doesn't have an initial "baseline" migration file (relying instead on `db push` for structural synchronization).
* **The Solution**:
  * Documented `npx prisma db push --force-reset` as the recommended command to clear and rebuild tables from scratch in:
    * **CLAUDE.md** (common developer commands)
    * **README.md** (running locally instructions)

---

## Validation
* Both `npm run format:check` and `npm run lint` are completely clean (0 errors, 0 warnings).
* `npm run typecheck` passes with no compilation errors.