### PR TITLE
fix(stocks): harden watchlist caching, validation, and API routes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Vendored agent skills — not part of the app source.
+    ".agents/**",
   ]),
   // Disallow raw console calls — use src/lib/logger.ts instead (server) or eslint-disable for client components
   {

--- a/src/app/api/stocks/quote/route.ts
+++ b/src/app/api/stocks/quote/route.ts
@@ -1,8 +1,12 @@
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure } from "@/lib/api-responses";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { fetchEquityQuote, warmStockPrice } from "@/lib/services/stock-watch-service";
 
 export const GET = withAuth(async (request) => {
+  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "stocks-quote" });
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
   const symbol = searchParams.get("symbol")?.trim().toUpperCase();
   if (!symbol) return failure("Symbol is required");

--- a/src/app/api/stocks/refresh/route.ts
+++ b/src/app/api/stocks/refresh/route.ts
@@ -1,8 +1,14 @@
 import { withAuth } from "@/lib/api-handler";
 import { ok } from "@/lib/api-responses";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { refreshTrackedStockPrices } from "@/lib/services/stock-watch-service";
 
-export const POST = withAuth(async (_request, _ctx, userId) => {
+export const POST = withAuth(async (request, _ctx, userId) => {
+  // Tighter than the quote endpoint: each call fans out to Yahoo for every
+  // tracked symbol.
+  const limited = rateLimitCheckWithPrune(request, { limit: 10, prefix: "stocks-refresh" });
+  if (limited) return limited;
+
   const result = await refreshTrackedStockPrices(userId);
   return ok(result);
 });

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -30,6 +30,16 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   const quote = await fetchEquityQuote(symbol);
   if (!quote) return failure("Only stock symbols can be tracked.", 400);
 
+  // Yahoo may canonicalize the symbol (e.g. BRK.B → BRK-B); the row is created
+  // with quote.symbol, so the dedupe check must cover that form too.
+  if (quote.symbol !== symbol) {
+    const existingCanonical = await prisma.stockWatchItem.findUnique({
+      where: { userId_symbol: { userId, symbol: quote.symbol } },
+      select: { id: true },
+    });
+    if (existingCanonical) return failure("This stock is already tracked.", 409);
+  }
+
   const item = await prisma.stockWatchItem.create({
     data: {
       userId,

--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -38,15 +38,6 @@ function useMarketFormatters() {
   const { privacyMode } = usePrivacyMode();
 
   return {
-    money(value: number | null, currency: string) {
-      if (privacyMode) return HIDDEN;
-      if (value === null) return null;
-      return new Intl.NumberFormat(locale, {
-        style: "currency",
-        currency,
-        maximumFractionDigits: Math.abs(value) >= 100 ? 2 : 4,
-      }).format(value);
-    },
     percent(value: number | null) {
       if (privacyMode) return HIDDEN;
       if (value === null) return null;
@@ -62,7 +53,6 @@ function useMarketFormatters() {
 function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
   const t = useTranslations("stocks");
   const format = useMarketFormatters();
-  const currency = stock.latestPriceCurrency ?? stock.currency;
   const changePercent = format.percent(stock.changePercent);
   const isGain = (stock.change ?? stock.changePercent ?? 0) >= 0;
   const DirectionIcon = isGain ? TrendingUp : TrendingDown;

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -4,7 +4,7 @@ import { useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Plus, Target } from "lucide-react";
+import { Plus } from "lucide-react";
 import type { GoalWithProgress, SerializedAccount } from "@/lib/types";
 import type { ProjectionData } from "@/lib/services/projection-service";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";

--- a/src/lib/services/stock-watch-service.ts
+++ b/src/lib/services/stock-watch-service.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { revalidateTag } from "next/cache";
+import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshPricesForStockSymbols } from "@/lib/services/price-service";
 import { getYahooClient } from "@/lib/services/yahoo-client";
@@ -49,7 +49,11 @@ function withLatestPrice(
   price?: { price: number; currency: string; updatedAt: Date },
 ): SerializedTrackedStock {
   const latestPrice = price?.price ?? null;
-  const change = latestPrice === null ? null : latestPrice - item.recordPrice;
+  // Change math is only meaningful when the cached quote is denominated in the
+  // same currency the record price was captured in (PriceCache is shared with
+  // the holdings pipeline, so the currencies can diverge).
+  const comparable = latestPrice !== null && price?.currency === item.currency;
+  const change = comparable ? latestPrice - item.recordPrice : null;
   const changePercent =
     change === null || item.recordPrice === 0 ? null : (change / item.recordPrice) * 100;
 
@@ -64,6 +68,13 @@ function withLatestPrice(
 }
 
 export async function getCachedTrackedStocks(userId: string): Promise<SerializedTrackedStock[]> {
+  "use cache";
+  cacheTag("stocks");
+  cacheTag(`stocks:${userId}`);
+  // Also reads PriceCache, so any price refresh (cron, holdings, manual) must
+  // invalidate this read via the shared "prices" tag.
+  cacheTag("prices");
+  cacheLife("hours");
   const items = await prisma.stockWatchItem.findMany({
     where: { userId },
     orderBy: [{ createdAt: "desc" }, { symbol: "asc" }],

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -157,11 +157,7 @@ export const createGoalSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   targetAmount: z.number().positive("Target must be positive"),
   targetCurrency: z.string().length(3).default("USD"),
-  targetDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD")
-    .optional()
-    .nullable(),
+  targetDate: z.iso.date("Must be a valid YYYY-MM-DD date").optional().nullable(),
   scope: z.enum(GOAL_SCOPES),
   scopeRefId: z.string().min(1).optional().nullable(),
 });
@@ -178,7 +174,7 @@ const stockWatchItemFields = {
   exchange: z.string().max(80).default(""),
   currency: z.string().length(3).default("USD"),
   recordPrice: z.number().positive("Record price must be positive"),
-  recordDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
+  recordDate: z.iso.date("Must be a valid YYYY-MM-DD date"),
   note: z.string().max(2000).optional().nullable(),
 };
 


### PR DESCRIPTION
## Summary

Fixes the issues found in an audit of the stock-watchlist feature (#385–#392):

- **Watchlist cache was a no-op** — `getCachedTrackedStocks` had no `"use cache"`/`cacheTag`, and `invalidateStockWatchCaches` revalidated tags that were never registered. It is now a real cached read (`stocks`, `stocks:<userId>`, `prices` tags, `cacheLife("hours")`), following the same pattern as the settings/goals/net-worth services. Registering the `prices` tag also makes the existing app-wide `revalidateTag("prices")` calls (cron, holdings, manual refresh) invalidate the watchlist read.
- **Duplicate-tracking 500** — `POST /api/stocks` deduped on the raw input symbol but created the row with Yahoo's canonical symbol (e.g. `BRK.B` → `BRK-B`), so re-adding a variant spelling hit the unique constraint and returned an unhandled 500. The route now re-checks the canonical form and returns the friendly 409.
- **Date validation accepted impossible dates** — `recordDate` and goal `targetDate` only checked a `\d{4}-\d{2}-\d{2}` regex, so `2026-99-99` passed; worse, V8 rolls `2026-02-31` over to March 3, silently storing the wrong date. Both now use `z.iso.date()` (full calendar validation incl. leap days). Option `expiration` is intentionally untouched — the holding form sends a JSON-serialized `Date` (full ISO datetime), which its unanchored regex exists to accept.
- **Missing rate limits** — `/api/stocks/quote` (60/min) and `/api/stocks/refresh` (10/min, tighter since it fans out to Yahoo per tracked symbol) now use `rateLimitCheckWithPrune`, matching `/api/search` / `/api/options/chain` / `/api/exchange-rates`.
- **Cross-currency change math** — `withLatestPrice` nulls `change`/`changePercent` when the cached quote currency differs from the record-price currency (PriceCache is shared with the holdings pipeline), falling back to the existing "unavailable" UI state.
- **Cleanup** — removed the dead `money` formatter / unused `currency` var in `watchlist-card.tsx` and the unused `Target` import in `goals-view.tsx`; added vendored `.agents/**` to ESLint ignores (drops ~125 third-party warnings; lint is now fully clean).

## Test plan

- `npm run format:check`, `npm run lint` (0 errors / 0 warnings), `npm run typecheck` — all pass
- `npm run build` — compiles, all 32 pages generate, `/stocks` still partial-prerenders (validates the `"use cache"` change under `cacheComponents`)
- Schema behavior verified directly via tsx: create/PATCH stock schemas and create/update goal schemas reject `2026-99-99` and `2026-02-31`, accept `2024-02-29` (leap day), valid dates, and `null`/`undefined` for optional `targetDate`; symbol uppercasing transform intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)