### PR TITLE
feat: enable PWA install button via service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,10 @@
+// Minimal network-only service worker.
+// Satisfies Chrome's PWA installability requirement (needs a fetch listener)
+// without adding any caching — all requests pass through to the network.
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
+self.addEventListener("fetch", (e) => {
+  if (e.request.method === "GET") {
+    e.respondWith(fetch(e.request));
+  }
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
+import Script from "next/script";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { ColorSchemaProvider } from "@/components/layout/color-schema-context";
@@ -311,6 +312,11 @@ export default function RootLayout({
             ) : null}
           </ColorSchemaProvider>
         </ThemeProvider>
+        <Script id="pwa-sw" strategy="afterInteractive">{`
+          if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/sw.js');
+          }
+        `}</Script>
       </body>
     </html>
   );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -130,6 +130,6 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
 // component carrying them is excluded.
 export const config = {
   matcher: [
-    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
+    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|sw\\.js|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
   ],
 };


### PR DESCRIPTION
## Summary

Adds a minimal service worker to enable the browser's native PWA install button (shown in the address bar) on production (`astt.app`).

The app already has all PWA prerequisites in place (manifest, icons, HTTPS, `display: standalone`) — this simply adds the missing fetch event listener that Chrome requires to trigger the install prompt.

## Implementation

- **`public/sw.js`** — network-only passthrough service worker (no caching overhead)
- **`src/app/layout.tsx`** — registers SW via `<Script strategy="afterInteractive">` to avoid blocking page render
- **`src/proxy.ts`** — adds `sw.js` to the middleware exclusion so Chrome's periodic update checks aren't redirected to `/login`

## Behavior

- The install button will appear in the address bar on desktop browsers (Chrome, Edge, etc.) after the SW registers
- First visit: SW registers silently
- Second visit or app restart: Chrome shows the install prompt
- Mobile: iOS has `apple-web-app-capable` already set; Android users will see the address-bar install option

## Test plan

- [ ] `npm run format:check && npm run lint && npm run typecheck` — all pass
- [ ] Deploy to `astt.app` (or preview deployment)
- [ ] Open in Chrome desktop; check the address bar for an install icon after page load
- [ ] Confirm the install prompt appears on second visit or after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)