### PR TITLE
perf: bundle-size CI gate, public asset cache headers, cash-flow date floor (S18, V20, PE29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,56 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json', 'prisma/schema.prisma', 'next.config.ts') }}-
 
       - run: npm run build
+
+      - name: Measure bundle baseline
+        run: node scripts/ci/bundle-size.mjs --write bundle-baseline.json
+
+      - name: Save bundle baseline
+        uses: actions/cache/save@v4
+        with:
+          path: bundle-baseline.json
+          key: bundle-baseline-${{ github.sha }}
+
+  bundle-size:
+    name: Bundle size
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body || '', '[skip ci]')
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - name: Restore deps cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            src/generated/prisma
+            ~/.cache/prisma
+          key: deps-${{ runner.os }}-node22-${{ hashFiles('package-lock.json', 'prisma/schema.prisma') }}-v2
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json', 'prisma/schema.prisma', 'next.config.ts') }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json', 'prisma/schema.prisma', 'next.config.ts') }}-
+
+      - run: npm run build
+
+      - name: Measure head bundle
+        run: node scripts/ci/bundle-size.mjs --write bundle-head.json
+
+      - name: Restore bundle baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: bundle-baseline.json
+          key: bundle-baseline-pr-${{ github.sha }}
+          restore-keys: |
+            bundle-baseline-
+
+      - name: Compare against baseline
+        run: node scripts/ci/bundle-size.mjs --compare bundle-baseline.json --against bundle-head.json --max-growth 0.05

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -619,7 +619,7 @@ This lets the i18n + locale promises start immediately in parallel with the sett
 - **PE26 — analysis tab stays CSS-`hidden` on mobile** (`analysis-view.tsx`): `display:none` subtrees don't repaint and `HistoryView` is conditionally mounted; unmounting would restart chart animations. Low urgency.
 - **PE27 — cascaded `useMemo` chain on range change** (`analysis-view.tsx:126-216`): correctly dependency-keyed; collapse only after profiling shows it matters.
 - **PE28 — `ssr: false` on lazy charts**: charts SSR only their `!mounted` placeholder branch already, so the flip changes little; interacts with the PPR shell and open CLS item V23.
-- **PE29 — unbounded cashTransaction scan** in `getAccountMonthlyCashFlow`: fetches the user's full cash-transaction history on each cache fill; could be date-floored or pushed to SQL `GROUP BY`. Cached hourly, not urgent.
+- **PE29 — unbounded cashTransaction scan** in `getAccountMonthlyCashFlow`: ✅ Done (2026-06-11). Date-floored to the first day (UTC) of the month containing the user's earliest `NetWorthSnapshot` (a third member of the existing `Promise.all`; no floor when the user has no snapshots). Safe because analysis buckets and attribution are snapshot-derived — months before the first snapshot are unreachable by any range, including "All", so the floor changes no rendered output. The SQL `GROUP BY` alternative was not needed.
 
 ### Evaluated and rejected (recorded so they aren't re-flagged)
 

