### PR TITLE
perf(refresh): skip price and FX refetch when cached data is fresh

### DIFF
--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -7,11 +7,16 @@ import { log, withTiming } from "@/lib/logger";
 /** How long to wait (ms) before giving up on external rate APIs */
 const RATE_FETCH_TIMEOUT_MS = 1200;
 
-// Skip the external refresh entirely when the base currency's rates were
-// persisted within this window — FX sources update at most a few times a
-// day (Frankfurter/ECB once per business day), so refreshing on every
+// Skip the external refresh entirely when this base currency was refreshed
+// within this window — FX sources update at most a few times a day
+// (Frankfurter/ECB once per business day), so refreshing on every
 // dashboard interaction buys nothing.
 const RATE_REFRESH_TTL_MS = 60 * 60 * 1000;
+
+// In-process memo of the last successful refresh per base currency, so the
+// staleness check costs no DB read (same warm-instance pattern as
+// lib/rate-limit.ts). Cold starts simply refresh once and re-prime it.
+const lastRateRefreshAt = new Map<string, number>();
 
 /**
  * Cache Components read of all exchange rates.
@@ -146,12 +151,8 @@ async function persistExchangeRate(from: string, to: string, rate: number): Prom
  * Uses batched concurrent upserts instead of sequential writes.
  */
 export async function refreshExchangeRates(baseCurrency: string): Promise<number> {
-  const newest = await prisma.exchangeRate.findFirst({
-    where: { fromCurrency: baseCurrency },
-    orderBy: { updatedAt: "desc" },
-    select: { updatedAt: true },
-  });
-  if (newest && Date.now() - newest.updatedAt.getTime() < RATE_REFRESH_TTL_MS) {
+  const last = lastRateRefreshAt.get(baseCurrency);
+  if (last !== undefined && Date.now() - last < RATE_REFRESH_TTL_MS) {
     log.info("rates.refresh.skipped_fresh", { base: baseCurrency });
     return 0;
   }
@@ -177,6 +178,8 @@ export async function refreshExchangeRates(baseCurrency: string): Promise<number
     ...params,
   );
 
+  // Stamp only after a successful persist so failed refreshes retry.
+  lastRateRefreshAt.set(baseCurrency, Date.now());
   return entries.length;
 }
 

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -7,6 +7,12 @@ import { log, withTiming } from "@/lib/logger";
 /** How long to wait (ms) before giving up on external rate APIs */
 const RATE_FETCH_TIMEOUT_MS = 1200;
 
+// Skip the external refresh entirely when the base currency's rates were
+// persisted within this window — FX sources update at most a few times a
+// day (Frankfurter/ECB once per business day), so refreshing on every
+// dashboard interaction buys nothing.
+const RATE_REFRESH_TTL_MS = 60 * 60 * 1000;
+
 /**
  * Cache Components read of all exchange rates.
  * Returns a plain object (`"use cache"` compatible). Invalidated by
@@ -140,6 +146,16 @@ async function persistExchangeRate(from: string, to: string, rate: number): Prom
  * Uses batched concurrent upserts instead of sequential writes.
  */
 export async function refreshExchangeRates(baseCurrency: string): Promise<number> {
+  const newest = await prisma.exchangeRate.findFirst({
+    where: { fromCurrency: baseCurrency },
+    orderBy: { updatedAt: "desc" },
+    select: { updatedAt: true },
+  });
+  if (newest && Date.now() - newest.updatedAt.getTime() < RATE_REFRESH_TTL_MS) {
+    log.info("rates.refresh.skipped_fresh", { base: baseCurrency });
+    return 0;
+  }
+
   const rates = await fetchExchangeRates(baseCurrency);
   const entries = Object.entries(rates);
 

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -7,6 +7,10 @@ import { log, withTiming } from "@/lib/logger";
 const FETCH_TIMEOUT_MS = 5_000;
 const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 
+// Symbols whose PriceCache row is newer than this are skipped on refresh,
+// so rapid repeat refreshes (button + pull-to-refresh) don't re-hit Yahoo.
+const PRICE_REFRESH_TTL_MS = 2 * 60 * 1000;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -256,6 +260,22 @@ async function refreshPricesForHoldings(
   updated: number;
   errors: string[];
 }> {
+  if (holdings.length === 0) return { updated: 0, errors: [] };
+
+  const freshRows = await prisma.priceCache.findMany({
+    where: {
+      symbol: { in: holdings.map((h) => h.symbol) },
+      updatedAt: { gte: new Date(Date.now() - PRICE_REFRESH_TTL_MS) },
+    },
+    select: { symbol: true },
+  });
+  if (freshRows.length > 0) {
+    const freshSymbols = new Set(freshRows.map((row) => row.symbol));
+    log.info("price.refresh.skipped_fresh", { count: freshSymbols.size });
+    holdings = holdings.filter((h) => !freshSymbols.has(h.symbol));
+    if (holdings.length === 0) return { updated: 0, errors: [] };
+  }
+
   const stockSymbols = holdings
     .filter((h) => ["STOCK", "ETF", "MUTUAL_FUND", "BOND", "OPTION"].includes(h.assetType))
     .map((h) => h.symbol);

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -9,7 +9,7 @@ const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 
 // Symbols whose PriceCache row is newer than this are skipped on refresh,
 // so rapid repeat refreshes (button + pull-to-refresh) don't re-hit Yahoo.
-const PRICE_REFRESH_TTL_MS = 2 * 60 * 1000;
+const PRICE_REFRESH_TTL_MS = 60 * 1000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
## Summary

Neither refresh path checked how fresh the data already was: every dashboard refresh press or pull-to-refresh re-hit Yahoo Finance for every holding/watchlist symbol and the external FX APIs for every account currency — even seconds after the previous refresh.

- **Prices** — `refreshPricesForHoldings` now queries `PriceCache.updatedAt` for the requested symbols first and skips any updated within the last **1 minute**. One cheap indexed read replaces the full Yahoo fan-out when everything is fresh. Applies to all callers: dashboard refresh, pull-to-refresh, and the stock-watchlist refresh route.
- **Exchange rates** — `refreshExchangeRates` returns early when the base currency was refreshed within the last **hour**, tracked in an **in-process timestamp map** (same warm-instance pattern as `lib/rate-limit.ts`) so the guard costs zero DB reads. The timestamp is stamped only after a successful persist so failed refreshes retry; cold starts simply refresh once and re-prime the map. FX sources update at most a few times a day (Frankfurter/ECB once per business day), so intraday re-fetches were pure waste.

## Notes

- The daily cron (`/api/cron/snapshot`) is unaffected — by the time it runs, both TTLs have long expired (and cron runs in a fresh-enough instance either way).
- Callers already tolerate `updated: 0`: the dashboard freshness badge stamps the client refresh time independently (see comment in `dashboard-actions.tsx`).
- Skipped counts are logged (`price.refresh.skipped_fresh`, `rates.refresh.skipped_fresh`) for observability.

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck`
- [ ] Manual: press dashboard refresh twice within 1 min — second press should log skips and make no Yahoo/FX calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)