### PR TITLE
fix: harden snapshot integrity, cash-balance atomicity, and cron auth

### DIFF
--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -19,15 +19,16 @@ export const POST = withAuth(
     const account = await prisma.account.findUnique({ where: { id, userId } });
     if (!account) return failure("Account not found", 404);
 
-    const transaction = await prisma.cashTransaction.create({
-      data: { accountId: id, type, amount, note },
-    });
-
     const delta = calculateBalanceDelta(null, { type, amount });
-    await prisma.account.update({
-      where: { id },
-      data: { cashBalance: { increment: delta } },
-    });
+    const [transaction] = await prisma.$transaction([
+      prisma.cashTransaction.create({
+        data: { accountId: id, type, amount, note },
+      }),
+      prisma.account.update({
+        where: { id },
+        data: { cashBalance: { increment: delta } },
+      }),
+    ]);
 
     revalidateTag(`accounts:${userId}`, { expire: 0 });
     revalidateTag(`net-worth:${userId}`, { expire: 0 });

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -31,25 +31,27 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const existingAccount = await prisma.account.findUnique({ where: { id, userId } });
   if (!existingAccount) return failure("Not found", 404);
 
-  // If cashBalance is being updated to a new value, log it as an EDIT transaction
-  if (
-    parsed.data.cashBalance !== undefined &&
-    parsed.data.cashBalance !== Number(existingAccount.cashBalance)
-  ) {
-    const diff = parsed.data.cashBalance - Number(existingAccount.cashBalance);
-    await prisma.cashTransaction.create({
-      data: {
-        accountId: id,
-        type: "EDIT",
-        amount: diff,
-        note: body.note || `Manual balance update (${diff > 0 ? "+" : ""}${diff})`,
-      },
-    });
-  }
+  const account = await prisma.$transaction(async (tx) => {
+    // If cashBalance is being updated to a new value, log it as an EDIT transaction
+    if (
+      parsed.data.cashBalance !== undefined &&
+      parsed.data.cashBalance !== Number(existingAccount.cashBalance)
+    ) {
+      const diff = parsed.data.cashBalance - Number(existingAccount.cashBalance);
+      await tx.cashTransaction.create({
+        data: {
+          accountId: id,
+          type: "EDIT",
+          amount: diff,
+          note: body.note || `Manual balance update (${diff > 0 ? "+" : ""}${diff})`,
+        },
+      });
+    }
 
-  const account = await prisma.account.update({
-    where: { id, userId },
-    data: parsed.data,
+    return tx.account.update({
+      where: { id, userId },
+      data: parsed.data,
+    });
   });
   invalidateUserCaches(userId);
   return ok(account);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -109,18 +109,13 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
     if (amountError) return failure(amountError, 400);
 
     // Recompute balance delta whenever amount or type changes.
+    let delta = 0;
     if (data.amount !== undefined || data.type !== undefined) {
       const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
-      const delta = calculateBalanceDelta(oldTx, nextCashTx);
-      if (delta !== 0) {
-        await prisma.account.update({
-          where: { id: accountId },
-          data: { cashBalance: { increment: delta } },
-        });
-      }
+      delta = calculateBalanceDelta(oldTx, nextCashTx);
     }
 
-    const updatedTx = await prisma.cashTransaction.update({
+    const txUpdate = prisma.cashTransaction.update({
       where: { id: transactionId },
       data: {
         ...(data.amount !== undefined && { amount: data.amount }),
@@ -129,6 +124,17 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
         ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
       },
     });
+
+    const [updatedTx] =
+      delta !== 0
+        ? await prisma.$transaction([
+            txUpdate,
+            prisma.account.update({
+              where: { id: accountId },
+              data: { cashBalance: { increment: delta } },
+            }),
+          ])
+        : [await txUpdate];
 
     invalidateAccountCaches(userId);
     return ok(updatedTx);
@@ -187,12 +193,13 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
     }
 
     const delta = calculateBalanceDelta({ type: cashTx.type, amount: Number(cashTx.amount) }, null);
-    await prisma.account.update({
-      where: { id: accountId },
-      data: { cashBalance: { increment: delta } },
-    });
-
-    await prisma.cashTransaction.delete({ where: { id: transactionId } });
+    await prisma.$transaction([
+      prisma.cashTransaction.delete({ where: { id: transactionId } }),
+      prisma.account.update({
+        where: { id: accountId },
+        data: { cashBalance: { increment: delta } },
+      }),
+    ]);
     invalidateAccountCaches(userId);
     return ok({ ok: true });
   }

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
@@ -7,9 +8,14 @@ import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
 import { log } from "@/lib/logger";
 
+function isAuthorized(request: Request): boolean {
+  const provided = Buffer.from(request.headers.get("authorization") ?? "");
+  const expected = Buffer.from(`Bearer ${CRON_SECRET}`);
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}
+
 export async function GET(request: Request) {
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${CRON_SECRET}`) {
+  if (!isAuthorized(request)) {
     return new Response("Unauthorized", { status: 401 });
   }
 
@@ -77,14 +83,30 @@ export async function GET(request: Request) {
       include: { appSettings: true },
     });
 
-    // 3. Create snapshots for each user (in parallel)
-    const snapshots = await Promise.all(
+    // 3. Create snapshots for each user (in parallel, isolated so one
+    // user's failure — e.g. unresolved exchange rates — doesn't reject
+    // snapshots already written for everyone else)
+    const results = await Promise.allSettled(
       users.map((user) => {
         const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
         log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
         return createSnapshot(user.id, baseCurrency);
       }),
     );
+
+    const snapshotIds: string[] = [];
+    const failures: { userId: string; error: string }[] = [];
+    results.forEach((result, i) => {
+      if (result.status === "fulfilled") {
+        snapshotIds.push(result.value.id);
+      } else {
+        failures.push({ userId: users[i].id, error: String(result.reason) });
+        log.error("cron.snapshot.user_failed", {
+          userId: users[i].id,
+          error: String(result.reason),
+        });
+      }
+    });
 
     // 4. Invalidate snapshot/history caches now that new rows exist
     revalidateTag("snapshots", "max");
@@ -93,8 +115,9 @@ export async function GET(request: Request) {
     }
 
     return ok({
-      success: true,
-      snapshotIds: snapshots.map((s) => s.id),
+      success: failures.length === 0,
+      snapshotIds,
+      failures,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -187,6 +187,7 @@ async function computeNetWorthSummary(
     baseCurrency,
     currencyExposure,
     accounts: accountsWithValue,
+    unresolvedRatePairs: [...warnedPairs],
   };
 }
 

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,9 +1,33 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
 import { getNetWorthSummary } from "./net-worth-service";
+import { log } from "@/lib/logger";
+
+/**
+ * Thrown when a snapshot would be computed with missing exchange rates
+ * (values silently converted at 1:1). Snapshots are permanent records, so
+ * persisting them with known-wrong conversions is worse than skipping a day.
+ */
+export class UnresolvedRatesError extends Error {
+  constructor(
+    public readonly userId: string,
+    public readonly pairs: string[],
+  ) {
+    super(`Cannot snapshot with unresolved exchange rates: ${pairs.join(", ")}`);
+    this.name = "UnresolvedRatesError";
+  }
+}
 
 export async function createSnapshot(userId: string, baseCurrency: string) {
   const summary = await getNetWorthSummary(userId, baseCurrency);
+
+  // Optional chaining: summaries cached (unstable_cache) before this field
+  // existed may survive a deploy without it.
+  const unresolvedPairs = summary.unresolvedRatePairs ?? [];
+  if (unresolvedPairs.length > 0) {
+    log.error("snapshot.unresolved_rates", { userId, baseCurrency, pairs: unresolvedPairs });
+    throw new UnresolvedRatesError(userId, unresolvedPairs);
+  }
   const snapshotTakenAt = new Date();
   const today = new Date(snapshotTakenAt);
   today.setHours(0, 0, 0, 0);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,6 +84,12 @@ export type NetWorthSummary = {
   baseCurrency: string;
   currencyExposure: { currency: string; value: number }[];
   accounts: AccountWithValue[];
+  /**
+   * Currency pairs (as "FROM_TO") that could not be resolved and fell back
+   * to a 1:1 rate. Render paths tolerate this; persistence paths
+   * (snapshots) must treat a non-empty list as a hard error.
+   */
+  unresolvedRatePairs: string[];
 };
 
 export type AllocationItem = {


### PR DESCRIPTION
## Summary

Three data-integrity / security fixes found by a direct code audit of the API routes and service layer:

### 1. Snapshots no longer persist silently-wrong 1:1 currency conversions
- `computeNetWorthSummary` now reports every currency pair that fell back to a 1:1 rate via a new `NetWorthSummary.unresolvedRatePairs` field.
- Render paths still tolerate the fallback (dashboard keeps loading), but `createSnapshot` now throws a typed `UnresolvedRatesError` instead of writing a permanent `NetWorthSnapshot` built on known-wrong conversions — skipping a day beats recording a wrong number forever.
- The cron route now uses `Promise.allSettled` per user so one user's failure no longer rejects snapshots already written for everyone else; the response reports `snapshotIds` and per-user `failures` separately, and failures are logged as `cron.snapshot.user_failed`.
- Guarded against pre-deploy cached summaries (`unstable_cache` can survive deploys) that lack the new field.

### 2. Cash-balance writes are atomic with their ledger entries
All four spots that wrote `cashBalance` and its `CashTransaction` row in separate statements now run in a single `prisma.$transaction`:
- cash-transaction create (`POST /api/accounts/[id]/cash-transactions`)
- cash-transaction edit + delete (`/api/accounts/[id]/transactions/[transactionId]`)
- manual balance edit (`PATCH /api/accounts/[id]`)

A crash mid-request can no longer leave the balance out of sync with the transaction history. (The holding-transaction paths already used `$transaction`; the cash paths never got the same treatment.)

### 3. Timing-safe `CRON_SECRET` comparison
`GET /api/cron/snapshot` now compares the bearer token with `crypto.timingSafeEqual` on equal-length buffers instead of a string `!==`.

## Test plan
- [x] `npm run format:check` / `lint` / `typecheck` all pass (also enforced by pre-push hook)
- [ ] Verify a cash deposit/edit/delete round-trip keeps `cashBalance` consistent with the transaction list
- [ ] Verify `/api/cron/snapshot` with a valid `CRON_SECRET` still creates snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)