### PR TITLE
feat(observability): complete Sentry dashboard to all 19 planned widgets

### DIFF
--- a/docs/SENTRY_MONITORING_PLAN.md
+++ b/docs/SENTRY_MONITORING_PLAN.md
@@ -179,7 +179,7 @@ Repo setup path:
 
 Current Sentry resources:
 
-- Dashboard: `Assets Tracker - Production Health`, id `7021314`.
+- Dashboard: `Assets Tracker - Production Health`, id `7021314` (all 19 widgets applied 2026-06-13).
 - Metric alerts: production error spike `439337`, API error spike `439338`, cron snapshot failed `439339`, DB unreachable `439340`.
 
 1. New issue, level error
@@ -255,9 +255,16 @@ Recommended layout:
 | 5   | Browser render errors   | Table                  | `level:error runtime:browser` grouped by `transaction`, browser, release                                                  | Client-only failures and hydration/runtime crashes          |
 | 5   | Navigation/chunk errors | Table                  | Browser errors containing chunk/load/navigation terms                                                                     | Catches stale service worker or deployment skew             |
 | 5   | CSP violations          | Table                  | `message:"csp.violation"` grouped by violated directive and blocked URI                                                   | Verifies CSP changes without paging on internet noise       |
-| 6   | Backend p95 latency     | Line chart             | `p95(transaction.duration)` for `/api/health`, `/api/refresh`, `/api/cron/snapshot`                                       | Backend degradation trend after tracing is enabled          |
-| 6   | Page p95 latency        | Line chart             | `p95(transaction.duration)` for `/`, `/accounts`, `/accounts/[id]`, `/analysis`, `/history`                               | User-facing route performance trend                         |
+| 6   | Backend p95 latency     | Line chart             | `p95(span.duration)` for `/api/health`, `/api/refresh`, `/api/cron/snapshot`                                              | Backend degradation trend after tracing is enabled          |
+| 6   | Page p95 latency        | Line chart             | `p95(span.duration)` for `/`, `/accounts`, `/accounts/[id]`, `/analysis`, `/history`                                      | User-facing route performance trend                         |
 | 6   | CWV budget misses       | Bar/table              | `message:"cwv.budget_exceeded"` grouped by metric and URL                                                                 | Complements Vercel Speed Insights                           |
+
+Applied state (2026-06-13): all 19 widgets above are live on dashboard `7021314` via `npm run sentry:setup -- --apply`. Parity notes vs. the table:
+
+- Backend/Page p95 latency use the **spans** dataset (`widgetType: spans`) with an `is_transaction:true` filter and `p95(span.duration)` — Sentry's transactions dataset is deprecated under EAP. They stay empty until tracing is enabled (`SENTRY_TRACES_SAMPLE_RATE > 0`, Phase 4).
+- Navigation/chunk errors is scoped to `runtime:browser error.type:ChunkLoadError` (the dominant Next.js navigation failure), not a broad term match.
+- FX unresolved pairs groups by `message`, not `from`/`to`/`baseCurrency`; switch to those columns once the context tags in "Missing tags to add" below are emitted by the logger.
+- Warning volume only populates when `SENTRY_CAPTURE_WARNINGS=true`.
 
 Dashboard conventions:
 

--- a/scripts/setup-sentry-monitoring.mjs
+++ b/scripts/setup-sentry-monitoring.mjs
@@ -73,10 +73,14 @@ function getAlertActions() {
   return [];
 }
 
