### PR TITLE
perf(accounts): collapse account-detail page waterfall to dependency depth

### DIFF
--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -21,24 +21,31 @@ const CLIENT_NAMESPACES = [
 async function AccountDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
-  // Kick off independent queries before awaiting the account
+  // Kick off all queries at their true dependency depth: rates/messages/session
+  // are independent; the detail + accounts fetches chain off the session, and
+  // the price map chains off the detail's symbols. One await resolves them all.
   const ratesP = getAllExchangeRates();
   const messagesP = getMessages();
   const sessionP = getSession();
+  const detailP = sessionP.then((s) => (s?.user?.id ? getAccountDetail(s.user.id, id) : null));
+  const allAccountsP = sessionP.then((s) =>
+    s?.user?.id ? fetchUserAccountsWithHoldings(s.user.id) : [],
+  );
+  const priceMapP = detailP.then((d) =>
+    d ? getAccountPriceMap(d.holdings.map((h) => h.symbol)) : {},
+  );
 
-  const [session, allRatesMap, messages] = await Promise.all([sessionP, ratesP, messagesP]);
-
-  const userId = session?.user?.id;
-  if (!userId) notFound();
-
-  const [serialized, allAccounts] = await Promise.all([
-    getAccountDetail(userId, id),
-    fetchUserAccountsWithHoldings(userId),
+  const [session, allRatesMap, messages, serialized, allAccounts, priceMap] = await Promise.all([
+    sessionP,
+    ratesP,
+    messagesP,
+    detailP,
+    allAccountsP,
+    priceMapP,
   ]);
-  if (!serialized) notFound();
 
-  const symbols = serialized.holdings.map((h) => h.symbol);
-  const priceMap = await getAccountPriceMap(symbols);
+  if (!session?.user?.id) notFound();
+  if (!serialized) notFound();
 
   // Build rates map from bulk-loaded data. Render path is read-only
   // against ExchangeRate — missing pairs fall back to 1 (rates are warmed


### PR DESCRIPTION
## Problem

`src/app/(main)/accounts/[id]/page.tsx` resolved its data in **three sequential await stages**:

1. `Promise.all([session, rates, messages])`
2. `Promise.all([getAccountDetail, fetchUserAccountsWithHoldings])` — only needs the session
3. `getAccountPriceMap(symbols)` — only needs the detail's holding symbols

Stage 2 was blocked on rates + messages it doesn't depend on, and stage 3 added a full extra round trip. Total latency = sum of all three stages.

## Fix

Chain each fetch off its actual dependency (`detailP`/`allAccountsP` off `sessionP`, `priceMapP` off `detailP`) and await everything in a **single `Promise.all`**. Latency now equals the longest dependency chain (`session → detail → priceMap`), with rates, messages, and the accounts list resolving in parallel alongside it. The `notFound()` guards run after the single await; the chained promises fall back to `null` / `[]` / `{}` (matching `getAccountPriceMap`'s `Record<string, number>` return) when the session or detail is missing.

No behavior change — rates map construction and JSX are untouched.

## Checks

- `npm run format:check` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)