### PR TITLE
perf(accounts): start cached-price fetch in parallel with account batch

### DIFF
--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -30,18 +30,25 @@ async function AccountsContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   // Run all independent queries in parallel (translations + data). The net-worth
-  // summary that backs the heatmap depends on the base currency, so it chains off
-  // the settings read rather than blocking the whole batch.
+  // summary that backs the heatmap depends on the base currency, and the cached
+  // price read depends on the user's holding symbols, so they chain off the
+  // settings/accounts reads rather than blocking the whole batch.
   const settingsP = getOrCreateSettings(userId);
-  const [t, messages, accounts, archivedAccounts, settings, allRatesMap, summary] =
+  const accountsP = fetchUserAccountsWithHoldings(userId);
+  const [t, messages, accounts, archivedAccounts, settings, allRatesMap, summary, cachedPrices] =
     await Promise.all([
       getTranslations("accounts"),
       getMessages(),
-      fetchUserAccountsWithHoldings(userId),
+      accountsP,
       fetchUserArchivedAccountsWithHoldings(userId),
       settingsP,
       getAllExchangeRates(),
       settingsP.then((s) => getCachedNetWorthSummary(userId, s.baseCurrency)),
+      accountsP.then((accounts) =>
+        getCachedPricesForSymbols([
+          ...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol))),
+        ]),
+      ),
     ]);
 
   const baseCurrency = settings.baseCurrency;
@@ -49,9 +56,6 @@ async function AccountsContent() {
     (account) => account.type === "ASSET" && account.totalValueInBaseCurrency > 0,
   );
 
-  // Fetch cached prices for this user's holding symbols only
-  const allSymbols = [...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol)))];
-  const cachedPrices = await getCachedPricesForSymbols(allSymbols);
   const priceMap: Record<string, number> = Object.fromEntries(
     cachedPrices.map((p) => [p.symbol, p.price]),
   );


### PR DESCRIPTION
## Summary

Removes a request waterfall on the `/accounts` page (`src/app/(main)/accounts/page.tsx`).

**Before:** `getCachedPricesForSymbols` was awaited only after the full 7-way `Promise.all` (translations, messages, accounts, archived accounts, settings, rates, and the chained settings → net-worth summary read) resolved — even though it only depends on the accounts read. The price fetch was needlessly serialized behind the slowest member of the batch.

**After:** the accounts promise is hoisted (`accountsP`, same pattern as the existing `settingsP`) and the cached-price fetch is chained off it inside the same `Promise.all`, so it starts as soon as accounts resolve instead of waiting for the entire batch.

## Verification

- `npm run format:check` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)