### PR TITLE
perf(cron): batch option sweep, bound snapshot fan-out, add phase timings

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -5,7 +5,10 @@ import { refreshAllPrices } from "@/lib/services/price-service";
 import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
 import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
-import { log } from "@/lib/logger";
+import { log, withTiming } from "@/lib/logger";
+
+/** Bounded fan-out: each snapshot runs several queries against the pool. */
+const SNAPSHOT_CONCURRENCY = 5;
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -23,27 +26,30 @@ export async function GET(request: Request) {
         expiration: { lt: today },
         quantity: { gt: 0 },
       },
+      select: { id: true, quantity: true },
     });
     if (expiredOptions.length > 0) {
-      log.info("cron.options.expire", { count: expiredOptions.length });
-      await Promise.all(
-        expiredOptions.map((h) =>
+      // One atomic batch (two statements) instead of a transaction per
+      // option — bounded round-trips and the whole sweep commits together.
+      await withTiming(
+        "cron.phase.options_sweep",
+        () =>
           prisma.$transaction([
-            prisma.holdingTransaction.create({
-              data: {
+            prisma.holdingTransaction.createMany({
+              data: expiredOptions.map((h) => ({
                 holdingId: h.id,
-                type: "SELL",
-                quantity: Number(h.quantity),
+                type: "SELL" as const,
+                quantity: h.quantity,
                 price: 0,
                 note: "Expired",
-              },
+              })),
             }),
-            prisma.holding.update({
-              where: { id: h.id },
+            prisma.holding.updateMany({
+              where: { id: { in: expiredOptions.map((h) => h.id) } },
               data: { quantity: 0 },
             }),
           ]),
-        ),
+        { count: expiredOptions.length },
       );
       revalidateTag("accounts", "max");
     }
@@ -60,14 +66,16 @@ export async function GET(request: Request) {
     for (const row of accountCurrencies) sourceCurrencies.add(row.currency);
     for (const row of holdingCurrencies) if (row.currency) sourceCurrencies.add(row.currency);
     for (const row of settings) sourceCurrencies.add(row.baseCurrency);
-    log.info("cron.rates.refresh", { count: sourceCurrencies.size });
-    await Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c)));
+    await withTiming(
+      "cron.phase.rates_refresh",
+      () => Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c))),
+      { count: sourceCurrencies.size },
+    );
     revalidateTag("exchange-rates", "max");
     revalidateTag("net-worth", "max");
 
     // 1b. Refresh all prices to ensure the snapshot is accurate
