### PR TITLE
fix(e2e): update stale selectors and block service workers in Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
     baseURL: BASE_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    // The PWA service worker (#404) intercepts fetches, which bypasses
+    // page.route() mocks (e.g. the /api/search mock in stocks.spec.ts).
+    serviceWorkers: "block",
   },
   projects: [
     {

--- a/tests/e2e/mobile-plan.spec.ts
+++ b/tests/e2e/mobile-plan.spec.ts
@@ -65,7 +65,9 @@ test.describe("desktop plan split", () => {
     await expect(page.getByRole("tablist")).toHaveCount(0);
 
     await page.goto("/stocks");
-    await expect(page.getByRole("heading", { name: "Watchlist" })).toBeVisible();
+    // exact: the StocksOnboarding heading ("Start a watchlist from…") also matches a
+    // substring-based "Watchlist" heading query.
+    await expect(page.getByRole("heading", { name: "Watchlist", exact: true })).toBeVisible();
     await expect(page.getByText("Track stocks from a chosen price and date.")).toBeVisible();
   });
 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -106,7 +106,8 @@ test("2. create an account, add a holding manually, and see it in the list", asy
   const createdAccountId = createdAccount!.id;
 
   // ── Add holding ─────────────────────────────────────────────────────────
-  await page.getByRole("button", { name: "Add Item" }).click();
+  // Toolbar button was renamed "Add Item" → "Add Holding" in #377.
+  await page.getByRole("button", { name: "Add Holding" }).click();
   await expect(page.getByRole("dialog")).toBeVisible();
 
   // Skip the search step and enter the ticker manually
@@ -130,7 +131,9 @@ test("2. create an account, add a holding manually, and see it in the list", asy
     await page.getByRole("option", { name: accountName }).click();
   }
 
-  await page.getByRole("button", { name: "Add Holding" }).click();
+  // Scope to the dialog: the toolbar "Add Holding" trigger is still in the
+  // accessibility tree behind the overlay.
+  await page.getByRole("dialog").getByRole("button", { name: "Add Holding" }).click();
 
   // Verify persistence via API to avoid UI cache timing flakiness.
   await expect(async () => {

--- a/tests/e2e/stocks.spec.ts
+++ b/tests/e2e/stocks.spec.ts
@@ -45,7 +45,11 @@ test.describe("stock tracker", () => {
     }
 
     await page.goto("/stocks");
-    await expect(page.getByRole("heading", { name: "No stocks tracked yet" })).toBeVisible();
+    // The bare empty state was replaced by StocksOnboarding (stocks-onboarding.tsx).
+    await expect(
+      page.getByRole("heading", { name: "Start a watchlist from your own reference price." }),
+    ).toBeVisible();
+    await expect(page.getByText("No tracked stocks")).toBeVisible();
 
     await page.route("**/api/search**", async (route) => {
       await route.fulfill({


### PR DESCRIPTION
## Summary

The e2e suite had four failing tests, all stale tests versus UI that evolved without test updates (none caused by recent branch work). This PR fixes all of them; the full suite now passes locally against a production build: **13 passed, 7 skipped (project-scoped), 0 failed**.

## Fixes

- **`smoke.spec.ts` #2 (chromium + Mobile Chrome)** — the accounts toolbar button was renamed "Add Item" → "Add Holding" in #377 but the test still clicked the old name. Also scoped the dialog submit click to the dialog, since the toolbar trigger now shares the same accessible name and would otherwise trip a strict-mode violation.
- **`stocks.spec.ts`** — the bare "No stocks tracked yet" empty state was replaced by the `StocksOnboarding` component; the test now asserts the onboarding heading ("Start a watchlist from your own reference price.") plus the zero-count label ("No tracked stocks").
- **`mobile-plan.spec.ts`** — `getByRole("heading", { name: "Watchlist" })` now substring-matches the `StocksOnboarding` heading too; switched to an exact heading query.
- **`playwright.config.ts`** — added `serviceWorkers: "block"`. The PWA service worker enabled in #404 intercepts fetches and silently bypasses `page.route()` mocks; the `/api/search` mock in `stocks.spec.ts` was returning real Yahoo Finance results (AAPL + AAPL.MX), breaking the deterministic option click.

## Test plan

- [x] `npm run build` + `npm run start` (preview env) on a clean port, then `PLAYWRIGHT_TEST_BASE_URL=... npm run test:e2e` → 13 passed / 7 skipped / 0 failed
- [x] `npm run format:check`, `npm run lint`, `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)