### PR TITLE
fix(cron): isolate snapshot failures, surface refresh errors, add catch-up run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,19 @@ A personal net-worth / asset tracking application built with **Next.js 16** (App
 | Validation | Zod 4                                            |
 | Fonts      | Geist Sans / Geist Mono via `next/font/google`   |
 
+## Hosting Constraints (Free Plans)
+
+The app is deployed on **Vercel Hobby** and **Neon Free** — both free tiers. Any implementation must fit inside their limits:
+
+- **Vercel Hobby**
+  - **Only one cron job** is allowed, and the daily snapshot owns it (`vercel.json` must keep a single `crons` entry — adding a second one breaks the deploy). Anything that needs scheduled retries or follow-up work must live _inside_ that single run (see the in-route retry in `/api/cron/snapshot`) or use an external trigger (e.g. a GitHub Actions schedule calling the endpoint with `CRON_SECRET`).
+  - Cron timing is **best-effort** — the run can fire up to ~an hour late, and failed runs are **not retried** automatically.
+  - Function `maxDuration` caps at **60s**; long pipelines must budget their phases.
+- **Neon Free**
+  - Compute **autosuspends when idle** — expect cold-start latency on the first query of a request; don't treat a slow first query as a regression.
+  - The connection pool is small: **bound any parallel query fan-out** (chunked batches instead of unbounded `Promise.all`, batched statements over per-row transactions) and avoid long-running interactive transactions.
+  - Storage/compute quotas are limited — avoid designs that accumulate unbounded rows (prefer upserts for daily data, prune or skip pointless rows).
+
 ## Commands
 
 ```bash

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -163,6 +163,7 @@
     "pricesUpdated": "Updated {count} prices",
     "pricesFailed": "Failed to refresh prices",
     "marketDataUpdated": "Updated {prices} prices and {rates} exchange rates",
+    "marketDataUpToDate": "Market data already up to date",
     "marketDataFailed": "Failed to refresh market data",
     "snapshotCreated": "Snapshot created",
     "snapshotFailed": "Failed to create snapshot",
@@ -669,6 +670,7 @@
     "refreshPrices": "Refresh Prices",
     "refreshing": "Refreshing...",
     "refreshSuccess": "Updated {count} prices & exchange rates",
+    "refreshUpToDate": "Prices already up to date",
     "refreshFailed": "Failed to refresh prices"
   },
   "freshness": {
@@ -1113,6 +1115,7 @@
     "deleteFailed": "Failed to delete stock",
     "deleting": "Deleting...",
     "refreshSuccess": "Updated {count} prices",
+    "refreshUpToDate": "Stock prices already up to date",
     "refreshFailed": "Failed to refresh stock prices",
     "saveStock": "Save stock",
     "saving": "Saving...",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -163,6 +163,7 @@
     "pricesUpdated": "已更新 {count} 個價格",
     "pricesFailed": "更新價格失敗",
     "marketDataUpdated": "已更新 {prices} 個價格與 {rates} 筆匯率",
+    "marketDataUpToDate": "市場資料已是最新",
     "marketDataFailed": "更新市場資料失敗",
     "snapshotCreated": "快照已建立",
     "snapshotFailed": "建立快照失敗",
@@ -669,6 +670,7 @@
     "refreshPrices": "更新價格",
     "refreshing": "更新中...",
     "refreshSuccess": "已更新 {count} 個價格和匯率",
+    "refreshUpToDate": "價格已是最新",
     "refreshFailed": "更新價格失敗"
   },
   "freshness": {
@@ -1113,6 +1115,7 @@
     "deleteFailed": "刪除股票失敗",
     "deleting": "刪除中...",
     "refreshSuccess": "已更新 {count} 筆價格",
+    "refreshUpToDate": "股價已是最新",
     "refreshFailed": "更新股票價格失敗",
     "saveStock": "儲存股票",
     "saving": "儲存中...",

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -69,8 +69,8 @@ export async function GET(request: Request) {
     log.info("cron.prices.refresh");
     const priceResult = await refreshAllPrices();
     if (priceResult.errors.length > 0) {
-      // Snapshots still proceed on cached prices; the catch-up cron run
-      // retries with fresh data and the upsert overwrites today's rows.
+      // Snapshots still proceed on cached prices — a stale data point
+      // beats a missing one.
       log.warn("cron.prices.refresh_errors", {
         updated: priceResult.updated,
         errors: priceResult.errors,
@@ -86,30 +86,41 @@ export async function GET(request: Request) {
       include: { appSettings: true },
     });
 
-    // 3. Create snapshots for each user (in parallel), isolating failures —
-    // cron has no retry, so one bad user must not cost everyone else
-    // their daily snapshot.
-    const results = await Promise.allSettled(
-      users.map((user) => {
-        const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
-        log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
-        return createSnapshot(user.id, baseCurrency);
-      }),
-    );
+    type SnapshotUser = (typeof users)[number];
 
-    const snapshotIds: string[] = [];
-    const failedUserIds: string[] = [];
-    results.forEach((result, i) => {
-      if (result.status === "fulfilled") {
-        snapshotIds.push(result.value.id);
-      } else {
-        failedUserIds.push(users[i].id);
-        log.error("cron.snapshot.user_failed", {
-          userId: users[i].id,
-          error: String(result.reason),
-        });
-      }
-    });
+    // 3. Create snapshots for each user (in parallel), isolating failures —
+    // one bad user must not cost everyone else their daily snapshot.
+    const runSnapshots = async (batch: SnapshotUser[]) => {
+      const settled = await Promise.allSettled(
+        batch.map((user) => createSnapshot(user.id, user.appSettings?.baseCurrency ?? "USD")),
+      );
+      const ids: string[] = [];
+      const failed: { user: SnapshotUser; reason: unknown }[] = [];
+      settled.forEach((result, i) => {
+        if (result.status === "fulfilled") ids.push(result.value.id);
+        else failed.push({ user: batch[i], reason: result.reason });
+      });
+      return { ids, failed };
+    };
+
+    const first = await runSnapshots(users);
+    const snapshotIds = first.ids;
+    let failures = first.failed;
+
+    // One in-route retry: the Hobby plan allows a single daily cron, so
+    // transient failures (DB hiccup, fetch blip) get their second chance
+    // here rather than via a second scheduled run.
+    if (failures.length > 0) {
+      log.warn("cron.snapshot.retrying", { count: failures.length });
+      const retry = await runSnapshots(failures.map((f) => f.user));
+      snapshotIds.push(...retry.ids);
+      failures = retry.failed;
+    }
+
+    const failedUserIds = failures.map((f) => f.user.id);
+    for (const f of failures) {
+      log.error("cron.snapshot.user_failed", { userId: f.user.id, error: String(f.reason) });
+    }
 
     if (users.length > 0 && snapshotIds.length === 0) {
       // Total failure: 500 so cron monitoring flags the run as failed.

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -67,7 +67,15 @@ export async function GET(request: Request) {
 
     // 1b. Refresh all prices to ensure the snapshot is accurate
     log.info("cron.prices.refresh");
-    await refreshAllPrices();
+    const priceResult = await refreshAllPrices();
+    if (priceResult.errors.length > 0) {
+      // Snapshots still proceed on cached prices; the catch-up cron run
+      // retries with fresh data and the upsert overwrites today's rows.
+      log.warn("cron.prices.refresh_errors", {
+        updated: priceResult.updated,
+        errors: priceResult.errors,
+      });
+    }
     // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
     revalidateTag("net-worth", "max");
     revalidateTag("prices", "max");
@@ -78,14 +86,36 @@ export async function GET(request: Request) {
       include: { appSettings: true },
     });
 
-    // 3. Create snapshots for each user (in parallel)
-    const snapshots = await Promise.all(
+    // 3. Create snapshots for each user (in parallel), isolating failures —
+    // cron has no retry, so one bad user must not cost everyone else
+    // their daily snapshot.
+    const results = await Promise.allSettled(
       users.map((user) => {
         const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
         log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
         return createSnapshot(user.id, baseCurrency);
       }),
     );
+
+    const snapshotIds: string[] = [];
+    const failedUserIds: string[] = [];
+    results.forEach((result, i) => {
+      if (result.status === "fulfilled") {
+        snapshotIds.push(result.value.id);
+      } else {
+        failedUserIds.push(users[i].id);
+        log.error("cron.snapshot.user_failed", {
+          userId: users[i].id,
+          error: String(result.reason),
+        });
+      }
+    });
+
+    if (users.length > 0 && snapshotIds.length === 0) {
+      // Total failure: 500 so cron monitoring flags the run as failed.
+      log.error("cron.snapshot.all_failed", { userCount: users.length });
+      return failure("All snapshots failed", 500);
+    }
 
     // 4. Invalidate snapshot/history caches now that new rows exist
     revalidateTag("snapshots", "max");
@@ -94,8 +124,10 @@ export async function GET(request: Request) {
     }
 
     return ok({
-      success: true,
-      snapshotIds: snapshots.map((s) => s.id),
+      success: failedUserIds.length === 0,
+      snapshotIds,
+      ...(failedUserIds.length > 0 && { failedUserIds }),
+      priceRefresh: { updated: priceResult.updated, errors: priceResult.errors },
       timestamp: new Date().toISOString(),
     });
   } catch (error) {

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -31,7 +31,16 @@ export function DashboardActions({ lastPriceUpdate, lastSnapshotDate }: Dashboar
       ]);
       if (!priceRes.ok || !ratesRes.ok) throw new Error("Refresh failed");
       const { data: priceData } = await priceRes.json();
-      toast.success(t("refreshSuccess", { count: priceData.updated }));
+      if (priceData.updated > 0) {
+        toast.success(t("refreshSuccess", { count: priceData.updated }));
+      } else if (priceData.errors?.length) {
+        // Fetch failed for every symbol — don't dress it up as a success
+        toast.error(t("refreshFailed"));
+      } else {
+        // Everything was inside the refresh TTL — "0 updated" reads like a
+        // failure, so say what actually happened
+        toast.success(t("refreshUpToDate"));
+      }
       setClientRefreshAt(new Date().toISOString());
       window.dispatchEvent(new CustomEvent("prices:refreshed"));
       router.refresh();

--- a/src/components/dashboard/dashboard-pull-refresh.tsx
+++ b/src/components/dashboard/dashboard-pull-refresh.tsx
@@ -18,7 +18,16 @@ export function DashboardPullRefresh({ children }: { children: React.ReactNode }
       ]);
       if (!priceRes.ok || !ratesRes.ok) throw new Error("Refresh failed");
       const { data: priceData } = await priceRes.json();
-      toast.success(t("refreshSuccess", { count: priceData.updated }));
+      if (priceData.updated > 0) {
+        toast.success(t("refreshSuccess", { count: priceData.updated }));
+      } else if (priceData.errors?.length) {
+        // Fetch failed for every symbol — don't dress it up as a success
+        toast.error(t("refreshFailed"));
+      } else {
+        // Everything was inside the refresh TTL — "0 updated" reads like a
+        // failure, so say what actually happened
+        toast.success(t("refreshUpToDate"));
+      }
       window.dispatchEvent(new CustomEvent("prices:refreshed"));
       router.refresh();
     } catch {

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -215,12 +215,21 @@ export function SettingsForm({
       setClientPriceRefreshAt(refreshedAt);
       setClientRatesRefreshAt(refreshedAt);
       window.dispatchEvent(new CustomEvent("prices:refreshed"));
-      toast.success(
-        t("toast.marketDataUpdated", {
-          prices: priceData.updated,
-          rates: ratesData.updated,
-        }),
-      );
+      if (priceData.updated === 0 && priceData.errors?.length) {
+        // Price fetch failed for every symbol — don't dress it up as a success
+        toast.error(t("toast.marketDataFailed"));
+      } else if (priceData.updated === 0 && ratesData.updated === 0) {
+        // Both inside their refresh TTLs — "Updated 0 prices and 0 rates"
+        // reads like a failure, so say what actually happened
+        toast.success(t("toast.marketDataUpToDate"));
+      } else {
+        toast.success(
+          t("toast.marketDataUpdated", {
+            prices: priceData.updated,
+            rates: ratesData.updated,
+          }),
+        );
+      }
       router.refresh();
     } catch {
       toast.error(t("toast.marketDataFailed"));

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -637,8 +637,18 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
     try {
       const res = await fetch("/api/stocks/refresh", { method: "POST" });
       if (!res.ok) throw new Error("refresh failed");
-      const { data }: { data: { updated: number } } = await res.json();
-      toast.success(t("refreshSuccess", { count: data.updated }));
+      const { data }: { data: { updated: number; skipped: number; errors: string[] } } =
+        await res.json();
+      if (data.updated > 0) {
+        toast.success(t("refreshSuccess", { count: data.updated }));
+      } else if (data.errors?.length) {
+        // Fetch failed for every symbol — don't dress it up as a success
+        toast.error(t("refreshFailed"));
+      } else {
+        // Everything was inside the refresh TTL — "0 updated" reads like a
+        // failure, so say what actually happened
+        toast.success(t("refreshUpToDate"));
+      }
       window.dispatchEvent(new CustomEvent("prices:refreshed"));
       startTransition(() => router.refresh());
     } catch {

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -213,11 +213,25 @@ export async function refreshAllPrices(): Promise<{
   updated: number;
   errors: string[];
 }> {
-  const holdings = await prisma.holding.findMany({
-    select: { symbol: true, assetType: true },
-    distinct: ["symbol"],
-  });
-  return refreshPricesForHoldings(holdings);
+  // Watchlist symbols are included so their cached prices don't silently
+  // age until a user happens to trigger refreshPricesForUser.
+  const [holdings, trackedStocks] = await Promise.all([
+    prisma.holding.findMany({
+      select: { symbol: true, assetType: true },
+      distinct: ["symbol"],
+    }),
+    prisma.stockWatchItem.findMany({
+      select: { symbol: true },
+      distinct: ["symbol"],
+    }),
+  ]);
+
+  const holdingKeys = new Set(holdings.map((holding) => holding.symbol));
+  const stockWatchHoldings = trackedStocks
+    .filter((stock) => !holdingKeys.has(stock.symbol))
+    .map((stock) => ({ symbol: stock.symbol, assetType: "STOCK" }));
+
+  return refreshPricesForHoldings([...holdings, ...stockWatchHoldings]);
 }
 
 export async function refreshPricesForUser(userId: string): Promise<{
@@ -293,7 +307,15 @@ async function refreshPricesForHoldings(
   const allPrices = new Map([...stockPrices, ...cryptoPrices]);
 
   const entries = [...allPrices];
-  if (entries.length === 0) return { updated: 0, errors: [] };
+  if (entries.length === 0) {
+    // Every fetch came back empty — report it instead of a silent success
+    // so callers (cron, manual refresh) can tell "all fresh" from "all failed".
+    const requested = stockSymbols.length + cryptoSymbols.length;
+    if (requested > 0) {
+      errors.push(`No prices returned for any of ${requested} symbol(s)`);
+    }
+    return { updated: 0, errors };
+  }
 
   try {
     const params: unknown[] = [];

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -209,10 +209,14 @@ export async function getCachedPricesForSymbols(
   return all.filter((p) => symbolSet.has(p.symbol));
 }
 
-export async function refreshAllPrices(): Promise<{
+export type PriceRefreshResult = {
   updated: number;
+  /** Symbols skipped because their cached price was within the refresh TTL. */
+  skipped: number;
   errors: string[];
-}> {
+};
+
+export async function refreshAllPrices(): Promise<PriceRefreshResult> {
   // Watchlist symbols are included so their cached prices don't silently
   // age until a user happens to trigger refreshPricesForUser.
   const [holdings, trackedStocks] = await Promise.all([
@@ -234,10 +238,7 @@ export async function refreshAllPrices(): Promise<{
   return refreshPricesForHoldings([...holdings, ...stockWatchHoldings]);
 }
 
-export async function refreshPricesForUser(userId: string): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshPricesForUser(userId: string): Promise<PriceRefreshResult> {
   const [holdings, trackedStocks] = await Promise.all([
     prisma.holding.findMany({
       where: { account: { userId } },
@@ -259,23 +260,18 @@ export async function refreshPricesForUser(userId: string): Promise<{
   return refreshPricesForHoldings([...holdings, ...stockWatchHoldings]);
 }
 
-export async function refreshPricesForStockSymbols(symbols: string[]): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshPricesForStockSymbols(symbols: string[]): Promise<PriceRefreshResult> {
   const uniqueSymbols = [...new Set(symbols.map((symbol) => symbol.toUpperCase()))];
-  if (uniqueSymbols.length === 0) return { updated: 0, errors: [] };
+  if (uniqueSymbols.length === 0) return { updated: 0, skipped: 0, errors: [] };
   return refreshPricesForHoldings(uniqueSymbols.map((symbol) => ({ symbol, assetType: "STOCK" })));
 }
 
 async function refreshPricesForHoldings(
   holdings: { symbol: string; assetType: string }[],
-): Promise<{
-  updated: number;
-  errors: string[];
-}> {
-  if (holdings.length === 0) return { updated: 0, errors: [] };
+): Promise<PriceRefreshResult> {
+  if (holdings.length === 0) return { updated: 0, skipped: 0, errors: [] };
 
+  let skipped = 0;
   const freshRows = await prisma.priceCache.findMany({
     where: {
       symbol: { in: holdings.map((h) => h.symbol) },
@@ -285,9 +281,10 @@ async function refreshPricesForHoldings(
   });
   if (freshRows.length > 0) {
     const freshSymbols = new Set(freshRows.map((row) => row.symbol));
-    log.info("price.refresh.skipped_fresh", { count: freshSymbols.size });
+    skipped = freshSymbols.size;
+    log.info("price.refresh.skipped_fresh", { count: skipped });
     holdings = holdings.filter((h) => !freshSymbols.has(h.symbol));
-    if (holdings.length === 0) return { updated: 0, errors: [] };
+    if (holdings.length === 0) return { updated: 0, skipped, errors: [] };
   }
 
   const stockSymbols = holdings
@@ -314,7 +311,7 @@ async function refreshPricesForHoldings(
     if (requested > 0) {
       errors.push(`No prices returned for any of ${requested} symbol(s)`);
     }
-    return { updated: 0, errors };
+    return { updated: 0, skipped, errors };
   }
 
   try {
@@ -339,5 +336,5 @@ async function refreshPricesForHoldings(
     errors.push(`Bulk upsert failed: ${String(error)}`);
   }
 
-  return { updated, errors };
+  return { updated, skipped, errors };
 }

--- a/src/lib/services/stock-watch-service.ts
+++ b/src/lib/services/stock-watch-service.ts
@@ -1,7 +1,10 @@
 import "server-only";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { refreshPricesForStockSymbols } from "@/lib/services/price-service";
+import {
+  refreshPricesForStockSymbols,
+  type PriceRefreshResult,
+} from "@/lib/services/price-service";
 import { getYahooClient } from "@/lib/services/yahoo-client";
 import { log } from "@/lib/logger";
 import type { StockWatchItem } from "@/generated/prisma/client";
@@ -163,10 +166,7 @@ export async function warmStockPrice(symbol: string): Promise<{
   };
 }
 
-export async function refreshTrackedStockPrices(userId: string): Promise<{
-  updated: number;
-  errors: string[];
-}> {
+export async function refreshTrackedStockPrices(userId: string): Promise<PriceRefreshResult> {
   const stocks = await prisma.stockWatchItem.findMany({
     where: { userId },
     select: { symbol: true },

--- a/vercel.json
+++ b/vercel.json
@@ -6,10 +6,6 @@
     {
       "path": "/api/cron/snapshot",
       "schedule": "30 21 * * *"
-    },
-    {
-      "path": "/api/cron/snapshot",
-      "schedule": "30 23 * * *"
     }
   ],
   "functions": {

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
     {
       "path": "/api/cron/snapshot",
       "schedule": "30 21 * * *"
+    },
+    {
+      "path": "/api/cron/snapshot",
+      "schedule": "30 23 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
> **Stacked on #399** (base: `feat/db-checks-and-tx-provenance`); retargets automatically as the stack merges. High-value items from the cron-job review; the medium items follow in #401 stacked on this one.

## Problem

The daily snapshot job exists to produce an unbroken net-worth history, but three failure modes quietly threatened it:

1. **One bad user killed everyone's snapshot.** `Promise.all` over all users meant a single thrown `createSnapshot` rejected the batch, the route 500'd, and — since Vercel cron has no retry — *every* user permanently lost that day's data point.
2. **A total price-fetch failure looked like success.** `refreshAllPrices()` returned `{ updated: 0, errors: [] }` when Yahoo + CoinGecko both failed; the cron discarded the result entirely and snapshotted everyone on stale prices while reporting success.
3. **Transient per-user failures had no second chance** within the single daily run.

Bonus gap found while fixing #2: `refreshAllPrices` only covered `Holding` symbols — **watchlist (`StockWatchItem`) prices were never refreshed by the cron**, aging until a user happened to trigger a manual refresh.

## Changes

- **Per-user isolation** — snapshot creation uses `Promise.allSettled`; one user's failure no longer rejects the batch. Still-failed users are logged (`cron.snapshot.user_failed`) and returned as `failedUserIds`. An all-failed run returns 500 so cron monitoring flags it; partial success returns 200 with details.
- **In-route retry** — users whose snapshot fails on the first pass get one immediate retry within the same invocation (`cron.snapshot.retrying`). The project runs on the Vercel **Hobby plan (single cron job)**, so resilience lives inside the one run rather than in a second scheduled catch-up. A full-run outage would need an external trigger (e.g. a GitHub Actions schedule hitting the endpoint with `CRON_SECRET`) — left as a follow-up if ever needed.
- **Refresh errors surfaced** — `refreshPricesForHoldings` now reports "no prices returned" when every fetch comes back empty (distinguishing it from the all-fresh TTL skip), and the cron logs the result (`cron.prices.refresh_errors`) and includes `priceRefresh` in its response.
- **Watchlist coverage** — `refreshAllPrices` unions `StockWatchItem` symbols, mirroring `refreshPricesForUser`.

## Also: accurate refresh toasts (`f995314`)

The same `updated: 0` ambiguity produced a weird UX on user-triggered refreshes: a quick second pull-to-refresh hits the 1-minute price TTL, skips every symbol, and the toast read **"Updated 0 prices"** — looking like a failure. Worse, a total fetch failure surfaced as a *success* toast with count 0.

- Refresh results now include `skipped` (TTL-fresh symbols) via a shared `PriceRefreshResult` type, threaded through all refresh entry points.
- All four refresh UIs (dashboard button, dashboard pull-to-refresh, settings market-data button, stocks watchlist) branch on the richer result:
  - `updated > 0` → existing count toast
  - `updated == 0` + errors → **error toast** (was a fake success)
  - all-fresh → new **"already up to date"** success toast
- New i18n strings (`refreshUpToDate`, `marketDataUpToDate`) in `en-US` and `zh-TW`.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass.
- Cron response shape change (`priceRefresh`, optional `failedUserIds`) only affects the cron caller, which ignores the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)