### PR TITLE
feat(theme): add a --warning semantic color role

### DIFF
--- a/docs/WARNING_SEMANTIC_COLOR.md
+++ b/docs/WARNING_SEMANTIC_COLOR.md
@@ -1,0 +1,51 @@
+# `--warning` semantic color role
+
+## Context
+
+The color system is schema-governed but its semantic status vocabulary was incomplete: `globals.css` defined `--gain`, `--loss`, `--destructive`, `--primary`, and `--chart-1..9`, but no `--warning` / `--success` / `--info` — even though the product register (`PRODUCT.md` / `DESIGN.md`) explicitly calls for "a state-rich semantic vocabulary: …error, warning, success, info."
+
+The practical consequence was **no caution lane**: feedback was binary (22 `toast.error` / 18 `toast.success`, zero `toast.warning`), and genuine data-quality cautions rendered as invisible gray or a calm primary tint that didn't distinguish stale from fresh.
+
+This change adds **`--warning` only** (a calm amber caution role). `--success`/`--info` stay out of scope: `--primary` already reads as positive and there is no concrete `info` surface today.
+
+## Token design (`src/app/globals.css`)
+
+Wired exactly like `--destructive`:
+
+- `--warning` + `--warning-foreground` in `:root` and `.dark`, bound via `--color-warning` / `--color-warning-foreground` in `@theme inline` → generates `bg-warning`, `text-warning`, `border-warning`, and `/opacity` variants.
+- **Stable amber across schemas**, overridden only in the **Amber** schema (light + dark), where the primary is amber `~65` and a gold warning would blur into the brand color — shifted toward orange (`H50`). Same distinctness precedent as the `--loss` decoupling.
+
+Values are contrast-checked (`text-warning` must pass WCAG AA for small text):
+
+| Context              | OKLCH          | Contrast on its bg |
+| -------------------- | -------------- | ------------------ |
+| Light (default)      | `0.55 0.12 72` | 4.83:1             |
+| Light (Amber schema) | `0.55 0.15 50` | 4.99:1             |
+| Dark (default)       | `0.82 0.13 80` | 11.2:1             |
+| Dark (Amber schema)  | `0.80 0.15 50` | 10.3:1             |
+
+`--warning-foreground`: light `0.99 0.01 80`, dark `0.18 0.03 80` (ink on a solid warning fill).
+
+## Plumbing
+
+- **Badge** (`src/components/ui/badge.tsx`): a `warning` variant mirroring `gain`/`loss` (`bg-[color-mix(... --warning 18%)] text-[var(--warning)]`).
+- **Toast lane** (`globals.css`): sonner already configures a `warning` `TriangleAlertIcon`; added `[data-sonner-toast][data-type="warning"]` rules to tint the icon + border with `--warning`, so `toast.warning(...)` reads as caution.
+
+## Applied to (real caution surfaces)
+
+1. **Unpriced-holdings note** (`portfolio-heatmap.tsx`): "N holdings have no price" was `text-muted-foreground` gray → `text-warning` + a `TriangleAlert` icon.
+2. **Stale freshness badge** (`freshness-badge.tsx`): "prices/rates updated X ago" rendered with the same primary tint regardless of age. Now, when price/rates data is older than **72h** (clears normal weekend gaps; snapshots are point-in-time and never "stale"), the badge switches to the warning tone **and** a `TriangleAlert` icon (not color-alone, so it survives color-blindness).
+
+Deliberately left neutral: `noPriceData` / `noPriceUpdate` first-run "pending" states (Clock icon) — amber there would alarm new users.
+
+## Verification
+
+- Compiles through the real Tailwind v4 pipeline; all four `--warning` values + `text/bg/border-warning` utilities emitted; served live on the dev server.
+- `format:check` + `lint` + `typecheck` clean.
+- Manual: toggle each schema (esp. Amber) in light + dark; confirm warning ≠ primary and ≠ error/loss; check the heatmap unpriced note and an aged freshness badge.
+
+## Non-goals
+
+- No `--success` / `--info` tokens.
+- No bulk reclassification of existing `toast.error` calls.
+- No tokenizing of `CATEGORY_COLORS`.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,8 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -80,6 +82,11 @@
   --accent-foreground: oklch(0.2 0.02 260);
   --destructive: oklch(0.6 0.18 20);
   --destructive-foreground: oklch(0.98 0 0);
