### PR TITLE
feat(stocks): colorize watchlist with directional schema awareness

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1082,6 +1082,7 @@
     "searchLabel": "Search stock",
     "searchPlaceholder": "e.g. Apple, TSMC, NVDA...",
     "selectedStock": "Selected stock",
+    "symbol": "Symbol",
     "recordPrice": "Record price",
     "recordPriceInvalid": "Enter a positive record price.",
     "recordDate": "Record date",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1082,6 +1082,7 @@
     "searchLabel": "搜尋股票",
     "searchPlaceholder": "例如 Apple、台積電、NVDA...",
     "selectedStock": "已選股票",
+    "symbol": "股票代號",
     "recordPrice": "記錄價格",
     "recordPriceInvalid": "請輸入大於 0 的記錄價格。",
     "recordDate": "記錄日期",

--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -100,7 +100,9 @@ function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
             <span
               className={cn(
                 "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-[13px] font-semibold tabular-nums leading-none",
-                isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+                isGain
+                  ? "bg-[var(--gain)]/15 text-[var(--gain)]"
+                  : "bg-[var(--loss)]/15 text-[var(--loss)]",
               )}
             >
               <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden="true" />

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -366,6 +366,7 @@ function StockRow({
   const format = useFormatters();
   const currency = stock.latestPriceCurrency ?? stock.currency;
   const isGain = (stock.change ?? 0) >= 0;
+  const hasDirection = stock.changePercent !== null;
   const DirectionIcon = isGain ? TrendingUp : TrendingDown;
   const latestPrice = format.money(stock.latestPrice, currency);
   const recordPrice = format.money(stock.recordPrice, stock.currency);
@@ -451,7 +452,14 @@ function StockRow({
   return (
     <Card
       size="sm"
-      className="overflow-visible transition-colors hover:border-primary/20 hover:bg-primary/[0.02] md:py-2"
+      className={cn(
+        "overflow-visible transition-colors md:py-2",
+        hasDirection
+          ? isGain
+            ? "border-[var(--gain)]/35 bg-[var(--gain)]/5 hover:border-[var(--gain)]/60 hover:bg-[var(--gain)]/8"
+            : "border-[var(--loss)]/35 bg-[var(--loss)]/5 hover:border-[var(--loss)]/60 hover:bg-[var(--loss)]/8"
+          : "hover:border-primary/20 hover:bg-primary/[0.02]",
+      )}
     >
       <CardContent className="space-y-3 md:px-3">
         <div className="hidden items-center gap-3 md:grid md:grid-cols-[minmax(190px,1.6fr)_minmax(118px,0.9fr)_minmax(122px,0.9fr)_minmax(120px,0.9fr)_1.75rem]">
@@ -486,8 +494,10 @@ function StockRow({
               {stock.changePercent !== null ? (
                 <span
                   className={cn(
-                    "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none",
-                    isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+                    "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
+                    isGain
+                      ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
+                      : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
                   )}
                 >
                   <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
@@ -518,8 +528,10 @@ function StockRow({
                 {stock.changePercent !== null ? (
                   <span
                     className={cn(
-                      "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none",
-                      isGain ? "bg-gain/15 text-gain" : "bg-loss/15 text-loss",
+                      "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
+                      isGain
+                        ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
+                        : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
                     )}
                   >
                     <DirectionIcon className="h-4 w-4 shrink-0" />
@@ -557,9 +569,9 @@ function StockRow({
         </div>
 
         {noteText && (
-          <div className="rounded-lg border border-primary/10 bg-primary/5 px-3 py-2.5">
+          <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2.5">
             <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-              <span className="mr-2 text-xs font-medium text-primary/70">{t("note")}:</span>
+              <span className="mr-2 text-xs font-medium text-muted-foreground">{t("note")}:</span>
               {noteText}
             </p>
           </div>


### PR DESCRIPTION
## Summary

- **Change % pills** now track the active color schema using `text-[var(--gain/loss)]` arbitrary forms (was broken `text-gain` shorthand that fell back to foreground)
- **Directional card tints** for each row: gainers carry gain-color border + surface wash, losers carry loss-color (varies per schema)
- **Schema-aware design**: verified across all 6 color schemas (default emerald, ocean blue, amber, rose, violet, anthropic coral) + light/dark themes
- **Crisper focal point**: inset ring on change pills
- **Fixed dashboard watchlist** preview pill to also track schema

## Technical

Fixed a codebase-wide gotcha: gain/loss color wasn't registering in Tailwind because `--gain`/`--loss` lack `@theme` registration as `--color-*`. The working idiom (used by analysis, badges, onboarding) is the arbitrary-value form `text-[var(--gain)]`, not the inert shorthand `text-gain`. Watchlist files were the only ones on the broken pattern.

## Testing

Verified in browser across:
- All 6 color schemas (default, ocean, amber, rose, violet, anthropic)
- Light & dark themes
- Desktop, tablet, mobile
- Both change pills (desktop desktop table + mobile card view)
- Dashboard watchlist preview

Quality gates pass (format, typecheck, lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)