### PR TITLE
feat: throttle manual market-data refreshes against external APIs

### DIFF
--- a/docs/REFRESH_THROTTLING_PLAN.md
+++ b/docs/REFRESH_THROTTLING_PLAN.md
@@ -1,0 +1,89 @@
+# Refresh Throttling — Freshness Gate + Per-User Rate Limits + Client Cooldown
+
+## Context
+
+> **Status note (2026-06-10):** the service-level freshness gate itself landed separately on master via #396 (1-min price TTL via `PriceCache.updatedAt`; 60-min FX TTL via an in-process per-base map), and #397 added USD cross-rate derivation before the rate=1 fallback. This change keeps the layers master still lacks — per-user rate limits, the cron `force` bypass, `skippedFresh`/`retryAfterSeconds` response hints, the shared client cooldown UX, and the `warmStockPrice` gate — and adopts #396's reviewed TTL values into `refresh-policy.ts`.
+
+Users can spam the manual refresh surfaces (dashboard pull-to-refresh, dashboard refresh button, settings "refresh market data", stocks watchlist refresh) and every trigger hits external APIs (Yahoo Finance, CoinGecko, frankfurter.app / open.er-api.com) unconditionally:
+
+- `POST /api/prices/refresh` and `POST /api/exchange-rates/refresh` have **no rate limit and no freshness check** — every call re-fetches all user symbols/currencies even if the cache is seconds old.
+- Only `/api/stocks/refresh` (10/min) and `/api/stocks/quote` (60/min) are rate-limited, and only **per-IP**, never per-user.
+- `PriceCache.updatedAt` / `ExchangeRate.updatedAt` exist but are never compared for staleness.
+- Client buttons only have a transient `refreshing` disabled state.
+
+Defense in depth, in order of authority:
+
+1. **DB-backed freshness gate in the service layer** (primary — survives cold starts/multi-instance since it reads `updatedAt` from Postgres).
+2. **Per-user in-memory rate limit** on refresh routes (secondary — protects the route itself).
+3. **Client cooldown + honest toasts** (UX only, never trusted).
+
+User chose: **server + client UX** (full stack).
+
+## Tuning values
+
+| Knob                                              | Value                                 | Rationale                                                                                                          |
+| ------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `PRICE_REFRESH_TTL_MS`                            | 2 min                                 | Near-real-time feel kept; caps a spam-puller at ~30 Yahoo batches/hr. Matches existing 300s read-cache revalidate. |
+| `FX_REFRESH_TTL_MS`                               | 30 min                                | frankfurter = ECB daily data; open.er-api daily. 30 min is already overkill.                                       |
+| `prices-refresh` / `rates-refresh` per-user limit | 5 / 60s                               | Allows honest retries, blocks loops.                                                                               |
+| `stocks-refresh` limit                            | keep 10 / 60s, switch key IP → userId |                                                                                                                    |
+| Client cooldown floor                             | 15 s                                  | Extended to server `retryAfterSeconds` when everything is fresh.                                                   |
+
+## Implementation steps
+
+### Infra
+
+1. **New `src/lib/refresh-policy.ts`** — isomorphic constants (no `server-only`): `PRICE_REFRESH_TTL_MS`, `FX_REFRESH_TTL_MS`, `CLIENT_REFRESH_COOLDOWN_MS = 15_000`. Single source so server gate and client cooldown don't drift.
+2. **`src/lib/rate-limit.ts`** — add optional `key?: string` to `RateLimitOptions`; `const id = options.key ?? getClientIp(request)`. Existing callers unchanged; existing 429 already sends `Retry-After`.
+
+### Services
+
+3. **`src/lib/services/price-service.ts`** — `refreshPricesForHoldings(holdings, opts?: { force?: boolean })`:
+   - Unless `force`: query `priceCache.findMany({ where: { symbol: { in: symbols }, updatedAt: { gt: now - PRICE_REFRESH_TTL_MS } } })`, drop fresh symbols before the Yahoo/CoinGecko fetch.
+   - Return shape (additive): `{ updated, skippedFresh, errors, nextRefreshAt: string | null, retryAfterSeconds: number | null }` — `nextRefreshAt` = earliest fresh `updatedAt` + TTL when everything was skipped.
+   - `refreshAllPrices()` (cron) passes `{ force: true }`; `refreshPricesForUser` / `refreshPricesForStockSymbols` forward `opts` (default gated).
+   - `log.info("prices.refresh.skipped_fresh", { skipped, requested })`.
+4. **`src/lib/services/exchange-rate-service.ts`** — `refreshExchangeRates(base, opts?: { force?: boolean })` → `{ updated, skippedFresh, nextRefreshAt }` (was bare `number`). Unless `force`: `exchangeRate.aggregate({ where: { fromCurrency: base }, _max: { updatedAt }, _count })`; if rows exist and `_max` within TTL, early-return without external fetch. Comment the known caveat: a lazy single-pair persist can mark the base fresh for up to 30 min (acceptable — same day-grain upstream). Lazy `getExchangeRate` path untouched.
+
+### Routes
+
+5. **`src/app/api/prices/refresh/route.ts`** — per-user limiter (`{ limit: 5, prefix: "prices-refresh", key: userId }`); only `revalidateTag` when `updated > 0`; payload `ok({ updated, skippedFresh, errors, nextRefreshAt, retryAfterSeconds })` (keeps `updated` for back-compat).
+6. **`src/app/api/exchange-rates/refresh/route.ts`** — same limiter pattern (`rates-refresh`); aggregate per-currency results; `nextRefreshAt` = earliest non-null; revalidate only when `totalUpdated > 0`.
+7. **`src/app/api/stocks/refresh/route.ts`** — one line: add `key: userId`. Service gate applies automatically.
+8. **`src/app/api/cron/snapshot/route.ts`** — `refreshExchangeRates(c, { force: true })`; `refreshAllPrices()` already forces internally. Cron is CRON_SECRET-gated, not `withAuth`, so per-user limits can't touch it.
+9. **`src/lib/services/stock-watch-service.ts`** — `warmStockPrice`: return cached row without Yahoo upsert when `PriceCache.updatedAt` within `PRICE_REFRESH_TTL_MS`.
+
+### Client
+
+10. **New `src/lib/refresh-client.ts`** — shared client module with module-level `cooldownUntil`:
+    - `refreshMarketData(): Promise<RefreshOutcome>` where outcome ∈ `updated | fresh | cooldown | error`; fires both POSTs in parallel; on 429 reads `Retry-After`; when both return `updated === 0` + `skippedFresh > 0` → `fresh` with payload `retryAfterSeconds`; success sets `cooldownUntil = now + CLIENT_REFRESH_COOLDOWN_MS`.
+    - Dispatches `refresh:cooldown` CustomEvent on change (same pattern as existing `prices:refresh*` events in `dashboard-actions.tsx`); `getCooldownRemainingMs()` helper.
+11. **New `src/hooks/use-refresh-cooldown.ts`** — subscribes to the event, 1s tick while active, returns `{ coolingDown, secondsLeft }` (follows `use-count-up` pattern).
+12. **Component swaps** (replace inline fetch pairs with `refreshMarketData()` + outcome switch; `disabled={refreshing || coolingDown}`):
+    - `src/components/dashboard/dashboard-actions.tsx`
+    - `src/components/dashboard/dashboard-pull-refresh.tsx` (`router.refresh()` only on `updated`; `toast.info` for fresh/cooldown)
+    - `src/components/settings/settings-form.tsx`
+    - `src/components/stocks/stock-tracker-view.tsx` — keeps its own `/api/stocks/refresh` fetch; add 429 + fresh handling and a local 15s cooldown.
+13. **i18n** (`messages/en-US.json` + `messages/zh-TW.json`), info-style not error:
+    - `dashboardActions.alreadyFresh` — "Prices are already up to date — try again in {seconds}s"
+    - `dashboardActions.cooldownWait` — "Please wait {seconds}s before refreshing"
+    - `settings.toast.marketDataFresh`, `stocks.alreadyFresh`
+
+## Edge cases
+
+- **In-memory limiter resets** on cold start / per instance — accepted; the DB freshness gate is the shared source of truth. Worst-case race: two concurrent requests both pass the gate → bounded 2× fetch, safe via `ON CONFLICT` upserts.
+- **Clock skew**: client only uses server-computed `retryAfterSeconds` / `Retry-After`, never wall-clock math on `nextRefreshAt`.
+- **Back-compat**: `updated` retained in payloads; `refreshExchangeRates` return-type change has exactly two call sites (its route + cron), both updated here. Also `maybeWarmExchangeRate` callers ignore the return value — verify they still typecheck.
+- **New currency, zero rows**: `_count === 0` → gate skipped, fetch proceeds.
+- **E2E**: grep `tests/e2e/` for assertions on refresh `updated > 0` before merging (double-refresh may now hit the fresh path).
+
+## Verification
+
+1. `npm run format:check && npm run lint && npm run typecheck`.
+2. Manual dev: dashboard refresh → success toast; immediate second refresh → "already up to date — try again in Xs", button disabled; confirm `PriceCache.updatedAt` did **not** advance (SQL/Prisma Studio).
+3. 7× `curl -X POST /api/prices/refresh` with session cookie → 6th returns 429 with `Retry-After`.
+4. `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/snapshot` right after a manual refresh → `updatedAt` columns **do** advance (force bypass works).
+5. Watchlist double-refresh on `/stocks` → second shows info toast; `prices.refresh.skipped_fresh` appears in dev logs.
+6. `npm run test:e2e`.
+
+Order: infra (1–2) → services (3–4, 9) → routes (5–8) → client (10–12) → i18n (13) → verification.

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -171,7 +171,9 @@
     "languageUpdated": "Language updated",
     "languageFailed": "Failed to update language",
     "preferencesUpdated": "Settings updated",