-function dashboardWidget(title, displayType, fields, conditions, layout) {
+function dashboardWidget(spec, layout) {
+  const { title, displayType, fields, conditions, widgetType = "error-events" } = spec;
   return {
     title,
     displayType,
+    // Sentry defaults un-typed widgets to the errors dataset; p95(transaction.duration)
+    // only resolves on the transactions dataset, so latency widgets must opt out.
+    widgetType,
     interval: "5m",
     limit: 10,
     layout: {
@@ -97,6 +101,153 @@ function dashboardWidget(title, displayType, fields, conditions, layout) {
   };
 }
 
+// Two-column auto-layout on Sentry's 6-col grid (each widget is half-width).
+// Bin-packs into whichever column is currently shorter so mixed big-number (h2)
+// and table/line (h3) heights never overlap, regardless of widget count.
+function layoutWidgets(specs) {
+  let yLeft = 0;
+  let yRight = 0;
+  return specs.map((spec) => {
+    const h = spec.displayType === "big_number" ? 2 : 3;
+    if (yLeft <= yRight) {
+      const widget = dashboardWidget(spec, { x: 0, y: yLeft, w: 3, h });
+      yLeft += h;
+      return widget;
+    }
+    const widget = dashboardWidget(spec, { x: 3, y: yRight, w: 3, h });
+    yRight += h;
+    return widget;
+  });
+}
+
+// The full set documented in docs/SENTRY_MONITORING_PLAN.md "Recommended layout".
+// Order follows the plan's reading order; layoutWidgets() places them two-per-row.
+const WIDGET_SPECS = [
+  {
+    title: "Production errors",
+    displayType: "big_number",
+    fields: ["count()"],
+    conditions: "level:error",
+  },
+  {
+    title: "Affected users",
+    displayType: "big_number",
+    fields: ["count_unique(user)"],
+    conditions: "level:error",
+  },
+  {
+    title: "Latest release errors",
+    displayType: "big_number",
+    fields: ["count()"],
+    conditions: "level:error release:latest",
+  },
+  // Only populated when SENTRY_CAPTURE_WARNINGS=true forwards warnings as events.
+  {
+    title: "Warning volume",
+    displayType: "area",
+    fields: ["count()"],
+    conditions: "level:warning",
+  },
+  {
+    title: "Errors by route",
+    displayType: "table",
+    fields: ["transaction", "count()"],
+    conditions: "level:error",
+  },
+  {
+    title: "Errors by release",
+    displayType: "table",
+    fields: ["release", "count()"],
+    conditions: "level:error",
+  },
+  {
+    title: "Errors by runtime",
+    displayType: "table",
+    fields: ["runtime", "count()"],
+    conditions: "level:error",
+  },
+  {
+    title: "Cron failures",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"cron.snapshot.failed" OR message:"cron.snapshot.audit_failed"',
+  },
+  {
+    title: "DB failures",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"health.db_unreachable" OR error.type:*Prisma*',
+  },
+  {
+    title: "Import/export failures",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"export.failed" OR message:"import.failed"',
+  },
+  {
+    title: "Market providers",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions:
+      'message:"price.yahoo.*" OR message:"price.coingecko.failed" OR message:"rates.fetch.failed"',
+  },
+  {
+    title: "FX unresolved pairs",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"rates.unresolved"',
+  },
+  {
+    title: "Slow Prisma operations",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"prisma.slow_query"',
+  },
+  {
+    title: "Browser render errors",
+    displayType: "table",
+    fields: ["transaction", "browser.name", "release", "count()"],
+    conditions: "level:error runtime:browser",
+  },
+  {
+    title: "Navigation/chunk errors",
+    displayType: "table",
+    fields: ["transaction", "count()"],
+    conditions: "runtime:browser error.type:ChunkLoadError",
+  },
+  {
+    title: "CSP violations",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"csp.violation"',
+  },
+  // p95 widgets use the spans dataset (the transactions dataset is deprecated in
+  // Sentry EAP) filtered to transaction-root spans, and need tracing enabled
+  // (SENTRY_TRACES_SAMPLE_RATE > 0 — Plan Phase 4). They render empty until then.
+  {
+    title: "Backend p95 latency",
+    displayType: "line",
+    fields: ["transaction", "p95(span.duration)"],
+    conditions:
+      "is_transaction:true (transaction:/api/health OR transaction:/api/refresh OR transaction:/api/cron/snapshot)",
+    widgetType: "spans",
+  },
+  {
+    title: "Page p95 latency",
+    displayType: "line",
+    fields: ["transaction", "p95(span.duration)"],
+    conditions:
+      "is_transaction:true (transaction:/ OR transaction:/accounts OR transaction:/accounts/* OR transaction:/analysis OR transaction:/history)",
+    widgetType: "spans",
+  },
+  {
+    title: "CWV budget misses",
+    displayType: "table",
+    fields: ["message", "count()"],
+    conditions: 'message:"cwv.budget_exceeded"',
+  },
+];
+
 function dashboardPayload(projectId) {
   return {
     title: DASHBOARD_TITLE,
@@ -105,79 +256,7 @@ function dashboardPayload(projectId) {
     period: "24h",
     utc: true,
     is_favorited: true,
-    widgets: [
-      dashboardWidget("Production errors", "big_number", ["count()"], "level:error", {
-        x: 0,
-        y: 0,
-        w: 3,
-        h: 2,
-      }),
-      dashboardWidget("Affected users", "big_number", ["count_unique(user)"], "level:error", {
-        x: 3,
-        y: 0,
-        w: 3,
-        h: 2,
-      }),
-      dashboardWidget("Errors by route", "table", ["transaction", "count()"], "level:error", {
-        x: 0,
-        y: 2,
-        w: 3,
-        h: 3,
-      }),
-      dashboardWidget("Errors by release", "table", ["release", "count()"], "level:error", {
-        x: 3,
-        y: 2,
-        w: 3,
-        h: 3,
-      }),
-      dashboardWidget(
-        "Cron failures",
-        "table",
-        ["message", "count()"],
-        'message:"cron.snapshot.failed" OR message:"cron.snapshot.audit_failed"',
-        { x: 0, y: 5, w: 3, h: 3 },
-      ),
-      dashboardWidget(
-        "DB failures",
-        "table",
-        ["message", "count()"],
-        'message:"health.db_unreachable" OR error.type:*Prisma*',
-        { x: 3, y: 5, w: 3, h: 3 },
-      ),
-      dashboardWidget(
-        "Market providers",
-        "table",
-        ["message", "count()"],
-        'message:"price.yahoo.*" OR message:"price.coingecko.failed" OR message:"rates.fetch.failed"',
-        { x: 0, y: 8, w: 3, h: 3 },
-      ),
-      dashboardWidget(
-        "Browser render errors",
-        "table",
-        ["transaction", "browser.name", "count()"],
-        "runtime:browser",
-        {
-          x: 3,
-          y: 8,
-          w: 3,
-          h: 3,
-        },
-      ),
-      dashboardWidget(
-        "Backend p95 latency",
-        "line",
-        ["p95(transaction.duration)", "transaction"],
-        "transaction:/api/health OR transaction:/api/refresh OR transaction:/api/cron/snapshot",
-        { x: 0, y: 11, w: 3, h: 3 },
-      ),
-      dashboardWidget(
-        "Page p95 latency",
-        "line",
-        ["p95(transaction.duration)", "transaction"],
-        "transaction:/ OR transaction:/accounts OR transaction:/accounts/* OR transaction:/analysis OR transaction:/history",
-        { x: 3, y: 11, w: 3, h: 3 },
-      ),
-    ],
+    widgets: layoutWidgets(WIDGET_SPECS),
   };
 }
 
@@ -263,12 +342,18 @@ async function main() {
 
   const projectInfo = await sentryFetch(`/projects/${org}/${project}/`);
   const existingDashboard = await getExistingDashboard(org);
-  const dashboard =
-    existingDashboard ??
-    (await sentryFetch(`/organizations/${org}/dashboards/`, {
-      method: "POST",
-      body: JSON.stringify(dashboardPayload(projectInfo.id)),
-    }));
+  // PUT replaces the existing dashboard's widget set with the current spec (the
+  // widgets carry no id, so Sentry recreates them); POST creates it on first run.
+  // Without the update branch a re-run would no-op against a stale dashboard.
+  const dashboard = existingDashboard
+    ? await sentryFetch(`/organizations/${org}/dashboards/${existingDashboard.id}/`, {
+        method: "PUT",
+        body: JSON.stringify(dashboardPayload(projectInfo.id)),
+      })
+    : await sentryFetch(`/organizations/${org}/dashboards/`, {
+        method: "POST",
+        body: JSON.stringify(dashboardPayload(projectInfo.id)),
+      });
 
   const alertResults = [];
   if (alertActions.length === 0) {

--- a/scripts/setup-sentry-monitoring.mjs
+++ b/scripts/setup-sentry-monitoring.mjs
@@ -105,7 +105,9 @@ function dashboardWidget(spec, layout) {
 // Widgets are paired in declaration order; both cells in a row share the same y
 // and a uniform height (the taller of the pair), so the left and right columns
 // stay aligned row-for-row. A trailing odd widget sits alone in the left column.
-const widgetHeight = (spec) => (spec.displayType === "big_number" ? 2 : 3);
+// Height: big_number widgets are kept at 2 so their auto-scaled font matches
+// across KPIs; a spec may set an explicit `h` to share a KPI row (see below).
+const widgetHeight = (spec) => spec.h ?? (spec.displayType === "big_number" ? 2 : 3);
 
 function layoutWidgets(specs) {
   const widgets = [];
@@ -143,11 +145,14 @@ const WIDGET_SPECS = [
     conditions: "level:error release:latest",
   },
   // Only populated when SENTRY_CAPTURE_WARNINGS=true forwards warnings as events.
+  // h:2 keeps it level with the "Latest release errors" KPI it shares a row with,
+  // so that big-number stays at height 2 and renders the same font as the others.
   {
     title: "Warning volume",
     displayType: "area",
     fields: ["count()"],
     conditions: "level:warning",
+    h: 2,
   },
   {
     title: "Errors by route",

--- a/scripts/setup-sentry-monitoring.mjs
+++ b/scripts/setup-sentry-monitoring.mjs
@@ -101,23 +101,24 @@ function dashboardWidget(spec, layout) {
   };
 }
 
-// Two-column auto-layout on Sentry's 6-col grid (each widget is half-width).
-// Bin-packs into whichever column is currently shorter so mixed big-number (h2)
-// and table/line (h3) heights never overlap, regardless of widget count.
+// Row-based two-column layout on Sentry's 6-col grid (each widget is half-width).
+// Widgets are paired in declaration order; both cells in a row share the same y
+// and a uniform height (the taller of the pair), so the left and right columns
+// stay aligned row-for-row. A trailing odd widget sits alone in the left column.
+const widgetHeight = (spec) => (spec.displayType === "big_number" ? 2 : 3);
+
 function layoutWidgets(specs) {
-  let yLeft = 0;
-  let yRight = 0;
-  return specs.map((spec) => {
-    const h = spec.displayType === "big_number" ? 2 : 3;
-    if (yLeft <= yRight) {
-      const widget = dashboardWidget(spec, { x: 0, y: yLeft, w: 3, h });
-      yLeft += h;
-      return widget;
-    }
-    const widget = dashboardWidget(spec, { x: 3, y: yRight, w: 3, h });
-    yRight += h;
-    return widget;
-  });
+  const widgets = [];
+  let y = 0;
+  for (let i = 0; i < specs.length; i += 2) {
+    const row = specs.slice(i, i + 2);
+    const rowH = Math.max(...row.map(widgetHeight));
+    row.forEach((spec, col) => {
+      widgets.push(dashboardWidget(spec, { x: col * 3, y, w: 3, h: rowH }));
+    });
+    y += rowH;
+  }
+  return widgets;
 }
 
 // The full set documented in docs/SENTRY_MONITORING_PLAN.md "Recommended layout".


### PR DESCRIPTION
## What

Brings the Sentry monitoring dashboard up to the full **19-widget** layout documented in `docs/SENTRY_MONITORING_PLAN.md`. The setup script previously defined only **10** widgets, and its apply path could only *create* a dashboard — re-running against the already-existing dashboard `7021314` was a silent no-op, so the gap could never be closed by re-applying.

## Why

A verification pass against the live dashboard found it had only 10 of the 19 documented widgets, and the two p95-latency widgets were non-functional (querying transaction-duration metrics on the errors dataset). The plan doc oversold this as done.

## Changes

**`scripts/setup-sentry-monitoring.mjs`**
- Refactored widgets into a `WIDGET_SPECS` array (all 19) + a `layoutWidgets()` bin-packer that places them two-per-row with no overlap.
- Added a `widgetType` field to `dashboardWidget()` (was hardcoded to the default errors dataset).
- Added the 9 missing widgets: Latest release errors, Warning volume, Errors by runtime, Import/export failures, FX unresolved pairs, Slow Prisma operations, Navigation/chunk errors, CSP violations, CWV budget misses.
- Tightened **Browser render errors** to `level:error runtime:browser` + `release` grouping (matches the plan).
- Moved both **p95 latency** widgets to the **spans** dataset (`widgetType: spans`, `p95(span.duration)`, `is_transaction:true`) — Sentry's transactions dataset is deprecated under EAP (the first apply 400'd on the old `transaction-like` type).
- Added a **PUT update branch** so an existing dashboard is refreshed instead of skipped.

**`docs/SENTRY_MONITORING_PLAN.md`**
- Updated the p95 rows to `p95(span.duration)`, marked the dashboard as "all 19 widgets applied 2026-06-13", and added an **Applied state** note documenting parity caveats.

## Verification

- Applied to live dashboard `7021314` via `npm run sentry:setup -- --apply`; re-fetched via the Sentry API and confirmed all **19 widgets** present with correct datasets and a non-overlapping layout. The 4 metric alerts (`439337`–`439340`) are intact.
- `format:check`, `lint`, `typecheck` all pass.

## Reviewer notes — widgets that are intentionally empty for now (not bugs)

- **Backend / Page p95 latency** — empty until tracing is enabled (`SENTRY_TRACES_SAMPLE_RATE > 0`, Plan Phase 4).
- **Warning volume** — empty unless `SENTRY_CAPTURE_WARNINGS=true`.
- **FX unresolved pairs** groups by `message` rather than `from`/`to`/`baseCurrency` because those context tags aren't emitted yet (the outstanding E20 / Phase-3 tag work).
- **Navigation/chunk errors** is scoped to `error.type:ChunkLoadError` rather than a broad term match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)