### PR TITLE
fix(dashboard): align desktop loading skeleton with net-worth layout

### DIFF
--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -29,9 +29,11 @@ export function DashboardSkeleton() {
       {/* Net Worth Cards — full-bleed headline; mirror NetWorthCard internals
           (icon + label + value). No fixed height: content sizes the card like
           the real card so the text-shaped lines never overflow on mobile. */}
-      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
-        {/* Primary: Net Worth */}
-        <Card className="col-span-2 lg:col-span-1 rounded-2xl">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6">
+        {/* Primary: Net Worth — spans half the row on desktop, mirroring
+            NetWorthCard's col-span-2 in a 4-col grid so loading.tsx doesn't
+            snap from equal thirds to hero+two-narrow on reveal. */}
+        <Card className="col-span-2 rounded-2xl">
           <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
             <div className="flex items-center gap-2.5 mb-1.5">
               <Skeleton className="h-8 w-8 rounded-full shrink-0" />


### PR DESCRIPTION
## Summary

Fixes a desktop layout jump when navigating to the dashboard. The route-level loading skeleton disagreed with the real net-worth row, so `loading.tsx` flashed one layout and then snapped to another on reveal.

**Root cause:** two skeletons existed for the net-worth row and they used different desktop grids.

| | Net-worth grid on desktop (`lg`) |
|---|---|
| Real `NetWorthCard` | `grid-cols-4` → hero half-width (`col-span-2`) + Assets/Liabilities each a quarter |
| In-content fallback `NetWorthSkeleton` | matches the real card ✓ |
| Route skeleton `DashboardSkeleton` (`loading.tsx`) | `grid-cols-3` → three equal thirds ✗ |

So on a desktop monitor, `loading.tsx` rendered three equal cards, then the page snapped to a wide hero + two narrow cards.

## Change

`src/components/dashboard/dashboard-skeleton.tsx`: net-worth grid → `lg:grid-cols-4`, hero card → `col-span-2` (dropping the `lg:col-span-1` override). The route skeleton now matches the real card and the in-content fallback at every breakpoint. Mobile (`grid-cols-2`, full-width hero) is unchanged.

## Testing

- `npm run format:check` — passes
- `npm run lint` — no new errors (pre-existing warnings in unrelated files only)
- `npm run typecheck` — passes (ran via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)