### PR TITLE
feat(db): transaction provenance columns + money CHECK constraints

### DIFF
--- a/prisma/migrations/20260610000000_add_tx_provenance_and_check_constraints/migration.sql
+++ b/prisma/migrations/20260610000000_add_tx_provenance_and_check_constraints/migration.sql
@@ -1,0 +1,22 @@
+-- Provenance columns: capture information at write time that cannot be
+-- backfilled later.
+
+-- Market price per unit at transaction time (null when unknown / legacy rows).
+ALTER TABLE "HoldingTransaction" ADD COLUMN "price" DECIMAL(18, 8);
+
+-- Account currency at write time, so changing an account's currency later
+-- does not silently reinterpret historical cash flows (null on legacy rows;
+-- readers fall back to account.currency).
+ALTER TABLE "CashTransaction" ADD COLUMN "currency" TEXT;
+
+-- Money invariants enforced at the database level — the last line of defense
+-- behind the app-level guards in lib/services/balance.ts and lib/validators.ts.
+
+ALTER TABLE "Holding"
+  ADD CONSTRAINT "holding_quantity_nonnegative" CHECK ("quantity" >= 0);
+
+ALTER TABLE "PriceCache"
+  ADD CONSTRAINT "price_cache_price_positive" CHECK ("price" > 0);
+
+ALTER TABLE "ExchangeRate"
+  ADD CONSTRAINT "exchange_rate_rate_positive" CHECK ("rate" > 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,8 @@ model HoldingTransaction {
   holding   Holding         @relation(fields: [holdingId], references: [id], onDelete: Cascade)
   type      TransactionType
   quantity  Decimal         @db.Decimal(18, 8)
+  /// Market price per unit at transaction time (best effort; null when unknown).
+  price     Decimal?        @db.Decimal(18, 8)
   note      String?
   createdAt DateTime        @default(now())
 
@@ -120,6 +122,8 @@ model CashTransaction {
   account   Account             @relation(fields: [accountId], references: [id], onDelete: Cascade)
   type      CashTransactionType
   amount    Decimal             @db.Decimal(18, 8)
+  /// Account currency at write time (null on legacy rows; fall back to account.currency).
+  currency  String?
   note      String?
   createdAt DateTime            @default(now())
 

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -20,7 +20,7 @@ export const POST = withAuth(
     if (!account) return failure("Account not found", 404);
 
     const transaction = await prisma.cashTransaction.create({
-      data: { accountId: id, type, amount, note },
+      data: { accountId: id, type, amount, note, currency: account.currency },
     });
 
     const delta = calculateBalanceDelta(null, { type, amount });

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -85,6 +85,20 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
     }
   }
 
+  // Best-effort market price fetch BEFORE the write so the BUY log can
+  // record the price at transaction time. A fetch failure never blocks
+  // the holding creation — the log's price is simply null.
+  let quote: { price: number; currency: string } | undefined;
+  try {
+    const isCrypto = parsed.data.assetType === "CRYPTO";
+    const priceResults = isCrypto
+      ? await fetchCryptoPrices([parsed.data.symbol])
+      : await fetchStockPrices([parsed.data.symbol]);
+    quote = priceResults.get(parsed.data.symbol);
+  } catch (error) {
+    log.error("holdings.price_fetch.failed", { symbol: parsed.data.symbol, error: String(error) });
+  }
+
   // Atomic upsert: increment on the existing row avoids the read-modify-write
   // race when two adds for the same symbol land concurrently, and the BUY log
   // commits with the holding so the audit trail can't diverge.
@@ -110,31 +124,29 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
     });
 
     await tx.holdingTransaction.create({
-      data: { holdingId: upserted.id, type: "BUY", quantity: parsed.data.quantity },
+      data: {
+        holdingId: upserted.id,
+        type: "BUY",
+        quantity: parsed.data.quantity,
+        price: quote?.price ?? null,
+      },
     });
 
     return upserted;
   });
 
