### PR TITLE
perf(cron): gate global cache revalidations on actual price/rate changes (P6)

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -370,6 +370,8 @@ Ordered by **expected Active-CPU saved per change**, given the bot-dominated tra
 
 #### P6 — Gate the cron's `revalidateTag` calls on "anything-changed"
 
+> **Status: ✅ Done 2026-06-11.** `refreshExchangeRates` / `refreshPricesForHoldings` now return a `changed` count (existing rows read with one cheap pre-write SELECT, values compared exactly after normalizing both sides to the `Decimal(18,8)` column precision), and the cron gates `exchange-rates` / `prices` / `prices:crypto` / `net-worth` revalidations on it — logged via `cron.revalidate.gate`. `snapshots` + per-user `history:${id}` invalidations stay always-on (snapshot rows are written every night). Changed-count gating was chosen over the ε net-worth comparison sketched below: exact per-table value comparison, no epsilon tuning, one cheap pre-write SELECT.
+
 **Effect:** Medium. Today the cron unconditionally invalidates `net-worth`, `prices:crypto`, `snapshots`, and a per-user `history:${user.id}` tag for every user. Every invalidation forces the **next** page load to rebuild via expensive RSC reads — wasted Active CPU on days when no prices actually moved.
 
 - File: `src/app/api/cron/snapshot/route.ts:53-74`.
@@ -423,7 +425,7 @@ After P1–P3 land, re-pull MCP logs for 3 days and recompute the Active-CPU tra
 | P7                                   | `src/lib/auth-session.ts`, `src/lib/api-handler.ts`                                                                                                                                              |
 | P3                                   | `src/app/privacy/page.tsx`, `src/app/login/page.tsx`, `src/app/terms/page.tsx`                                                                                                                   |
 | P5                                   | `src/app/api/prices/refresh/route.ts`, `src/app/api/exchange-rates/refresh/route.ts`, `src/components/dashboard/dashboard-actions.tsx`, `src/lib/services/price-service.ts` (`refreshAllPrices`) |
-| P6                                   | `src/app/api/cron/snapshot/route.ts`                                                                                                                                                             |
+| P6 ✅                                | `src/app/api/cron/snapshot/route.ts`, `src/lib/services/price-service.ts`, `src/lib/services/exchange-rate-service.ts`                                                                           |
 | P8                                   | `src/lib/services/price-service.ts`, `src/app/api/search/route.ts`, `src/app/api/options/chain/route.ts`, new `src/lib/yahoo.ts`                                                                 |
 | P2                                   | None in repo (managed in Vercel dashboard; export JSON to `docs/firewall_rules.json` for tracking)                                                                                               |
 

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -62,15 +62,29 @@ export async function GET(request: Request) {
     log.info("cron.prices.refresh");
     // force: snapshots must be computed from current rates; the manual-refresh
     // freshness gate doesn't apply to the cron.
-    await Promise.all([
-      ...[...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true })),
+    const [rateResults, priceResult] = await Promise.all([
+      Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true }))),
       refreshAllPrices(),
     ]);
+
+    // Gate the global cache revalidations on actual value changes (P6): the
+    // forced refreshes above rewrite rows even when every value is identical
+    // (weekends/holidays), so `updated` is nearly always > 0 — only evict the
+    // warm caches when a price or rate really moved.
+    const ratesChanged = rateResults.reduce((sum, r) => sum + r.changed, 0);
+    const pricesChanged = priceResult.changed;
+    log.info("cron.revalidate.gate", { ratesChanged, pricesChanged });
     // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-    revalidateTag("exchange-rates", "max");
