### PR TITLE
feat(search): rank TW and US stocks higher in autocomplete

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -74,6 +74,12 @@ function inferCurrency(symbol: string, exchange: string): string {
   return exchangeCurrencyMap[exchange] || "USD";
 }
 
+function rankResult(r: SearchResult): number {
+  if (r.symbol.endsWith(".TW") || r.symbol.endsWith(".TWO")) return 0;
+  if (r.currency === "USD") return 1;
+  return 2;
+}
+
 // NOTE: this intentionally does NOT swallow errors. A thrown error (Yahoo down,
 // network failure) must propagate so the handler can return a non-200 and the
 // caller can tell "search is broken" apart from "no matches". Errors also aren't
@@ -107,7 +113,8 @@ const cachedYahooSearch = unstable_cache(
         exchange: (q.exchDisp as string) || (q.exchange as string) || "",
         type: mapQuoteType(q.quoteType as string),
         currency: inferCurrency(q.symbol as string, (q.exchange as string) || ""),
-      }));
+      }))
+      .sort((a: SearchResult, b: SearchResult) => rankResult(a) - rankResult(b));
   },
   ["yahoo-search"],
   { revalidate: 3600 },


### PR DESCRIPTION
## Summary

- Taiwan stocks (`.TW` / `.TWO` symbol suffix) are sorted to the top of search autocomplete results
- USD-currency stocks (US exchanges: NASDAQ, NYSE, etc.) sort second
- All other markets sort third
- Yahoo's own relevance order is preserved within each tier

## Implementation

Added a `rankResult()` helper in `src/app/api/search/route.ts` that assigns a priority score (0/1/2) and applies a stable `.sort()` after the Yahoo Finance results are mapped. Since ranking is server-side, all four search surfaces (holding form, quick-add, option builder, stock watchlist) automatically get the updated order — no client changes needed.

## Test plan

- [ ] Search for "2330" — TSMC (2330.TW) should appear first
- [ ] Search for "Apple" — AAPL (USD) should appear before any non-USD results
- [ ] Search for a non-TW/non-USD ticker (e.g. "HSBC") — HKD results should appear after USD ones
- [ ] Verify search works in all four surfaces: add holding, quick-add, option builder, stock watchlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)