### PR TITLE
fix(pwa): serve manifest.webmanifest anonymously so app install works on production

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -119,6 +119,9 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
 // Negative-lookahead exclusions:
 //   - Next/Vercel internals + cron + file-based metadata (already excluded before P1).
 //   - robots.txt / sitemap.xml served from `public/`.
+//   - PWA assets sw.js + manifest.webmanifest: the browser fetches these without
+//     credentials, so they must resolve to 200 (not a /login redirect) or Chrome's
+//     installability check fails and the install prompt never appears.
 //   - Public legal pages, so they can render without NextAuth cookie work.
 //   - Common bot/scanner probes observed in production logs and in the wild:
 //     wp-admin/wp-login/wp-content/wp-includes/wordpress, xmlrpc, cgi-bin,
@@ -130,6 +133,6 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
 // component carrying them is excluded.
 export const config = {
   matcher: [
-    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|sw\\.js|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
+    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|sw\\.js|manifest\\.webmanifest|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
   ],
 };


### PR DESCRIPTION
## Problem

App install (PWA) worked on localhost/preview but **not on production** (https://astt.app), despite PR #404 enabling the service worker.

Root cause: the web manifest was still behind the auth middleware. On production:

```
$ curl -sS -D - -o /dev/null https://astt.app/manifest.webmanifest
HTTP/2 302
location: /login
```

Browsers fetch the web manifest **without credentials** by default, so the request hit the middleware's anonymous fast-path and got redirected to `/login`. Chrome received an HTML redirect instead of the JSON manifest, so its installability check failed and the install prompt never appeared. It looked fine on localhost/preview because Chrome is more lenient there and a session cookie was active, masking the gap.

PR #404 added `sw.js` to the middleware matcher exclusion list but not `manifest.webmanifest`.

## Fix

Exclude `manifest.webmanifest` from the `src/proxy.ts` (Next 16 middleware) matcher's negative-lookahead, right next to `sw.js`, so it resolves to a 200 anonymously. The manifest contains no sensitive data. Required icons (`/icon.svg`, `/apple-icon.png`) were already excluded.

## Verification

- Regex still excludes `manifest.webmanifest` + `sw.js`, still matches protected routes like `/dashboard`
- `format:check`, `lint`, `typecheck` all pass
- After deploy, confirm: `curl -sS -D - -o /dev/null https://astt.app/manifest.webmanifest` should return `HTTP/2 200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)