### PR TITLE
Mobile UX critique fixes (Design Health 28 → 33)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -237,7 +237,9 @@
     "viewAll": "View all ({count})",
     "allCompleted": "All goals completed!",
     "due": "Due {date}",
-    "viewProjection": "View projections"
+    "viewProjection": "View projections",
+    "projectionTitle": "Projections",
+    "projectionHint": "Estimate when you'll reach financial independence."
   },
   "analysis": {
     "title": "Analysis",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -27,7 +27,7 @@
     "togglePrivacy": "Toggle privacy mode",
     "refreshPrices": "Refresh prices",
     "createNew": "New account or holding (Accounts page only)",
-    "addItem": "Add item / holding (Accounts page only)",
+    "addItem": "Add holding (Accounts page only)",
     "signOut": "Sign Out",
     "searchHint": "Search..."
   },
@@ -175,7 +175,8 @@
     "title": "Dashboard",
     "emptyTitle": "Welcome to Assets Tracker",
     "emptyDescription": "Start by adding your first account — a bank account, brokerage, crypto wallet, or anything else you want to track.",
-    "emptyAction": "Add your first account"
+    "emptyAction": "Add your first account",
+    "viewFullHistory": "View full history"
   },
   "accounts": {
     "title": "Accounts"
@@ -235,7 +236,8 @@
     "title": "Goals",
     "viewAll": "View all ({count})",
     "allCompleted": "All goals completed!",
-    "due": "Due {date}"
+    "due": "Due {date}",
+    "viewProjection": "View projections"
   },
   "analysis": {
     "title": "Analysis",
@@ -434,11 +436,11 @@
   },
   "freshness": {
     "pricesUpdated": "Prices updated {age}",
-    "pricesUpdatedMobile": "{age}",
+    "pricesUpdatedMobile": "Prices {age}",
     "ratesUpdated": "Rates updated {age}",
-    "ratesUpdatedMobile": "{age}",
+    "ratesUpdatedMobile": "Rates {age}",
     "snapshot": "Snapshot {age}",
-    "snapshotMobile": "{age}",
+    "snapshotMobile": "Snapshot {age}",
     "snapshotHint": "A new snapshot is captured automatically each day.",
     "noData": "No data yet",
     "refreshing": "Refreshing..."
@@ -473,7 +475,7 @@
     "total": "Total"
   },
   "accountsList": {
-    "addItem": "Add Item",
+    "addItem": "Add Holding",
     "addAccount": "Add Account",
     "manageOrder": "Manage Order",
     "manageOrderHint": "Drag accounts to reorder. Pinned accounts always stay above unpinned ones.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -27,7 +27,7 @@
     "togglePrivacy": "切換隱私模式",
     "refreshPrices": "更新價格",
     "createNew": "新增帳戶或持倉（僅限帳戶頁面）",
-    "addItem": "新增項目 / 持倉（僅限帳戶頁面）",
+    "addItem": "新增持倉（僅限帳戶頁面）",
     "signOut": "登出",
     "searchHint": "搜尋..."
   },
@@ -175,7 +175,8 @@
     "title": "儀表板",
     "emptyTitle": "歡迎使用資產追蹤器",
     "emptyDescription": "從新增第一個帳戶開始——銀行帳戶、券商、加密貨幣錢包，或任何您想追蹤的項目。",
