### PR TITLE
feat(accounts): move portfolio heatmap to accounts tab, with a11y + allocation color link

### DIFF
--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -4,11 +4,13 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { AccountsList } from "@/components/accounts/accounts-list";
+import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
 import {
   fetchUserAccountsWithHoldings,
   fetchUserArchivedAccountsWithHoldings,
+  getCachedNetWorthSummary,
 } from "@/lib/services/net-worth-service";
 import { getCachedPricesForSymbols } from "@/lib/services/price-service";
 import { log } from "@/lib/logger";
@@ -20,23 +22,32 @@ const CLIENT_NAMESPACES = [
   "holdingSearch",
   "categories",
   "common",
+  "analysis",
 ];
 
 async function AccountsContent() {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
-  // Run all independent queries in parallel (translations + data)
-  const [t, messages, accounts, archivedAccounts, settings, allRatesMap] = await Promise.all([
-    getTranslations("accounts"),
-    getMessages(),
-    fetchUserAccountsWithHoldings(userId),
-    fetchUserArchivedAccountsWithHoldings(userId),
-    getOrCreateSettings(userId),
-    getAllExchangeRates(),
-  ]);
+  // Run all independent queries in parallel (translations + data). The net-worth
+  // summary that backs the heatmap depends on the base currency, so it chains off
+  // the settings read rather than blocking the whole batch.
+  const settingsP = getOrCreateSettings(userId);
+  const [t, messages, accounts, archivedAccounts, settings, allRatesMap, summary] =
+    await Promise.all([
+      getTranslations("accounts"),
+      getMessages(),
+      fetchUserAccountsWithHoldings(userId),
+      fetchUserArchivedAccountsWithHoldings(userId),
+      settingsP,
+      getAllExchangeRates(),
+      settingsP.then((s) => getCachedNetWorthSummary(userId, s.baseCurrency)),
+    ]);
 
   const baseCurrency = settings.baseCurrency;
+  const hasAssetAccounts = summary.accounts.some(
+    (account) => account.type === "ASSET" && account.totalValueInBaseCurrency > 0,
+  );
 
   // Fetch cached prices for this user's holding symbols only
   const allSymbols = [...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol)))];
