### PR TITLE
[codex] Warm top-level nav prefetch

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -29,6 +29,15 @@ import { AppIcon } from "./app-icon";
 const SIDEBAR_STORAGE_KEY = "asset-tracker:sidebar-collapsed";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 const SIDEBAR_SHORTCUT_HINT = "Ctrl+\\ (⌘\\ on Mac)";
+const TOP_LEVEL_NAV_HREFS = [
+  "/",
+  "/accounts",
+  "/goals",
+  "/analysis",
+  "/projections",
+  "/history",
+  "/settings",
+];
 
 // Mirror the collapsed flag into a cookie so the server can render the correct
 // width on the next load (localStorage is client-only, which is what caused the
@@ -80,6 +89,12 @@ export function Sidebar({
       document.cookie = `${SIDEBAR_STORAGE_KEY}=${stored}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
     }
   }, []);
+
+  useEffect(() => {
+    for (const href of TOP_LEVEL_NAV_HREFS) {
+      router.prefetch(href);
+    }
+  }, [router]);
 
   const toggleCollapsed = useCallback(() => {
     persistCollapsed(!collapsed);
@@ -165,7 +180,6 @@ export function Sidebar({
             <Link
               key={item.href}
               href={item.href}
-              prefetch={false}
               onMouseEnter={() => router.prefetch(item.href)}
               onFocus={() => router.prefetch(item.href)}
               title={collapsed ? item.label : undefined}


### PR DESCRIPTION
## Summary

Warms the fixed top-level app routes from the sidebar after the app shell mounts, and removes the explicit `prefetch={false}` from desktop sidebar links so Next.js can use its default App Router prefetch behavior.

## Why

Tab switching felt slower than expected even on local PostgreSQL. The route traces showed RSC payloads rendering quickly, but the sidebar was opting out of automatic prefetching, so destination tabs often fetched only after click.

## Impact

Top-level tabs should feel more responsive while avoiding forced `prefetch={true}` full-route prefetching for every dynamic page.

## Validation

- `npm run lint -- src/components/layout/sidebar.tsx`
- `npx prettier --check src/components/layout/sidebar.tsx`
- Commit hook ran `npm run format:check`, `npm run lint`, and `npm run typecheck`; lint reported pre-existing warnings in `src/components/accounts/account-detail.tsx` only.