### PR TITLE
Refine dashboard: net-worth hero, charts, and layout density

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -657,7 +657,8 @@
     "netWorth": "Net Worth",
     "totalAssets": "Total Assets",
     "totalLiabilities": "Total Liabilities",
-    "sinceSnapshot": "since {date}"
+    "sinceSnapshot": "since {date}",
+    "accountCount": "{count, plural, =0 {no accounts} one {# account} other {# accounts}}"
   },
   "dashboardActions": {
     "pricesUpdated": "Prices updated {age}",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -657,7 +657,8 @@
     "netWorth": "淨資產",
     "totalAssets": "總資產",
     "totalLiabilities": "總負債",
-    "sinceSnapshot": "自 {date}"
+    "sinceSnapshot": "自 {date}",
+    "accountCount": "{count, plural, =0 {無帳戶} other {# 個帳戶}}"
   },
   "dashboardActions": {
     "pricesUpdated": "價格更新於 {age}",

--- a/src/components/dashboard/allocation-chart.tsx
+++ b/src/components/dashboard/allocation-chart.tsx
@@ -53,6 +53,8 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
       .sort((a, b) => b.value - a.value);
   }, [summary.accounts, t]);
 
+  const total = useMemo(() => data.reduce((sum, d) => sum + d.value, 0), [data]);
+
   const handleMouseEnter = useCallback((_: unknown, index: number) => setActiveIndex(index), []);
   const handleMouseLeave = useCallback(() => setActiveIndex(-1), []);
 
