### PR TITLE
feat(stocks): redesign watchlist row layout, harden, and colorize

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1111,6 +1111,7 @@
     "deleteBody": "This removes its recorded price, date, and note.",
     "deleteSuccess": "Deleted {symbol}",
     "deleteFailed": "Failed to delete stock",
+    "deleting": "Deleting...",
     "refreshSuccess": "Updated {count} prices",
     "refreshFailed": "Failed to refresh stock prices",
     "saveStock": "Save stock",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1111,6 +1111,7 @@
     "deleteBody": "這會移除記錄價格、日期與備註。",
     "deleteSuccess": "已刪除 {symbol}",
     "deleteFailed": "刪除股票失敗",
+    "deleting": "刪除中...",
     "refreshSuccess": "已更新 {count} 筆價格",
     "refreshFailed": "更新股票價格失敗",
     "saveStock": "儲存股票",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,13 @@
      --loss with a distinct counter-hue so positive vs negative stay legible. */
   --gain: var(--chart-1);
   --loss: var(--chart-2);
+  /* Deepened directional hues for small text and connector accents. The bright
+     --gain/--loss chips clear 3:1 as large/pill text but not 4.5:1 as 11px body
+     (e.g. cyan loss on the light canvas is ~2.97:1). Mixing 30% toward the ink
+     end lifts both themes and every schema past 4.5:1 while keeping the hue read.
+     Defined once: lazy var() substitution re-resolves per cascaded theme/schema. */
+  --gain-ink: color-mix(in oklab, var(--gain), var(--foreground) 30%);
+  --loss-ink: color-mix(in oklab, var(--loss), var(--foreground) 30%);
   --app-icon-gradient-start: #34d399;
   --app-icon-gradient-end: #065f46;
 

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -4,6 +4,7 @@ import { startTransition, useEffect, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import {
+  ArrowRight,
   ChartCandlestick,
   MoreHorizontal,
   Pencil,
@@ -306,6 +307,7 @@ function StockForm({
           onChange={(event) => setNote(event.target.value)}
           placeholder={t("notePlaceholder")}
           rows={4}
+          maxLength={2000}
         />
       </div>
 
@@ -368,6 +370,13 @@ function StockRow({
   const isGain = (stock.change ?? 0) >= 0;
   const hasDirection = stock.changePercent !== null;
   const DirectionIcon = isGain ? TrendingUp : TrendingDown;
+  // Deepened schema hue for the secondary directional cues (connector arrow,
+  // absolute change). Null when there's no quote, so those stay neutral gray.
+  const directionInk = hasDirection
+    ? isGain
+      ? "text-[var(--gain-ink)]"
+      : "text-[var(--loss-ink)]"
+    : null;
   const latestPrice = format.money(stock.latestPrice, currency);
   const recordPrice = format.money(stock.recordPrice, stock.currency);
   const change = format.money(stock.change, currency);
@@ -462,24 +471,32 @@ function StockRow({
       )}
     >
       <CardContent className="space-y-3 md:px-3">
-        <div className="hidden items-center gap-3 md:grid md:grid-cols-[minmax(190px,1.6fr)_minmax(118px,0.9fr)_minmax(122px,0.9fr)_minmax(120px,0.9fr)_1.75rem]">
+        <div className="hidden items-center gap-5 md:grid md:grid-cols-[minmax(180px,1.5fr)_minmax(280px,1.3fr)_minmax(116px,auto)_1.75rem]">
           {renderIdentity(true)}
 
+          {/* Price journey: the recorded reference price, then the live quote it's measured against. */}
           <div className="min-w-0">
-            <p className="text-[11px] font-medium text-muted-foreground">{t("recorded")}</p>
-            <p className="mt-0.5 truncate font-mono text-sm font-semibold tabular-nums">
-              {recordPrice}
+            <p className="text-[11px] font-medium text-muted-foreground">
+              {t("recorded")}
+              <ArrowRight className="mx-1.5 inline h-3 w-3 -translate-y-px text-muted-foreground/40" />
+              {t("latestPrice")}
             </p>
-            <div className="mt-0.5 space-y-0.5 text-[11px] leading-4 text-muted-foreground">
-              <p className="truncate">{format.date(stock.recordDate)}</p>
-              {recordPeriodLabel && <p className="truncate">{recordPeriodLabel}</p>}
-            </div>
-          </div>
-
-          <div className="min-w-0">
-            <p className="text-[11px] font-medium text-muted-foreground">{t("latestPrice")}</p>
-            <p className="mt-0.5 truncate font-mono text-sm font-semibold tabular-nums">
-              {latestPrice ?? t("unavailable")}
+            {/* flex-wrap (not truncate): a long price must never be clipped mid-number. */}
+            <p className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5 font-mono tabular-nums">
+              <span className="text-sm font-medium text-muted-foreground">{recordPrice}</span>
+              <ArrowRight
+                className={cn(
+                  "h-3.5 w-3.5 shrink-0 translate-y-0.5",
+                  directionInk ?? "text-muted-foreground/40",
+                )}
+              />
+              <span className="text-base font-semibold text-foreground">
+                {latestPrice ?? t("unavailable")}
+              </span>
+            </p>
+            <p className="mt-1 truncate text-[11px] leading-4 text-muted-foreground/80">
+              {format.date(stock.recordDate)}
+              {recordPeriodLabel && ` · ${recordPeriodLabel}`}
             </p>
             {!stock.latestPriceUpdatedAt && (
               <p className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground">
@@ -488,32 +505,35 @@ function StockRow({
             )}
           </div>
 
-          <div className="min-w-0">
-            <p className="text-[11px] font-medium text-muted-foreground">{t("change")}</p>
-            <div className="mt-1 flex flex-col items-start gap-1">
-              {stock.changePercent !== null ? (
-                <span
-                  className={cn(
-                    "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
-                    isGain
-                      ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
-                      : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
-                  )}
-                >
-                  <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
-                  {percent}
-                </span>
-              ) : (
-                <p className="font-mono text-sm font-semibold tabular-nums text-muted-foreground">
-                  {t("unavailable")}
-                </p>
-              )}
-              {stock.change !== null && (
-                <p className="truncate font-mono text-[11px] font-medium tabular-nums text-muted-foreground">
-                  {change}
-                </p>
-              )}
-            </div>
+          {/* Change: the payoff, anchored to the row's right edge so pills line up down the list. */}
+          <div className="flex flex-col items-end gap-1 justify-self-end">
+            {stock.changePercent !== null ? (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
+                  isGain
+                    ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
+                    : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
+                )}
+              >
+                <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
+                {percent}
+              </span>
+            ) : (
+              <p className="font-mono text-sm font-semibold tabular-nums text-muted-foreground">
+                {t("unavailable")}
+              </p>
+            )}
+            {stock.change !== null && (
+              <p
+                className={cn(
+                  "font-mono text-[11px] font-medium tabular-nums",
+                  directionInk ?? "text-muted-foreground",
+                )}
+              >
+                {change}
+              </p>
+            )}
           </div>
 
           <div className="justify-self-end">{renderActions()}</div>
@@ -523,29 +543,37 @@ function StockRow({
           <div className="flex items-start justify-between gap-4">
             {renderIdentity()}
 
-            <div className="min-w-0 shrink-0 flex flex-col items-end">
-              <div>
-                {stock.changePercent !== null ? (
-                  <span
-                    className={cn(
-                      "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
-                      isGain
-                        ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
-                        : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
-                    )}
-                  >
-                    <DirectionIcon className="h-4 w-4 shrink-0" />
-                    {percent}
-                  </span>
-                ) : (
-                  <p className="font-mono text-base font-bold tabular-nums text-muted-foreground">
-                    {t("unavailable")}
-                  </p>
-                )}
-              </div>
-              <p className="mt-1.5 font-mono text-sm font-medium tabular-nums text-muted-foreground">
+            <div className="flex min-w-0 shrink-0 flex-col items-end">
+              {stock.changePercent !== null ? (
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
+                    isGain
+                      ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
+                      : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
+                  )}
+                >
+                  <DirectionIcon className="h-4 w-4 shrink-0" />
+                  {percent}
+                </span>
+              ) : (
+                <p className="font-mono text-base font-bold tabular-nums text-muted-foreground">
+                  {t("unavailable")}
+                </p>
+              )}
+              <p className="mt-2 font-mono text-base font-semibold tabular-nums text-foreground">
                 {latestPrice ?? t("unavailable")}
               </p>
+              {change && (
+                <p
+                  className={cn(
+                    "mt-0.5 font-mono text-[11px] font-medium tabular-nums",
+                    directionInk ?? "text-muted-foreground",
+                  )}
+                >
+                  {change}
+                </p>
+              )}
             </div>
           </div>
 
@@ -570,7 +598,7 @@ function StockRow({
 
         {noteText && (
           <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2.5">
-            <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+            <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground">
               <span className="mr-2 text-xs font-medium text-muted-foreground">{t("note")}:</span>
               {noteText}
             </p>
@@ -588,6 +616,7 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
   const [formOpen, setFormOpen] = useState(false);
   const [editingStock, setEditingStock] = useState<SerializedTrackedStock | null>(null);
   const [deletingStock, setDeletingStock] = useState<SerializedTrackedStock | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   // Derive the most recent price update timestamp across all stocks.
@@ -620,8 +649,9 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
   }
 
   async function deleteStock() {
-    if (!deletingStock) return;
+    if (!deletingStock || isDeleting) return;
     const stock = deletingStock;
+    setIsDeleting(true);
     try {
       const res = await fetch(`/api/stocks/${stock.id}`, { method: "DELETE" });
       if (!res.ok) throw new Error("delete failed");
@@ -629,7 +659,10 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
       setDeletingStock(null);
       startTransition(() => router.refresh());
     } catch {
+      // Keep the dialog open so the user can retry; only success dismisses it.
       toast.error(t("deleteFailed"));
+    } finally {
+      setIsDeleting(false);
     }
   }
 
@@ -704,7 +737,10 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
         />
       )}
 
-      <AlertDialog open={!!deletingStock} onOpenChange={(open) => !open && setDeletingStock(null)}>
+      <AlertDialog
+        open={!!deletingStock}
+        onOpenChange={(open) => !open && !isDeleting && setDeletingStock(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
@@ -715,8 +751,16 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
             <AlertDialogDescription>{t("deleteBody")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{common("cancel")}</AlertDialogCancel>
-            <AlertDialogAction onClick={deleteStock}>{t("deleteStock")}</AlertDialogAction>
+            <AlertDialogCancel disabled={isDeleting}>{common("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isDeleting}
+              onClick={(event) => {
+                event.preventDefault();
+                deleteStock();
+              }}
+            >
+              {isDeleting ? t("deleting") : t("deleteStock")}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
Reworks the **watchlist tab**'s information layout and resilience. One card per item is kept (no table container); only the in-card layout and color change. The app icon/favicon are unchanged from `master`.

## Layout
- Replaces the four equal-weight columns with a left-to-right **price journey**: identity, then `recorded → latest` on a single baseline with the latest quote emphasized, then the change pill anchored to the row's right edge so pills line up down the list.
- Mobile: latest price emphasized as the current value; absolute change surfaced beneath the percent pill.

## Hardening
- Prices never clip — the journey values wrap instead of truncating mid-number.
- Notes wrap long unbroken strings (`break-words`) instead of overflowing the card.
- Delete keeps its dialog open with a pending **Deleting…** state and only dismisses on success, so a failed delete can be retried; guards against double-submit.
- Note textarea bounded to 2000 chars to match the server-side cap.

## Colorize
- Adds schema tokens `--gain-ink` / `--loss-ink`. The bright `--gain`/`--loss` chips clear 3:1 as pill text but not 4.5:1 as 11px body (light-mode cyan loss is ~2.97:1); mixing 30% toward the ink end clears **4.5:1 in both themes and every schema** (measured min 5.63:1). Defined once; lazy `var()` substitution adapts per theme/schema.
- Applies them to the directional cues that were dead gray: the journey connector arrow and the absolute-change figure. Neutral when there's no quote; identity, labels, dates, and the latest-price value stay ink.

## Verification
- `format:check`, `lint` (0 errors), `typecheck` all green.
- Contrast computed in OKLCH→sRGB for both directions × both themes (text ≥4.5:1, arrow ≥3:1).
- Visually verified gain + loss, light + dark, desktop + mobile, plus edge cases (large numbers, long names, long unbroken-string notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)