### PR TITLE
perf(dashboard): parallelize orchestrator reads and stream trend chart

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -256,6 +256,44 @@ async function GoalsMilestoneSection({
   );
 }
 
+/**
+ * Trend chart + history heatmap — streams behind its Suspense boundary so the
+ * dashboard shell never waits on snapshot history. getNormalizedHistory is
+ * "use cache" with cacheLife("hours"), so the snapshot fetch — shared by
+ * TrendChartSection and HistoryHeatmap — is a cache read on warm requests.
+ */
+async function TrendSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
+  const [snapshots, t] = await Promise.all([
+    getNormalizedHistory(userId, baseCurrency),
+    getTranslations("dashboard"),
+  ]);
+
+  return (
+    <TrendChartSection
+      baseCurrency={baseCurrency}
+      snapshots={snapshots}
+      footer={
+        <>
+          <HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />
+          {/* Mobile-only entry point — History is a sub-tab of /analysis, so
+              the tab bar gives it no scent. The trend chart is the preview;
+              this names the destination. Desktop uses the sidebar route. */}
+          <Link
+            href="/analysis#history"
+            className="md:hidden mt-3 flex items-center justify-between gap-2 rounded-sm border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <span className="flex items-center gap-1.5">
+              <History className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("viewFullHistory")}
+            </span>
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </Link>
+        </>
+      }
+    />
+  );
+}
+
 async function WatchlistSection({ userId }: { userId: string }) {
   const stocks = await getCachedTrackedStocks(userId);
 
@@ -309,18 +347,13 @@ export async function DashboardContent({ userId }: { userId: string }) {
   void fetchUserAccountsWithHoldings(userId);
   void getAllExchangeRates();
 
-  // Run the remaining reads in parallel — only the snapshot history depends on
-  // settings (for baseCurrency); the account count and translations are
-  // independent, so nothing here waits on anything it doesn't need.
-  // getNormalizedHistory is "use cache" with cacheLife("hours"), so the
-  // snapshot fetch — shared by TrendChartSection and HistoryHeatmap — is a
-  // cache read on warm requests. No extra DB query on repeat renders.
-  const [settings, snapshots, accountCount, t] = await Promise.all([
+  // First paint waits only on settings + the account count — everything else
+  // (including the snapshot history, now inside TrendSection) streams behind
+  // its own Suspense boundary.
+  const [settings, accountCount] = await Promise.all([
     settingsP,
-    settingsP.then((s) => getNormalizedHistory(userId, s.baseCurrency)),
     // Fast check: does this user have any active accounts?
     prisma.account.count({ where: { userId, isActive: true } }),
-    getTranslations("dashboard"),
   ]);
   const baseCurrency = settings.baseCurrency;
 
@@ -347,28 +380,7 @@ export async function DashboardContent({ userId }: { userId: string }) {
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-8 motion-slow fill-mode-both delay-75">
         <div className="min-w-0 lg:col-span-8">
           <Suspense fallback={<TrendChartSkeleton />}>
-            <TrendChartSection
-              baseCurrency={baseCurrency}
-              snapshots={snapshots}
-              footer={
-                <>
-                  <HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />
-                  {/* Mobile-only entry point — History is a sub-tab of /analysis, so
-                      the tab bar gives it no scent. The trend chart is the preview;
-                      this names the destination. Desktop uses the sidebar route. */}
-                  <Link
-                    href="/analysis#history"
-                    className="md:hidden mt-3 flex items-center justify-between gap-2 rounded-sm border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  >
-                    <span className="flex items-center gap-1.5">
-                      <History className="h-3.5 w-3.5" aria-hidden="true" />
-                      {t("viewFullHistory")}
-                    </span>
-                    <ArrowRight className="h-3 w-3" aria-hidden="true" />
-                  </Link>
-                </>
-              }
-            />
+            <TrendSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>
         </div>
         <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4">

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -303,28 +303,30 @@ async function PortfolioHeatmapSection({
 
 export async function DashboardContent({ userId }: { userId: string }) {
   // Settings are data-cached (30s TTL) — resolves near-instantly on cache hit
-  const settings = await getOrCreateSettings(userId);
-  const baseCurrency = settings.baseCurrency;
+  const settingsP = getOrCreateSettings(userId);
 
   // Pre-warm React caches for the inner sections
   void fetchUserAccountsWithHoldings(userId);
   void getAllExchangeRates();
 
-  // Fetch snapshot history once — shared by TrendChartSection and HistoryHeatmap.
-  // getNormalizedHistory is "use cache" with cacheLife("hours"), so this is a
+  // Run the remaining reads in parallel — only the snapshot history depends on
+  // settings (for baseCurrency); the account count and translations are
+  // independent, so nothing here waits on anything it doesn't need.
+  // getNormalizedHistory is "use cache" with cacheLife("hours"), so the
+  // snapshot fetch — shared by TrendChartSection and HistoryHeatmap — is a
   // cache read on warm requests. No extra DB query on repeat renders.
-  const snapshots = await getNormalizedHistory(userId, baseCurrency);
-
-  // Fast check: does this user have any active accounts?
-  const accountCount = await prisma.account.count({
-    where: { userId, isActive: true },
-  });
+  const [settings, snapshots, accountCount, t] = await Promise.all([
+    settingsP,
+    settingsP.then((s) => getNormalizedHistory(userId, s.baseCurrency)),
+    // Fast check: does this user have any active accounts?
+    prisma.account.count({ where: { userId, isActive: true } }),
+    getTranslations("dashboard"),
+  ]);
+  const baseCurrency = settings.baseCurrency;
 
   if (accountCount === 0) {
     return <DashboardOnboarding />;
   }
-
-  const t = await getTranslations("dashboard");
 
   return (
     <>


### PR DESCRIPTION
## Summary

The `DashboardContent` orchestrator previously blocked **all** of its Suspense boundaries on four sequential awaits — settings → snapshot history → account count → translations — so nothing streamed until the sum of all four resolved.

**Commit 1 — `perf(dashboard): parallelize orchestrator reads`**
Replaces the sequential awaits with a single `Promise.all`. Only the history read depends on settings (for `baseCurrency`), so it chains off the settings promise; the account count and translations run fully in parallel. Pre-warm `void` calls and the zero-account onboarding early-return are unchanged.

**Commit 2 — `perf(dashboard): stream trend chart behind its Suspense boundary`**
Moves the `getNormalizedHistory` read out of the orchestrator entirely, into a new async `TrendSection` component rendered behind the existing tier-2 `<Suspense fallback={<TrendChartSkeleton />}>` boundary. The `viewFullHistory` translation (only used by the mobile footer link) moves with it. The shell now paints after **settings + account count only**, with the trend chart streaming in behind its skeleton.

`getNormalizedHistory` is `"use cache"`'d, so `TrendChartSection` and `HistoryHeatmap` still share a single fetch. Layout classes, comments, and grid placement are preserved exactly.

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` — all pass
- `npm run build` — succeeds (dashboard still partial-prerenders)

## Before merge

Worth a quick visual check:
- Dashboard skeleton flow — the trend chart now streams behind `TrendChartSkeleton` instead of arriving with the shell
- Zero-account onboarding state still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)