--- a/docs/PERF_ROUND3_PLAN.md
+++ b/docs/PERF_ROUND3_PLAN.md
@@ -1,0 +1,113 @@
+# Performance Enhancements — Next Round (3 PRs)
+
+## Context
+
+Audit of `docs/` trackers + fresh code scan (2026-06-11) to find remaining performance work. Key conclusions from verification:
+
+- **Already shipped, docs stale:** S19 preconnect (`src/app/layout.tsx:288`), P8 Yahoo singleton (`src/lib/services/yahoo-client.ts`), S21/V23 chart height reserves (skeletons + `initialDimension`), V22/V33 analyzer wiring.
+- **False alarms from code scan (do NOT implement):** "settings waterfalls" in analysis/goals pages are the intentional dependency-depth pattern (PR #408); CoinGecko "sequential retries" is a parallel `allSettled` fallback that only runs on batch failure; `/accounts` summary dedupe works via React `cache()`; `fetchAllCachedPrices` full-table read is a deliberate single-cache-entry design (49 rows).
+- **Genuinely open + chosen by user:** quick wins (S18, V20, PE29, TopMoversList memo) + Fluid-CPU mediums (P5, P6).
+
+Per user preference: copy this plan into repo `docs/` as the first implementation step. Per memory: perf findings were double-checked (Fable Plan agent + manual verification) before this plan.
+
+**PR ordering constraint:** PR #414 (open, mergeable) touches `src/app/api/prices/refresh/route.ts`, which PR 2 deletes. **Merge #414 (and #416) before starting PR 2.**
+
+---
+
+## PR 1 — Quick wins (Workstream A)
+
+### A0. Plan doc
+
+Copy this plan to `docs/PERF_ROUND3_PLAN.md` (user preference: plans live in repo docs/).
+
+### A1. S18 — Bundle-size CI gate
+
+**Approach:** one build per PR + baseline saved on master pushes, exchanged via `actions/cache`. Metric: total gzipped bytes of `.js`+`.css` under `.next/static` (per-file diffs unreliable — content-hashed names). CI facts: PRs run lint+typecheck only; `build` job runs on master push with placeholder env (no DB needed); deps cache includes `src/generated/prisma`.
+
+- **New `scripts/ci/bundle-size.mjs`** (zero deps; `node:zlib.gzipSync`):
+  - `--write <out.json>`: walk `.next/static`, write `{ totalGzipBytes, jsGzipBytes, cssGzipBytes, fileCount, sha }`.
+  - `--compare <baseline> --against <head> --max-growth 0.05`: missing baseline → `::warning::` + exit 0 (self-heals on next master push); writes markdown table to `$GITHUB_STEP_SUMMARY`; exit 1 with `::error::` if growth >5%.
+- **`.github/workflows/ci.yml`:**
+  - Master `build` job: append `Measure bundle baseline` (`--write bundle-baseline.json`) + `actions/cache/save@v4` with key `bundle-baseline-${{ github.sha }}`.
+  - New PR-only `bundle-size` job (copy `[skip ci]` guard + deps-cache + `.next/cache` restore boilerplate from existing jobs): `npm run build` → `--write bundle-head.json` → `actions/cache/restore@v4` with `restore-keys: bundle-baseline-` → compare.
+- Edge cases: cache eviction → soft-pass warning; deliberate growth merges via baseline bump (note in script header).
+
+### A2. V20 — Cache-Control for /public assets
+
+**`next.config.ts`** — append to existing `headers()` array:
+
+- `source: "/splash/:path*"` → `public, max-age=31536000, immutable` (iOS PWA splash, only producer is `scripts/generate-splash-screens.mjs`; comment: rename file if design changes).
+- `source: "/sw.js"` → `public, max-age=0, must-revalidate` (pin explicitly so future patterns can't long-cache the service worker).
+- Deliberately NOT cached: og/twitter images, robots.txt (Vercel default ETag/304 is correct). Root SVGs (`file/globe/next/vercel/window.svg`) are unreferenced starter leftovers — delete-candidate note, not cache target.
+
+### A3. PE29 — Date-floor `getAccountMonthlyCashFlow`
+
+`src/lib/services/history-service.ts:280-310`. Safe despite the "All" range: analysis buckets + attribution are anchored to the first snapshot's month, so older transactions are unreachable by any range.
+
+- Add `netWorthSnapshot.findFirst({ where: { userId }, orderBy: { date: "asc" }, select: { date: true } })` to the existing `Promise.all`.
+- Floor = first day of first snapshot's month (UTC); add `createdAt: { gte: floor }` to the `cashTransaction.findMany` where (no floor if no snapshots).
+- Comment the invariant. Cache tags already correct (`history:${userId}` fires on snapshot writes → floor refreshes).
+
+### A4. TopMoversList memo
+
+`src/components/analysis/top-movers-list.tsx`: wrap component in `React.memo` (consistent with the 5 charts memoized in PR #403; `AnalysisView` re-renders on sticky-sentinel `isStuck` flips while `movers`/`baseCurrency` are stable). Skip per-row memo (capped at 10 rows).
+
+### A5. Doc updates (same PR)
+
+- `docs/ROADMAP.md`: S18 ✅ (this PR), S19 ✅ (layout.tsx:288), S21 ✅ (skeletons + `initialDimension` — cite `lazy-analysis-charts.tsx`, `trend-chart-skeleton.tsx`, `src/components/ui/chart.tsx`). Quick-ref rows + detail blocks.
+- `docs/PLATFORM.md`: V20 ✅ (this PR), V22/V33 ⚠️→✅, V23 ✅, P8 ✅ (verify `search/route.ts` + `options/chain/route.ts` import yahoo-client first).
+- `docs/PERFORMANCE.md`: PE29 ✅ with chosen approach.
+
+### Verification (PR 1)
+
+`npm run format:check && npm run lint && npm run typecheck && npm run build`. Headers: `npm run start` + `curl -sI localhost:3000/splash/<file> | grep -i cache-control` (immutable) and `/sw.js` (must-revalidate); authoritative re-check on Vercel preview. PE29: `/analysis` "All" range renders identical charts before/after (preview login per memory). CI gate: job soft-passes on this PR (no baseline); after merge, open a throwaway PR with a fat client import → job fails.
+
+---
+
+## PR 2 — P5: single user-scoped `POST /api/refresh` (after #414 + #416 merge)
+
+**New `src/app/api/refresh/route.ts`** (withAuth + `rateLimitCheckWithPrune({ limit: 5, prefix: "market-refresh", key: userId })`):
+
+1. Read user's `baseCurrency` + distinct account currencies (verbatim from old exchange-rates/refresh route).
+2. `Promise.all([refreshPricesForUser(userId), Promise.all(currencies.map(c => refreshExchangeRates(c)))])` — `refreshExchangeRates` already per-base-currency with 1h freshness gate; no service change needed.
+3. ONE revalidation block (convention: per-user `{ expire: 0 }`, global `"max"`):
+   - prices dirty → `prices`, `prices:crypto` ("max")
+   - rates dirty → `exchange-rates` ("max"), `history:${userId}` ({ expire: 0 })
+   - either dirty → `net-worth` ("max"), `net-worth:${userId}` ({ expire: 0 }), **`accounts:${userId}` ({ expire: 0 }) — carries forward PR #414's fix; must not be lost when the old route is deleted**
+4. Response: `ok({ prices: { updated, skippedFresh, retryAfterSeconds }, rates: { ... } })` (aggregate as old route did).
+
+**Delete** `src/app/api/prices/refresh/route.ts` + `src/app/api/exchange-rates/refresh/route.ts` (verified sole caller: `src/lib/refresh-client.ts`). **`vercel.json`:** swap the two `functions` entries for `"src/app/api/refresh/route.ts": { "maxDuration": 60 }`.
+
+**Client:** only `src/lib/refresh-client.ts` changes — replace two-fetch `Promise.all` (lines 58-74) with one `fetch("/api/refresh", { method: "POST" })`; keep `RefreshOutcome` union, cooldown/429/`Retry-After` handling, `prices:refreshed` event unchanged → zero edits in `dashboard-actions.tsx`, `dashboard-pull-refresh.tsx`, `settings-form.tsx`, `use-refresh-cooldown.ts`.
+
+**Docs:** P5 ✅ in `docs/PLATFORM.md` (section + critical-files table); note the `{ expire: 0 }` semantic upgrade in PR body.
+
+### Verification (PR 2)
+
+`npm run check`; locally (preview login + seed): Refresh button → exactly ONE `POST /api/refresh` in network tab; prices update after `router.refresh()`; pull-to-refresh + Settings refresh still work; 6th click in a minute → 429 cooldown toast; re-click within TTL → "already fresh" toast.
+
+---
+
+## PR 3 — P6: gate cron revalidations on actual change
+
+**Key insight:** `updated`-count gating is insufficient — cron forces refreshes and upserts rewrite rows even when values are identical, so `updated > 0` ~every night. ε net-worth comparison also unnecessary. **Chosen: `changed`-count** — pre-write SELECT of existing rows, exact value comparison normalized to 8 dp (column is `Decimal(18,8)` — round-trip exact, no epsilon).
+
+1. `src/lib/services/price-service.ts`: add `changed: number` to `RefreshPricesResult` (early returns get 0). In `refreshPricesForHoldings` before upsert (~line 350): fetch prev prices by symbol, count `prev.get(sym) !== Number(price.toFixed(8))` (missing = changed). Do NOT add `IS DISTINCT FROM` to the upsert — `updatedAt` must keep bumping (freshness gate + FreshnessBadge depend on it).
+2. `src/lib/services/exchange-rate-service.ts`: same pattern — `changed` on `RefreshRatesResult`, pre-read before the `$executeRawUnsafe` upsert (~line 193).
+3. `src/app/api/cron/snapshot/route.ts` (lines 65-93): capture results; `log.info("cron.revalidate.gate", { ratesChanged, pricesChanged })`; revalidate `exchange-rates` only if ratesChanged, `prices`/`prices:crypto` only if pricesChanged, `net-worth` if either; ALWAYS `snapshots` + per-user `history:${id}` (snapshot rows always written). Keep option-expiry `accounts` revalidation as-is. All cron calls stay `"max"`.
+4. Leave PR 2's `/api/refresh` gating on `updated` (its non-forced freshness gate makes that meaningful); optional follow-up to use `changed`.
+
+**Docs:** P6 ✅ in `docs/PLATFORM.md`, noting changed-count over ε-comparison and why.
+
+### Verification (PR 3)
+
+Hit `GET /api/cron/snapshot` with `Bearer $CRON_SECRET` twice locally: 1st run logs `pricesChanged > 0`; 2nd logs 0 and skips prices/net-worth revalidations while history still shows the new snapshot. After deploy: confirm `cron.revalidate.gate` in Vercel runtime logs.
+
+---
+
+## Risks
+
+- A1: +1 `next build` (~2-4 min warm) per PR — inherent to any gate.
+- A2: splash stale up to 1y if changed without rename (comment + regeneration script makes rename cheap).
+- B (P6): a missed invalidation bounded by `cacheLife("hours")`; gate is exact value comparison, not heuristic.
+- PR 2 deletes a route #414 just fixed — the `accounts:${userId}` invalidation is explicitly carried into the new route (step 3).

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -31,10 +31,10 @@ Findings sourced from the Vercel MCP connector against project `prj_soY30S7ki1x3
 | V17 | `Cache-Control` + `"use cache"` / `cacheTag("exchange-rates")` on `/api/exchange-rates`                                                                                                                                    | Performance              | 🟡 Medium | 20 min  | ✅ Done                |
 | V18 | Opt `/analysis` and `/history` into PPR with `"use cache"` + `cacheTag`                                                                                                                                                    | Performance              | 🟡 Medium | 1 hr    | ❌ Not Done            |
 | V19 | Dynamic-import `AllocationChart` + `CurrencyExposureChart` like `TrendChart`                                                                                                                                               | Bundle                   | 🟡 Medium | 30 min  | ✅ Done                |
-| V20 | `Cache-Control: public, max-age=31536000, immutable` for `/public/*`                                                                                                                                                       | Performance              | 🟢 Low    | 15 min  | ❌ Not Done            |
+| V20 | `Cache-Control: public, max-age=31536000, immutable` for `/public/*`                                                                                                                                                       | Performance              | 🟢 Low    | 15 min  | ✅ Done                |
 | V21 | Audit `revalidateTag` after `POST /accounts`, `/holdings`, `/transactions`                                                                                                                                                 | Performance              | 🟡 Medium | 1–2 hrs | ❌ Not Done            |
-| V22 | Add `@next/bundle-analyzer` + baseline dashboard RSC payload                                                                                                                                                               | Observability            | 🟢 Low    | 30 min  | ⚠️ Partial             |
-| V23 | Reserve `min-h` / `aspect-ratio` on chart cards (CLS fix)                                                                                                                                                                  | Speed Insights · CLS     | 🔴 High   | 30 min  | ❌ Not Done            |
+| V22 | Add `@next/bundle-analyzer` + baseline dashboard RSC payload                                                                                                                                                               | Observability            | 🟢 Low    | 30 min  | ✅ Done                |
+| V23 | Reserve `min-h` / `aspect-ratio` on chart cards (CLS fix)                                                                                                                                                                  | Speed Insights · CLS     | 🔴 High   | 30 min  | ✅ Done                |
 | V24 | Preload Geist Sans `.woff2` + `content-visibility: auto` on below-fold cards                                                                                                                                               | Speed Insights · LCP/FCP | 🟡 Medium | 45 min  | ✅ Done                |
 | V25 | `startTransition` + memoize privacy/theme-toggle consumers                                                                                                                                                                 | Speed Insights · INP     | 🟡 Medium | 1 hr    | ✅ Done                |
 | V26 | Extend V18's PPR pattern to `/settings` and `/` (per-user cache key)                                                                                                                                                       | Speed Insights · TTFB    | 🟡 Medium | 1–2 hrs | ✅ Done                |
@@ -44,7 +44,7 @@ Findings sourced from the Vercel MCP connector against project `prj_soY30S7ki1x3
 | V30 | Wrap `router.refresh()` + inline-edit state setters in `startTransition` across transaction/holding mutators                                                                                                               | Speed Insights · INP     | 🟡 Medium | 45 min  | ✅ Done                |
 | V31 | Add `next.config.ts` `images.formats = ["image/avif", "image/webp"]` + `remotePatterns` for `lh3.googleusercontent.com`                                                                                                    | Speed Insights · LCP     | 🟢 Low    | 15 min  | ✅ Done                |
 | V32 | Configure `<SpeedInsights beforeSend={…}>` to drop `/login` + `/privacy` from telemetry                                                                                                                                    | Observability            | 🟢 Low    | 15 min  | ✅ Done                |
-| V33 | Ship `@next/bundle-analyzer` (supersedes V22) — prerequisite for measuring any further client-JS Speed Insights wins                                                                                                       | Observability            | 🟢 Low    | 30 min  | ⚠️ Partial             |
+| V33 | Ship `@next/bundle-analyzer` (supersedes V22) — prerequisite for measuring any further client-JS Speed Insights wins                                                                                                       | Observability            | 🟢 Low    | 30 min  | ✅ Done                |
 | V34 | Extend `maxDuration` in `vercel.json` to cover `/api/prices/refresh` (60 s) and `/api/exchange-rates/refresh` (30 s)                                                                                                       | Reliability              | 🟡 Medium | 5 min   | ✅ Done                |
 | V35 | Enable Skew Protection — keeps old deployment assets alive during transition so users don't hit JS chunk 404s on new deploy (configure via Vercel Dashboard → Project Settings → Deployment Protection, not `vercel.json`) | Reliability              | 🟢 Low    | 2 min   | ❌ Not Done            |
 | V36 | Add `poweredByHeader: false` to `next.config.ts`; set `images.minimumCacheTTL: 86400` for Google profile-picture cache (was 60 s default)                                                                                  | Performance              | 🟢 Low    | 5 min   | ✅ Done                |
@@ -107,13 +107,13 @@ Deployment `dpl_3KqPj4qBr3ZojdDaSxtKvo8iNhC2` (44s total, 292 MB build cache):
 
 **V19 — Dynamic-import sibling dashboard charts.** Extend the existing `lazy-charts` pattern to add `LazyAllocationChart` and `LazyCurrencyExposureChart`. Keep SSR enabled (unlike TrendChart which uses `ssr: false`) to preserve CLS. Critical files: `src/components/dashboard/lazy-charts.tsx`, `src/components/dashboard/dashboard-content.tsx`.
 
-**V20 — Long-cache `/public/*` static assets.** Add a second `source: "/:all*(svg|jpg|png|webp|avif|ico|woff2)"` entry in `next.config.ts` `headers()` with `Cache-Control: public, max-age=31536000, immutable`. Critical files: `next.config.ts`.
+**V20 — Long-cache `/public/*` static assets.** Done 2026-06-11. Implemented as two targeted `headers()` entries in `next.config.ts` rather than a broad extension-glob: `/splash/:path*` gets `public, max-age=31536000, immutable` (iOS PWA splash screens — produced only by `scripts/generate-splash-screens.mjs`; a design change requires renaming the file), and `/sw.js` is explicitly pinned to `public, max-age=0, must-revalidate` so no future broad pattern can long-cache the service worker. Deliberately not cached: og/twitter images, `robots.txt` (Vercel's default ETag/304 behavior is correct), and the unreferenced root starter SVGs (delete-candidates, not cache targets). Critical files: `next.config.ts`.
 
 **V21 — Audit `revalidateTag` fan-out.** Map each mutation to the narrowest tag(s) it should invalidate. Land V18 first so there are actual tagged reads to invalidate. Correct tag mappings: `POST /api/accounts` → `accounts:${userId}`, `net-worth:${userId}`; `POST /api/accounts/[id]/holdings` → `account:${id}`, `net-worth:${userId}`; etc.
 
-**V22 — Bundle-analyzer baseline.** `npm i -D @next/bundle-analyzer`. Wrap the export in `next.config.ts`. Run `ANALYZE=true npm run build` once and commit baseline numbers. Superseded by V33 / PE4.
+**V22 — Bundle-analyzer baseline.** Done 2026-06-11. The analyzer is wired (`ANALYZE=true npm run build` via `@next/bundle-analyzer` in `next.config.ts`), and the "commit a baseline" half is superseded by the S18 bundle-size CI gate: every master push saves a gzip baseline of `.next/static` via `scripts/ci/bundle-size.mjs`, and every PR is compared against it (fails at >5% growth). Superseded by V33 / PE4 / ROADMAP S18.
 
-**V23 — Reserve chart card height (CLS).** Set explicit `min-h-[320px]` on each chart card wrapper in `allocation-chart.tsx`, `currency-exposure-chart.tsx`, `trend-chart.tsx`. Match the skeleton in `dashboard-skeleton.tsx`. Verify CLS < 0.1.
+**V23 — Reserve chart card height (CLS).** Done 2026-06-11 (verified shipped, docs were stale). Lazy charts render fixed-height skeleton fallbacks and pass `initialDimension` to Recharts' `ResponsiveContainer` so the first paint already occupies the final height: see `src/components/analysis/lazy-analysis-charts.tsx`, `src/components/dashboard/trend-chart-skeleton.tsx`, and the `initialDimension` prop plumbed through `src/components/ui/chart.tsx`. Same evidence closes ROADMAP S21.
 
 **V24 — Preload fonts + defer below-fold work.** Mark the `next/font/local` declaration with `preload: true` for the weights used by the hero (`400`, `600`). Add `content-visibility: auto` to below-fold chart cards. Critical files: `src/app/layout.tsx`, chart card components.
 
@@ -133,7 +133,7 @@ Deployment `dpl_3KqPj4qBr3ZojdDaSxtKvo8iNhC2` (44s total, 292 MB build cache):
 
 **V32 — Trim Speed Insights telemetry.** Configure `<SpeedInsights beforeSend={(data) => { if (data.url.includes("/login") || data.url.includes("/privacy")) return null; return data; }} />`. Critical files: `src/app/layout.tsx`.
 
-**V33 — Ship `@next/bundle-analyzer`.** `npm i -D @next/bundle-analyzer`. Wrap the export in `next.config.ts`. Commit the `ANALYZE=true npm run build` baseline (dashboard route JS, shared chunks, largest single module) to this doc. Re-run on every Speed Insights PR.
+**V33 — Ship `@next/bundle-analyzer`.** Done 2026-06-11. The analyzer ships in `next.config.ts` (enabled via `ANALYZE=true npm run build`). The "commit a baseline to this doc" step is superseded by the automated S18 CI gate (`scripts/ci/bundle-size.mjs` + the `bundle-size` job in `.github/workflows/ci.yml`): master pushes save the gzip baseline, PRs fail on >5% total-gzip growth, so the baseline maintains itself instead of rotting in a doc.
 
 **V34 — Extend `maxDuration` for refresh routes.** Add per-function entries: `"src/app/api/prices/refresh/route.ts": { "maxDuration": 60 }` and `"src/app/api/exchange-rates/refresh/route.ts": { "maxDuration": 30 }`. Critical files: `vercel.json`.
 
@@ -245,7 +245,7 @@ Findings sourced against Vercel project on **2026-04-24**. Scope: only **launch 
 ### Deferred (not launch blockers)
 
 - Bundle-size reduction items (PERFORMANCE.md B-series)
-- Remaining Vercel ❌ items not listed above (V7, V15, V17/V18/V20, V22/V33, V23)
+- Remaining Vercel ❌ items not listed above (V7, V15, V18; V17/V20/V22/V33/V23 have since shipped)
 - Feature backlog (SUGGESTIONS.md #7 cost basis, #17 dividends, #23 2FA, #24 Plaid)
 - Rendering ladder items (PERFORMANCE.md S/P/I/X)
 - PWA manifest / install prompt
@@ -391,9 +391,11 @@ Ordered by **expected Active-CPU saved per change**, given the bot-dominated tra
 
 #### P8 — Cache `yahoo-finance2` module + class instance at module scope
 
-**Effect:** Low. `price-service.ts:73-74`, `search/route.ts:79-80`, `options/chain/route.ts:44-45` each do `await import("yahoo-finance2")` and `new YahooFinance()` per call. Node's ESM cache makes the second import a no-op, but instantiating a new class per call still allocates state.
+**✅ Done (verified 2026-06-11, docs were stale).** Shipped as `src/lib/services/yahoo-client.ts` exporting `getYahooClient()`; all callers (`src/lib/services/price-service.ts`, `src/lib/services/stock-watch-service.ts`, `src/app/api/search/route.ts`, `src/app/api/options/chain/route.ts`) import the shared singleton instead of doing `await import("yahoo-finance2")` + `new YahooFinance()` per call.
 
-- Add `src/lib/yahoo.ts` exporting a `const yf = new YahooFinance()` singleton; update the three callers to import it.
+**Effect:** Low. `price-service.ts:73-74`, `search/route.ts:79-80`, `options/chain/route.ts:44-45` each did `await import("yahoo-finance2")` and `new YahooFinance()` per call. Node's ESM cache makes the second import a no-op, but instantiating a new class per call still allocates state.
+
+- Add a module exporting a Yahoo client singleton; update the three callers to import it.
 
 **Pros:** Slightly lower per-call CPU/allocation; cleaner code; warm HTTP keep-alive across Fluid invocations.
 **Cons:** Minor — singletons can hold internal state across requests; in Fluid that's actually a benefit.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,10 +45,10 @@ The existing `docs/` folder has trackers (PERFORMANCE, PLATFORM, UI*UX, CODE_QUA
 | S15                                | Dividend / income tracking (`IncomeEvent` model)                       | L      | 🟡     | ❌     | fresh                  |
 | S16                                | Expand crypto symbol coverage beyond ~20 CoinGecko entries             | S      | 🟡     | ❌     | fresh                  |
 | S17                                | `Cache-Control` on `/api/snapshots`, `/api/exchange-rates`             | S      | 🟡     | ✅     | V17 / V18              |
-| S18                                | Bundle-size CI gate (PR-fail if main grows >5%)                        | S      | 🟡     | ❌     | V22 / V33              |
-| S19                                | Preconnect to `va.vercel-scripts.com`                                  | XS     | 🟡     | ❌     | V28                    |
+| S18                                | Bundle-size CI gate (PR-fail if main grows >5%)                        | S      | 🟡     | ✅     | V22 / V33              |
+| S19                                | Preconnect to `va.vercel-scripts.com`                                  | XS     | 🟡     | ✅     | V28                    |
 | S20                                | Vercel Skew Protection on (**promote to Tier 1** — bundle with F6)     | XS     | 🟡     | ❌     | V35                    |
-| S21                                | Chart CLS reserve (explicit `min-height` on lazy charts)               | XS     | 🟡     | ❌     | V23                    |
+| S21                                | Chart CLS reserve (explicit `min-height` on lazy charts)               | XS     | 🟡     | ✅     | V23                    |
 | S22                                | Holding price-alert thresholds (email / web push)                      | L      | 🟡     | ❌     | fresh                  |
 | S23                                | Tax-lot tracking (FIFO / specific-lot cost basis)                      | L      | 🟡     | ❌     | fresh                  |
 | **Tier 3 — Polish & DX**           |                                                                        |        |        |        |
@@ -208,15 +208,15 @@ New `IncomeEvent { id, holdingId, type: DIVIDEND|COUPON|INTEREST, amount, curren
 
 #### S18 — Bundle-size CI gate
 
-**S | 🟡 | ❌ — closes V22 / V33**
+**S | 🟡 | ✅ Done (2026-06-11) — closes V22 / V33**
 
-`@next/bundle-analyzer` already runs locally. Wire a GitHub Action that compares main-chunk size against the base branch and fails the PR if growth >5%. Prevents bundle regressions from creeping back after B1–B15 closure.
+Shipped as `scripts/ci/bundle-size.mjs` (zero-dep; gzips all `.js`/`.css` under `.next/static`) plus a PR-only `bundle-size` job in `.github/workflows/ci.yml`. Master pushes save a `bundle-baseline.json` via `actions/cache`; PRs build, measure, and fail at >5% total-gzip growth (soft-pass with a `::warning::` when the baseline is missing — first run or cache eviction — so it self-heals on the next master push). Deliberate growth: the gate only blocks the introducing PR; the baseline absorbs the growth after merge.
 
 #### S19 — Preconnect to `va.vercel-scripts.com`
 
-**XS | 🟡 | ❌ — closes V28**
+**XS | 🟡 | ✅ Done (verified 2026-06-11, docs were stale) — closes V28**
 
-Add `<link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin>` to root layout `<head>`. Web Vitals beacon currently does a cold DNS+TLS handshake on every fresh session.
+Already shipped: `src/app/layout.tsx:288-289` has `<link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />` plus a `dns-prefetch` fallback (and `dns-prefetch` for the exchange-rate APIs).
 
 #### S20 — Vercel Skew Protection
 
@@ -228,9 +228,9 @@ Enable in Vercel project settings + read `x-deployment-id` header in client. Pre
 
 #### S21 — Chart CLS reserve
 
-**XS | 🟡 | ❌ — closes V23**
+**XS | 🟡 | ✅ Done (verified 2026-06-11, docs were stale) — closes V23**
 
-Dynamic-imported charts (`AllocationChart`, `CurrencyExposureChart`, `TrendChart`) currently shift layout when they hydrate. Add explicit `min-height` to their wrappers matching the rendered height. Pure CSS, no behavior change.
+Height reserves shipped via fixed-height chart skeletons and Recharts `initialDimension`: lazy analysis charts render sized fallbacks (`src/components/analysis/lazy-analysis-charts.tsx`), the dashboard trend chart has a dedicated skeleton (`src/components/dashboard/trend-chart-skeleton.tsx`), and `src/components/ui/chart.tsx` plumbs `initialDimension` into `ResponsiveContainer` so charts occupy their final height on first paint.
 
 #### S22 — Holding price-alert thresholds
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -84,6 +84,22 @@ const nextConfig: NextConfig = {
         },
       ],
     },
+    // V20 — iOS PWA splash screens are immutable build artifacts: they are
+    // produced only by `scripts/generate-splash-screens.mjs` and referenced
+    // from the root layout's `appleWebApp.startupImage`. Cached for 1 year —
+    // if a splash design ever changes, RENAME the file (and update the layout
+    // references) instead of editing it in place.
+    {
+      source: "/splash/:path*",
+      headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+    },
+    // V20 — the service worker must never be long-cached or clients can get
+    // stuck on a stale SW. Pinned explicitly so a future broad caching
+    // pattern can't accidentally cover it.
+    {
+      source: "/sw.js",
+      headers: [{ key: "Cache-Control", value: "public, max-age=0, must-revalidate" }],
+    },
   ],
 };
 

--- a/scripts/ci/bundle-size.mjs
+++ b/scripts/ci/bundle-size.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Bundle-size CI gate (S18).
+ *
+ * Measures the total gzipped bytes of client assets (`.js` + `.css`) under
+ * `.next/static` after a production build, and compares a PR's measurement
+ * against the baseline saved by the most recent master-push build.
+ *
+ * Usage:
+ *   node scripts/ci/bundle-size.mjs --write <out.json>
+ *   node scripts/ci/bundle-size.mjs --compare <baseline.json> --against <head.json> [--max-growth 0.05]
+ *
+ * Handling deliberate bundle growth:
+ *   The gate only blocks the PR that introduces the growth. If the growth is
+ *   intentional (new feature, new dependency that earns its weight), note the
+ *   justification in the PR and merge with the failing job acknowledged (or
+ *   temporarily raise --max-growth in the workflow within the same PR). The
+ *   baseline self-heals: the next push to master rebuilds and saves a fresh
+ *   baseline that includes the growth, so subsequent PRs compare against it.
+ *
+ *   A missing baseline (first run, or GitHub Actions cache eviction) is a
+ *   soft pass: the compare step prints a warning and exits 0, and the next
+ *   master push restores the baseline.
+ *
+ * Zero dependencies — uses node:fs, node:path, node:zlib only.
+ */
+
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  existsSync,
+  appendFileSync,
+} from "node:fs";
+import { join, extname } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const STATIC_DIR = join(process.cwd(), ".next", "static");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function measure() {
+  if (!existsSync(STATIC_DIR)) {
+    console.error(`::error::${STATIC_DIR} not found — run \`npm run build\` first`);
+    process.exit(1);
+  }
+  let jsGzipBytes = 0;
+  let cssGzipBytes = 0;
+  let fileCount = 0;
+  for (const file of walk(STATIC_DIR)) {
+    const ext = extname(file);
+    if (ext !== ".js" && ext !== ".css") continue;
+    const gz = gzipSync(readFileSync(file)).length;
+    if (ext === ".js") jsGzipBytes += gz;
+    else cssGzipBytes += gz;
+    fileCount += 1;
+  }
+  return {
+    totalGzipBytes: jsGzipBytes + cssGzipBytes,
+    jsGzipBytes,
+    cssGzipBytes,
+    fileCount,
+    generatedAt: new Date().toISOString(),
+    sha: process.env.GITHUB_SHA ?? null,
+  };
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+function readArg(name) {
+  const idx = process.argv.indexOf(name);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+}
+
+const writeOut = readArg("--write");
+const baselinePath = readArg("--compare");
+
+if (writeOut) {
+  const result = measure();
+  writeFileSync(writeOut, JSON.stringify(result, null, 2) + "\n");
+  console.log(
+    `Measured ${result.fileCount} files: total ${formatBytes(result.totalGzipBytes)} gzip ` +
+      `(js ${formatBytes(result.jsGzipBytes)}, css ${formatBytes(result.cssGzipBytes)}) → ${writeOut}`,
+  );
+  process.exit(0);
+}
+
+if (baselinePath) {
+  const headPath = readArg("--against");
+  const maxGrowth = Number(readArg("--max-growth") ?? "0.05");
+  if (!headPath) {
+    console.error("::error::--compare requires --against <head.json>");
+    process.exit(1);
+  }
+  if (!existsSync(baselinePath)) {
+    console.log("::warning::No bundle baseline found (first run or cache evicted) — skipping gate");
+    process.exit(0);
+  }
+
+  const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+  const head = JSON.parse(readFileSync(headPath, "utf8"));
+  const deltaBytes = head.totalGzipBytes - baseline.totalGzipBytes;
+  const growth = baseline.totalGzipBytes > 0 ? deltaBytes / baseline.totalGzipBytes : 0;
+  const growthPct = (growth * 100).toFixed(2);
+
+  const rows = [
+    ["Total gzip", baseline.totalGzipBytes, head.totalGzipBytes],
+    ["JS gzip", baseline.jsGzipBytes, head.jsGzipBytes],
+    ["CSS gzip", baseline.cssGzipBytes, head.cssGzipBytes],
+  ];
+  const summaryLines = [
+    "## Bundle size (gzip, `.next/static`)",
+    "",
+    `Baseline sha: \`${baseline.sha ?? "unknown"}\` · Head sha: \`${head.sha ?? "unknown"}\` · Limit: +${(maxGrowth * 100).toFixed(0)}%`,
+    "",
+    "| Metric | Baseline | Head | Delta | Delta % |",
+    "| --- | ---: | ---: | ---: | ---: |",
+    ...rows.map(([label, base, cur]) => {
+      const d = cur - base;
+      const pct = base > 0 ? ((d / base) * 100).toFixed(2) : "n/a";
+      const sign = d >= 0 ? "+" : "";
+      return `| ${label} | ${formatBytes(base)} | ${formatBytes(cur)} | ${sign}${d} B | ${sign}${pct}% |`;
+    }),
+    "",
+  ];
+  console.log(summaryLines.join("\n"));
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines.join("\n") + "\n");
+  }
+
+  if (growth > maxGrowth) {
+    console.error(
+      `::error::Client bundle grew ${growthPct}% (>${(maxGrowth * 100).toFixed(0)}% limit)`,
+    );
+    process.exit(1);
+  }
+  console.log(`Bundle growth ${growthPct}% is within the +${(maxGrowth * 100).toFixed(0)}% limit.`);
+  process.exit(0);
+}
+
+console.error(
+  "::error::Usage: bundle-size.mjs --write <out.json> | --compare <baseline.json> --against <head.json> [--max-growth 0.05]",
+);
+process.exit(1);

--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartEmptyState } from "./chart-empty-state";
@@ -22,7 +23,7 @@ interface Props {
   baseCurrency: string;
 }
 