-    "emptyAction": "新增第一個帳戶"
+    "emptyAction": "新增第一個帳戶",
+    "viewFullHistory": "查看完整歷史"
   },
   "accounts": {
     "title": "帳戶"
@@ -235,7 +236,8 @@
     "title": "目標",
     "viewAll": "查看全部（{count}）",
     "allCompleted": "所有目標已達成！",
-    "due": "到期：{date}"
+    "due": "到期：{date}",
+    "viewProjection": "查看財務預測"
   },
   "analysis": {
     "title": "分析",
@@ -434,11 +436,11 @@
   },
   "freshness": {
     "pricesUpdated": "價格更新於 {age}",
-    "pricesUpdatedMobile": "{age}",
+    "pricesUpdatedMobile": "價格 {age}",
     "ratesUpdated": "匯率更新於 {age}",
-    "ratesUpdatedMobile": "{age}",
+    "ratesUpdatedMobile": "匯率 {age}",
     "snapshot": "快照於 {age}",
-    "snapshotMobile": "{age}",
+    "snapshotMobile": "快照 {age}",
     "snapshotHint": "系統每天會自動建立一次快照。",
     "noData": "尚無資料",
     "refreshing": "更新中..."
@@ -473,7 +475,7 @@
     "total": "小計"
   },
   "accountsList": {
-    "addItem": "新增項目",
+    "addItem": "新增持倉",
     "addAccount": "新增帳戶",
     "manageOrder": "管理排序",
     "manageOrderHint": "拖曳帳戶即可重新排序。已釘選帳戶會固定在未釘選帳戶上方。",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -237,7 +237,9 @@
     "viewAll": "查看全部（{count}）",
     "allCompleted": "所有目標已達成！",
     "due": "到期：{date}",
-    "viewProjection": "查看財務預測"
+    "viewProjection": "查看財務預測",
+    "projectionTitle": "財務預測",
+    "projectionHint": "估算您何時能達到財務獨立。"
   },
   "analysis": {
     "title": "分析",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -248,6 +248,10 @@
   .ios-tab-pop {
     animation: ios-tab-pop 320ms var(--ease-spring) both;
   }
+
+  .float-soft {
+    animation: float-soft 3.2s ease-in-out infinite;
+  }
 }
 
 .hero-mesh-neutral,
@@ -354,6 +358,19 @@
   }
 }
 