-  // Auto-fetch the market price for the holding
-  try {
-    const isCrypto = parsed.data.assetType === "CRYPTO";
-    const priceResults = isCrypto
-      ? await fetchCryptoPrices([holding.symbol])
-      : await fetchStockPrices([holding.symbol]);
-
-    const result = priceResults.get(holding.symbol);
-    if (result) {
+  if (quote) {
+    try {
       await prisma.priceCache.upsert({
         where: { symbol: holding.symbol },
-        update: { price: result.price, currency: result.currency, updatedAt: new Date() },
-        create: { symbol: holding.symbol, price: result.price, currency: result.currency },
+        update: { price: quote.price, currency: quote.currency, updatedAt: new Date() },
+        create: { symbol: holding.symbol, price: quote.price, currency: quote.currency },
       });
       revalidateTag("prices", "max");
+    } catch (error) {
+      // Non-blocking: the holding and BUY log are already committed
+      log.error("holdings.price_cache.failed", { symbol: holding.symbol, error: String(error) });
     }
-  } catch (error) {
-    // Non-blocking: if price fetch fails, holding is still created
-    log.error("holdings.price_fetch.failed", { symbol: holding.symbol, error: String(error) });
   }
 
   invalidateUserCaches(userId);

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -42,6 +42,9 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
         accountId: id,
         type: "EDIT",
         amount: diff,
+        // The new balance is denominated in the currency the account will
+        // have after this update, so capture that one.
+        currency: parsed.data.currency ?? existingAccount.currency,
         note: body.note || `Manual balance update (${diff > 0 ? "+" : ""}${diff})`,
       },
     });

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -34,6 +34,7 @@ export async function GET(request: Request) {
                 holdingId: h.id,
                 type: "SELL",
                 quantity: Number(h.quantity),
+                price: 0,
                 note: "Expired",
               },
             }),

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -196,7 +196,9 @@ export const GET = withAuth(async (_req, _ctx, userId) => {
     if (!data) return failure("User not found", 404);
 
     const exportData = {
-      version: "1.1",
+      // 1.2: holding transactions may carry `price`, cash transactions
+      // may carry `currency` (both optional; 1.1 backups import unchanged).
+      version: "1.2",
       exportedAt: new Date().toISOString(),
       settings: data.appSettings,
       accounts: data.appAccounts,

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -311,6 +311,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                     holdingId: newHolding.id,
                     type: t.type,
                     quantity: t.quantity,
+                    price: t.price ?? null,
                     note: t.note,
                     createdAt: t.createdAt,
                   })),
@@ -327,6 +328,9 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                 accountId: newAccount.id,
                 type: t.type,
                 amount: t.amount,
+                // Legacy backups predate the currency column — assume the
+                // account's currency, which is what readers fall back to.
+                currency: t.currency ?? acc.currency,
                 note: t.note,
                 createdAt: t.createdAt,
               })),

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -298,7 +298,7 @@ export async function getAccountMonthlyCashFlow(
       accountId: { in: accounts.map((a) => a.id) },
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
     },
-    select: { amount: true, type: true, createdAt: true, accountId: true },
+    select: { amount: true, type: true, currency: true, createdAt: true, accountId: true },
     orderBy: { createdAt: "asc" },
   });
 
@@ -307,7 +307,9 @@ export async function getAccountMonthlyCashFlow(
   for (const tx of transactions) {
     const monthKey = tx.createdAt.toISOString().slice(0, 7);
     const key = `${tx.accountId}::${monthKey}`;
-    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    // Prefer the currency captured at write time; legacy rows (null) fall
+    // back to the account's current currency.
+    const currency = tx.currency ?? accountCurrencyMap.get(tx.accountId) ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
     const amount = Number(tx.amount) * rate;
     const signed = tx.type === "DEPOSIT" ? amount : -amount;
@@ -352,7 +354,7 @@ export async function getMonthlyCashFlow(
       accountId: { in: accounts.map((a) => a.id) },
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
     },
-    select: { amount: true, type: true, createdAt: true, accountId: true },
+    select: { amount: true, type: true, currency: true, createdAt: true, accountId: true },
     orderBy: { createdAt: "asc" },
   });
 
