### PR TITLE
perf(net-worth): migrate getCachedNetWorthSummary to "use cache" with hours TTL

### DIFF
--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { cache } from "react";
-import { cacheLife, cacheTag, unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
 import { serializeAccountWithHoldings } from "@/lib/types";
@@ -194,19 +194,23 @@ async function computeNetWorthSummary(
 }
 
 /**
- * Cached version of net worth summary (5-minute TTL).
+ * Cached version of net worth summary (`"use cache"`, "hours" profile —
+ * freshness is driven by tag invalidation rather than the TTL, since every
+ * mutation route revalidates `net-worth:${userId}` or `net-worth`).
  * Tagged both broadly (`net-worth`) and per-user (`net-worth:${userId}`)
  * so global invalidators (cron snapshot, price refresh) keep working
  * while per-user mutations (account/holding writes) can scope their
  * invalidation. React cache() dedupes per-render.
  */
-export const getCachedNetWorthSummary = cache((userId: string, baseCurrency: string) =>
-  unstable_cache(
-    () => computeNetWorthSummary(userId, baseCurrency),
-    ["net-worth-summary", userId, baseCurrency],
-    {
-      revalidate: 300,
-      tags: ["net-worth", `net-worth:${userId}`],
-    },
-  )(),
-);
+async function getCachedNetWorthSummaryInner(
+  userId: string,
+  baseCurrency: string,
+): Promise<NetWorthSummary> {
+  "use cache";
+  cacheTag("net-worth");
+  cacheTag(`net-worth:${userId}`);
+  cacheLife("hours");
+  return computeNetWorthSummary(userId, baseCurrency);
+}
+
+export const getCachedNetWorthSummary = cache(getCachedNetWorthSummaryInner);


### PR DESCRIPTION
## Summary

Removes the app's **last remaining `unstable_cache` usage** (`getCachedNetWorthSummary` in `src/lib/services/net-worth-service.ts`) and migrates it to the `"use cache"` directive pattern already used by every other cached read in `src/lib/services/` (mirroring `fetchUserAccountsWithHoldings` in the same file):

- `"use cache"` + `cacheTag("net-worth")` + `cacheTag(`net-worth:${userId}`)` + `cacheLife("hours")`
- Wrapped in React `cache()` for per-render dedupe, exported name and `(userId, baseCurrency)` signature unchanged — no caller changes
- Unused `unstable_cache` import removed; JSDoc updated (no longer claims a 5-minute TTL)

## Why "hours" instead of the old 300s TTL is safe

Post-#415, tag invalidation is comprehensive: every mutation route revalidates `net-worth:${userId}` (account/holding/transaction writes) or the broad `net-worth` tag (cron snapshot, price refresh). The TTL is therefore just a backstop, not the freshness mechanism — both tags are kept exactly as before, so all existing invalidators continue to hit this entry.

## Serialization safety

`"use cache"` uses RSC serialization, which rejects Prisma `Decimal`/`Date`/class instances. Verified `computeNetWorthSummary` end-to-end:

- Accounts come from `fetchUserAccountsWithHoldings`, which serializes via `serializeAccountWithHoldings` **before** its own cache boundary (commit `c7b424a`): `cashBalance`/`quantity`/`strike` → `number`, `createdAt`/`updatedAt`/`expiration` → ISO strings; all other Account/Holding fields are strings, booleans, ints, or enum string literals (confirmed against `prisma/schema.prisma`).
- `PriceCache.price` (Decimal) is converted via `Number(...)` into a plain `priceMap`.
- The exchange-rate `Map` and the `warnedPairs` `Set` stay internal to the cached scope; the temporary `_cashBalance`/`_currency` fields are deleted before return.
- The returned `NetWorthSummary` (`src/lib/types.ts`) is plain numbers, strings, and arrays of plain objects (`AccountWithValue` / `HoldingWithPrice` build on the Serialized* types). No Decimal, Date, Map, Set, or class instance can appear in the return value.

## Verification

- `npm run format:check` / `npm run lint` / `npm run typecheck` — all pass
- `npm run build` — passes (compile-time validation of `use cache` directive placement)
- Runtime smoke: dev server with `PREVIEW_AUTH_DISABLED=true`, preview-credentials login (302), `GET /` → 200 with **no** "Only plain objects" / digest errors in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)