### PR TITLE
fix(api): make balance and holding mutations atomic

### DIFF
--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -85,44 +85,35 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
     }
   }
 
-  // Check if holding already exists in this account
-  const existing = await prisma.holding.findUnique({
-    where: { accountId_symbol: { accountId: id, symbol: parsed.data.symbol } },
-  });
+  // Atomic upsert: increment on the existing row avoids the read-modify-write
+  // race when two adds for the same symbol land concurrently, and the BUY log
+  // commits with the holding so the audit trail can't diverge.
+  const holding = await prisma.$transaction(async (tx) => {
+    const upserted = await tx.holding.upsert({
+      where: { accountId_symbol: { accountId: id, symbol: parsed.data.symbol } },
+      update: { quantity: { increment: parsed.data.quantity } },
+      create: optionMetadata
+        ? {
+            accountId: id,
+            symbol: parsed.data.symbol,
+            name: optionMetadata.name,
+            quantity: parsed.data.quantity,
+            currency: optionMetadata.currency,
+            assetType: "OPTION",
+            underlyingSymbol: optionMetadata.underlyingSymbol,
+            optionType: optionMetadata.optionType,
+            strike: optionMetadata.strike,
+            expiration: optionMetadata.expiration,
+            contractMultiplier: optionMetadata.contractMultiplier,
+          }
+        : { accountId: id, ...parsed.data },
+    });
 
-  let holding;
-  if (existing) {
-    // Add to existing holding quantity
-    const newQuantity = Number(existing.quantity) + parsed.data.quantity;
-    holding = await prisma.holding.update({
-      where: { id: existing.id },
-      data: { quantity: newQuantity },
+    await tx.holdingTransaction.create({
+      data: { holdingId: upserted.id, type: "BUY", quantity: parsed.data.quantity },
     });
-  } else if (optionMetadata) {
-    holding = await prisma.holding.create({
-      data: {
-        accountId: id,
-        symbol: parsed.data.symbol,
-        name: optionMetadata.name,
-        quantity: parsed.data.quantity,
-        currency: optionMetadata.currency,
-        assetType: "OPTION",
-        underlyingSymbol: optionMetadata.underlyingSymbol,
-        optionType: optionMetadata.optionType,
-        strike: optionMetadata.strike,
-        expiration: optionMetadata.expiration,
-        contractMultiplier: optionMetadata.contractMultiplier,
-      },
-    });
-  } else {
-    holding = await prisma.holding.create({
-      data: { accountId: id, ...parsed.data },
-    });
-  }
 
-  // Log the transaction
-  await prisma.holdingTransaction.create({
-    data: { holdingId: holding.id, type: "BUY", quantity: parsed.data.quantity },
+    return upserted;
   });
 
   // Auto-fetch the market price for the holding
@@ -163,22 +154,27 @@ export const PATCH = withAuth<IdCtx>(async (request, _ctx, userId) => {
   });
   if (!existing) return failure("Not found", 404);
 
-  // Log quantity change as EDIT transaction
-  if (data.quantity !== undefined) {
-    const diff = data.quantity - Number(existing.quantity);
-    if (diff !== 0) {
-      await prisma.holdingTransaction.create({
-        data: {
-          holdingId: id,
-          type: "EDIT",
-          quantity: diff,
-          note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
-        },
-      });
-    }
-  }
+  // Update and EDIT audit log commit together — a failed update must not
+  // leave a phantom EDIT transaction behind.
+  const holding = await prisma.$transaction(async (tx) => {
+    const updated = await tx.holding.update({ where: { id }, data });
 
-  const holding = await prisma.holding.update({ where: { id }, data });
+    if (data.quantity !== undefined) {
+      const diff = data.quantity - Number(existing.quantity);
+      if (diff !== 0) {
+        await tx.holdingTransaction.create({
+          data: {
+            holdingId: id,
+            type: "EDIT",
+            quantity: diff,
+            note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
+          },
+        });
+      }
+    }
+
+    return updated;
+  });
   invalidateUserCaches(userId);
   return ok(holding);
 });

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -108,26 +108,30 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
     const amountError = getCashTransactionAmountError(nextCashTx);
     if (amountError) return failure(amountError, 400);
 
-    // Recompute balance delta whenever amount or type changes.
-    if (data.amount !== undefined || data.type !== undefined) {
-      const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
-      const delta = calculateBalanceDelta(oldTx, nextCashTx);
-      if (delta !== 0) {
-        await prisma.account.update({
-          where: { id: accountId },
-          data: { cashBalance: { increment: delta } },
-        });
+    // Balance adjustment and transaction update commit atomically so a
+    // failure can't leave the cash balance out of sync with the ledger.
+    const updatedTx = await prisma.$transaction(async (tx) => {
+      // Recompute balance delta whenever amount or type changes.
+      if (data.amount !== undefined || data.type !== undefined) {
+        const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
+        const delta = calculateBalanceDelta(oldTx, nextCashTx);
+        if (delta !== 0) {
+          await tx.account.update({
+            where: { id: accountId },
+            data: { cashBalance: { increment: delta } },
+          });
+        }
       }
-    }
 
-    const updatedTx = await prisma.cashTransaction.update({
-      where: { id: transactionId },
-      data: {
-        ...(data.amount !== undefined && { amount: data.amount }),
-        ...(data.type !== undefined && { type: data.type }),
-        ...(data.note !== undefined && { note: data.note }),
-        ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
-      },
+      return tx.cashTransaction.update({
+        where: { id: transactionId },
+        data: {
+          ...(data.amount !== undefined && { amount: data.amount }),
+          ...(data.type !== undefined && { type: data.type }),
+          ...(data.note !== undefined && { note: data.note }),
+          ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
+        },
+      });
     });
 
     invalidateAccountCaches(userId);
@@ -187,12 +191,13 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
     }
 
     const delta = calculateBalanceDelta({ type: cashTx.type, amount: Number(cashTx.amount) }, null);
-    await prisma.account.update({
-      where: { id: accountId },
-      data: { cashBalance: { increment: delta } },
-    });
-
-    await prisma.cashTransaction.delete({ where: { id: transactionId } });
+    await prisma.$transaction([
+      prisma.account.update({
+        where: { id: accountId },
+        data: { cashBalance: { increment: delta } },
+      }),
+      prisma.cashTransaction.delete({ where: { id: transactionId } }),
+    ]);
     invalidateAccountCaches(userId);
     return ok({ ok: true });
   }


### PR DESCRIPTION
## Summary

Fixes three data-integrity issues found in an audit of the money-mutation API routes. All three are cases where multi-statement writes could partially fail (or race), leaving balances or the audit trail inconsistent.

### 1. Cash transaction PATCH/DELETE were not atomic
`src/app/api/accounts/[id]/transactions/[transactionId]/route.ts`

The `account.cashBalance` increment and the `CashTransaction` update/delete were issued as two separate calls. A failure between them permanently desynced the balance from the ledger. Both now commit in a single `$transaction` — the same pattern the holding paths in this file already used.

### 2. Add-to-existing-holding was a read-modify-write race
`src/app/api/accounts/[id]/holdings/route.ts` (POST)

The route read the existing quantity, added in JS (`Number(existing.quantity) + qty`), and wrote it back — two concurrent adds for the same symbol lost one update. Replaced with an atomic `upsert` using `quantity: { increment }`, which also removes the lossy `Decimal → Number` round-trip and the separate existence pre-read.

### 3. Holding writes and their audit log could diverge
`src/app/api/accounts/[id]/holdings/route.ts` (POST + PATCH)

The holding create/update and the `HoldingTransaction` log were separate statements; PATCH additionally logged the EDIT *before* applying the update, so a failed update left a phantom audit entry. Write + log now commit in one transaction, with the log recorded after the write inside the transaction.

## Behavior notes

- No API contract changes — request/response shapes are identical.
- POST holdings: on the upsert create-conflict edge (two simultaneous first-adds), one request now increments instead of failing, which is the intended semantics.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass (also enforced by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)