-export function TopMoversList({ movers, baseCurrency }: Props) {
+export const TopMoversList = memo(function TopMoversList({ movers, baseCurrency }: Props) {
   const t = useTranslations("analysis");
   const tCat = useTranslations("categories");
   const { privacyMode } = usePrivacyMode();
@@ -121,4 +122,4 @@ export function TopMoversList({ movers, baseCurrency }: Props) {
       </CardContent>
     </Card>
   );
-}
+});

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -286,17 +286,32 @@ export async function getAccountMonthlyCashFlow(
   cacheTag(`history:${userId}`);
   cacheLife("hours");
 
-  const [accounts, allRatesMap] = await Promise.all([
+  const [accounts, allRatesMap, firstSnapshot] = await Promise.all([
     prisma.account.findMany({ where: { userId }, select: { id: true, currency: true } }),
     getAllExchangeRates(),
+    prisma.netWorthSnapshot.findFirst({
+      where: { userId },
+      orderBy: { date: "asc" },
+      select: { date: true },
+    }),
   ]);
 
   const accountCurrencyMap = new Map(accounts.map((a) => [a.id, a.currency]));
+
+  // PE29 — floor the transaction scan to the first day (UTC) of the month
+  // containing the user's earliest snapshot. Months before the first snapshot
+  // are unreachable by the analysis UI: the axis buckets and attribution math
+  // are snapshot-derived (including the "All" range), so this floor changes no
+  // rendered output — it only avoids scanning/converting unreachable rows.
+  const floor = firstSnapshot
+    ? new Date(Date.UTC(firstSnapshot.date.getUTCFullYear(), firstSnapshot.date.getUTCMonth(), 1))
+    : null;
 
   const transactions = await prisma.cashTransaction.findMany({
     where: {
       accountId: { in: accounts.map((a) => a.id) },
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
+      ...(floor ? { createdAt: { gte: floor } } : {}),
     },
     select: { amount: true, type: true, createdAt: true, accountId: true },
     orderBy: { createdAt: "asc" },


### PR DESCRIPTION
PR 1 of the round-3 performance plan (plan doc included as `docs/PERF_ROUND3_PLAN.md`).

## Changes

### S18 — Bundle-size CI gate
- New zero-dependency `scripts/ci/bundle-size.mjs`: gzips every `.js`/`.css` under `.next/static` and writes/compares JSON measurements.
- `.github/workflows/ci.yml`: the master-only `build` job now saves a `bundle-baseline.json` via `actions/cache/save`; a new PR-only `bundle-size` job builds, measures, restores the latest baseline (`restore-keys: bundle-baseline-`), and fails at >5% total-gzip growth, with a markdown delta table in the step summary.
- **Note: the gate soft-passes (`::warning::`, exit 0) until the first master push after merge saves a baseline** — same behavior on cache eviction, so it self-heals. Deliberate growth only blocks the introducing PR; the baseline absorbs it after merge.

### V20 — Cache-Control for /public assets
- `next.config.ts` `headers()`: `/splash/:path*` → `public, max-age=31536000, immutable` (splash images are generated artifacts; design changes require a rename) and `/sw.js` → `public, max-age=0, must-revalidate` (pinned so no future broad pattern can long-cache the service worker).
- Verified present in the built `.next/routes-manifest.json`. Local `next start` serves `/public` through its own static handler (and `/splash/*` 302s through the auth middleware when unauthenticated), so the authoritative header check is the Vercel preview deployment.

### PE29 — Date-floor `getAccountMonthlyCashFlow`
- `src/lib/services/history-service.ts`: the earliest `NetWorthSnapshot` is fetched as a third member of the existing `Promise.all`, and the `cashTransaction` scan is floored to the first day (UTC) of that snapshot's month. Months before the first snapshot are unreachable by the analysis UI (axis buckets and attribution are snapshot-derived, including "All"), so rendered output is unchanged.

### TopMoversList memo
- `src/components/analysis/top-movers-list.tsx` wrapped in `React.memo` (same pattern as the five charts memoized in PR #403) so sticky-header `isStuck` flips in `AnalysisView` no longer re-render it.

## Doc syncs (2026-06-11)
- `docs/ROADMAP.md`: S18 ✅ (this PR); S19 ✅ (preconnect already shipped at `src/app/layout.tsx:288-289`); S21 ✅ (chart skeletons + `initialDimension`).
- `docs/PLATFORM.md`: V20 ✅ (this PR); V22/V33 ⚠️→✅ (analyzer wired; S18 gate supersedes the committed baseline); V23 ✅ (same evidence as S21); P8 ✅ (verified `search/route.ts` + `options/chain/route.ts` use the `yahoo-client.ts` singleton).
- `docs/PERFORMANCE.md`: PE29 ✅ with the chosen first-snapshot-month floor approach.

## Verification
- `format:check`, `lint`, `typecheck`, `build` all pass.
- `bundle-size.mjs` sanity-run after the build: 102 files, 1430.0 KiB total gzip (JS 1398.8 KiB, CSS 31.2 KiB); compare path tested for missing baseline (warn + exit 0), +2% (pass), and +10% (exit 1 with `::error::`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)