@@ -153,7 +155,11 @@ export function AllocationChart({ summary }: { summary: NetWorthSummary }) {
                         content={({ viewBox }) => {
                           if (viewBox && "cx" in viewBox && "cy" in viewBox) {
                             const activeItem = activeIndex >= 0 ? data[activeIndex] : null;
-                            const displayPct = activeItem ? `${activeItem.percentage}%` : "100%";
+                            const displayPct = activeItem
+                              ? `${activeItem.percentage}%`
+                              : privacyMode
+                                ? "••••"
+                                : formatCurrency(total, summary.baseCurrency, true);
                             const displayLabel = activeItem
                               ? activeItem.name
                               : t("allocationChart.total");

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -61,6 +61,11 @@ function NetWorthSkeleton() {
               <Skeleton className="h-3.5 sm:h-4 w-16" />
             </div>
             <Skeleton className="h-5 sm:h-6 w-24 max-w-full mt-1" />
+            <Skeleton className="h-1.5 w-full rounded-full mt-3 sm:mt-4" />
+            <div className="mt-1.5 flex items-center justify-between">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-8" />
+            </div>
           </CardContent>
         </Card>
       ))}
@@ -333,7 +338,10 @@ export async function DashboardContent({ userId }: { userId: string }) {
         <NetWorthSection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
 
-      {/* Tier 2 — "what changed": trend chart (8) + goals/allocation rail (4) */}
+      {/* Tier 2 — "what changed": trend chart (8) + goals/watchlist rail (4).
+          The rail is intentionally short (two cards) so the trend card, which
+          stretches to match it, stays a compact height rather than ballooning
+          to a three-card rail. Allocation moved to the donut row below. */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
         <div className="min-w-0 lg:col-span-8">
           <Suspense fallback={<TrendChartSkeleton />}>
@@ -368,36 +376,28 @@ export async function DashboardContent({ userId }: { userId: string }) {
           <Suspense fallback={<ChartCardSkeleton />}>
             <WatchlistSection userId={userId} />
           </Suspense>
-          {/* Allocation lives in the desktop rail; on mobile it joins the donut pair below */}
-          <div className="hidden lg:block">
-            <Suspense fallback={<ChartCardSkeleton />}>
-              <AllocationSection userId={userId} baseCurrency={baseCurrency} />
-            </Suspense>
-          </div>
         </div>
       </div>
 
-      {/* Mobile-only — keep the two donuts side by side below the desktop breakpoint */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 lg:hidden animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
-        <Suspense fallback={<ChartCardSkeleton />}>
-          <AllocationSection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
-        <Suspense fallback={<ChartCardSkeleton />}>
-          <CurrencySection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
-      </div>
-
-      {/* Tier 3 — "what it's made of": portfolio composition (8) + currency donut (4) */}
+      {/* Tier 3 — "what it's made of": the portfolio treemap (wide) sits beside a
+          stacked allocation + currency-exposure column so the short currency card
+          no longer leaves a gap. Source order is allocation → currency → portfolio
+          (the phone reading order); on desktop the donut stack is placed in the
+          right column and the treemap fills the left, same row. */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
-        <div className="min-w-0 lg:col-span-8">
-          <Suspense fallback={<PortfolioHeatmapSkeleton />}>
-            <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <AllocationSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>
-        </div>
-        {/* Currency lives in the desktop rail; on mobile it joins the donut pair above */}
-        <div className="hidden min-w-0 lg:col-span-4 lg:block">
           <Suspense fallback={<ChartCardSkeleton />}>
             <CurrencySection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+        </div>
+        {/* Force the treemap card to fill the row so its bottom aligns with the
+            stacked allocation + currency column to its right. */}
+        <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 [&>*]:min-h-0 [&>*]:flex-1">
+          <Suspense fallback={<PortfolioHeatmapSkeleton />}>
+            <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>
         </div>
       </div>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -62,6 +62,45 @@ function FitCurrency({
   );
 }
 
+/**
+ * Slim share-of-gross meter shown under the Assets / Liabilities figures.
+ * `share` is a 0–100 percentage; the fill is floored to a visible sliver so a
+ * tiny share still registers. The percentage caption is suppressed in privacy
+ * mode (the account count stays, since a count leaks no balances).
+ */
+function CompositionMeter({
+  share,
+  caption,
+  tone,
+  privacy,
+}: {
+  share: number;
+  caption: string;
+  tone: "gain" | "loss";
+  privacy: boolean;
+}) {
+  const color = tone === "gain" ? "var(--gain)" : "var(--loss)";
+  return (
+    <div className="mt-3 sm:mt-4">
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-foreground/10"
+        role="presentation"
+      >
+        <div
+          className="h-full rounded-full motion-safe:transition-[width] motion-safe:duration-700 motion-safe:ease-out"
+          style={{ width: `${Math.max(share, 3)}%`, backgroundColor: color, opacity: 0.7 }}
+        />
+      </div>
+      <div className="mt-1.5 flex items-center justify-between gap-2 text-[11px] tabular-nums text-muted-foreground">
+        <span className="truncate">{caption}</span>
+        {!privacy && (
+          <span className="shrink-0 font-medium text-foreground/70">{share.toFixed(0)}%</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function NetWorthCard({
   summary,
   previousNetWorth,
@@ -98,6 +137,15 @@ export function NetWorthCard({
     : null;
   const meshClass =
     delta === null ? "hero-mesh-neutral" : isPositive ? "hero-mesh-positive" : "hero-mesh-negative";
+
+  // Gross = assets + liabilities. Each secondary card carries a slim meter of
+  // its share of gross so the two cards read as complementary halves of the
+  // net-worth equation rather than two isolated numbers.
+  const gross = totalAssets + totalLiabilities;
+  const assetsShare = gross > 0 ? (totalAssets / gross) * 100 : 0;
+  const liabilitiesShare = gross > 0 ? (totalLiabilities / gross) * 100 : 0;
+  const assetCount = summary.accounts.filter((a) => a.type === "ASSET").length;
+  const liabilityCount = summary.accounts.filter((a) => a.type === "LIABILITY").length;
 
   return (
     <div
@@ -175,6 +223,14 @@ export function NetWorthCard({
             privacy={privacyMode}
             className="relative text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums truncate"
           />
+          {!isCompact && (
+            <CompositionMeter
+              share={assetsShare}
+              caption={t("accountCount", { count: assetCount })}
+              tone="gain"
+              privacy={privacyMode}
+            />
+          )}
         </CardContent>
       </Card>
 
@@ -195,6 +251,14 @@ export function NetWorthCard({
             privacy={privacyMode}
             className="relative text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums truncate"
           />
+          {!isCompact && (
+            <CompositionMeter
+              share={liabilitiesShare}
+              caption={t("accountCount", { count: liabilityCount })}
+              tone="loss"
+              privacy={privacyMode}
+            />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -202,6 +202,27 @@ export function TrendChart({
     return { delta, pct };
   }, [filtered]);
 
+  // Fit the Y-axis to the visible range (with breathing room) instead of
+  // anchoring at zero. Net-worth series rarely approach zero, so a 0-based
+  // axis spends most of the canvas on empty space and flattens the trend.
+  // Percent mode already centers on its own baseline, so leave it to recharts.
+  const yDomain = useMemo<[number, number] | undefined>(() => {
+    if (isPercentMode || filtered.length === 0) return undefined;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const s of filtered) {
+      if (s.netWorth < min) min = s.netWorth;
+      if (s.netWorth > max) max = s.netWorth;
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) return undefined;
+    if (min === max) {
+      const pad = Math.abs(min) * 0.05 || 1;
+      return [min - pad, max + pad];
+    }
+    const pad = (max - min) * 0.18;
+    return [min - pad, max + pad];
+  }, [filtered, isPercentMode]);
+
   return (
     <Card className="relative h-full flex flex-col pb-0">
       <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2 pb-2 px-4">
@@ -324,7 +345,12 @@ export function TrendChart({
                     textAnchor="end"
                     tickFormatter={xTickFormatter}
                   />
-                  <YAxis width={42} tick={{ fontSize: 12 }} tickFormatter={yTickFormatter} />
+                  <YAxis
+                    width={42}
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={yTickFormatter}
+                    domain={yDomain ?? ["auto", "auto"]}
+                  />
                   <Tooltip
                     cursor={false}
                     content={


### PR DESCRIPTION
Polishes the dashboard tab across composition, charts, and layout. Structure is preserved where it worked; the changes target craft and information density.

## Changes
**Net-worth hero**
- The Assets / Liabilities cards were a label + number floating in empty space next to the rich hero. Each now carries a slim share-of-gross meter + account count, so the two read as complementary halves of net worth (e.g. 78% assets vs 22% liabilities). The % is suppressed in privacy mode; the non-sensitive proportion bar and count remain.

**Charts**
- Allocation donut center now shows the total asset value instead of a meaningless "100%".
- Trend chart fits its Y-axis to the visible range instead of anchoring at 0, so the trend shape is legible instead of hugging the top third. Percent mode keeps its own zero-centered domain.

**Layout / density**
- Allocation moved out of the trend rail into a donut row paired with Currency Exposure. The trend rail is now two cards (Goals + Watchlist), so the trend card stays compact (~480px) and balanced instead of stretching to a three-card rail.
- Portfolio Composition shares a row with the Allocation + Currency stack: the treemap fills the wide left column and bottom-aligns with the stack, removing the prior empty gap and collapsing a row of vertical scroll.

**i18n**
- Added `accountCount` plural string (en-US, zh-TW).

## Verification
- Checked desktop (1100 / 1280 / 1440), mobile, light + dark, privacy mode, and the trend percent toggle.
- Multi-card rows bottom-align: Trend↔Watchlist (1px) and Portfolio↔Currency (exact) across widths.
- Mobile reading order preserved (Trend → Goals → Watchlist → Allocation → Currency → Portfolio → Accounts).
- `format:check`, `lint` (0 errors), and `typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)