-    "preferencesFailed": "Failed to update settings"
+    "preferencesFailed": "Failed to update settings",
+    "marketDataFresh": "Market data is already up to date",
+    "refreshCooldown": "Please wait {seconds}s before refreshing"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -669,7 +671,9 @@
     "refreshPrices": "Refresh Prices",
     "refreshing": "Refreshing...",
     "refreshSuccess": "Updated {count} prices & exchange rates",
-    "refreshFailed": "Failed to refresh prices"
+    "refreshFailed": "Failed to refresh prices",
+    "alreadyFresh": "Prices are already up to date — try again in {seconds}s",
+    "cooldownWait": "Please wait {seconds}s before refreshing"
   },
   "freshness": {
     "pricesUpdated": "Prices updated {age}",
@@ -1123,7 +1127,9 @@
     "viewAllAria": "View full watchlist",
     "dashboardEmptyTitle": "No watchlist yet",
     "dashboardEmptyBody": "Track ideas separately from accounts before they become holdings.",
-    "dashboardPreviewCount": "Showing {shown} of {count} tracked stocks"
+    "dashboardPreviewCount": "Showing {shown} of {count} tracked stocks",
+    "alreadyFresh": "Watchlist prices are already up to date",
+    "refreshCooldown": "Please wait {seconds}s before refreshing"
   },
   "transactionHistory": {
     "title": "Transaction History",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -171,7 +171,9 @@
     "languageUpdated": "語言已更新",
     "languageFailed": "更新語言失敗",
     "preferencesUpdated": "設定已更新",
-    "preferencesFailed": "更新設定失敗"
+    "preferencesFailed": "更新設定失敗",
+    "marketDataFresh": "市場資料已是最新",
+    "refreshCooldown": "請稍候 {seconds} 秒後再重新整理"
   },
   "dashboard": {
     "title": "儀表板",
@@ -669,7 +671,9 @@
     "refreshPrices": "更新價格",
     "refreshing": "更新中...",
     "refreshSuccess": "已更新 {count} 個價格和匯率",
-    "refreshFailed": "更新價格失敗"
+    "refreshFailed": "更新價格失敗",
+    "alreadyFresh": "價格已是最新 — 請於 {seconds} 秒後再試",
+    "cooldownWait": "請稍候 {seconds} 秒後再重新整理"
   },
   "freshness": {
     "pricesUpdated": "價格更新於 {age}",
@@ -1123,7 +1127,9 @@
     "viewAllAria": "查看完整自選股",
     "dashboardEmptyTitle": "尚未建立自選股",
     "dashboardEmptyBody": "先把投資想法獨立追蹤，之後再加入帳戶持倉。",
-    "dashboardPreviewCount": "顯示 {count} 檔中的 {shown} 檔自選股"
+    "dashboardPreviewCount": "顯示 {count} 檔中的 {shown} 檔自選股",
+    "alreadyFresh": "追蹤清單價格已是最新",
+    "refreshCooldown": "請稍候 {seconds} 秒後再重新整理"
   },
   "transactionHistory": {
     "title": "交易紀錄",

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -60,7 +60,9 @@ export async function GET(request: Request) {
     for (const row of holdingCurrencies) if (row.currency) sourceCurrencies.add(row.currency);
     for (const row of settings) sourceCurrencies.add(row.baseCurrency);
     log.info("cron.rates.refresh", { count: sourceCurrencies.size });
-    await Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c)));
+    // force: snapshots must be computed from current rates; the manual-refresh
+    // freshness gate doesn't apply to the cron.
+    await Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true })));
     revalidateTag("exchange-rates", "max");
     revalidateTag("net-worth", "max");
 

