### PR TITLE
Print the active database connection on dev startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "next dev -H 0.0.0.0",
+    "dev": "node scripts/print-db-connection.mjs && next dev -H 0.0.0.0",
     "build": "next build",
     "build:vercel": "node scripts/vercel-build.mjs",
     "start": "next start",

--- a/scripts/print-db-connection.mjs
+++ b/scripts/print-db-connection.mjs
@@ -1,0 +1,45 @@
+import nextEnv from "@next/env";
+
+const { loadEnvConfig } = nextEnv;
+
+loadEnvConfig(process.cwd(), true);
+
+const databaseUrl = process.env.DATABASE_URL;
+const directUrl = process.env.DIRECT_URL;
+
+function classifyHost(hostname) {
+  if (hostname.includes("neon.tech")) return "Neon";
+  if (hostname === "localhost" || hostname === "127.0.0.1") return "Local PostgreSQL";
+  return "PostgreSQL";
+}
+
+function adapterFor(hostname) {
+  return hostname.includes("neon.tech") ? "PrismaNeon" : "PrismaPg";
+}
+
+function summarizeConnection(value) {
+  if (!value) return "unset";
+
+  try {
+    const url = new URL(value);
+    const host = url.hostname;
+    const port = url.port ? `:${url.port}` : "";
+    const database = url.pathname.replace(/^\//, "") || "(none)";
+    const sslmode = url.searchParams.get("sslmode");
+    const ssl = sslmode ? ` sslmode=${sslmode}` : "";
+
+    return `${classifyHost(host)} (${adapterFor(host)}) host=${host}${port} db=${database}${ssl}`;
+  } catch {
+    return "invalid PostgreSQL URL";
+  }
+}
+
+function printInfo(label, value) {
+  console.log(`- ${`${label}:`.padEnd(15)}${value}`);
+}
+
+printInfo("Database", summarizeConnection(databaseUrl));
+
+if (directUrl && directUrl !== databaseUrl) {
+  printInfo("Direct URL", `${summarizeConnection(directUrl)} (Prisma CLI/migrations only)`);
+}


### PR DESCRIPTION
## Summary
- Print the effective database connection at `npm run dev` startup in the same info-line style as Next's own boot output.
- Show whether the app is using Neon or local PostgreSQL, plus the resolved host, database, and SSL mode.
- Include the direct Prisma URL separately when it differs from `DATABASE_URL`.

## Testing
- Verified the new startup output in a local `npm run dev` launch.
- Confirmed the connection line renders before Next boot and matches the existing `- Label:        value` format.