### PR TITLE
ci(e2e): restore deployment_status trigger so the suite targets live preview URLs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,25 +1,28 @@
 name: E2E Smoke Tests
 
 on:
-  push:
-    branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
+  deployment_status:
 
 concurrency:
-  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  group: e2e-${{ github.event.deployment.sha }}
   cancel-in-progress: true
 
 jobs:
   e2e:
     name: Playwright smoke tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, '[skip ci]')
+    # Run only on preview deployments — production uses VERCEL_ENV=production
+    # which never renders the preview-credentials password form.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment != 'Production'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Check out the exact commit that was deployed
+          ref: ${{ github.event.deployment.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -64,6 +67,10 @@ jobs:
 
       - name: Run E2E tests
         run: npm run test:e2e
+        env:
+          # Vercel posts the live URL here automatically — no hardcoding needed
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ git worktree remove ../asset_tracker-<task-name>
 This repository uses a **light-vs-heavy CI split**:
 
 - **Pull requests**: run fast checks only (`lint`, `typecheck`).
-- **Push to `master`** (production merge path): run heavy checks (`build`, Playwright `e2e`).
+- **Push to `master`** (production merge path): run heavy checks (`build`).
+- **Vercel preview deployments**: the Playwright `e2e` smoke suite runs against the live preview URL (`deployment_status` trigger; production deployments are skipped since they never render the preview-credentials login). Requires the `E2E_PASSWORD` repo secret to match `PREVIEW_AUTH_PASSWORD` on Vercel previews.
 - **Docs-only / markdown-only changes** on push are skipped via workflow `paths-ignore`.
 - Add `[skip ci]` to a commit message to skip push-triggered heavy jobs.
 - Add `[skip ci]` to PR title/body to skip PR lint/typecheck jobs.


### PR DESCRIPTION
## Summary

The `E2E Smoke Tests` workflow has failed on **every master push since #332** (0 successes in the last 50 runs). #332 switched the trigger from `deployment_status` to `push: [master]` and dropped the `PLAYWRIGHT_TEST_BASE_URL` / `E2E_PASSWORD` env wiring from the test step. The failure chain:

1. No `PLAYWRIGHT_TEST_BASE_URL` → `playwright.config.ts` falls back to its local `webServer` (`npm run build && npm run start`).
2. The build evaluates `/api/cron/snapshot` → `src/lib/prisma.ts` → `src/lib/env.ts`, which fails fast on the missing `DATABASE_URL` / `AUTH_SECRET` / `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` / `CRON_SECRET` (the runner has none of them, unlike `ci.yml` which sets placeholders).
3. `Process from config.webServer was not able to start` — the tests never run.

## Change

Restores the pre-#332 flow (the design CLAUDE.md still documents):

- Trigger on `deployment_status`; run only when the deployment succeeded and the environment isn't Production (production never renders the preview-credentials login).
- Check out the exact deployed SHA and run the suite against the live preview URL via `PLAYWRIGHT_TEST_BASE_URL` + the `E2E_PASSWORD` secret (verified the secret still exists in the repo).
- Dependency / Playwright-browser caching steps unchanged.
- README CI-policy section updated: e2e now runs on Vercel preview deployments rather than master pushes.

Note the deliberate trade-off (chosen over making the push-triggered job self-contained with a DB service container): the suite validates PR preview deployments, not the post-merge master commit, and it will run once per preview deployment.

## Test plan

- [x] Workflow YAML matches the last known-passing `deployment_status` revision (`f8b702b~1`) plus the since-added caching steps (already present in both)
- [x] `E2E_PASSWORD` repo secret confirmed present (`gh secret list`)
- [x] `prettier --check` on changed files
- [ ] After merge: confirm the next Vercel preview deployment triggers a green "Playwright smoke tests" run

🤖 Generated with [Claude Code](https://claude.com/claude-code)