--- a/src/app/api/exchange-rates/refresh/route.ts
+++ b/src/app/api/exchange-rates/refresh/route.ts
@@ -2,9 +2,19 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { withAuth } from "@/lib/api-handler";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { ok } from "@/lib/api-responses";
 
-export const POST = withAuth(async (_request, _ctx, userId) => {
+export const POST = withAuth(async (request, _ctx, userId) => {
+  // Per-user secondary defense; the service-level FX freshness gate is the
+  // primary one (upstream sources update at day grain anyway).
+  const limited = rateLimitCheckWithPrune(request, {
+    limit: 5,
+    prefix: "rates-refresh",
+    key: userId,
+  });
+  if (limited) return limited;
+
   const settings = await prisma.setting.findUnique({ where: { userId } });
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
@@ -19,12 +29,31 @@ export const POST = withAuth(async (_request, _ctx, userId) => {
     refreshExchangeRates(baseCurrency),
     ...otherCurrencies.map((currency) => refreshExchangeRates(currency)),
   ]);
-  const totalUpdated = results.reduce((a, b) => a + b, 0);
+  const totalUpdated = results.reduce((sum, r) => sum + r.updated, 0);
+  const skippedFresh = results.filter((r) => r.skippedFresh).length;
+  // Earliest moment a retry would actually fetch something.
+  const nextRefreshAt =
+    results
+      .map((r) => r.nextRefreshAt)
+      .filter((v): v is string => v !== null)
+      .sort()[0] ?? null;
+  const retryAfterSeconds = nextRefreshAt
+    ? Math.max(1, Math.ceil((Date.parse(nextRefreshAt) - Date.now()) / 1000))
+    : null;
 
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag("exchange-rates", "max");
-  revalidateTag("net-worth", "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag(`history:${userId}`, "max");
-  return ok({ updated: totalUpdated, baseCurrency });
+  // Only bust caches when something actually changed.
+  if (totalUpdated > 0) {
+    // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+    revalidateTag("exchange-rates", "max");
+    revalidateTag("net-worth", "max");
+    revalidateTag(`net-worth:${userId}`, "max");
+    revalidateTag(`history:${userId}`, "max");
+  }
+  return ok({
+    updated: totalUpdated,
+    skippedFresh,
+    baseCurrency,
+    nextRefreshAt,
+    retryAfterSeconds,
+  });
 });

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -1,14 +1,30 @@
 import { revalidateTag } from "next/cache";
 import { withAuth } from "@/lib/api-handler";
 import { refreshPricesForUser } from "@/lib/services/price-service";
+import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { ok } from "@/lib/api-responses";
 
-export const POST = withAuth(async (_request, _ctx, userId) => {
+export const POST = withAuth(async (request, _ctx, userId) => {
+  // Per-user (not per-IP): each call fans out to Yahoo/CoinGecko for every
+  // holding symbol. The service-level freshness gate is the primary defense;
+  // this just stops request loops from reaching the DB queries.
+  const limited = rateLimitCheckWithPrune(request, {
+    limit: 5,
+    prefix: "prices-refresh",
+    key: userId,
+  });
+  if (limited) return limited;
+
   const result = await refreshPricesForUser(userId);
-  // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-  revalidateTag("net-worth", "max");
-  revalidateTag(`net-worth:${userId}`, "max");
-  revalidateTag("prices", "max");
-  revalidateTag("prices:crypto", "max");
+
+  // Only bust caches when something actually changed — a fully-fresh refresh
+  // shouldn't force every cached read to recompute.
+  if (result.updated > 0) {
+    // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
+    revalidateTag("net-worth", "max");
+    revalidateTag(`net-worth:${userId}`, "max");
+    revalidateTag("prices", "max");
+    revalidateTag("prices:crypto", "max");
+  }
   return ok(result);
 });

--- a/src/app/api/stocks/refresh/route.ts
+++ b/src/app/api/stocks/refresh/route.ts
@@ -5,8 +5,12 @@ import { refreshTrackedStockPrices } from "@/lib/services/stock-watch-service";
 
 export const POST = withAuth(async (request, _ctx, userId) => {
   // Tighter than the quote endpoint: each call fans out to Yahoo for every
-  // tracked symbol.
-  const limited = rateLimitCheckWithPrune(request, { limit: 10, prefix: "stocks-refresh" });
+  // tracked symbol. Keyed per-user so a shared IP can't exhaust the budget.
+  const limited = rateLimitCheckWithPrune(request, {
+    limit: 10,
+    prefix: "stocks-refresh",
+    key: userId,
+  });
   if (limited) return limited;
 
   const result = await refreshTrackedStockPrices(userId);

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { hapticTick } from "@/lib/haptics";
+import { refreshMarketData } from "@/lib/refresh-client";
+import { useRefreshCooldown } from "@/hooks/use-refresh-cooldown";
 import { FreshnessBadge } from "@/components/ui/freshness-badge";
 
 interface DashboardActionsProps {
@@ -20,23 +22,29 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
   const t = useTranslations("dashboardActions");
   const [refreshing, setRefreshing] = useState(false);
   const [clientRefreshAt, setClientRefreshAt] = useState<string | null>(null);
+  const { coolingDown, secondsLeft } = useRefreshCooldown();
 
   const handleRefreshPrices = useCallback(async () => {
     hapticTick();
     setRefreshing(true);
     try {
-      const [priceRes, ratesRes] = await Promise.all([
-        fetch("/api/prices/refresh", { method: "POST" }),
-        fetch("/api/exchange-rates/refresh", { method: "POST" }),
-      ]);
-      if (!priceRes.ok || !ratesRes.ok) throw new Error("Refresh failed");
-      const { data: priceData } = await priceRes.json();
-      toast.success(t("refreshSuccess", { count: priceData.updated }));
-      setClientRefreshAt(new Date().toISOString());
-      window.dispatchEvent(new CustomEvent("prices:refreshed"));
-      router.refresh();
-    } catch {
-      toast.error(t("refreshFailed"));
+      const outcome = await refreshMarketData();
+      switch (outcome.status) {
+        case "updated":
+          toast.success(t("refreshSuccess", { count: outcome.prices }));
+          setClientRefreshAt(new Date().toISOString());
+          router.refresh();
+          break;
+        case "fresh":
+          toast.info(t("alreadyFresh", { seconds: outcome.retryAfterSeconds }));
+          break;
+        case "cooldown":
+          toast.info(t("cooldownWait", { seconds: outcome.retryAfterSeconds }));
+          break;
+        case "error":
+          toast.error(t("refreshFailed"));
+          break;
+      }
     } finally {
       setRefreshing(false);
     }
@@ -89,7 +97,8 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
           variant="outline"
           size="sm"
           onClick={handleRefreshPrices}
-          disabled={refreshing}
+          disabled={refreshing || coolingDown}
+          title={coolingDown ? t("cooldownWait", { seconds: secondsLeft }) : undefined}
           className="gap-2 rounded-full px-5 border-primary/20 bg-primary/5 hover:bg-primary/15 text-primary hover:text-primary transition-all shadow-sm hover:shadow"
         >
           <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />

--- a/src/components/dashboard/dashboard-pull-refresh.tsx
+++ b/src/components/dashboard/dashboard-pull-refresh.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { refreshMarketData } from "@/lib/refresh-client";
 import { PullToRefresh } from "@/components/layout/pull-to-refresh";
 
 export function DashboardPullRefresh({ children }: { children: React.ReactNode }) {
@@ -11,18 +12,21 @@ export function DashboardPullRefresh({ children }: { children: React.ReactNode }
   const t = useTranslations("dashboardActions");
 
   const onRefresh = useCallback(async () => {
-    try {
-      const [priceRes, ratesRes] = await Promise.all([
-        fetch("/api/prices/refresh", { method: "POST" }),
-        fetch("/api/exchange-rates/refresh", { method: "POST" }),
-      ]);
-      if (!priceRes.ok || !ratesRes.ok) throw new Error("Refresh failed");
-      const { data: priceData } = await priceRes.json();
-      toast.success(t("refreshSuccess", { count: priceData.updated }));
-      window.dispatchEvent(new CustomEvent("prices:refreshed"));
-      router.refresh();
-    } catch {
-      toast.error(t("refreshFailed"));
+    const outcome = await refreshMarketData();
+    switch (outcome.status) {
+      case "updated":
+        toast.success(t("refreshSuccess", { count: outcome.prices }));
+        router.refresh();
+        break;
+      case "fresh":
+        toast.info(t("alreadyFresh", { seconds: outcome.retryAfterSeconds }));
+        break;
+      case "cooldown":
+        toast.info(t("cooldownWait", { seconds: outcome.retryAfterSeconds }));
+        break;
+      case "error":
+        toast.error(t("refreshFailed"));
+        break;
     }
   }, [router, t]);
 

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -20,6 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FreshnessBadge } from "@/components/ui/freshness-badge";
+import { refreshMarketData as requestMarketDataRefresh } from "@/lib/refresh-client";
+import { useRefreshCooldown } from "@/hooks/use-refresh-cooldown";
 import { CURRENCIES, getLocaleDefaultCurrency } from "@/lib/currencies";
 import { toast } from "sonner";
 import { useLocale, useTranslations } from "next-intl";
@@ -157,6 +159,7 @@ export function SettingsForm({
   );
   const [saving, setSaving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const { coolingDown, secondsLeft } = useRefreshCooldown();
   const [clientPriceRefreshAt, setClientPriceRefreshAt] = useState<string | null>(null);
   const [clientRatesRefreshAt, setClientRatesRefreshAt] = useState<string | null>(null);
 
@@ -202,28 +205,31 @@ export function SettingsForm({
   async function refreshMarketData() {
     setRefreshing(true);
     try {
-      const [priceRes, ratesRes] = await Promise.all([
-        fetch("/api/prices/refresh", { method: "POST" }),
-        fetch("/api/exchange-rates/refresh", { method: "POST" }),
-      ]);
-      if (!priceRes.ok || !ratesRes.ok) throw new Error("Refresh failed");
-      const [{ data: priceData }, { data: ratesData }] = await Promise.all([
-        priceRes.json(),
-        ratesRes.json(),
-      ]);
-      const refreshedAt = new Date().toISOString();
-      setClientPriceRefreshAt(refreshedAt);
-      setClientRatesRefreshAt(refreshedAt);
-      window.dispatchEvent(new CustomEvent("prices:refreshed"));
-      toast.success(
-        t("toast.marketDataUpdated", {
-          prices: priceData.updated,
-          rates: ratesData.updated,
-        }),
-      );
-      router.refresh();
-    } catch {
-      toast.error(t("toast.marketDataFailed"));
+      const outcome = await requestMarketDataRefresh();
+      switch (outcome.status) {
+        case "updated": {
+          const refreshedAt = new Date().toISOString();
+          setClientPriceRefreshAt(refreshedAt);
+          setClientRatesRefreshAt(refreshedAt);
+          toast.success(
+            t("toast.marketDataUpdated", {
+              prices: outcome.prices,
+              rates: outcome.rates,
+            }),
+          );
+          router.refresh();
+          break;
+        }
+        case "fresh":
+          toast.info(t("toast.marketDataFresh"));
+          break;
+        case "cooldown":
+          toast.info(t("toast.refreshCooldown", { seconds: outcome.retryAfterSeconds }));
+          break;
+        case "error":
+          toast.error(t("toast.marketDataFailed"));
+          break;
+      }
     } finally {
       setRefreshing(false);
     }
@@ -401,7 +407,10 @@ export function SettingsForm({
               <Button
                 variant="outline"
                 onClick={refreshMarketData}
-                disabled={refreshing}
+                disabled={refreshing || coolingDown}
+                title={
+                  coolingDown ? t("toast.refreshCooldown", { seconds: secondsLeft }) : undefined
+                }
                 className="w-full sm:w-auto min-w-[150px]"
               >
                 <RefreshCw className={`mr-2 size-4 ${refreshing ? "animate-spin" : ""}`} />

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -47,6 +47,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { StocksOnboarding } from "./stocks-onboarding";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { hapticTick } from "@/lib/haptics";
+import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
 import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
 
@@ -618,6 +619,22 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
   const [deletingStock, setDeletingStock] = useState<SerializedTrackedStock | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [cooldownUntil, setCooldownUntil] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+
+  // 1s tick while a cooldown is active so the button re-enables on time.
+  useEffect(() => {
+    if (cooldownUntil <= now) return;
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, [cooldownUntil, now]);
+
+  const coolingDown = cooldownUntil > now;
+
+  function startCooldown(seconds: number) {
+    setCooldownUntil(Date.now() + seconds * 1000);
+    setNow(Date.now());
+  }
 
   // Derive the most recent price update timestamp across all stocks.
   // Since all prices are refreshed in the same batch, they share one timestamp.
@@ -636,8 +653,23 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
     setRefreshing(true);
     try {
       const res = await fetch("/api/stocks/refresh", { method: "POST" });
+      if (res.status === 429) {
+        const retryAfter = Number(res.headers.get("Retry-After"));
+        const seconds =
+          Number.isFinite(retryAfter) && retryAfter > 0
+            ? Math.ceil(retryAfter)
+            : Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000);
+        startCooldown(seconds);
+        toast.info(t("refreshCooldown", { seconds }));
+        return;
+      }
       if (!res.ok) throw new Error("refresh failed");
-      const { data }: { data: { updated: number } } = await res.json();
+      const { data }: { data: { updated: number; skippedFresh?: number } } = await res.json();
+      startCooldown(Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000));
+      if (data.updated === 0 && (data.skippedFresh ?? 0) > 0) {
+        toast.info(t("alreadyFresh"));
+        return;
+      }
       toast.success(t("refreshSuccess", { count: data.updated }));
       window.dispatchEvent(new CustomEvent("prices:refreshed"));
       startTransition(() => router.refresh());
@@ -686,7 +718,7 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
           <Button
             variant="outline"
             onClick={refreshPrices}
-            disabled={refreshing || stocks.length === 0}
+            disabled={refreshing || coolingDown || stocks.length === 0}
             className="w-full sm:w-auto"
           >
             <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} />

--- a/src/hooks/use-refresh-cooldown.ts
+++ b/src/hooks/use-refresh-cooldown.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getCooldownRemainingMs, REFRESH_COOLDOWN_EVENT } from "@/lib/refresh-client";
+
+/**
+ * Tracks the shared market-data refresh cooldown (see lib/refresh-client.ts)
+ * so refresh buttons across the app disable in sync.
+ */
+export function useRefreshCooldown() {
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  useEffect(() => {
+    const sync = () => setSecondsLeft(Math.ceil(getCooldownRemainingMs() / 1000));
+    sync();
+    window.addEventListener(REFRESH_COOLDOWN_EVENT, sync);
+    const interval = window.setInterval(sync, 1000);
+    return () => {
+      window.removeEventListener(REFRESH_COOLDOWN_EVENT, sync);
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return { coolingDown: secondsLeft > 0, secondsLeft };
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,6 +18,11 @@ interface RateLimitOptions {
   windowMs?: number;
   /** Identifier prefix to namespace the key in the shared store. */
   prefix?: string;
+  /**
+   * Explicit identity to limit on (e.g. userId for authenticated routes).
+   * Falls back to the client IP when omitted.
+   */
+  key?: string;
 }
 
 interface WindowEntry {
@@ -42,8 +47,8 @@ function getClientIp(request: Request): string {
  */
 export function rateLimitCheck(request: Request, options: RateLimitOptions): Response | null {
   const { limit, windowMs = 60_000, prefix = "rl" } = options;
-  const ip = getClientIp(request);
-  const key = `${prefix}:${ip}`;
+  const id = options.key ?? getClientIp(request);
+  const key = `${prefix}:${id}`;
   const now = Date.now();
 
   const entry = store.get(key);

--- a/src/lib/refresh-client.ts
+++ b/src/lib/refresh-client.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
+
+/**
+ * Shared client-side entry point for the dashboard/settings "refresh market
+ * data" action. Centralizes the two POSTs plus a module-level cooldown so
+ * every refresh surface (button, pull-to-refresh, settings) shares one state.
+ *
+ * UX layer only — the server enforces its own freshness gate and per-user
+ * rate limits regardless of what this module does.
+ */
+
+export type RefreshOutcome =
+  | { status: "updated"; prices: number; rates: number }
+  | { status: "fresh"; retryAfterSeconds: number }
+  | { status: "cooldown"; retryAfterSeconds: number }
+  | { status: "error" };
+
+export const REFRESH_COOLDOWN_EVENT = "refresh:cooldown";
+
+let cooldownUntil = 0;
+
+export function getCooldownRemainingMs(): number {
+  return Math.max(0, cooldownUntil - Date.now());
+}
+
+function setCooldown(untilMs: number) {
+  if (untilMs <= cooldownUntil) return;
+  cooldownUntil = untilMs;
+  window.dispatchEvent(new CustomEvent(REFRESH_COOLDOWN_EVENT, { detail: { until: untilMs } }));
+}
+
+function parseRetryAfterSeconds(res: Response): number {
+  const header = Number(res.headers.get("Retry-After"));
+  return Number.isFinite(header) && header > 0
+    ? Math.ceil(header)
+    : Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000);
+}
+
+type RefreshPayload = {
+  updated?: number;
+  skippedFresh?: number | boolean;
+  retryAfterSeconds?: number | null;
+};
+
+export async function refreshMarketData(): Promise<RefreshOutcome> {
+  const remainingMs = getCooldownRemainingMs();
+  if (remainingMs > 0) {
+    return { status: "cooldown", retryAfterSeconds: Math.ceil(remainingMs / 1000) };
+  }
+
+  // Floor cooldown immediately so a double-fire (pull + button) can't send a
+  // second pair of requests while the first is in flight.
+  setCooldown(Date.now() + CLIENT_REFRESH_COOLDOWN_MS);
+
+  try {
+    const [priceRes, ratesRes] = await Promise.all([
+      fetch("/api/prices/refresh", { method: "POST" }),
+      fetch("/api/exchange-rates/refresh", { method: "POST" }),
+    ]);
+
+    if (priceRes.status === 429 || ratesRes.status === 429) {
+      const limited = priceRes.status === 429 ? priceRes : ratesRes;
+      const retryAfterSeconds = parseRetryAfterSeconds(limited);
+      setCooldown(Date.now() + retryAfterSeconds * 1000);
+      return { status: "cooldown", retryAfterSeconds };
+    }
+    if (!priceRes.ok || !ratesRes.ok) return { status: "error" };
+
+    const [{ data: priceData }, { data: ratesData }] = (await Promise.all([
+      priceRes.json(),
+      ratesRes.json(),
+    ])) as [{ data: RefreshPayload }, { data: RefreshPayload }];
+
+    const pricesUpdated = priceData.updated ?? 0;
+    const ratesUpdated = ratesData.updated ?? 0;
+    const anySkipped = Boolean(priceData.skippedFresh) || Boolean(ratesData.skippedFresh);
+
+    if (pricesUpdated === 0 && ratesUpdated === 0 && anySkipped) {
+      // Earliest moment a retry would fetch *something* (prices have a much
+      // shorter TTL than FX rates, so min — not max — is the honest hint).
+      const hints = [priceData.retryAfterSeconds, ratesData.retryAfterSeconds].filter(
+        (v): v is number => typeof v === "number" && v > 0,
+      );
+      const retryAfterSeconds = Math.max(
+        hints.length > 0 ? Math.min(...hints) : 0,
+        Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000),
+      );
+      setCooldown(Date.now() + retryAfterSeconds * 1000);
+      return { status: "fresh", retryAfterSeconds };
+    }
+
+    window.dispatchEvent(new CustomEvent("prices:refreshed"));
+    return { status: "updated", prices: pricesUpdated, rates: ratesUpdated };
+  } catch {
+    return { status: "error" };
+  }
+}

--- a/src/lib/refresh-policy.ts
+++ b/src/lib/refresh-policy.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared throttling policy for manual market-data refreshes.
+ *
+ * Isomorphic constants (no `server-only`): the server freshness gate and the
+ * client cooldown both import from here so the two layers can't drift apart.
+ */
+
+/** Skip external price fetches for symbols cached more recently than this. */
+export const PRICE_REFRESH_TTL_MS = 60 * 1000;
+
+/**
+ * Skip external FX fetches for base currencies refreshed more recently than
+ * this. Upstream sources (frankfurter = ECB, open.er-api) update at most a
+ * few times a day, so an hour is already generous.
+ */
+export const FX_REFRESH_TTL_MS = 60 * 60 * 1000;
+
+/** Minimum client-side cooldown after any manual refresh attempt. */
+export const CLIENT_REFRESH_COOLDOWN_MS = 15_000;

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -2,16 +2,19 @@ import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
+import { FX_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log, withTiming } from "@/lib/logger";
+
+export type RefreshRatesResult = {
+  updated: number;
+  /** True when the base currency's rates were fresh and no fetch happened. */
+  skippedFresh: boolean;
+  /** When the rates become stale again; null unless skippedFresh. */
+  nextRefreshAt: string | null;
+};
 
 /** How long to wait (ms) before giving up on external rate APIs */
 const RATE_FETCH_TIMEOUT_MS = 1200;
-
-// Skip the external refresh entirely when this base currency was refreshed
-// within this window — FX sources update at most a few times a day
-// (Frankfurter/ECB once per business day), so refreshing on every
-// dashboard interaction buys nothing.
-const RATE_REFRESH_TTL_MS = 60 * 60 * 1000;
 
 // In-process memo of the last successful refresh per base currency, so the
 // staleness check costs no DB read (same warm-instance pattern as
@@ -173,18 +176,30 @@ async function persistExchangeRate(from: string, to: string, rate: number): Prom
 /**
  * Refresh all exchange rates for a base currency and persist to DB.
  * Uses batched concurrent upserts instead of sequential writes.
+ *
+ * Unless `force` (cron path), skips the external fetch entirely when this
+ * base currency was refreshed within FX_REFRESH_TTL_MS — FX sources update
+ * at most a few times a day, so refreshing on every dashboard interaction
+ * buys nothing.
  */
-export async function refreshExchangeRates(baseCurrency: string): Promise<number> {
+export async function refreshExchangeRates(
+  baseCurrency: string,
+  opts: { force?: boolean } = {},
+): Promise<RefreshRatesResult> {
   const last = lastRateRefreshAt.get(baseCurrency);
-  if (last !== undefined && Date.now() - last < RATE_REFRESH_TTL_MS) {
+  if (!opts.force && last !== undefined && Date.now() - last < FX_REFRESH_TTL_MS) {
     log.info("rates.refresh.skipped_fresh", { base: baseCurrency });
-    return 0;
+    return {
+      updated: 0,
+      skippedFresh: true,
+      nextRefreshAt: new Date(last + FX_REFRESH_TTL_MS).toISOString(),
+    };
   }
 
   const rates = await fetchExchangeRates(baseCurrency);
   const entries = Object.entries(rates);
 
-  if (entries.length === 0) return 0;
+  if (entries.length === 0) return { updated: 0, skippedFresh: false, nextRefreshAt: null };
 
   const params: unknown[] = [];
   const placeholders = entries.map(([toCurrency, rate]) => {
@@ -204,7 +219,7 @@ export async function refreshExchangeRates(baseCurrency: string): Promise<number
 
   // Stamp only after a successful persist so failed refreshes retry.
   lastRateRefreshAt.set(baseCurrency, Date.now());
-  return entries.length;
+  return { updated: entries.length, skippedFresh: false, nextRefreshAt: null };
 }
 
 /**

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -2,14 +2,26 @@ import "server-only";
 import { revalidateTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getYahooClient } from "@/lib/services/yahoo-client";
+import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log, withTiming } from "@/lib/logger";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 
-// Symbols whose PriceCache row is newer than this are skipped on refresh,
-// so rapid repeat refreshes (button + pull-to-refresh) don't re-hit Yahoo.
-const PRICE_REFRESH_TTL_MS = 60 * 1000;
+export type RefreshPricesResult = {
+  updated: number;
+  /** Symbols skipped because their cached price was younger than the TTL. */
+  skippedFresh: number;
+  errors: string[];
+  /** When the earliest skipped symbol becomes stale; null unless everything was skipped. */
+  nextRefreshAt: string | null;
+  retryAfterSeconds: number | null;
+};
+
+export type RefreshPricesOptions = {
+  /** Bypass the freshness gate (cron path — snapshots need current prices). */
+  force?: boolean;
+};
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -209,21 +221,18 @@ export async function getCachedPricesForSymbols(
   return all.filter((p) => symbolSet.has(p.symbol));
 }
 
-export async function refreshAllPrices(): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshAllPrices(): Promise<RefreshPricesResult> {
   const holdings = await prisma.holding.findMany({
     select: { symbol: true, assetType: true },
     distinct: ["symbol"],
   });
-  return refreshPricesForHoldings(holdings);
+  return refreshPricesForHoldings(holdings, { force: true });
 }
 
-export async function refreshPricesForUser(userId: string): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshPricesForUser(
+  userId: string,
+  opts: RefreshPricesOptions = {},
+): Promise<RefreshPricesResult> {
   const [holdings, trackedStocks] = await Promise.all([
     prisma.holding.findMany({
       where: { account: { userId } },
@@ -242,38 +251,84 @@ export async function refreshPricesForUser(userId: string): Promise<{
     .filter((stock) => !holdingKeys.has(stock.symbol))
     .map((stock) => ({ symbol: stock.symbol, assetType: "STOCK" }));
 
-  return refreshPricesForHoldings([...holdings, ...stockWatchHoldings]);
+  return refreshPricesForHoldings([...holdings, ...stockWatchHoldings], opts);
 }
 
-export async function refreshPricesForStockSymbols(symbols: string[]): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshPricesForStockSymbols(
+  symbols: string[],
+  opts: RefreshPricesOptions = {},
+): Promise<RefreshPricesResult> {
   const uniqueSymbols = [...new Set(symbols.map((symbol) => symbol.toUpperCase()))];
-  if (uniqueSymbols.length === 0) return { updated: 0, errors: [] };
-  return refreshPricesForHoldings(uniqueSymbols.map((symbol) => ({ symbol, assetType: "STOCK" })));
+  if (uniqueSymbols.length === 0) {
+    return {
+      updated: 0,
+      skippedFresh: 0,
+      errors: [],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
+  }
+  return refreshPricesForHoldings(
+    uniqueSymbols.map((symbol) => ({ symbol, assetType: "STOCK" })),
+    opts,
+  );
 }
 
 async function refreshPricesForHoldings(
   holdings: { symbol: string; assetType: string }[],
-): Promise<{
-  updated: number;
-  errors: string[];
-}> {
-  if (holdings.length === 0) return { updated: 0, errors: [] };
+  opts: RefreshPricesOptions = {},
+): Promise<RefreshPricesResult> {
+  if (holdings.length === 0) {
+    return {
+      updated: 0,
+      skippedFresh: 0,
+      errors: [],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
+  }
 
-  const freshRows = await prisma.priceCache.findMany({
-    where: {
-      symbol: { in: holdings.map((h) => h.symbol) },
-      updatedAt: { gte: new Date(Date.now() - PRICE_REFRESH_TTL_MS) },
-    },
-    select: { symbol: true },
-  });
-  if (freshRows.length > 0) {
-    const freshSymbols = new Set(freshRows.map((row) => row.symbol));
-    log.info("price.refresh.skipped_fresh", { count: freshSymbols.size });
-    holdings = holdings.filter((h) => !freshSymbols.has(h.symbol));
-    if (holdings.length === 0) return { updated: 0, errors: [] };
+  // Freshness gate: drop symbols whose cached price is younger than the TTL
+  // so repeated manual refreshes don't re-hit Yahoo/CoinGecko. The DB
+  // updatedAt is the shared source of truth across serverless instances.
+  let skippedFresh = 0;
+  let earliestFreshUpdatedAt: Date | null = null;
+  if (!opts.force) {
+    const freshRows = await prisma.priceCache.findMany({
+      where: {
+        symbol: { in: holdings.map((h) => h.symbol) },
+        updatedAt: { gte: new Date(Date.now() - PRICE_REFRESH_TTL_MS) },
+      },
+      select: { symbol: true, updatedAt: true },
+    });
+    if (freshRows.length > 0) {
+      const freshSymbols = new Set(freshRows.map((row) => row.symbol));
+      skippedFresh = freshSymbols.size;
+      log.info("price.refresh.skipped_fresh", { count: skippedFresh });
+      for (const row of freshRows) {
+        if (!earliestFreshUpdatedAt || row.updatedAt < earliestFreshUpdatedAt) {
+          earliestFreshUpdatedAt = row.updatedAt;
+        }
+      }
+      holdings = holdings.filter((h) => !freshSymbols.has(h.symbol));
+      if (holdings.length === 0) {
+        // Everything is fresh. Tell the caller when a retry will actually do
+        // something, in server-computed seconds so clients don't have to
+        // trust their own clock.
+        const nextRefreshAt = earliestFreshUpdatedAt
+          ? new Date(earliestFreshUpdatedAt.getTime() + PRICE_REFRESH_TTL_MS)
+          : null;
+        return {
+          updated: 0,
+          skippedFresh,
+          errors: [],
+          nextRefreshAt: nextRefreshAt?.toISOString() ?? null,
+          retryAfterSeconds: nextRefreshAt
+            ? Math.max(1, Math.ceil((nextRefreshAt.getTime() - Date.now()) / 1000))
+            : null,
+        };
+      }
+    }
   }
 
   const stockSymbols = holdings
@@ -293,7 +348,9 @@ async function refreshPricesForHoldings(
   const allPrices = new Map([...stockPrices, ...cryptoPrices]);
 
   const entries = [...allPrices];
-  if (entries.length === 0) return { updated: 0, errors: [] };
+  if (entries.length === 0) {
+    return { updated: 0, skippedFresh, errors: [], nextRefreshAt: null, retryAfterSeconds: null };
+  }
 
   try {
     const params: unknown[] = [];
@@ -317,5 +374,5 @@ async function refreshPricesForHoldings(
     errors.push(`Bulk upsert failed: ${String(error)}`);
   }
 
-  return { updated, errors };
+  return { updated, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
 }

--- a/src/lib/services/stock-watch-service.ts
+++ b/src/lib/services/stock-watch-service.ts
@@ -3,6 +3,7 @@ import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { refreshPricesForStockSymbols } from "@/lib/services/price-service";
 import { getYahooClient } from "@/lib/services/yahoo-client";
+import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log } from "@/lib/logger";
 import type { StockWatchItem } from "@/generated/prisma/client";
 
@@ -139,6 +140,21 @@ export async function warmStockPrice(symbol: string): Promise<{
   updatedAt: string;
 } | null> {
   const normalized = symbol.toUpperCase();
+
+  // Freshness gate: serve the cached price without a Yahoo round-trip when
+  // it's younger than the shared TTL.
+  const existing = await prisma.priceCache.findUnique({
+    where: { symbol: normalized },
+    select: { price: true, currency: true, updatedAt: true },
+  });
+  if (existing && Date.now() - existing.updatedAt.getTime() < PRICE_REFRESH_TTL_MS) {
+    return {
+      price: Number(existing.price),
+      currency: existing.currency,
+      updatedAt: existing.updatedAt.toISOString(),
+    };
+  }
+
   const quote = await fetchEquityQuote(normalized);
   const result = quote ? { price: quote.price, currency: quote.currency } : null;
   if (!result) return null;
@@ -163,17 +179,15 @@ export async function warmStockPrice(symbol: string): Promise<{
   };
 }
 
-export async function refreshTrackedStockPrices(userId: string): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshTrackedStockPrices(userId: string) {
   const stocks = await prisma.stockWatchItem.findMany({
     where: { userId },
     select: { symbol: true },
     distinct: ["symbol"],
   });
   const result = await refreshPricesForStockSymbols(stocks.map((stock) => stock.symbol));
-  invalidateStockWatchCaches(userId);
+  // Skip the cache bust when nothing changed (e.g. everything was fresh).
+  if (result.updated > 0) invalidateStockWatchCaches(userId);
   return result;
 }
 


### PR DESCRIPTION
## Summary

> **Rebased onto master after #396/#397 landed.** #396 already implemented the service-level freshness gate (1-min price TTL via `PriceCache.updatedAt`, 60-min FX TTL via an in-process per-base map), so this PR no longer introduces its own gate — it keeps #396's reviewed implementations and TTL values (moved into the shared `refresh-policy.ts`) and adds only the layers master still lacks.

Users could spam the manual refresh surfaces (dashboard button, pull-to-refresh, settings, watchlist) and the refresh routes remained unthrottled with no client feedback. What this PR adds on top of #396's gate:

### 1. Gate extensions (service layer)
- `force` option on `refreshPricesForHoldings` / `refreshExchangeRates` — the **cron now bypasses both gates**. This matters: with #396's in-memory FX gate, a manual refresh on a warm instance could otherwise make the nightly cron silently skip the FX warm for up to an hour.
- Structured results: `skippedFresh` + server-computed `nextRefreshAt` / `retryAfterSeconds` so clients can tell "nothing changed because everything is fresh" apart from "0 symbols updated", with no client clock math.
- `warmStockPrice` serves the cached row without a Yahoo round-trip when fresh; cache tags only revalidate when something actually changed.

### 2. Per-user rate limits
- `rate-limit.ts` gains an explicit `key` option (falls back to IP as before).
- `prices-refresh` / `rates-refresh`: **5/min per user**; `stocks-refresh` keeps 10/min, now keyed by userId.

### 3. Client cooldown UX
- New shared `src/lib/refresh-client.ts` (single entry point for the price+rates POST pair, module-level cooldown, 429/`Retry-After` handling) + `useRefreshCooldown` hook — all refresh surfaces share one synchronized cooldown (15 s floor, extended to the **earliest** server retry hint).
- "Already up to date — try again in Xs" / cooldown info toasts instead of error toasts; buttons disable with a countdown `title`. New i18n keys in `en-US` + `zh-TW`.

## Tuning (adopted from #396 review)

| Knob | Value |
|---|---|
| Price freshness TTL | 1 min |
| FX freshness TTL | 60 min |
| prices/rates refresh per-user limit | 5 / min |
| Client cooldown floor | 15 s |

## Verification (re-run after rebase, local dev server)

- ✅ 2nd price refresh within TTL → `updated: 0, skippedFresh: 8, retryAfterSeconds: 60`, no Yahoo call
- ✅ 2nd rates refresh → `skippedFresh: 2, retryAfterSeconds: 3600` (in-memory gate)
- ✅ 6th request within a minute → **429** with `Retry-After`
- ✅ `GET /api/cron/snapshot` with `CRON_SECRET` → 200 (force bypass)
- ✅ Playwright UI check: success/fresh toasts + cooldown-disabled button with countdown title
- ✅ `format:check` / `lint` / `typecheck` pass; e2e failures match the master baseline (pre-existing local flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)