+  /* Caution / data-quality status: distinct from --destructive (error) and the
+     schema primary. Stable amber across schemas, overridden only where it would
+     collide with the primary (Amber schema). Tuned to >=4.5:1 as text on bg. */
+  --warning: oklch(0.55 0.12 72);
+  --warning-foreground: oklch(0.99 0.01 80);
   --border: oklch(0.9 0.02 260);
   --input: oklch(0.9 0.02 260);
   --ring: oklch(0.6 0.16 150);
@@ -128,6 +135,8 @@
   --accent-foreground: oklch(0.96 0.01 190);
   --destructive: oklch(0.7 0.19 20);
   --destructive-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.82 0.13 80);
+  --warning-foreground: oklch(0.18 0.03 80);
   --border: oklch(0.3 0.038 200);
   --input: oklch(0.22 0.038 200);
   --ring: oklch(0.8 0.17 170);
@@ -670,6 +679,8 @@ html[data-vt-theme]::view-transition-new(root) {
   --chart-3: oklch(0.6 0.15 90);
   --chart-4: oklch(0.62 0.14 110);
   --chart-5: oklch(0.72 0.1 150);
+  /* primary is amber ~65 here, so shift warning toward orange to stay distinct */
+  --warning: oklch(0.55 0.15 50);
   --app-icon-gradient-start: #fbbf24;
   --app-icon-gradient-end: #92400e;
 }