-    revalidateTag("net-worth", "max");
-    revalidateTag("prices", "max");
-    revalidateTag("prices:crypto", "max");
+    if (ratesChanged > 0) {
+      revalidateTag("exchange-rates", "max");
+    }
+    if (pricesChanged > 0) {
+      revalidateTag("prices", "max");
+      revalidateTag("prices:crypto", "max");
+    }
+    if (ratesChanged > 0 || pricesChanged > 0) {
+      revalidateTag("net-worth", "max");
+    }
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -7,6 +7,13 @@ import { log, withTiming } from "@/lib/logger";
 
 export type RefreshRatesResult = {
   updated: number;
+  /**
+   * Pairs whose persisted rate actually differs from the previously stored
+   * value (or had no row). Compared exactly after normalizing both sides to
+   * the Decimal(18,8) column precision — no epsilon. Lets callers (the cron)
+   * gate global cache revalidations on real change.
+   */
+  changed: number;
   /** True when the base currency's rates were fresh and no fetch happened. */
   skippedFresh: boolean;
   /** When the rates become stale again; null unless skippedFresh. */
@@ -20,6 +27,14 @@ const RATE_FETCH_TIMEOUT_MS = 1200;
 // staleness check costs no DB read (same warm-instance pattern as
 // lib/rate-limit.ts). Cold starts simply refresh once and re-prime it.
 const lastRateRefreshAt = new Map<string, number>();
+
+/**
+ * Normalize to the Decimal(18,8) column precision so a freshly fetched float
+ * and a value read back from the DB round-trip to the same number.
+ */
+function normalizeTo8dp(value: number): number {
+  return Number(value.toFixed(8));
+}
 
 /**
  * Cache Components read of all exchange rates.
@@ -173,6 +188,7 @@ export async function refreshExchangeRates(
     log.info("rates.refresh.skipped_fresh", { base: baseCurrency });
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: true,
       nextRefreshAt: new Date(last + FX_REFRESH_TTL_MS).toISOString(),
     };
@@ -181,7 +197,24 @@ export async function refreshExchangeRates(
   const rates = await fetchExchangeRates(baseCurrency);
   const entries = Object.entries(rates);
 
-  if (entries.length === 0) return { updated: 0, skippedFresh: false, nextRefreshAt: null };
+  if (entries.length === 0) {
+    return { updated: 0, changed: 0, skippedFresh: false, nextRefreshAt: null };
+  }
+
+  // Count real value changes before the write so callers (the cron) can gate
+  // global cache revalidations. One cheap PK SELECT; the upsert below still
+  // bumps updatedAt on every write so freshness logic keeps working.
+  const existingRows = await prisma.exchangeRate.findMany({
+    where: { id: { in: entries.map(([toCurrency]) => `${baseCurrency}_${toCurrency}`) } },
+    select: { id: true, rate: true },
+  });
+  const existingRateById = new Map(
+    existingRows.map((row) => [row.id, normalizeTo8dp(Number(row.rate))]),
+  );
+  const changed = entries.filter(([toCurrency, rate]) => {
+    const previous = existingRateById.get(`${baseCurrency}_${toCurrency}`);
+    return previous === undefined || previous !== normalizeTo8dp(rate);
+  }).length;
 
   const params: unknown[] = [];
   const placeholders = entries.map(([toCurrency, rate]) => {
@@ -201,5 +234,5 @@ export async function refreshExchangeRates(
 
   // Stamp only after a successful persist so failed refreshes retry.
   lastRateRefreshAt.set(baseCurrency, Date.now());
-  return { updated: entries.length, skippedFresh: false, nextRefreshAt: null };
+  return { updated: entries.length, changed, skippedFresh: false, nextRefreshAt: null };
 }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -10,6 +10,13 @@ const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 
 export type RefreshPricesResult = {
   updated: number;
+  /**
+   * Symbols whose persisted price actually differs from the previously cached
+   * value (or had no cached row). Compared exactly after normalizing both
+   * sides to the Decimal(18,8) column precision — no epsilon. Lets callers
+   * (the cron) gate global cache revalidations on real change.
+   */
+  changed: number;
   /** Symbols skipped because their cached price was younger than the TTL. */
   skippedFresh: number;
   errors: string[];
@@ -25,6 +32,14 @@ export type RefreshPricesOptions = {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Normalize to the Decimal(18,8) column precision so a freshly fetched float
+ * and a value read back from the DB round-trip to the same number.
+ */
+function normalizeTo8dp(value: number): number {
+  return Number(value.toFixed(8));
 }
 
 function isRetryable(err: unknown): boolean {
@@ -262,6 +277,7 @@ export async function refreshPricesForStockSymbols(
   if (uniqueSymbols.length === 0) {
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: 0,
       errors: [],
       nextRefreshAt: null,
@@ -281,6 +297,7 @@ async function refreshPricesForHoldings(
   if (holdings.length === 0) {
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: 0,
       errors: [],
       nextRefreshAt: null,
@@ -320,6 +337,7 @@ async function refreshPricesForHoldings(
           : null;
         return {
           updated: 0,
+          changed: 0,
           skippedFresh,
           errors: [],
           nextRefreshAt: nextRefreshAt?.toISOString() ?? null,
@@ -349,9 +367,33 @@ async function refreshPricesForHoldings(
 
   const entries = [...allPrices];
   if (entries.length === 0) {
-    return { updated: 0, skippedFresh, errors: [], nextRefreshAt: null, retryAfterSeconds: null };
+    return {
+      updated: 0,
+      changed: 0,
+      skippedFresh,
+      errors: [],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
   }
 
+  // Count real value changes before the write so callers (the cron) can gate
+  // global cache revalidations. Reading the existing rows first is one cheap
+  // indexed SELECT; the upsert below still bumps updatedAt on every write so
+  // the freshness gate and FreshnessBadge keep working.
+  const existingRows = await prisma.priceCache.findMany({
+    where: { symbol: { in: entries.map(([symbol]) => symbol) } },
+    select: { symbol: true, price: true },
+  });
+  const existingPriceBySymbol = new Map(
+    existingRows.map((row) => [row.symbol, normalizeTo8dp(Number(row.price))]),
+  );
+  const changedCount = entries.filter(([symbol, { price }]) => {
+    const previous = existingPriceBySymbol.get(symbol);
+    return previous === undefined || previous !== normalizeTo8dp(price);
+  }).length;
+
+  let changed = 0;
   try {
     const params: unknown[] = [];
     const placeholders = entries.map(([symbol, { price, currency }]) => {
@@ -369,10 +411,15 @@ async function refreshPricesForHoldings(
       ...params,
     );
     updated = entries.length;
-    revalidateTag("prices", "max");
+    changed = changedCount;
+    // Only bust the cached price reads when a value actually changed — a
+    // write that rewrites identical values leaves cache contents identical.
+    if (changed > 0) {
+      revalidateTag("prices", "max");
+    }
   } catch (error) {
     errors.push(`Bulk upsert failed: ${String(error)}`);
   }
 
-  return { updated, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
+  return { updated, changed, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
 }


### PR DESCRIPTION
## Problem

The nightly cron (`/api/cron/snapshot`) unconditionally revalidated the global cache tags (`exchange-rates`, `prices`, `prices:crypto`, `net-worth`) on every run. Every eviction forces the next page load for **every user** to rebuild via the expensive RSC reads — wasted Active CPU on weekends/holidays when no price or rate actually moved.

## Why changed-count gating

- **Not `updated`-count:** the cron forces refreshes (`force: true`) and the upserts rewrite rows even when values are identical, so `updated > 0` nearly every night — it gates nothing.
- **Not ε net-worth comparison** (the original P6 sketch in `docs/PLATFORM.md`): requires epsilon tuning and conflates rate noise with price noise. Instead: exact per-table value comparison with one cheap pre-write SELECT.

`refreshExchangeRates` and `refreshPricesForHoldings` now return an additive `changed: number`: before writing, the existing cached rows are read (`findMany` on the PK/indexed column) and compared exactly after normalizing both sides to the `Decimal(18,8)` column precision via `Number(v.toFixed(8))` — the round-trip is exact, no epsilon. Missing rows count as changed. Existing callers are unaffected (none consume `changed`).

## What still always revalidates

- `snapshots` + per-user `history:${user.id}` — snapshot rows are written every night regardless.
- The option-expiry sweep's conditional `revalidateTag("accounts", "max")` is unchanged.
- All cron revalidations keep the `"max"` background convention.

The upsert statements are untouched: `updatedAt` keeps bumping on every write, so the manual-refresh freshness gate and the FreshnessBadge behave exactly as before.

One adjacent change: `refreshPricesForHoldings` internally called `revalidateTag("prices", "max")` unconditionally on every successful write, which would have made the cron-level `prices` gate moot. That call is now gated on `changed > 0` as well — semantically a no-op skip, since identical values mean identical cache contents.

## Observability

New log line every cron run:

```
cron.revalidate.gate { ratesChanged, pricesChanged }
```

Verified locally against the dev DB: first run logged `pricesChanged: 1` (revalidations fired); an immediate second run logged `ratesChanged: 0, pricesChanged: 0` and skipped the gated revalidations.

`format:check` / `lint` / `typecheck` / `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)