-    log.info("cron.prices.refresh");
-    const priceResult = await refreshAllPrices();
+    const priceResult = await withTiming("cron.phase.prices_refresh", () => refreshAllPrices());
     if (priceResult.errors.length > 0) {
       // Snapshots still proceed on cached prices — a stale data point
       // beats a missing one.
@@ -81,41 +89,54 @@ export async function GET(request: Request) {
     revalidateTag("prices", "max");
     revalidateTag("prices:crypto", "max");
 
-    // 2. Get all users and their settings
+    // 2. Snapshot only users with at least one active account — everyone
+    // else would just accumulate pointless netWorth: 0 rows.
     const users = await prisma.user.findMany({
+      where: { appAccounts: { some: { isActive: true } } },
       include: { appSettings: true },
     });
 
     type SnapshotUser = (typeof users)[number];
 
-    // 3. Create snapshots for each user (in parallel), isolating failures —
-    // one bad user must not cost everyone else their daily snapshot.
+    // 3. Create snapshots in bounded batches, isolating failures — one bad
+    // user must not cost everyone else their daily snapshot.
     const runSnapshots = async (batch: SnapshotUser[]) => {
-      const settled = await Promise.allSettled(
-        batch.map((user) => createSnapshot(user.id, user.appSettings?.baseCurrency ?? "USD")),
-      );
       const ids: string[] = [];
       const failed: { user: SnapshotUser; reason: unknown }[] = [];
-      settled.forEach((result, i) => {
-        if (result.status === "fulfilled") ids.push(result.value.id);
-        else failed.push({ user: batch[i], reason: result.reason });
-      });
+      for (let i = 0; i < batch.length; i += SNAPSHOT_CONCURRENCY) {
+        const chunk = batch.slice(i, i + SNAPSHOT_CONCURRENCY);
+        const settled = await Promise.allSettled(
+          chunk.map((user) => createSnapshot(user.id, user.appSettings?.baseCurrency ?? "USD")),
+        );
+        settled.forEach((result, j) => {
+          if (result.status === "fulfilled") ids.push(result.value.id);
+          else failed.push({ user: chunk[j], reason: result.reason });
+        });
+      }
       return { ids, failed };
     };
 
-    const first = await runSnapshots(users);
-    const snapshotIds = first.ids;
-    let failures = first.failed;
+    const { snapshotIds, failures } = await withTiming(
+      "cron.phase.snapshots",
+      async () => {
+        const first = await runSnapshots(users);
+        const ids = first.ids;
+        let failed = first.failed;
 
-    // One in-route retry: the Hobby plan allows a single daily cron, so
-    // transient failures (DB hiccup, fetch blip) get their second chance
-    // here rather than via a second scheduled run.
-    if (failures.length > 0) {
-      log.warn("cron.snapshot.retrying", { count: failures.length });
-      const retry = await runSnapshots(failures.map((f) => f.user));
-      snapshotIds.push(...retry.ids);
-      failures = retry.failed;
-    }
+        // One in-route retry: the Hobby plan allows a single daily cron, so
+        // transient failures (DB hiccup, fetch blip) get their second chance
+        // here rather than via a second scheduled run.
+        if (failed.length > 0) {
+          log.warn("cron.snapshot.retrying", { count: failed.length });
+          const retry = await runSnapshots(failed.map((f) => f.user));
+          ids.push(...retry.ids);
+          failed = retry.failed;
+        }
+
+        return { snapshotIds: ids, failures: failed };
+      },
+      { userCount: users.length },
+    );
 
     const failedUserIds = failures.map((f) => f.user.id);
     for (const f of failures) {


### PR DESCRIPTION
> **Stacked on #400** (base: `feat/cron-resilience`); retargets automatically as the stack merges. Medium-priority items from the cron-job review — the high-value resilience fixes are in #400.

## Changes

All in `src/app/api/cron/snapshot/route.ts`:

**Batched expired-option sweep.** Previously one interactive `$transaction` per expired option, fanned out with unbounded `Promise.all`. Now a single atomic transaction with two batch statements: `holdingTransaction.createMany` (SELL logs, `price: 0`) + `holding.updateMany` (quantities to 0). Bounded round-trips to Neon, and the whole sweep commits or rolls back together. Side benefit: the SELL log now passes the `Decimal` quantity straight through instead of converting via `Number`.

**Bounded, filtered snapshot fan-out.**
- Users with no active account are skipped — they previously accumulated a pointless `netWorth: 0` row every day.
- Snapshots run in chunks of 5 (`SNAPSHOT_CONCURRENCY`) instead of unbounded `Promise.all`; each `createSnapshot` fans out into several queries, so the unbounded version hammered the connection pool and the 60s `maxDuration` budget in proportion to user count.
- The per-user `cron.snapshot.create` info log is dropped (one line per user per day of noise); the phase log carries `userCount`, and failures are still logged individually via #400's `cron.snapshot.user_failed`.

**Per-phase timings.** The four phases — options sweep, FX refresh, price refresh, snapshot creation — are wrapped in the existing `withTiming` helper, so when the job approaches its 60s budget the Vercel logs show exactly which phase is eating it (`cron.phase.options_sweep`, `cron.phase.rates_refresh`, `cron.phase.prices_refresh`, `cron.phase.snapshots`).

## Behavior notes

- `Promise.allSettled` failure isolation from #400 is preserved inside the chunked loop; response shape is unchanged from #400.
- A user whose accounts are all archived stops receiving new snapshots; their existing history is untouched.

## Testing

- `npm run format:check`, `npm run lint`, `npm run typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)