@@ -360,7 +362,9 @@ export async function getMonthlyCashFlow(
 
   for (const tx of transactions) {
     const monthKey = tx.createdAt.toISOString().slice(0, 7); // "YYYY-MM"
-    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    // Prefer the currency captured at write time; legacy rows (null) fall
+    // back to the account's current currency.
+    const currency = tx.currency ?? accountCurrencyMap.get(tx.accountId) ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
     const amount = Number(tx.amount) * rate;
     const signed = tx.type === "DEPOSIT" ? amount : -amount;

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -79,12 +79,14 @@ export async function getProjectionData(
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
       createdAt: { gte: twelveMonthsAgo },
     },
-    select: { amount: true, type: true, accountId: true },
+    select: { amount: true, type: true, currency: true, accountId: true },
   });
 
   let trailing12mSavings = 0;
   for (const tx of transactions) {
-    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    // Prefer the currency captured at write time; legacy rows (null) fall
+    // back to the account's current currency.
+    const currency = tx.currency ?? accountCurrencyMap.get(tx.accountId) ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
     const amount = Number(tx.amount) * rate;
     trailing12mSavings += tx.type === "DEPOSIT" ? amount : -amount;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -233,6 +233,7 @@ export const dataImportSchema = z.object({
                 z.object({
                   type: z.enum(HOLDING_TRANSACTION_TYPES),
                   quantity: decimalSchema,
+                  price: decimalSchema.optional().nullable(),
                   note: z.string().optional().nullable(),
                   createdAt: z.string().optional(),
                 }),
@@ -246,6 +247,7 @@ export const dataImportSchema = z.object({
           z.object({
             type: z.enum(CASH_TRANSACTION_TYPES),
             amount: decimalSchema,
+            currency: z.string().length(3).optional().nullable(),
             note: z.string().optional().nullable(),
             createdAt: z.string().optional(),
           }),


### PR DESCRIPTION
> **Stacked on #398** — base is `fix/atomic-money-mutations`; GitHub will retarget to `master` automatically once #398 merges.

## Summary

Implements two database enhancements from the schema audit: DB-level CHECK constraints on money invariants, and write-time provenance columns that cannot be backfilled later.

## Migration (`20260610000000_add_tx_provenance_and_check_constraints`)

**New columns**
- `HoldingTransaction.price Decimal(18,8)?` — market price per unit at transaction time
- `CashTransaction.currency String?` — the account's currency at write time

**CHECK constraints** (last line of defense behind the app guards in `balance.ts` / `validators.ts`; they pair with the transaction-atomicity fixes in #398):
- `Holding.quantity >= 0`
- `PriceCache.price > 0`
- `ExchangeRate.rate > 0`

Verified by replaying the baseline schema + the new migration on a scratch Postgres, including negative tests confirming the constraints reject `price = 0` and `rate = -1` rows.

## Write paths now capturing provenance

| Path | Captures |
|---|---|
| Holdings POST (BUY log) | best-effort market quote, fetched **before** the write so the log commits with the price; fetch failure → `null`, never blocks the create |
| Cron expired-option sweep (SELL log) | `price: 0` (expired worthless) |
| Cash-transactions POST | `currency: account.currency` |
| Account PATCH balance-EDIT log | currency in effect after the update (`parsed.data.currency ?? existing.currency`) |
| Data import | `price` / `currency` from backup; legacy backups default currency to the account currency |

## Readers updated

`history-service.ts` (both monthly cash-flow aggregations) and `projection-service.ts` (trailing-12-month savings) now prefer the stored per-transaction currency and fall back to `account.currency` for legacy `null` rows — so changing an account's currency no longer silently reinterprets historical cash flows recorded from now on.

`dataImportSchema` accepts the new optional fields, keeping export → import round-trips lossless.

## Notes

- Columns are nullable; no backfill needed and no behavior change for existing rows.
- The BUY `price` is the market quote at write time (the API takes no user-supplied trade price today) — an approximation of cost basis, but the best signal available, and the column is ready for an explicit price input later.
- `prisma migrate deploy` runs on Vercel via `build:vercel`. The three constraints match invariants the app has always enforced, so existing prod rows should pass validation.

## Testing

- Migration chain replay + constraint negative tests on scratch Postgres (see above)
- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)