+/* Empty-state illustration drift: a gentle, symmetric float (transform-only, no
+   bounce or overshoot) that keeps a first-run screen feeling alive without
+   pulling focus. ease-in-out so it settles softly at both extremes. */
+@keyframes float-soft {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
 /* ─── Skeleton loading shimmer ───────────────────────────────────────────────
    A highlight band sweeps across placeholders so the loading state is obvious
    rather than reading as a static gray block. Applied via [data-slot="skeleton"]
@@ -431,6 +448,9 @@
     animation: none;
   }
   .ios-tab-pop {
+    animation: none;
+  }
+  .float-soft {
     animation: none;
   }
   .history-cell-in,

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -460,7 +460,7 @@ export function AccountsList({
                   onClick={() => setShowQuickAdd(true)}
                 >
                   <Plus className="h-4 w-4 mr-1.5" />
-                  {t("accountsList.addItem", { defaultValue: "Add Item" })}
+                  {t("accountsList.addItem", { defaultValue: "Add Holding" })}
                 </Button>
                 <Button
                   variant="outline"
@@ -625,7 +625,7 @@ export function AccountsList({
                       onClick={() => setShowQuickAdd(true)}
                     >
                       <Plus className="h-4 w-4 mr-1.5" />
-                      {t("accountsList.addItem", { defaultValue: "Add Item" })}
+                      {t("accountsList.addItem", { defaultValue: "Add Holding" })}
                     </Button>
                     <Button
                       variant="outline"

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useMemo, useRef, useState, useEffect, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 import { motion, useReducedMotion } from "framer-motion";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
@@ -214,7 +214,28 @@ export function AnalysisView({
   const hasData = snapshots.length > 0;
   const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
 
-  const [activeTab, setActiveTab] = useState<"analysis" | "history">("analysis");
+  // Deep link: the dashboard's "View full history" link points at /analysis#history
+  // so the History sub-view opens directly. useSyncExternalStore reads the hash with
+  // a server snapshot of "" so SSR and hydration agree (no mismatch), then the client
+  // settles on the real hash. A manual tab switch sets `override`, which wins and
+  // rewrites the hash so the URL stays shareable and Back is predictable.
+  const hash = useSyncExternalStore(
+    (onChange) => {
+      window.addEventListener("hashchange", onChange);
+      return () => window.removeEventListener("hashchange", onChange);
+    },
+    () => window.location.hash,
+    () => "",
+  );
+  const [override, setOverride] = useState<"analysis" | "history" | null>(null);
+  const activeTab: "analysis" | "history" =
+    override ?? (hash === "#history" ? "history" : "analysis");
+
+  const handleTabChange = (tab: "analysis" | "history") => {
+    setOverride(tab);
+    const base = window.location.pathname + window.location.search;
+    window.history.replaceState(null, "", tab === "history" ? `${base}#history` : base);
+  };
 
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [isStuck, setIsStuck] = useState(false);
@@ -235,7 +256,7 @@ export function AnalysisView({
         variant="underline"
         options={tabOptions}
         value={activeTab}
-        onValueChange={setActiveTab}
+        onValueChange={handleTabChange}
         className="md:hidden"
         aria-label={tNav("analysis")}
       />

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -16,15 +16,116 @@ interface Props {
   locale: string;
 }
 
+type Tone = "positive" | "negative" | "neutral";
+
+function toneFor(n: number): Tone {
+  if (n > 0) return "positive";
+  if (n < 0) return "negative";
+  return "neutral";
+}
+
 // Settles the figure to its value the way the dashboard hero does, so the strip
 // reads as "freshly computed" on load and on each range change. Width is stable
 // (tabular-nums) and the hook returns the final value under reduced motion.
-function CountUpMoney({ amount, currency }: { amount: number; currency: string }) {
+function CountUpMoney({
+  amount,
+  currency,
+  compact = false,
+}: {
+  amount: number;
+  currency: string;
+  compact?: boolean;
+}) {
   const value = useCountUp(amount, 700);
   const sign = amount > 0 ? "+" : "";
-  return <>{`${sign}${formatCurrency(value, currency)}`}</>;
+  return <>{`${sign}${formatCurrency(value, currency, compact)}`}</>;
 }
 
+// Direction is carried by a caret (icon, not color alone) per the gain/loss rule.
+// Positives stay ink so the strip never reads as one saturated block; only a real
+// loss recolors the number.
+function DirectionCaret({ tone, className }: { tone: Tone; className?: string }) {
+  if (tone === "positive")
+    return (
+      <ArrowUpRight className={`text-[var(--gain)] shrink-0 ${className ?? ""}`} aria-hidden />
+    );
+  if (tone === "negative")
+    return (
+      <ArrowDownRight className={`text-[var(--loss)] shrink-0 ${className ?? ""}`} aria-hidden />
+    );
+  return null;
+}
+
+/**
+ * Lead metric. Full-width band that anchors the strip: the value reads large on
+ * the left, its rate sits as a pill on the right. This is the focal point the
+ * four equal tiles used to lack.
+ */
+function HeroTile({
+  title,
+  amount,
+  pct,
+  currency,
+  privacyMode,
+  isCompact,
+}: {
+  title: string;
+  amount: number | null;
+  pct: string | null;
+  currency: string;
+  privacyMode: boolean;
+  isCompact: boolean;
+}) {
+  const tone: Tone = privacyMode || amount === null ? "neutral" : toneFor(amount);
+  const pillClass =
+    tone === "negative"
+      ? "bg-[var(--loss)]/10 text-[var(--loss)]"
+      : tone === "positive"
+        ? "bg-[var(--gain)]/10 text-[var(--gain)]"
+        : "bg-muted text-muted-foreground";
+
+  return (
+    <Card className="min-w-0">
+      <CardContent
+        className={`flex items-center justify-between gap-3 ${isCompact ? "py-3" : "py-4"}`}
+      >
+        <div className="min-w-0 space-y-1">
+          <div className="text-xs font-medium text-muted-foreground">{title}</div>
+          <div className="overflow-x-auto scrollbar-none">
+            <div
+              className={`flex items-center gap-1.5 font-semibold tracking-tight tabular-nums whitespace-nowrap ${
+                isCompact ? "text-2xl" : "text-2xl sm:text-3xl"
+              } ${tone === "negative" ? "text-[var(--loss)]" : "text-foreground"}`}
+            >
+              <DirectionCaret tone={tone} className={isCompact ? "size-5" : "size-6"} />
+              <span>
+                {privacyMode ? (
+                  "***"
+                ) : amount === null ? (
+                  "—"
+                ) : (
+                  <CountUpMoney amount={amount} currency={currency} />
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+        {!privacyMode && pct && (
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold tabular-nums ${pillClass}`}
+          >
+            {pct}
+          </span>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Supporting metric. Smaller than the hero; three of these read as a peer cluster
+ * (the monthly-change distribution) beneath the year headline.
+ */
 function Tile({
   title,
   amount,
@@ -39,52 +140,37 @@ function Tile({
   currency: string;
   privacyMode: boolean;
   subtitle?: string;
-  tone?: "positive" | "negative" | "neutral";
+  tone: Tone;
   isCompact: boolean;
 }) {
-  // Data-first restraint: positives stay ink so the strip never reads as one
-  // saturated block; only a real loss recolors the number. Direction is carried
-  // by a caret (icon, not color alone) per the gain/loss design rule.
-  const valueClass = tone === "negative" ? "text-[var(--loss)]" : "text-foreground";
-  const DirIcon = tone === "positive" ? ArrowUpRight : tone === "negative" ? ArrowDownRight : null;
-  const iconClass = tone === "positive" ? "text-[var(--gain)]" : "text-[var(--loss)]";
   return (
-    <Card size={isCompact ? "sm" : "default"} className="min-w-0">
-      <CardContent className={isCompact ? "space-y-1 min-w-0" : "space-y-1.5 min-w-0"}>
-        <div className="text-xs text-muted-foreground font-medium truncate">{title}</div>
+    <Card size="sm" className="min-w-0">
+      <CardContent className={isCompact ? "space-y-0.5 min-w-0" : "space-y-1 min-w-0"}>
+        <div className="truncate text-xs font-medium text-muted-foreground">{title}</div>
         <div className="overflow-x-auto scrollbar-none">
           <div
-            className={`flex items-center gap-1 ${isCompact ? "text-lg sm:text-xl" : "text-xl sm:text-2xl"} font-semibold tracking-tight tabular-nums whitespace-nowrap ${valueClass}`}
+            className={`flex items-center gap-1 font-semibold tracking-tight tabular-nums whitespace-nowrap ${
+              isCompact ? "text-sm" : "text-base sm:text-lg"
+            } ${tone === "negative" ? "text-[var(--loss)]" : "text-foreground"}`}
           >
-            {DirIcon && (
-              <DirIcon
-                className={`${iconClass} ${isCompact ? "size-4" : "size-5"} shrink-0`}
-                aria-hidden
-              />
-            )}
+            <DirectionCaret tone={tone} className="size-4" />
             <span>
               {privacyMode ? (
                 "***"
               ) : amount === null ? (
                 "—"
               ) : (
-                <CountUpMoney amount={amount} currency={currency} />
+                <CountUpMoney amount={amount} currency={currency} compact />
               )}
             </span>
           </div>
         </div>
         {subtitle && (
-          <div className="text-xs text-muted-foreground tabular-nums truncate">{subtitle}</div>
+          <div className="truncate text-xs tabular-nums text-muted-foreground">{subtitle}</div>
         )}
       </CardContent>
     </Card>
   );
-}
-
-function toneFor(n: number): "positive" | "negative" | "neutral" {
-  if (n > 0) return "positive";
-  if (n < 0) return "negative";
-  return "neutral";
 }
 
 export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
@@ -107,49 +193,56 @@ export function KpiTiles({ kpis, baseCurrency, locale }: Props) {
       ? t("smallestGain")
       : t("worstMonth");
 
-  const ytdSub = privacyMode
-    ? undefined
-    : kpis.ytdPct === null
-      ? undefined
+  const ytdPct =
+    privacyMode || kpis.ytdPct === null
+      ? null
       : `${kpis.ytdPct >= 0 ? "+" : ""}${kpis.ytdPct.toFixed(1)}%`;
 
   return (
-    <div className={`grid grid-cols-2 ${isCompact ? "gap-2" : "gap-3 sm:gap-4"} md:grid-cols-4`}>
-      <Tile
-        title={bestTitle}
-        amount={kpis.best ? kpis.best.deltaNetWorth : null}
-        currency={baseCurrency}
-        privacyMode={privacyMode}
-        subtitle={bestSub}
-        tone={privacyMode ? "neutral" : kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"}
-        isCompact={isCompact}
-      />
-      <Tile
-        title={worstTitle}
-        amount={kpis.worst ? kpis.worst.deltaNetWorth : null}
-        currency={baseCurrency}
-        privacyMode={privacyMode}
-        subtitle={worstSub}
-        tone={privacyMode ? "neutral" : kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"}
-        isCompact={isCompact}
-      />
-      <Tile
-        title={t("avgMonthly")}
-        amount={kpis.avgMonthlyDelta}
-        currency={baseCurrency}
-        privacyMode={privacyMode}
-        tone={privacyMode ? "neutral" : toneFor(kpis.avgMonthlyDelta)}
-        isCompact={isCompact}
-      />
-      <Tile
+    <div className={isCompact ? "space-y-2" : "space-y-3 sm:space-y-4"}>
+      {/* Lead: the year headline. Fixed to YTD regardless of the range selector,
+          so it stays the stable answer to "how's the year going". */}
+      <HeroTile
         title={t("ytdGrowth")}
         amount={kpis.ytdDelta}
+        pct={ytdPct}
         currency={baseCurrency}
         privacyMode={privacyMode}
-        subtitle={ytdSub}
-        tone={privacyMode ? "neutral" : toneFor(kpis.ytdDelta)}
         isCompact={isCompact}
       />
+
+      {/* Supporting cluster: the monthly-change distribution over the selected
+          range (the range chips drive these three, not the YTD lead). */}
+      <div className={`grid grid-cols-3 ${isCompact ? "gap-2" : "gap-2 sm:gap-3"}`}>
+        <Tile
+          title={t("avgMonthly")}
+          amount={kpis.avgMonthlyDelta}
+          currency={baseCurrency}
+          privacyMode={privacyMode}
+          tone={privacyMode ? "neutral" : toneFor(kpis.avgMonthlyDelta)}
+          isCompact={isCompact}
+        />
+        <Tile
+          title={bestTitle}
+          amount={kpis.best ? kpis.best.deltaNetWorth : null}
+          currency={baseCurrency}
+          privacyMode={privacyMode}
+          subtitle={bestSub}
+          tone={privacyMode ? "neutral" : kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"}
+          isCompact={isCompact}
+        />
+        <Tile
+          title={worstTitle}
+          amount={kpis.worst ? kpis.worst.deltaNetWorth : null}
+          currency={baseCurrency}
+          privacyMode={privacyMode}
+          subtitle={worstSub}
+          tone={
+            privacyMode ? "neutral" : kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"
+          }
+          isCompact={isCompact}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -18,6 +18,7 @@ import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card";
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import Link from "next/link";
+import { ArrowRight, History } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -307,7 +308,7 @@ export async function DashboardContent({ userId }: { userId: string }) {
       <div className="flex flex-col items-center justify-center py-12 md:py-24 gap-4 md:gap-6 text-center animate-in fade-in zoom-in-95 motion-normal">
         <div className="rounded-full bg-primary/10 p-8 shadow-sm">
           <svg
-            className="h-12 w-12 text-primary animate-bounce-slow"
+            className="h-12 w-12 text-primary float-soft"
             fill="none"
             viewBox="0 0 24 24"
             strokeWidth={1.5}
@@ -335,6 +336,8 @@ export async function DashboardContent({ userId }: { userId: string }) {
     );
   }
 
+  const t = await getTranslations("dashboard");
+
   return (
     <>
       {/* Actions stream first — lightweight metadata, no summary needed */}
@@ -354,7 +357,24 @@ export async function DashboardContent({ userId }: { userId: string }) {
             <TrendChartSection
               baseCurrency={baseCurrency}
               snapshots={snapshots}
-              footer={<HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />}
+              footer={
+                <>
+                  <HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />
+                  {/* Mobile-only entry point — History is a sub-tab of /analysis, so
+                      the tab bar gives it no scent. The trend chart is the preview;
+                      this names the destination. Desktop uses the sidebar route. */}
+                  <Link
+                    href="/analysis#history"
+                    className="md:hidden mt-3 flex items-center justify-between gap-2 rounded-sm border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <History className="h-3.5 w-3.5" aria-hidden="true" />
+                      {t("viewFullHistory")}
+                    </span>
+                    <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                  </Link>
+                </>
+              }
             />
           </Suspense>
         </div>

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -16,6 +16,7 @@ import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card";
+import { ProjectionEntryCard } from "@/components/dashboard/projection-entry-card";
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import Link from "next/link";
 import { ArrowRight, History } from "lucide-react";
@@ -220,7 +221,10 @@ async function GoalsMilestoneSection({
   baseCurrency: string;
 }) {
   const goalsWithProgress = await computeGoalsWithProgress(userId, baseCurrency);
-  if (goalsWithProgress.length === 0) return null;
+  // No goals: the planning rail would otherwise be empty and Projections (a
+  // sub-tab of /goals) would have no dashboard scent. Surface a projection entry
+  // instead so the feature stays discoverable for goal-less users.
+  if (goalsWithProgress.length === 0) return <ProjectionEntryCard />;
 
   // Prefer soonest deadline; fall back to highest progress
   const active = goalsWithProgress.filter((g) => !g.isCompleted);

--- a/src/components/dashboard/goals-milestone-card.tsx
+++ b/src/components/dashboard/goals-milestone-card.tsx
@@ -6,7 +6,7 @@ import { useReducedMotion } from "framer-motion";
 import { useLocale, useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/currencies";
-import { Target, ArrowRight, CheckCircle2 } from "lucide-react";
+import { Target, ArrowRight, CheckCircle2, TrendingUp } from "lucide-react";
 import type { GoalWithProgress } from "@/lib/types";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
@@ -108,6 +108,20 @@ export function GoalsMilestoneCard({
             )}
           </div>
         )}
+
+        {/* Mobile-only entry point — Projections is a sub-tab of /goals, so the
+            tab bar gives it no scent. Surface it here, where Goals already lives
+            on the dashboard. Desktop reaches Projections via the sidebar. */}
+        <Link
+          href="/goals#projections"
+          className="md:hidden mt-3 flex items-center justify-between gap-2 rounded-sm border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <span className="flex items-center gap-1.5">
+            <TrendingUp className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("viewProjection")}
+          </span>
+          <ArrowRight className="h-3 w-3" aria-hidden="true" />
+        </Link>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/projection-entry-card.tsx
+++ b/src/components/dashboard/projection-entry-card.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { TrendingUp, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * Dashboard rail fallback shown when the user has no goals. Projections is a
+ * sub-tab of /goals, so without this the planning rail is empty and the feature
+ * has no home-screen scent for goal-less users. A whole-card deep link into the
+ * Projections sub-tab fills that gap; the in-card link on GoalsMilestoneCard
+ * covers the has-goals case.
+ */
+export function ProjectionEntryCard() {
+  const t = useTranslations("goalsMilestone");
+  return (
+    <Link
+      href="/goals#projections"
+      className="group block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <Card className="transition-colors hover:bg-muted/30">
+        <CardContent className="space-y-1.5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="flex items-center gap-2">
+              <TrendingUp className="h-4 w-4 text-primary" aria-hidden="true" />
+              <span className="text-sm font-medium text-foreground">{t("projectionTitle")}</span>
+            </span>
+            <ArrowRight
+              className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 motion-reduce:transform-none"
+              aria-hidden="true"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">{t("projectionHint")}</p>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -27,7 +27,27 @@ export function GoalsView({
   const t = useTranslations("goals");
   const tNav = useTranslations("nav");
   const [createOpen, setCreateOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<"goals" | "projections">("goals");
+  // Deep link: the dashboard's "View projections" link points at /goals#projections
+  // so the Projections sub-view opens directly. useSyncExternalStore reads the hash
+  // with a server snapshot of "" so SSR and hydration agree; a manual switch sets
+  // `override`, which wins and rewrites the hash for shareable, Back-friendly URLs.
+  const hash = useSyncExternalStore(
+    (onChange) => {
+      window.addEventListener("hashchange", onChange);
+      return () => window.removeEventListener("hashchange", onChange);
+    },
+    () => window.location.hash,
+    () => "",
+  );
+  const [override, setOverride] = useState<"goals" | "projections" | null>(null);
+  const activeTab: "goals" | "projections" =
+    override ?? (hash === "#projections" ? "projections" : "goals");
+
+  const handleTabChange = (tab: "goals" | "projections") => {
+    setOverride(tab);
+    const base = window.location.pathname + window.location.search;
+    window.history.replaceState(null, "", tab === "projections" ? `${base}#projections` : base);
+  };
 
   return (
     <div className="space-y-4">
@@ -38,7 +58,7 @@ export function GoalsView({
             key={tab}
             role="tab"
             type="button"
-            onClick={() => setActiveTab(tab)}
+            onClick={() => handleTabChange(tab)}
             aria-selected={activeTab === tab}
             tabIndex={activeTab === tab ? 0 : -1}
             className={cn(

--- a/src/components/ui/freshness-badge.tsx
+++ b/src/components/ui/freshness-badge.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Camera, Clock, RefreshCw, TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { formatRelativeTime } from "@/lib/format-relative-time";
+import { formatRelativeTime, formatRelativeTimeShort } from "@/lib/format-relative-time";
 
 type FreshnessKind = "price" | "rates" | "snapshot";
 
@@ -38,6 +38,7 @@ export function FreshnessBadge({
   if (!timestamp) return null;
 
   const age = formatRelativeTime(timestamp, locale, now);
+  const shortAge = formatRelativeTimeShort(timestamp, locale, now);
   // Price/rates refresh daily; older than 3 days reads as a trust caution (the
   // 72h window clears normal weekend gaps). Snapshots are point-in-time, never "stale".
   const STALE_MS = 72 * 60 * 60 * 1000;
@@ -57,6 +58,10 @@ export function FreshnessBadge({
       : kind === "rates"
         ? "ratesUpdatedMobile"
         : "pricesUpdatedMobile";
+  // Full localized sentence ("Prices updated 3 days ago") — used as the accessible
+  // name so screen readers always get the subject, even when the visible chip is
+  // abbreviated to "Prices 3d" on mobile.
+  const fullLabel = t(longKey, { age });
   const hint = kind === "snapshot" ? t("snapshotHint") : undefined;
   const tone = isStale
     ? "border-warning/35 bg-warning/10 text-warning"
@@ -72,16 +77,17 @@ export function FreshnessBadge({
         className,
       )}
       title={hint}
+      aria-label={fullLabel}
       aria-live="polite"
     >
-      <Icon className="h-3 w-3 shrink-0" />
+      <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
       {mobileShort ? (
         <>
-          <span className="sm:hidden">{t(shortKey, { age })}</span>
-          <span className="hidden sm:inline">{t(longKey, { age })}</span>
+          <span className="sm:hidden">{t(shortKey, { age: shortAge })}</span>
+          <span className="hidden sm:inline">{fullLabel}</span>
         </>
       ) : (
-        <span>{t(longKey, { age })}</span>
+        <span>{fullLabel}</span>
       )}
     </span>
   );

--- a/src/lib/format-relative-time.ts
+++ b/src/lib/format-relative-time.ts
@@ -23,3 +23,47 @@ export function formatRelativeTime(
   if (absDiff < 31536000) return rtf.format(Math.round(diffInSeconds / 2592000), "month");
   return rtf.format(Math.round(diffInSeconds / 31536000), "year");
 }
+
+/**
+ * Compact age for space-constrained chips, e.g. "3d", "5h", "2mo" (en) or
+ * "3天前", "5小時前" (zh). Always pair this with a full-sentence accessible name
+ * (see FreshnessBadge): the abbreviation is for sighted scanning only.
+ */
+export function formatRelativeTimeShort(
+  date: Date | string,
+  locale: string,
+  now: number = Date.now(),
+): string {
+  let localDate: Date;
+  if (date instanceof Date) {
+    localDate = date;
+  } else {
+    localDate = date.includes("T") ? new Date(date) : new Date(`${date}T12:00:00`);
+  }
+
+  const absDiff = Math.abs(Math.round((localDate.getTime() - now) / 1000));
+  const isZh = locale.toLowerCase().startsWith("zh");
+
+  if (absDiff < 60) return isZh ? "剛剛" : "now";
+
+  let value: number;
+  let unit: string;
+  if (absDiff < 3600) {
+    value = Math.round(absDiff / 60);
+    unit = isZh ? "分鐘" : "m";
+  } else if (absDiff < 86400) {
+    value = Math.round(absDiff / 3600);
+    unit = isZh ? "小時" : "h";
+  } else if (absDiff < 2592000) {
+    value = Math.round(absDiff / 86400);
+    unit = isZh ? "天" : "d";
+  } else if (absDiff < 31536000) {
+    value = Math.round(absDiff / 2592000);
+    unit = isZh ? "個月" : "mo";
+  } else {
+    value = Math.round(absDiff / 31536000);
+    unit = isZh ? "年" : "y";
+  }
+
+  return isZh ? `${value}${unit}前` : `${value}${unit}`;
+}


### PR DESCRIPTION
Resolves the findings from an `/impeccable` mobile critique of the app surfaces (iPhone-width). Design Health score moved **28 → 33 / 40** across two re-runs; no P0/P1 remain.

## Changes

**Freshness badges — labeled + accessible** (`freshness-badge.tsx`, `format-relative-time.ts`, messages)
Mobile chips dropped their subject ("3 days ago" with icon-only meaning). They now read `Prices 4d` / `Snapshot 7d` with a full-sentence `aria-label`, so the subject survives for screen readers. Adds `formatRelativeTimeShort` (en + zh).

**Projections & History discoverability** (`dashboard-content.tsx`, `goals-milestone-card.tsx`, `analysis-view.tsx`, `goals-view.tsx`, messages)
On mobile these are folded under the Goals/Analysis tabs (the tab bar caps at 5). They had no home-screen scent. Added dashboard entry points that hash deep-link (`/analysis#history`, `/goals#projections`) into the sub-tab; the views read the hash via `useSyncExternalStore` and light the correct bottom-nav item.

**Projections entry for goal-less users** (`projection-entry-card.tsx`, `dashboard-content.tsx`, messages)
The "View projections" link lived inside the Goals card, which renders nothing without goals. A `ProjectionEntryCard` now fills the planning rail in that case.

**Analysis KPI hierarchy** (`kpi-tiles.tsx`)
Replaced the flat 2×2 identical-card grid with a YTD hero band over a compact Avg / Best / Worst supporting trio. Supporting tiles use compact currency to avoid mobile clipping.

**"Add Item" → "Add Holding"** (`accounts-list.tsx`, messages)
The trigger now matches its own dialog and the page's existing "holdings" vocabulary, distinct from "Add Account".

**Empty-state motion** (`globals.css`, `dashboard-content.tsx`)
Replaced the inert, bounce-named `animate-bounce-slow` with a defined `float-soft` (ease-in-out, transform-only, reduced-motion guarded).

## Verification
- `format:check`, `lint` (0 errors), `typecheck` all green; enforced by the pre-push hook.
- Each fix verified in a headless mobile browser (authenticated): badge accessible names, deep-link landings, KPI layout/no-clipping, Add Holding label, `float-soft` computed style + reduced-motion, and the no-goals projection card (via a reversible DB delete/restore).
- i18n: en-US + zh-TW updated for every new/changed string.

## Not included (remaining critique backlog, lower-severity)
- Delete-confirm/undo for the bare trash-icon delete (P2)
- Privacy mode leaks chart axes + deltas (P3)
- Dashboard header density (P3)
- Mobile command-palette / search entry (heuristic #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)