@@ -696,6 +707,7 @@ html[data-vt-theme]::view-transition-new(root) {
   --chart-3: oklch(0.8 0.15 90);
   --chart-4: oklch(0.82 0.14 110);
   --chart-5: oklch(0.86 0.12 150);
+  --warning: oklch(0.8 0.15 50);
 }
 [data-color-schema="amber"] body {
   background-image:
@@ -757,6 +769,15 @@ html[data-vt-theme]::view-transition-new(root) {
   background-image:
     radial-gradient(ellipse 80% 50% at 50% -10%, oklch(0.76 0.18 15 / 0.08), transparent),
     radial-gradient(ellipse 60% 40% at 100% 80%, oklch(0.8 0.14 330 / 0.05), transparent);
+}
+
+/* Warning toast lane — the warning icon is configured in sonner.tsx; tint it and
+   the border with --warning so toast.warning() reads as caution, not error. */
+[data-sonner-toast][data-type="warning"] [data-icon] {
+  color: var(--warning);
+}
+[data-sonner-toast][data-type="warning"] {
+  border-color: color-mix(in oklch, var(--warning) 40%, var(--border));
 }
 
 /* Sonner toast action button — theme-aware outline style */

--- a/src/components/analysis/portfolio-heatmap.tsx
+++ b/src/components/analysis/portfolio-heatmap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useMemo, useRef, useState, type CSSProperties } from "react";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, TriangleAlert } from "lucide-react";
 import { useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { Treemap, type TreemapNode } from "recharts";
@@ -590,7 +590,8 @@ export function PortfolioHeatmap({
             </div>
 
             {unpricedCount > 0 && !privacyMode && (
-              <p className="text-xs text-muted-foreground">
+              <p className="flex items-center gap-1.5 text-xs text-warning">
+                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
                 {t("heatmapUnpricedNote", { count: unpricedCount })}
               </p>
             )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -15,6 +15,7 @@ const badgeVariants = cva(
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         gain: "bg-[color-mix(in_oklch,var(--gain)_18%,transparent)] text-[var(--gain)]",
         loss: "bg-[color-mix(in_oklch,var(--loss)_18%,transparent)] text-[var(--loss)]",
+        warning: "bg-[color-mix(in_oklch,var(--warning)_18%,transparent)] text-[var(--warning)]",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/freshness-badge.tsx
+++ b/src/components/ui/freshness-badge.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { Camera, Clock, RefreshCw } from "lucide-react";
+import { Camera, Clock, RefreshCw, TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 
@@ -38,7 +38,17 @@ export function FreshnessBadge({
   if (!timestamp) return null;
 
   const age = formatRelativeTime(timestamp, locale, now);
-  const Icon = kind === "snapshot" ? Camera : kind === "rates" ? RefreshCw : Clock;
+  // Price/rates refresh daily; older than 3 days reads as a trust caution (the
+  // 72h window clears normal weekend gaps). Snapshots are point-in-time, never "stale".
+  const STALE_MS = 72 * 60 * 60 * 1000;
+  const isStale = kind !== "snapshot" && now - new Date(timestamp).getTime() > STALE_MS;
+  const Icon = isStale
+    ? TriangleAlert
+    : kind === "snapshot"
+      ? Camera
+      : kind === "rates"
+        ? RefreshCw
+        : Clock;
   const longKey =
     kind === "snapshot" ? "snapshot" : kind === "rates" ? "ratesUpdated" : "pricesUpdated";
   const shortKey =
@@ -48,8 +58,9 @@ export function FreshnessBadge({
         ? "ratesUpdatedMobile"
         : "pricesUpdatedMobile";
   const hint = kind === "snapshot" ? t("snapshotHint") : undefined;
-  const tone =
-    kind === "snapshot"
+  const tone = isStale
+    ? "border-warning/35 bg-warning/10 text-warning"
+    : kind === "snapshot"
       ? "border-border/70 bg-muted/30"
       : "border-primary/25 bg-primary/5 text-primary";
 


### PR DESCRIPTION
## Problem

The schema-governed color system defined `--gain` / `--loss` / `--destructive` / `--primary` / `--chart-1..9` but **no `--warning` / `--success` / `--info`** — despite the product register (`PRODUCT.md` / `DESIGN.md`) explicitly asking for "a state-rich semantic vocabulary: …error, warning, success, info."

The result was **no caution lane**: feedback was binary (22 `toast.error` + 18 `toast.success`, zero `toast.warning`), and genuine data-quality cautions rendered as invisible gray or a calm primary tint that didn't distinguish stale from fresh.

## Change — add `--warning` only

Scoped to one role done well. `--success`/`--info` stay out (primary already reads as positive; no concrete `info` surface today).

**Token** (`globals.css`), wired exactly like `--destructive`:
- `--warning` + `--warning-foreground` in `:root`/`.dark`, bound via `@theme inline` → `bg-warning` / `text-warning` / `border-warning` + opacity variants.
- Stable amber across schemas, with an **orange override in the Amber schema** (light + dark) where it would collide with the amber primary — same distinctness precedent as the `--loss` fix.
- Contrast-verified (`text-warning` passes WCAG AA for small text): default light `0.55 0.12 72` → 4.83:1; Amber light `0.55 0.15 50` → 4.99:1; dark variants 10–11:1.

**Plumbing:**
- `warning` badge variant (mirrors the existing `gain`/`loss` `color-mix` pattern).
- Sonner `[data-type="warning"]` styling — the warning `TriangleAlertIcon` was already configured, just uncolored; `toast.warning(...)` now reads as caution.

**Applied to real caution surfaces:**
1. **Heatmap unpriced note** ("N holdings have no price") — was `text-muted-foreground` gray → `text-warning` + alert icon.
2. **`FreshnessBadge`** — "prices/rates updated X ago" used the same primary tint at any age. Now data older than **72h** (clears weekend gaps; snapshots never "stale") switches to the warning tone **and** a `TriangleAlert` icon (not color-alone, survives color-blindness).

Deliberately left neutral: `noPriceData` / `noPriceUpdate` first-run "pending" states (amber there would alarm new users).

## Verification

- Real Tailwind v4 pipeline compiles; all four `--warning` values + `text/bg/border-warning` utilities emitted; served live on the dev server across all six schemas.
- `format:check` + `lint` + `typecheck` clean.
- Rationale + token table documented in `docs/WARNING_SEMANTIC_COLOR.md`.

## Notes
- Independent of #372 (gain/loss theme work) — separate branch off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)