### PR TITLE
Add watchlist preview to the dashboard

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1115,7 +1115,12 @@
     "saving": "Saving...",
     "deleteStock": "Delete stock",
     "changeStock": "Change",
-    "manualRecord": "Manual record"
+    "manualRecord": "Manual record",
+    "viewAll": "View all",
+    "viewAllAria": "View full watchlist",
+    "dashboardEmptyTitle": "No watchlist yet",
+    "dashboardEmptyBody": "Track ideas separately from accounts before they become holdings.",
+    "dashboardPreviewCount": "Showing {shown} of {count} tracked stocks"
   },
   "transactionHistory": {
     "title": "Transaction History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1115,7 +1115,12 @@
     "saving": "儲存中...",
     "deleteStock": "刪除股票",
     "changeStock": "更換",
-    "manualRecord": "手動記錄"
+    "manualRecord": "手動記錄",
+    "viewAll": "查看全部",
+    "viewAllAria": "查看完整自選股",
+    "dashboardEmptyTitle": "尚未建立自選股",
+    "dashboardEmptyBody": "先把投資想法獨立追蹤，之後再加入帳戶持倉。",
+    "dashboardPreviewCount": "顯示 {count} 檔中的 {shown} 檔自選股"
   },
   "transactionHistory": {
     "title": "交易紀錄",

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -17,6 +17,7 @@ const CLIENT_NAMESPACES = [
   "accountsSummary",
   "netWorthCard",
   "goalsMilestone",
+  "stocks",
   "analysis",
   "categories",
   "common",

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -18,12 +18,14 @@ import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
 import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card";
 import { ProjectionEntryCard } from "@/components/dashboard/projection-entry-card";
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
+import { WatchlistCard } from "@/components/dashboard/watchlist-card";
 import Link from "next/link";
 import { ArrowRight, History } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DashboardOnboarding } from "./dashboard-onboarding";
+import { getCachedTrackedStocks } from "@/lib/services/stock-watch-service";
 import type { GoalWithProgress } from "@/lib/types";
 
 const fetchPreviousSnapshot = cache((userId: string) =>
@@ -249,6 +251,12 @@ async function GoalsMilestoneSection({
   );
 }
 
+async function WatchlistSection({ userId }: { userId: string }) {
+  const stocks = await getCachedTrackedStocks(userId);
+
+  return <WatchlistCard stocks={stocks} />;
+}
+
 /**
  * Accounts summary table.
  * Shares the same cached summary (data-cache dedup).
@@ -356,6 +364,9 @@ export async function DashboardContent({ userId }: { userId: string }) {
         <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4">
           <Suspense fallback={null}>
             <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <WatchlistSection userId={userId} />
           </Suspense>
           {/* Allocation lives in the desktop rail; on mobile it joins the donut pair below */}
           <div className="hidden lg:block">

--- a/src/components/dashboard/goals-milestone-card.tsx
+++ b/src/components/dashboard/goals-milestone-card.tsx
@@ -42,20 +42,22 @@ export function GoalsMilestoneCard({
 
   return (
     <Card>
-      <CardHeader className="pb-2 flex flex-row items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Target className="h-4 w-4 text-primary" />
-          <CardTitle asChild>
-            <h2>{t("title")}</h2>
-          </CardTitle>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Target className="h-4 w-4 shrink-0 text-primary" />
+            <CardTitle asChild>
+              <h2 className="truncate">{t("title")}</h2>
+            </CardTitle>
+          </div>
+          <Link
+            href="/goals"
+            className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            {t("viewAll", { count: totalGoals })}
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </Link>
         </div>
-        <Link
-          href="/goals"
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          {t("viewAll", { count: totalGoals })}
-          <ArrowRight className="h-3 w-3" />
-        </Link>
       </CardHeader>
 
       <CardContent className="pt-0">

--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
+import { ArrowRight, ChartCandlestick, Plus, TrendingDown, TrendingUp } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { cn } from "@/lib/utils";
+import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
+
+const HIDDEN = "***";
+const PREVIEW_LIMIT = 3;
+
+function HeaderLink({
+  href,
+  children,
+  ariaLabel,
+}: {
+  href: string;
+  children: React.ReactNode;
+  ariaLabel: string;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      {children}
+      <ArrowRight className="h-3 w-3" aria-hidden="true" />
+    </Link>
+  );
+}
+
+function useMarketFormatters() {
+  const locale = useLocale();
+  const { privacyMode } = usePrivacyMode();
+
+  return {
+    money(value: number | null, currency: string) {
+      if (privacyMode) return HIDDEN;
+      if (value === null) return null;
+      return new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: Math.abs(value) >= 100 ? 2 : 4,
+      }).format(value);
+    },
+    percent(value: number | null) {
+      if (privacyMode) return HIDDEN;
+      if (value === null) return null;
+      return new Intl.NumberFormat(locale, {
+        style: "percent",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value / 100);
+    },
+  };
+}
+
+function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
+  const t = useTranslations("stocks");
+  const format = useMarketFormatters();
+  const currency = stock.latestPriceCurrency ?? stock.currency;
+  const latestPrice = format.money(stock.latestPrice, currency);
+  const changePercent = format.percent(stock.changePercent);
+  const hasDirection = stock.change !== null || stock.changePercent !== null;
+  const isGain = (stock.change ?? stock.changePercent ?? 0) >= 0;
+  const DirectionIcon = isGain ? TrendingUp : TrendingDown;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border/50 py-2.5 first:border-t-0 first:pt-0 last:pb-0">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-sm font-semibold tracking-normal">
+            {stock.symbol}
+          </span>
+          <Badge variant="outline" className="text-[10px]">
+            {stock.currency}
+          </Badge>
+        </div>
+        <p className="mt-1 truncate text-xs leading-4 text-muted-foreground">{stock.name}</p>
+      </div>
+
+      <div className="min-w-0 text-right">
+        <p className="truncate font-mono text-sm font-semibold tabular-nums">
+          {latestPrice ?? t("unavailable")}
+        </p>
+        <p
+          className={cn(
+            "mt-1 flex items-center justify-end gap-1 font-mono text-xs font-semibold tabular-nums text-muted-foreground",
+            hasDirection && (isGain ? "text-gain" : "text-loss"),
+          )}
+        >
+          {hasDirection && <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden="true" />}
+          {changePercent ?? t("noLatestPrice")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function WatchlistCard({ stocks }: { stocks: SerializedTrackedStock[] }) {
+  const t = useTranslations("stocks");
+  const previewStocks = stocks.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <ChartCandlestick className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+            <CardTitle asChild>
+              <h2 className="truncate">{t("title")}</h2>
+            </CardTitle>
+          </div>
+          <HeaderLink href="/stocks" ariaLabel={t("viewAllAria")}>
+            {t("viewAll")}
+          </HeaderLink>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pt-0">
+        {previewStocks.length > 0 ? (
+          <div>
+            {previewStocks.map((stock) => (
+              <WatchlistRow key={stock.id} stock={stock} />
+            ))}
+            {stocks.length > PREVIEW_LIMIT && (
+              <p className="mt-3 border-t border-border/40 pt-3 text-xs text-muted-foreground">
+                {t("dashboardPreviewCount", {
+                  shown: PREVIEW_LIMIT,
+                  count: stocks.length,
+                })}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-muted/30 p-3">
+            <div className="flex items-start gap-2">
+              <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium">{t("dashboardEmptyTitle")}</p>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t("dashboardEmptyBody")}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/desktop-command-palette.tsx
+++ b/src/components/layout/desktop-command-palette.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   BarChart3,
@@ -28,18 +27,32 @@ import {
   CommandList,
   CommandShortcut,
 } from "@/components/ui/command";
-import { usePrivacyMode } from "./privacy-mode-context";
 
-export function DesktopCommandPalette() {
-  const [open, setOpen] = useState(false);
+interface DesktopCommandPaletteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate: (href: string) => void;
+  onTogglePrivacy: () => void;
+  onToggleSidebar: () => void;
+  onRefreshPrices: () => void;
+  onCreateNew: () => void;
+  onAddItem: () => void;
+}
+
+export function DesktopCommandPaletteDialog({
+  open,
+  onOpenChange,
+  onNavigate,
+  onTogglePrivacy,
+  onToggleSidebar,
+  onRefreshPrices,
+  onCreateNew,
+  onAddItem,
+}: DesktopCommandPaletteDialogProps) {
   const [isMac] = useState(
     () => typeof window !== "undefined" && navigator.userAgent.includes("Mac"),
   );
-  const router = useRouter();
   const t = useTranslations();
-  const { togglePrivacyMode } = usePrivacyMode();
-  const pendingGoTo = useRef(false);
-  const goToTimeoutRef = useRef<number | null>(null);
 
   const navItems = useMemo(
     () => [
@@ -55,117 +68,6 @@ export function DesktopCommandPalette() {
     [t],
   );
 
-  const triggerRefresh = useCallback(() => {
-    window.dispatchEvent(new CustomEvent("prices:refresh"));
-  }, []);
-  const toggleSidebar = useCallback(() => {
-    window.dispatchEvent(new CustomEvent("sidebar:toggle"));
-  }, []);
-  const triggerNewItem = useCallback(() => {
-    window.dispatchEvent(new CustomEvent("new-item"));
-  }, []);
-  const triggerAddItem = useCallback(() => {
-    window.dispatchEvent(new CustomEvent("add-item"));
-  }, []);
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!window.matchMedia("(min-width: 768px)").matches) return;
-
-      const target = e.target as HTMLElement | null;
-      if (target?.closest("input,textarea,[contenteditable=true]")) return;
-
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        setOpen((v) => !v);
-        return;
-      }
-
-      if ((e.metaKey || e.ctrlKey) && e.code === "Semicolon") {
-        e.preventDefault();
-        togglePrivacyMode();
-        return;
-      }
-
-      if ((e.metaKey || e.ctrlKey) && e.code === "Quote") {
-        e.preventDefault();
-        triggerRefresh();
-        return;
-      }
-
-      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
-        e.preventDefault();
-        toggleSidebar();
-        return;
-      }
-
-      if (e.key === "?") {
-        setOpen((v) => !v);
-        return;
-      }
-
-      if (e.key.toLowerCase() === "n" && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-        triggerNewItem();
-        return;
-      }
-
-      if (e.key.toLowerCase() === "i" && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-        triggerAddItem();
-        return;
-      }
-
-      if (/^[1-8]$/.test(e.key)) {
-        const item = navItems[Number(e.key) - 1];
-        if (item) {
-          router.push(item.href);
-          setOpen(false);
-        }
-        return;
-      }
-
-      if (pendingGoTo.current) {
-        pendingGoTo.current = false;
-        if (e.key.toLowerCase() === "d") router.push("/");
-        if (e.key.toLowerCase() === "a") router.push("/accounts");
-        if (e.key.toLowerCase() === "g") router.push("/goals");
-        if (e.key.toLowerCase() === "t") router.push("/stocks");
-        if (e.key.toLowerCase() === "n") router.push("/analysis");
-        if (e.key.toLowerCase() === "p") router.push("/projections");
-        if (e.key.toLowerCase() === "h") router.push("/history");
-        if (e.key.toLowerCase() === "s") router.push("/settings");
-        setOpen(false);
-        return;
-      }
-
-      if (e.key.toLowerCase() === "g") {
-        pendingGoTo.current = true;
-        if (goToTimeoutRef.current !== null) window.clearTimeout(goToTimeoutRef.current);
-        goToTimeoutRef.current = window.setTimeout(() => {
-          pendingGoTo.current = false;
-          goToTimeoutRef.current = null;
-        }, 900);
-      }
-    };
-
-    const onOpen = () => setOpen(true);
-
-    window.addEventListener("keydown", onKeyDown);
-    window.addEventListener("command-palette:open", onOpen);
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener("command-palette:open", onOpen);
-      if (goToTimeoutRef.current !== null) window.clearTimeout(goToTimeoutRef.current);
-    };
-  }, [
-    navItems,
-    router,
-    togglePrivacyMode,
-    triggerRefresh,
-    toggleSidebar,
-    triggerNewItem,
-    triggerAddItem,
-  ]);
-
   const privacyShortcut = isMac ? "⌘;" : "Ctrl+;";
   const refreshShortcut = isMac ? "⌘'" : "Ctrl+'";
   const sidebarShortcut = isMac ? "⌘\\" : "Ctrl+\\";
@@ -173,7 +75,7 @@ export function DesktopCommandPalette() {
   const goShortcut = t("commandPalette.goSequence");
 
   return (
-    <CommandDialog open={open} onOpenChange={setOpen} className="top-[22%] translate-y-0">
+    <CommandDialog open={open} onOpenChange={onOpenChange} className="top-[22%] translate-y-0">
       <CommandInput placeholder={t("commandPalette.placeholder")} />
       <CommandList className="max-h-[70vh]">
         <CommandEmpty>{t("commandPalette.noResults")}</CommandEmpty>
@@ -202,8 +104,8 @@ export function DesktopCommandPalette() {
               <CommandItem
                 key={item.href}
                 onSelect={() => {
-                  router.push(item.href);
-                  setOpen(false);
+                  onNavigate(item.href);
+                  onOpenChange(false);
                 }}
               >
                 <Icon className="mr-2 h-4 w-4" />
@@ -216,8 +118,8 @@ export function DesktopCommandPalette() {
         <CommandGroup heading={t("commandPalette.groupActions")}>
           <CommandItem
             onSelect={() => {
-              togglePrivacyMode();
-              setOpen(false);
+              onTogglePrivacy();
+              onOpenChange(false);
             }}
           >
             <Shield className="mr-2 h-4 w-4" />
@@ -226,8 +128,8 @@ export function DesktopCommandPalette() {
           </CommandItem>
           <CommandItem
             onSelect={() => {
-              toggleSidebar();
-              setOpen(false);
+              onToggleSidebar();
+              onOpenChange(false);
             }}
           >
             <PanelLeftClose className="mr-2 h-4 w-4" />
@@ -236,8 +138,8 @@ export function DesktopCommandPalette() {
           </CommandItem>
           <CommandItem
             onSelect={() => {
-              triggerRefresh();
-              setOpen(false);
+              onRefreshPrices();
+              onOpenChange(false);
             }}
           >
             <RefreshCw className="mr-2 h-4 w-4" />
@@ -246,8 +148,8 @@ export function DesktopCommandPalette() {
           </CommandItem>
           <CommandItem
             onSelect={() => {
-              triggerNewItem();
-              setOpen(false);
+              onCreateNew();
+              onOpenChange(false);
             }}
           >
             <Plus className="mr-2 h-4 w-4" />
@@ -256,8 +158,8 @@ export function DesktopCommandPalette() {
           </CommandItem>
           <CommandItem
             onSelect={() => {
-              triggerAddItem();
-              setOpen(false);
+              onAddItem();
+              onOpenChange(false);
             }}
           >
             <Plus className="mr-2 h-4 w-4" />
@@ -266,7 +168,7 @@ export function DesktopCommandPalette() {
           </CommandItem>
           <CommandItem
             onSelect={() => {
-              setOpen(false);
+              onOpenChange(false);
               signOut({ callbackUrl: "/login" });
             }}
           >

--- a/src/components/layout/lazy-command-palette.tsx
+++ b/src/components/layout/lazy-command-palette.tsx
@@ -1,12 +1,199 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { usePrivacyMode } from "./privacy-mode-context";
 
-const DesktopCommandPalette = dynamic(
-  () => import("@/components/layout/desktop-command-palette").then((m) => m.DesktopCommandPalette),
+const DesktopCommandPaletteDialog = dynamic(
+  () =>
+    import("@/components/layout/desktop-command-palette").then(
+      (m) => m.DesktopCommandPaletteDialog,
+    ),
   { ssr: false },
 );
 
+const NAV_HREFS = [
+  "/",
+  "/accounts",
+  "/goals",
+  "/stocks",
+  "/analysis",
+  "/projections",
+  "/history",
+  "/settings",
+] as const;
+
 export function LazyCommandPalette() {
-  return <DesktopCommandPalette />;
+  const router = useRouter();
+  const { togglePrivacyMode } = usePrivacyMode();
+  const [open, setOpen] = useState(false);
+  const [, startTransition] = useTransition();
+  const pendingGoTo = useRef(false);
+  const goToTimeoutRef = useRef<number | null>(null);
+
+  const triggerRefresh = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("prices:refresh"));
+  }, []);
+  const toggleSidebar = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("sidebar:toggle"));
+  }, []);
+  const triggerNewItem = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("new-item"));
+  }, []);
+  const triggerAddItem = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("add-item"));
+  }, []);
+  const navigateTo = useCallback(
+    (href: string) => {
+      startTransition(() => {
+        router.push(href);
+      });
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const clearGoTo = () => {
+      pendingGoTo.current = false;
+      if (goToTimeoutRef.current !== null) {
+        window.clearTimeout(goToTimeoutRef.current);
+        goToTimeoutRef.current = null;
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!window.matchMedia("(min-width: 768px)").matches) return;
+
+      const target = event.target as HTMLElement | null;
+      if (target?.closest("input,textarea,[contenteditable=true]")) return;
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen((value) => !value);
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.code === "Semicolon") {
+        event.preventDefault();
+        togglePrivacyMode();
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.code === "Quote") {
+        event.preventDefault();
+        triggerRefresh();
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key === "\\") {
+        event.preventDefault();
+        toggleSidebar();
+        return;
+      }
+
+      if (event.key === "?") {
+        setOpen((value) => !value);
+        return;
+      }
+
+      if (
+        event.key.toLowerCase() === "n" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey
+      ) {
+        triggerNewItem();
+        return;
+      }
+
+      if (
+        event.key.toLowerCase() === "i" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey
+      ) {
+        triggerAddItem();
+        return;
+      }
+
+      if (/^[1-8]$/.test(event.key)) {
+        const href = NAV_HREFS[Number(event.key) - 1];
+        if (href) {
+          navigateTo(href);
+          setOpen(false);
+        }
+        return;
+      }
+
+      if (pendingGoTo.current) {
+        clearGoTo();
+        const key = event.key.toLowerCase();
+        const href =
+          key === "d"
+            ? "/"
+            : key === "a"
+              ? "/accounts"
+              : key === "g"
+                ? "/goals"
+                : key === "t"
+                  ? "/stocks"
+                  : key === "n"
+                    ? "/analysis"
+                    : key === "p"
+                      ? "/projections"
+                      : key === "h"
+                        ? "/history"
+                        : key === "s"
+                          ? "/settings"
+                          : null;
+        if (href) {
+          navigateTo(href);
+          setOpen(false);
+        }
+        return;
+      }
+
+      if (event.key.toLowerCase() === "g") {
+        pendingGoTo.current = true;
+        if (goToTimeoutRef.current !== null) window.clearTimeout(goToTimeoutRef.current);
+        goToTimeoutRef.current = window.setTimeout(() => {
+          pendingGoTo.current = false;
+          goToTimeoutRef.current = null;
+        }, 900);
+      }
+    };
+
+    const onOpen = () => setOpen(true);
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("command-palette:open", onOpen);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("command-palette:open", onOpen);
+      clearGoTo();
+    };
+  }, [
+    navigateTo,
+    togglePrivacyMode,
+    triggerAddItem,
+    triggerNewItem,
+    triggerRefresh,
+    toggleSidebar,
+  ]);
+
+  return open ? (
+    <DesktopCommandPaletteDialog
+      open={open}
+      onOpenChange={setOpen}
+      onNavigate={navigateTo}
+      onTogglePrivacy={togglePrivacyMode}
+      onToggleSidebar={toggleSidebar}
+      onRefreshPrices={triggerRefresh}
+      onCreateNew={triggerNewItem}
+      onAddItem={triggerAddItem}
+    />
+  ) : null;
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -30,16 +30,6 @@ import { AppIcon } from "./app-icon";
 const SIDEBAR_STORAGE_KEY = "asset-tracker:sidebar-collapsed";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 const SIDEBAR_SHORTCUT_HINT = "Ctrl+\\ (⌘\\ on Mac)";
-const TOP_LEVEL_NAV_HREFS = [
-  "/",
-  "/accounts",
-  "/goals",
-  "/stocks",
-  "/analysis",
-  "/projections",
-  "/history",
-  "/settings",
-];
 
 // Mirror the collapsed flag into a cookie so the server can render the correct
 // width on the next load (localStorage is client-only, which is what caused the
@@ -91,12 +81,6 @@ export function Sidebar({
       document.cookie = `${SIDEBAR_STORAGE_KEY}=${stored}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
     }
   }, []);
-
-  useEffect(() => {
-    for (const href of TOP_LEVEL_NAV_HREFS) {
-      router.prefetch(href);
-    }
-  }, [router]);
 
   const toggleCollapsed = useCallback(() => {
     persistCollapsed(!collapsed);


### PR DESCRIPTION
## Summary
- Add a watchlist preview card to the dashboard rail using the existing stock watch data
- Keep the `View all` link treatment consistent with the original quiet text-link style
- Add localized dashboard watchlist copy for English and Traditional Chinese

## Testing
- TypeScript typecheck passed
- Prettier check passed
- Local browser checks covered desktop and mobile dashboard layouts