@@ -87,6 +98,7 @@ async function AccountsContent() {
           priceMap={priceMap}
           ratesMap={ratesMap}
           baseCurrency={baseCurrency}
+          overview={hasAssetAccounts ? <PortfolioHeatmap summary={summary} fillHeight /> : null}
         />
       </div>
     </NextIntlClientProvider>

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -15,19 +15,14 @@ async function AnalysisContent() {
   const userId = session.user.id;
 
   const settingsP = getOrCreateSettings(userId);
-  const [
-    t,
-    messages,
-    locale,
-    { snapshots, cashFlowData, rawHistory, accountCashFlow, summary },
-    settings,
-  ] = await Promise.all([
-    getTranslations("analysis"),
-    getMessages(),
-    getLocale(),
-    settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency)),
-    settingsP,
-  ]);
+  const [t, messages, locale, { snapshots, cashFlowData, rawHistory, accountCashFlow }, settings] =
+    await Promise.all([
+      getTranslations("analysis"),
+      getMessages(),
+      getLocale(),
+      settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency)),
+      settingsP,
+    ]);
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
@@ -39,7 +34,6 @@ async function AnalysisContent() {
           cashFlowData={cashFlowData}
           rawHistory={rawHistory}
           accountCashFlow={accountCashFlow}
-          summary={summary}
           baseCurrency={settings.baseCurrency}
           locale={locale}
         />

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -264,8 +264,8 @@ export function AccountDetail({
     <>
       {/* Mobile Back Nav */}
       <div className="flex items-center gap-1.5 mb-4 md:hidden">
-        <Link 
-          href="/accounts" 
+        <Link
+          href="/accounts"
           className="inline-flex items-center gap-0.5 text-sm font-medium text-primary hover:text-primary/80 active:text-primary/60 transition-colors -ml-1"
           transitionTypes={["nav-back"]}
         >
@@ -329,7 +329,8 @@ export function AccountDetail({
               {t(`common.${account.type.toLowerCase()}`, { defaultValue: account.type })}
             </Badge>
             <span className="text-sm text-muted-foreground">
-              {t(`categories.${account.category}`, { defaultValue: account.category })} · {account.currency}
+              {t(`categories.${account.category}`, { defaultValue: account.category })} ·{" "}
+              {account.currency}
             </span>
           </div>
         </div>
@@ -366,12 +367,17 @@ export function AccountDetail({
                   </span>
                 )}
               </h3>
-              <Button size="sm" variant="ghost" className="h-8 text-primary px-2" onClick={() => setShowHoldingForm(true)}>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 text-primary px-2"
+                onClick={() => setShowHoldingForm(true)}
+              >
                 <Plus className="h-4 w-4 mr-1.5" />
                 {t("accountDetail.addHolding")}
               </Button>
             </div>
-            
+
             {holdingsWithValue.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-12 px-4 text-center rounded-2xl border border-dashed border-border/60 bg-muted/10">
                 <div className="bg-primary/10 p-3 rounded-full mb-3">
@@ -389,77 +395,77 @@ export function AccountDetail({
               <>
                 {holdingsWithValue.length > 1 && (
                   <div className="sticky top-14 z-10 bg-background/90 backdrop-blur-sm border-b border-border/40 mb-2 py-2 flex items-center gap-1.5 flex-wrap">
-                      <span className="text-xs text-muted-foreground shrink-0">Sort:</span>
-                      {(
-                        [
-                          {
-                            field: "marketValue" as HoldingSortField,
-                            label: t("accountDetail.colValue"),
-                          },
-                          {
-                            field: "symbol" as HoldingSortField,
-                            label: t("accountDetail.colSymbol"),
-                          },
-                          {
-                            field: "percentage" as HoldingSortField,
-                            label: t("accountDetail.colPercentage"),
-                          },
-                          {
-                            field: "quantity" as HoldingSortField,
-                            label: t("accountDetail.colQty"),
-                          },
-                        ] as { field: HoldingSortField; label: string }[]
-                      ).map(({ field, label }) => (
-                        <button
-                          key={field}
-                          onClick={() => handleSort(field)}
-                          className={`text-xs px-3 py-2 sm:px-2.5 sm:py-1 rounded-full border transition-colors ${
-                            sortField === field
-                              ? "border-primary/40 bg-primary/10 text-primary font-medium"
-                              : "border-border/50 text-muted-foreground hover:text-foreground hover:border-border hover:bg-muted/40"
-                          }`}
-                        >
-                          {label}
-                          {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
-                    <AnimatePresence initial={false}>
-                      {visibleMobileHoldings.map((h, index) => (
-                        <motion.div
-                          key={h.id}
-                          layout={shouldReduceMotion ? false : "position"}
-                          initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
-                          transition={shouldReduceMotion ? { duration: 0 } : springConfig}
-                        >
-                          {index > 0 && <div className="h-px bg-border/60 mx-4" />}
-                          <HoldingRow
-                            holding={h}
-                            totalValue={totalHoldingsValue}
-                            accountCurrency={account.currency}
-                            onEdit={setEditingHolding}
-                            onDelete={deleteHolding}
-                          />
-                        </motion.div>
-                      ))}
-                    </AnimatePresence>
+                    <span className="text-xs text-muted-foreground shrink-0">Sort:</span>
+                    {(
+                      [
+                        {
+                          field: "marketValue" as HoldingSortField,
+                          label: t("accountDetail.colValue"),
+                        },
+                        {
+                          field: "symbol" as HoldingSortField,
+                          label: t("accountDetail.colSymbol"),
+                        },
+                        {
+                          field: "percentage" as HoldingSortField,
+                          label: t("accountDetail.colPercentage"),
+                        },
+                        {
+                          field: "quantity" as HoldingSortField,
+                          label: t("accountDetail.colQty"),
+                        },
+                      ] as { field: HoldingSortField; label: string }[]
+                    ).map(({ field, label }) => (
+                      <button
+                        key={field}
+                        onClick={() => handleSort(field)}
+                        className={`text-xs px-3 py-2 sm:px-2.5 sm:py-1 rounded-full border transition-colors ${
+                          sortField === field
+                            ? "border-primary/40 bg-primary/10 text-primary font-medium"
+                            : "border-border/50 text-muted-foreground hover:text-foreground hover:border-border hover:bg-muted/40"
+                        }`}
+                      >
+                        {label}
+                        {sortField === field ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                    ))}
                   </div>
-                  {!showAllMobileHoldings && filteredSortedHoldings.length > 20 && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setShowAllMobileHoldings(true)}
-                      className="w-full mt-2"
-                    >
-                      {t("accountDetail.showMore", { count: filteredSortedHoldings.length - 20 })}
-                    </Button>
-                  )}
-                </>
-              )}
+                )}
+                <div className="rounded-2xl overflow-hidden border border-border/40 bg-card">
+                  <AnimatePresence initial={false}>
+                    {visibleMobileHoldings.map((h, index) => (
+                      <motion.div
+                        key={h.id}
+                        layout={shouldReduceMotion ? false : "position"}
+                        initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+                        transition={shouldReduceMotion ? { duration: 0 } : springConfig}
+                      >
+                        {index > 0 && <div className="h-px bg-border/60 mx-4" />}
+                        <HoldingRow
+                          holding={h}
+                          totalValue={totalHoldingsValue}
+                          accountCurrency={account.currency}
+                          onEdit={setEditingHolding}
+                          onDelete={deleteHolding}
+                        />
+                      </motion.div>
+                    ))}
+                  </AnimatePresence>
+                </div>
+                {!showAllMobileHoldings && filteredSortedHoldings.length > 20 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowAllMobileHoldings(true)}
+                    className="w-full mt-2"
+                  >
+                    {t("accountDetail.showMore", { count: filteredSortedHoldings.length - 20 })}
+                  </Button>
+                )}
+              </>
+            )}
           </div>
 
           {/* Desktop: data table */}

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -57,6 +57,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { formatCurrency } from "@/lib/currencies";
+import { buildAssetAccountColorMap } from "@/lib/account-colors";
 import { springConfig } from "@/lib/motion";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
@@ -203,12 +204,16 @@ export function AccountsList({
   priceMap,
   ratesMap = {},
   baseCurrency = "USD",
+  overview,
 }: {
   accounts: SerializedAccountWithHoldings[];
   archivedAccounts: SerializedAccountWithHoldings[];
   priceMap: Record<string, number>;
   ratesMap?: Record<string, number>;
   baseCurrency?: string;
+  /** Optional overview block (e.g. the portfolio heatmap) rendered below the
+   *  account list as an allocation synthesis. Hidden during manage-order mode. */
+  overview?: React.ReactNode;
 }) {
   const router = useRouter();
   const t = useTranslations();
@@ -264,6 +269,16 @@ export function AccountsList({
   const totalLiabilities = useMemo(
     () => liabilities.reduce((sum, account) => sum + (accountBaseValues[account.id] ?? 0), 0),
     [liabilities, accountBaseValues],
+  );
+
+  // Same per-account hue the heatmap uses, so each asset row's allocation bar
+  // reads as the 1D analog of its tile.
+  const assetColorMap = useMemo(
+    () =>
+      buildAssetAccountColorMap(
+        assets.map((account) => ({ id: account.id, value: accountBaseValues[account.id] ?? 0 })),
+      ),
+    [assets, accountBaseValues],
   );
 
   const assetsByCategory = useMemo(() => {
@@ -470,15 +485,18 @@ export function AccountsList({
               {t("accountsList.totalNetWorth", { defaultValue: "Total Net Worth" })}
             </h3>
             <div className="flex items-baseline gap-2">
-              <span className="text-3xl md:text-4xl font-bold tabular-nums tracking-tight text-foreground" aria-live="polite">
+              <span
+                className="text-3xl md:text-4xl font-bold tabular-nums tracking-tight text-foreground"
+                aria-live="polite"
+              >
                 {privacyMode ? HIDDEN : formatCurrency(netWorth, baseCurrency)}
               </span>
-              <span className="text-sm font-mono text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded">
+              <span className="text-sm font-mono text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded-sm">
                 {baseCurrency}
               </span>
             </div>
           </div>
-          
+
           <div className="flex items-center gap-2">
             {manageMode ? (
               <>
@@ -488,16 +506,27 @@ export function AccountsList({
                 </Button>
                 <Button onClick={saveManageOrder} disabled={savingOrder}>
                   <Save className="h-4 w-4 mr-1.5" />
-                  {savingOrder ? t("common.saving", { defaultValue: "Saving..." }) : t("common.save")}
+                  {savingOrder
+                    ? t("common.saving", { defaultValue: "Saving..." })
+                    : t("common.save")}
                 </Button>
               </>
             ) : (
               <>
-                <Button variant="outline" className="hidden md:inline-flex" onClick={() => setShowQuickAdd(true)}>
+                <Button
+                  variant="outline"
+                  className="hidden md:inline-flex"
+                  onClick={() => setShowQuickAdd(true)}
+                >
                   <Plus className="h-4 w-4 mr-1.5" />
                   {t("accountsList.addItem", { defaultValue: "Add Item" })}
                 </Button>
-                <Button variant="outline" className="hidden md:inline-flex" onClick={enterManageMode} disabled={accounts.length === 0}>
+                <Button
+                  variant="outline"
+                  className="hidden md:inline-flex"
+                  onClick={enterManageMode}
+                  disabled={accounts.length === 0}
+                >
                   <ArrowUpDown className="h-4 w-4 mr-1.5" />
                   {t("accountsList.manageOrder")}
                 </Button>
@@ -530,7 +559,10 @@ export function AccountsList({
                 {t("accountsList.noAccountsTitle", { defaultValue: "No accounts yet" })}
               </h3>
               <p className="text-sm text-muted-foreground mb-6 max-w-sm">
-                {t("accountsList.noAccountsDesc", { defaultValue: "Add your first account to start tracking your net worth and balances." })}
+                {t("accountsList.noAccountsDesc", {
+                  defaultValue:
+                    "Add your first account to start tracking your net worth and balances.",
+                })}
               </p>
               <Button onClick={() => setShowForm(true)}>
                 <Plus className="h-4 w-4 mr-1.5" />
@@ -594,6 +626,7 @@ export function AccountsList({
                           isDeleting={deletingId === account.id}
                           isUpdating={updatingId === account.id}
                           allocationDenominator={totalAssets}
+                          barColor={assetColorMap[account.id]}
                         />
                       ))}
                     </>
@@ -645,11 +678,20 @@ export function AccountsList({
                 {/* Mobile quick actions */}
                 {!manageMode && (
                   <div className="flex md:hidden gap-2">
-                    <Button variant="outline" className="flex-1" onClick={() => setShowQuickAdd(true)}>
+                    <Button
+                      variant="outline"
+                      className="flex-1"
+                      onClick={() => setShowQuickAdd(true)}
+                    >
                       <Plus className="h-4 w-4 mr-1.5" />
                       {t("accountsList.addItem", { defaultValue: "Add Item" })}
                     </Button>
-                    <Button variant="outline" className="flex-1" onClick={enterManageMode} disabled={accounts.length === 0}>
+                    <Button
+                      variant="outline"
+                      className="flex-1"
+                      onClick={enterManageMode}
+                      disabled={accounts.length === 0}
+                    >
                       <ArrowUpDown className="h-4 w-4 mr-1.5" />
                       {t("accountsList.manageOrder")}
                     </Button>
@@ -657,13 +699,20 @@ export function AccountsList({
                 )}
                 {manageMode && (
                   <div className="flex md:hidden gap-2">
-                    <Button variant="outline" className="flex-1" onClick={cancelManageMode} disabled={savingOrder}>
+                    <Button
+                      variant="outline"
+                      className="flex-1"
+                      onClick={cancelManageMode}
+                      disabled={savingOrder}
+                    >
                       <X className="h-4 w-4 mr-1.5" />
                       {t("common.cancel")}
                     </Button>
                     <Button className="flex-1" onClick={saveManageOrder} disabled={savingOrder}>
                       <Save className="h-4 w-4 mr-1.5" />
-                      {savingOrder ? t("common.saving", { defaultValue: "Saving..." }) : t("common.save")}
+                      {savingOrder
+                        ? t("common.saving", { defaultValue: "Saving..." })
+                        : t("common.save")}
                     </Button>
                   </div>
                 )}
@@ -721,6 +770,8 @@ export function AccountsList({
               )}
             </div>
           </div>
+
+          {overview}
 
           {archivedAccounts.length > 0 && (
             <div className="rounded-xl border overflow-hidden">
@@ -1002,6 +1053,7 @@ function DesktopAccountRow({
   isDeleting,
   isUpdating,
   allocationDenominator,
+  barColor,
 }: {
   account: SerializedAccountWithHoldings;
   baseValue: number;
@@ -1015,6 +1067,8 @@ function DesktopAccountRow({
   isDeleting: boolean;
   isUpdating: boolean;
   allocationDenominator: number;
+  /** Per-account heatmap hue; tints the allocation bar to match the tile. */
+  barColor?: string;
 }) {
   const { privacyMode } = usePrivacyMode();
   const t = useTranslations();
@@ -1029,10 +1083,19 @@ function DesktopAccountRow({
   return (
     <tr className="group hover:bg-muted/40 cursor-pointer transition-colors" onClick={onNavigate}>
       <td className="px-4 py-3.5 font-medium max-w-[220px] xl:max-w-[280px]">
-        <span className="truncate block" title={account.name}>
-          {account.isPinned && <Pin className="inline h-3 w-3 mr-1 text-amber-600" />}
+        <Link
+          href={`/accounts/${account.id}`}
+          prefetch={false}
+          transitionTypes={["nav-forward"]}
+          onClick={(e) => e.stopPropagation()}
+          className="truncate block rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          title={account.name}
+        >
+          {account.isPinned && (
+            <Pin className="inline h-3 w-3 mr-1 text-amber-500 dark:text-amber-400" />
+          )}
           {account.name}
-        </span>
+        </Link>
       </td>
       <td className="px-4 py-3.5">
         <span
@@ -1072,10 +1135,17 @@ function DesktopAccountRow({
             {privacyMode ? "—" : pct !== null ? `${pct.toFixed(1)}%` : "—"}
           </span>
           {!privacyMode && pct !== null && (
-            <div className="w-14 h-1 bg-muted rounded-full overflow-hidden">
+            <div
+              className="w-14 h-1 bg-muted rounded-full overflow-hidden"
+              style={
+                barColor
+                  ? { backgroundColor: `color-mix(in oklch, ${barColor} 16%, var(--muted))` }
+                  : undefined
+              }
+            >
               <div
                 className="h-full bg-primary rounded-full"
-                style={{ width: `${Math.min(pct, 100)}%` }}
+                style={{ width: `${Math.min(pct, 100)}%`, backgroundColor: barColor }}
               />
             </div>
           )}
@@ -1084,7 +1154,7 @@ function DesktopAccountRow({
       <td className="px-2 py-3.5 w-10 text-center" onClick={(e) => e.stopPropagation()}>
         <DropdownMenu>
           <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 data-[state=open]:opacity-100 hover:bg-accent hover:text-accent-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
             disabled={isDeleting || isUpdating}
           >
             <MoreHorizontal className="h-4 w-4" />
@@ -1179,13 +1249,17 @@ function MobileAccountRow({
   return (
     <div className="relative group">
       <Link href={`/accounts/${account.id}`} prefetch={false} transitionTypes={["nav-forward"]}>
-        <div className={`flex items-center gap-3 ${isCompact ? "px-4 py-2.5" : "px-4 py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors`}>
+        <div
+          className={`flex items-center gap-3 ${isCompact ? "px-4 py-2.5" : "px-4 py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors`}
+        >
           <div className="flex items-center justify-center h-9 w-9 rounded-lg bg-muted/60 shrink-0">
             <CategoryIcon className="h-4 w-4 text-muted-foreground" />
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5">
-              {account.isPinned && <Pin className="h-3 w-3 text-amber-500 shrink-0" aria-hidden />}
+              {account.isPinned && (
+                <Pin className="h-3 w-3 text-amber-500 dark:text-amber-400 shrink-0" aria-hidden />
+              )}
               <p className="font-medium text-sm truncate">{account.name}</p>
             </div>
             <p className="text-xs text-muted-foreground mt-0.5">
@@ -1208,10 +1282,13 @@ function MobileAccountRow({
           <ChevronRight className="h-4 w-4 text-muted-foreground/50 shrink-0" />
         </div>
       </Link>
-      <div className="absolute top-1/2 -translate-y-1/2 right-10 z-10" onClick={(e) => e.preventDefault()}>
+      <div
+        className="absolute top-1/2 -translate-y-1/2 right-10 z-10"
+        onClick={(e) => e.preventDefault()}
+      >
         <DropdownMenu>
           <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 data-[state=open]:opacity-100 hover:bg-accent hover:text-accent-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
             disabled={isDeleting || isUpdating}
           >
             <MoreHorizontal className="h-4 w-4" />
@@ -1427,7 +1504,7 @@ function AccountCardWithHoldings({
                     aria-label={t("accountsList.pinned")}
                     className="h-4 gap-0 px-1"
                   >
-                    <Pin className="h-2.5 w-2.5 text-amber-600" aria-hidden />
+                    <Pin className="h-2.5 w-2.5 text-amber-500 dark:text-amber-400" aria-hidden />
                   </Badge>
                 )}
                 <CardTitle className="truncate">{account.name}</CardTitle>
@@ -1478,7 +1555,7 @@ function AccountCardWithHoldings({
       <div className="absolute top-2 right-2 z-10" onClick={(e) => e.preventDefault()}>
         <DropdownMenu>
           <DropdownMenuTrigger
-            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground transition-opacity"
+            className="inline-flex items-center justify-center rounded-md h-7 w-7 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 data-[state=open]:opacity-100 hover:bg-accent hover:text-accent-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
             disabled={isDeleting || isUpdating}
           >
             <MoreHorizontal className="h-4 w-4" />

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -34,16 +34,13 @@ import {
   LazyAttributionChart,
 } from "./lazy-analysis-charts";
 import { KpiTiles } from "./kpi-tiles";
-import { PortfolioHeatmap } from "./portfolio-heatmap";
 import { TopMoversList } from "./top-movers-list";
-import type { NetWorthSummary } from "@/lib/types";
 
 interface Props {
   snapshots: NormalizedSnapshot[];
   cashFlowData: MonthlyContribution[];
   rawHistory: RawHistoryData;
   accountCashFlow: AccountMonthlyContribution[];
-  summary: NetWorthSummary;
   baseCurrency: string;
   locale: string;
 }
@@ -71,7 +68,6 @@ export function AnalysisView({
   cashFlowData,
   rawHistory,
   accountCashFlow,
-  summary,
   baseCurrency,
   locale,
 }: Props) {
@@ -258,7 +254,6 @@ export function AnalysisView({
             className={isCompact ? "space-y-3" : "space-y-6"}
           >
             <KpiTiles kpis={kpis} baseCurrency={baseCurrency} locale={locale} />
-            <PortfolioHeatmap summary={summary} fillHeight />
             <Card size={isCompact ? "sm" : "default"}>
               <LazyMonthlyChangeChart
                 buckets={buckets}

--- a/src/components/analysis/portfolio-heatmap.tsx
+++ b/src/components/analysis/portfolio-heatmap.tsx
@@ -12,18 +12,11 @@ import { useContainerSize } from "@/hooks/use-container-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { formatCurrency } from "@/lib/currencies";
 import { cn } from "@/lib/utils";
+import { ACCOUNT_HEATMAP_COLORS as HEATMAP_COLORS } from "@/lib/account-colors";
 import type { NetWorthSummary } from "@/lib/types";
 
 const HIDDEN = "***";
 const CASH_ID = "cash";
-const HEATMAP_COLORS = [
-  "var(--primary)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-9)",
-  "var(--chart-8)",
-  "var(--chart-4)",
-];
 const ACCOUNT_TILE_TONE = 70;
 const CHILD_COLOR_MIX_TARGETS = [
   "var(--chart-8)",

--- a/src/lib/account-colors.ts
+++ b/src/lib/account-colors.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared account color palette for the portfolio heatmap and the accounts table.
+ *
+ * The heatmap encodes account identity by hue (and share by tile area); the
+ * accounts table reuses the same hue on each row's allocation bar so a row reads
+ * as the 1D analog of its tile. Both must rank accounts identically, hence one
+ * source of truth here. Colors are schema-aware design tokens (chart spectrum),
+ * not raw palette values, per DESIGN.md's chart-color boundary.
+ */
+export const ACCOUNT_HEATMAP_COLORS = [
+  "var(--primary)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-9)",
+  "var(--chart-8)",
+  "var(--chart-4)",
+] as const;
+
+/**
+ * Map asset account ids to a heatmap color. Mirrors the heatmap's assignment:
+ * keep positive-value accounts, rank by base-currency value descending, then
+ * index into the palette. Accounts with non-positive value are omitted (they
+ * have no heatmap tile either).
+ */
+export function buildAssetAccountColorMap(
+  accounts: { id: string; value: number }[],
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  [...accounts]
+    .filter((account) => account.value > 0)
+    .sort((a, b) => b.value - a.value)
+    .forEach((account, index) => {
+      map[account.id] = ACCOUNT_HEATMAP_COLORS[index % ACCOUNT_HEATMAP_COLORS.length];
+    });
+  return map;
+}

--- a/src/lib/services/analysis-payload-service.ts
+++ b/src/lib/services/analysis-payload-service.ts
@@ -6,14 +6,12 @@ import {
   getMonthlyCashFlow,
   getRawHistoryWithBreakdown,
 } from "@/lib/services/history-service";
-import { getCachedNetWorthSummary } from "@/lib/services/net-worth-service";
 
 export interface AnalysisPayload {
   snapshots: Awaited<ReturnType<typeof getFullNormalizedHistory>>;
   cashFlowData: Awaited<ReturnType<typeof getMonthlyCashFlow>>;
   rawHistory: Awaited<ReturnType<typeof getRawHistoryWithBreakdown>>;
   accountCashFlow: Awaited<ReturnType<typeof getAccountMonthlyCashFlow>>;
-  summary: Awaited<ReturnType<typeof getCachedNetWorthSummary>>;
 }
 
 export async function getCachedAnalysisPayload(
@@ -22,12 +20,11 @@ export async function getCachedAnalysisPayload(
 ): Promise<AnalysisPayload> {
   return unstable_cache(
     async () => {
-      const [snapshots, cashFlowData, rawHistory, accountCashFlow, summary] = await Promise.all([
+      const [snapshots, cashFlowData, rawHistory, accountCashFlow] = await Promise.all([
         getFullNormalizedHistory(userId, baseCurrency),
         getMonthlyCashFlow(userId, baseCurrency),
         getRawHistoryWithBreakdown(userId, baseCurrency),
         getAccountMonthlyCashFlow(userId, baseCurrency),
-        getCachedNetWorthSummary(userId, baseCurrency),
       ]);
 
       return {
@@ -35,7 +32,6 @@ export async function getCachedAnalysisPayload(
         cashFlowData,
         rawHistory,
         accountCashFlow,
-        summary,
       };
     },
     ["analysis-payload", userId, baseCurrency],


### PR DESCRIPTION
## Summary

Moves the **Account Heatmap** from the Analysis tab to the **Accounts tab**, then hardens and colorizes the surface around it. Built iteratively via `/impeccable` (layout → polish → critique → harden → colorize).

### Relocation
- Heatmap now renders on the Accounts tab **below the account list**, as an allocation synthesis, via a new optional `overview` slot on `AccountsList` (hidden in manage-order mode, suppressed when there are no asset accounts).
- Removed it from `AnalysisView`, and dropped the now-unused net-worth `summary` from the cached analysis payload so it isn't recomputed on every analysis load.
- Reading order on the tab: net-worth + actions → account list → heatmap → archived.

### Accessibility (harden)
- **Desktop rows are keyboard-operable**: the account name is now a real `next/link` (matching the mobile row), so the table is navigable without a mouse.
- **Row action menus reachable on touch + keyboard**: the `...` trigger was hover-only (`opacity-0 group-hover:opacity-100`); now also revealed via `pointer-coarse` (touch), `focus-visible` (keyboard, with a focus ring), and while its menu is open.

### Color (colorize)
- Each **asset row's allocation bar** is tinted with its **heatmap hue**, so a table row reads as the 1D analog of its 2D tile (share by length vs. area, same color identity).
- Palette + ranking extracted into one shared helper, `src/lib/account-colors.ts`, consumed by both the heatmap and the table so they can't drift. Uses schema-aware chart tokens, not raw palette values.

### Minor polish
- Unified the pinned-icon color across all row variants (was mixed amber-500/600, no dark variant).
- Fixed an off-scale radius token on the base-currency chip (`rounded` → `rounded-sm`).

### Not in scope (deferred from the critique)
- Redundant totals (net-worth hero + mobile assets/liabilities strip + heatmap "Total assets" badge).
- Category chips bypassing the color schema (a documented tension; recommended mapping them onto chart tokens later).
- Final `/impeccable polish` pass (44px touch targets on the now-visible triggers, etc.).

## Note for reviewers
`src/components/accounts/account-detail.tsx` is a **formatting-only** change: it had pre-existing Prettier drift on `master` and was reformatted so `format:check` (CI) stays green. No logic change there.

## Checks
- `format:check` clean, `lint` 0 errors (9 pre-existing unused-var warnings), `typecheck` clean.
- Verified locally against the running dev server (routes compile, 200). Touch/keyboard behavior verified by compile + reasoning, not a physical device (browser was read-tier this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)