### PR TITLE
feat(ui): redesign watchlist card layout to prioritize change percent

### DIFF
--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -1,12 +1,12 @@
 "use client";
-
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
 import { ArrowRight, ChartCandlestick, Plus, TrendingDown, TrendingUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
-import { cn } from "@/lib/utils";
+import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
 
 const HIDDEN = "***";
@@ -69,6 +69,16 @@ function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
   const isGain = (stock.change ?? stock.changePercent ?? 0) >= 0;
   const DirectionIcon = isGain ? TrendingUp : TrendingDown;
 
+  const [today, setToday] = useState<string | null>(null);
+  useEffect(() => {
+    const timer = window.setTimeout(() => setToday(localToday()), 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const recordPeriodDays = today ? daysBetweenDates(stock.recordDate, today) : null;
+  const recordPeriodLabel =
+    recordPeriodDays !== null ? t("recordPeriod", { days: recordPeriodDays }) : null;
+
   return (
     <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border/50 py-2.5 first:border-t-0 first:pt-0 last:pb-0">
       <div className="min-w-0">
@@ -76,25 +86,36 @@ function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
           <span className="truncate font-mono text-sm font-semibold tracking-normal">
             {stock.symbol}
           </span>
-          <Badge variant="outline" className="text-[10px]">
+          <Badge
+            variant="outline"
+            className="border-primary/20 bg-primary/5 text-[10px] font-medium text-primary/90"
+          >
             {stock.currency}
           </Badge>
         </div>
         <p className="mt-1 truncate text-xs leading-4 text-muted-foreground">{stock.name}</p>
       </div>
 
-      <div className="min-w-0 text-right">
-        <p className="truncate font-mono text-sm font-semibold tabular-nums">
-          {latestPrice ?? t("unavailable")}
-        </p>
-        <p
-          className={cn(
-            "mt-1 flex items-center justify-end gap-1 font-mono text-xs font-semibold tabular-nums text-muted-foreground",
-            hasDirection && (isGain ? "text-gain" : "text-loss"),
+      <div className="min-w-0 flex shrink-0 flex-col items-end">
+        <div>
+          {stock.changePercent !== null ? (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-[13px] font-semibold tabular-nums leading-none",
+                isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+              )}
+            >
+              <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+              {changePercent}
+            </span>
+          ) : (
+            <span className="font-mono text-[13px] font-semibold tabular-nums text-muted-foreground">
+              {t("unavailable")}
+            </span>
           )}
-        >
-          {hasDirection && <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden="true" />}
-          {changePercent ?? t("noLatestPrice")}
+        </div>
+        <p className="mt-1 font-mono text-[11px] font-medium text-muted-foreground tabular-nums">
+          {recordPeriodLabel ?? t("unavailable")}
         </p>
       </div>
     </div>

--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -63,9 +63,7 @@ function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
   const t = useTranslations("stocks");
   const format = useMarketFormatters();
   const currency = stock.latestPriceCurrency ?? stock.currency;
-  const latestPrice = format.money(stock.latestPrice, currency);
   const changePercent = format.percent(stock.changePercent);
-  const hasDirection = stock.change !== null || stock.changePercent !== null;
   const isGain = (stock.change ?? stock.changePercent ?? 0) >= 0;
   const DirectionIcon = isGain ? TrendingUp : TrendingDown;
 

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -411,11 +411,17 @@ function StockRow({
           >
             {stock.symbol}
           </span>
-          <Badge variant="outline" className="text-[10px]">
+          <Badge
+            variant="outline"
+            className="border-primary/20 bg-primary/5 text-[10px] font-medium text-primary/90"
+          >
             {stock.currency}
           </Badge>
           {stock.exchange && (
-            <Badge variant="secondary" className="max-w-40 truncate text-[10px]">
+            <Badge
+              variant="secondary"
+              className="max-w-40 truncate bg-muted/40 text-[10px] font-medium text-muted-foreground"
+            >
               {stock.exchange}
             </Badge>
           )}
@@ -428,11 +434,6 @@ function StockRow({
         >
           {stock.name}
         </p>
-        {compact && noteText && (
-          <p className="mt-1 truncate text-xs leading-4 text-muted-foreground">
-            <span className="text-muted-foreground/70">{t("note")}:</span> {noteText}
-          </p>
-        )}
       </div>
     );
   }
@@ -464,9 +465,12 @@ function StockRow({
   }
 
   return (
-    <Card size="sm" className="overflow-visible md:py-2">
+    <Card
+      size="sm"
+      className="overflow-visible transition-colors hover:border-primary/20 hover:bg-primary/[0.02] md:py-2"
+    >
       <CardContent className="space-y-3 md:px-3">
-        <div className="hidden items-center gap-3 md:grid md:grid-cols-[minmax(190px,1.45fr)_minmax(118px,0.85fr)_minmax(122px,0.9fr)_minmax(112px,0.8fr)_minmax(104px,0.72fr)_1.75rem]">
+        <div className="hidden items-center gap-3 md:grid md:grid-cols-[minmax(190px,1.6fr)_minmax(118px,0.9fr)_minmax(122px,0.9fr)_minmax(120px,0.9fr)_1.75rem]">
           {renderIdentity(true)}
 
           <div className="min-w-0">
@@ -485,113 +489,97 @@ function StockRow({
             <p className="mt-0.5 truncate font-mono text-sm font-semibold tabular-nums">
               {latestPrice ?? t("unavailable")}
             </p>
-            {stock.latestPriceUpdatedAt ? (
-              <FreshnessBadge
-                kind="price"
-                timestamp={stock.latestPriceUpdatedAt}
-                mobileShort
-                className="mt-1 max-w-full"
-              />
-            ) : (
+            {!stock.latestPriceUpdatedAt && (
               <p className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground">
                 {t("noLatestPrice")}
               </p>
             )}
           </div>
 
-          <div
-            className={cn("min-w-0", stock.change !== null && (isGain ? "text-gain" : "text-loss"))}
-          >
+          <div className="min-w-0">
             <p className="text-[11px] font-medium text-muted-foreground">{t("change")}</p>
-            <p className="mt-0.5 flex items-center gap-1 truncate font-mono text-sm font-semibold tabular-nums">
-              {stock.change !== null && <DirectionIcon className="h-3.5 w-3.5 shrink-0" />}
-              {change ?? t("unavailable")}
-            </p>
-          </div>
-
-          <div
-            className={cn(
-              "min-w-0",
-              stock.changePercent !== null && (isGain ? "text-gain" : "text-loss"),
-            )}
-          >
-            <p className="text-[11px] font-medium text-muted-foreground">{t("changePercent")}</p>
-            <p className="mt-0.5 truncate font-mono text-sm font-semibold tabular-nums">
-              {percent ?? t("unavailable")}
-            </p>
+            <div className="mt-1 flex flex-col items-start gap-1">
+              {stock.changePercent !== null ? (
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none",
+                    isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+                  )}
+                >
+                  <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
+                  {percent}
+                </span>
+              ) : (
+                <p className="font-mono text-sm font-semibold tabular-nums text-muted-foreground">
+                  {t("unavailable")}
+                </p>
+              )}
+              {stock.change !== null && (
+                <p className="truncate font-mono text-[11px] font-medium tabular-nums text-muted-foreground">
+                  {change}
+                </p>
+              )}
+            </div>
           </div>
 
           <div className="justify-self-end">{renderActions()}</div>
         </div>
 
-        <div className="flex items-start justify-between gap-3 md:hidden">
-          {renderIdentity()}
-          {renderActions()}
-        </div>
-
-        <div className="space-y-2 md:hidden">
-          <div className="rounded-lg border border-border/60 bg-muted/25 p-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p className="text-xs text-muted-foreground">{t("latestPrice")}</p>
-                <p className="mt-1 truncate font-mono text-lg font-semibold leading-6 tabular-nums">
-                  {latestPrice ?? t("unavailable")}
-                </p>
-              </div>
-              <div
-                className={cn(
-                  "min-w-0 shrink-0 text-right",
-                  (stock.change !== null || stock.changePercent !== null) &&
-                    (isGain ? "text-gain" : "text-loss"),
+        <div className="flex flex-col gap-3.5 md:hidden">
+          <div className="flex items-start justify-between gap-4">
+            {renderIdentity()}
+            
+            <div className="min-w-0 shrink-0 flex flex-col items-end">
+              <div>
+                {stock.changePercent !== null ? (
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none",
+                      isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+                    )}
+                  >
+                    <DirectionIcon className="h-4 w-4 shrink-0" />
+                    {percent}
+                  </span>
+                ) : (
+                  <p className="font-mono text-base font-bold tabular-nums text-muted-foreground">
+                    {t("unavailable")}
+                  </p>
                 )}
-              >
-                <p className="text-xs opacity-80">{t("change")}</p>
-                <p className="mt-1 flex items-center justify-end gap-1 font-mono text-sm font-semibold tabular-nums">
-                  {stock.change !== null && <DirectionIcon className="h-3.5 w-3.5 shrink-0" />}
-                  {change ?? t("unavailable")}
-                </p>
-                <p className="mt-0.5 font-mono text-sm font-semibold tabular-nums">
-                  {percent ?? t("unavailable")}
-                </p>
               </div>
-            </div>
-            {stock.latestPriceUpdatedAt ? (
-              <FreshnessBadge
-                kind="price"
-                timestamp={stock.latestPriceUpdatedAt}
-                mobileShort
-                className="mt-2"
-              />
-            ) : (
-              <p className="mt-2 text-xs text-muted-foreground">{t("noLatestPrice")}</p>
-            )}
-          </div>
-
-          <div className="grid grid-cols-2 gap-2">
-            <div className="min-w-0 rounded-lg bg-muted/30 p-2.5">
-              <p className="text-xs text-muted-foreground">{t("recorded")}</p>
-              <p className="mt-1 truncate font-mono text-sm font-semibold tabular-nums">
-                {recordPrice}
+              <p className="mt-1.5 font-mono text-sm font-medium tabular-nums text-muted-foreground">
+                {latestPrice ?? t("unavailable")}
               </p>
             </div>
-            <div className="min-w-0 rounded-lg bg-muted/30 p-2.5">
-              <p className="truncate text-xs text-muted-foreground">
+          </div>
+
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/30 px-3 py-2.5">
+            <div className="min-w-0">
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium text-foreground/80">{t("recorded")}:</span>{" "}
+                <span className="font-mono font-medium text-foreground/90">{recordPrice}</span>
+              </p>
+              <p className="mt-0.5 truncate text-[11px] text-muted-foreground/70">
                 {format.date(stock.recordDate)}
+                {recordPeriodLabel && ` • ${recordPeriodLabel}`}
               </p>
-              {recordPeriodLabel && (
-                <p className="mt-1 truncate text-xs text-muted-foreground">{recordPeriodLabel}</p>
-              )}
             </div>
+            <div className="shrink-0">{renderActions()}</div>
           </div>
 
-          {noteText && (
-            <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-              <p className="truncate text-sm text-muted-foreground">
-                <span className="text-xs text-muted-foreground/75">{t("note")}:</span> {noteText}
-              </p>
-            </div>
+          {!stock.latestPriceUpdatedAt && (
+            <p className="text-[11px] text-muted-foreground">{t("noLatestPrice")}</p>
           )}
         </div>
+
+        {noteText && (
+          <div className="rounded-lg border border-primary/10 bg-primary/5 px-3 py-2.5">
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+              <span className="mr-2 text-xs font-medium text-primary/70">{t("note")}:</span>
+              {noteText}
+            </p>
+          </div>
+        )}
       </CardContent>
     </Card>
   );
@@ -605,6 +593,18 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
   const [editingStock, setEditingStock] = useState<SerializedTrackedStock | null>(null);
   const [deletingStock, setDeletingStock] = useState<SerializedTrackedStock | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Derive the most recent price update timestamp across all stocks.
+  // Since all prices are refreshed in the same batch, they share one timestamp.
+  const latestPriceTimestamp = useMemo(() => {
+    let newest: string | null = null;
+    for (const stock of stocks) {
+      if (stock.latestPriceUpdatedAt && (!newest || stock.latestPriceUpdatedAt > newest)) {
+        newest = stock.latestPriceUpdatedAt;
+      }
+    }
+    return newest;
+  }, [stocks]);
 
   async function refreshPrices() {
     hapticTick();
@@ -640,9 +640,18 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <ChartCandlestick className="h-4 w-4 text-primary" />
-          <span>{t("trackedCount", { count: stocks.length })}</span>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <ChartCandlestick className="h-4 w-4" />
+            </div>
+            <span className="text-sm font-medium text-foreground">
+              {t("trackedCount", { count: stocks.length })}
+            </span>
+          </div>
+          {latestPriceTimestamp && (
+            <FreshnessBadge kind="price" timestamp={latestPriceTimestamp} mobileShort />
+          )}
         </div>
         <div className="grid grid-cols-2 gap-2 sm:flex">
           <Button

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -46,7 +46,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { StocksOnboarding } from "./stocks-onboarding";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { hapticTick } from "@/lib/haptics";
-import { cn } from "@/lib/utils";
+import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
 
 type QuoteResponse = {
@@ -60,12 +60,6 @@ type QuoteResponse = {
 
 const HIDDEN = "***";
 
-function localToday() {
-  const now = new Date();
-  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
-  return local.toISOString().slice(0, 10);
-}
-
 function parseMoney(value: string) {
   const normalized = value.replace(/,/g, "").trim();
   if (!normalized) return null;
@@ -75,16 +69,6 @@ function parseMoney(value: string) {
 
 function formatNumberInput(value: number) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 8 }).format(value);
-}
-
-function dateToLocalTime(value: string) {
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, month - 1, day).getTime();
-}
-
-function daysBetweenDates(startDate: string, endDate: string) {
-  const DAY_MS = 24 * 60 * 60 * 1000;
-  return Math.max(0, Math.floor((dateToLocalTime(endDate) - dateToLocalTime(startDate)) / DAY_MS));
 }
 
 function useFormatters() {
@@ -528,7 +512,7 @@ function StockRow({
         <div className="flex flex-col gap-3.5 md:hidden">
           <div className="flex items-start justify-between gap-4">
             {renderIdentity()}
-            
+
             <div className="min-w-0 shrink-0 flex flex-col items-end">
               <div>
                 {stock.changePercent !== null ? (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function localToday() {
+  const now = new Date();
+  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+export function dateToLocalTime(value: string) {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, month - 1, day).getTime();
+}
+
+export function daysBetweenDates(startDate: string, endDate: string) {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  return Math.max(0, Math.floor((dateToLocalTime(endDate) - dateToLocalTime(startDate)) / DAY_MS));
+}


### PR DESCRIPTION
## Description
Redesigned the watchlist card layout on both mobile and desktop to better align with typical financial app hierarchy.

- **Mobile:** Flattened the layout from multiple chunky boxes into a clean two-row design. The absolute price change is removed entirely to focus on the change %, and the percentage pill is prioritized and enlarged over the absolute price. The recorded metadata is merged into a single clean secondary row.
- **Desktop:** Merged the Change and Change Percent columns into a single unified Performance column that highlights the percentage pill.