### PR TITLE
refactor(auth): remove unreachable preview-auth guard, dedupe gate logic

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { auth, signIn } from "@/auth";
 import { Button } from "@/components/ui/button";
 import { TrendingUp, Lock, ShieldCheck, EyeOff } from "lucide-react";
 import { SESSION_COOKIE_NAMES } from "@/lib/auth-cookies";
+import { isPreviewOrLocal, previewAuthDisabled } from "@/lib/env";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import Link from "next/link";
@@ -23,14 +24,6 @@ async function hasSessionCookie(): Promise<boolean> {
 
 async function LoginContent() {
   const t = await getTranslations("login");
-  const isPreviewOrLocal =
-    process.env.VERCEL_ENV === "preview" ||
-    process.env.VERCEL_ENV === "development" ||
-    !process.env.VERCEL_ENV;
-  const previewAuthDisabled = ["1", "true", "yes", "on"].includes(
-    (process.env.PREVIEW_AUTH_DISABLED ?? "").toLowerCase(),
-  );
-  const showPreviewLogin = isPreviewOrLocal;
 
   return (
     <div className="flex min-h-screen w-full items-center justify-center relative overflow-hidden bg-background">
@@ -114,7 +107,7 @@ async function LoginContent() {
           </div>
         </div>
 
-        {showPreviewLogin && (
+        {isPreviewOrLocal && (
           <>
             <div className="flex items-center gap-3 pt-2">
               <div className="flex-1 h-px bg-border" />

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,12 +4,7 @@ import Credentials from "next-auth/providers/credentials";
 import authConfig from "./auth.config";
 import { customPrismaAdapter } from "@/lib/auth-adapter";
 import { prisma } from "@/lib/prisma";
-import { PREVIEW_AUTH_DISABLED, PREVIEW_AUTH_PASSWORD, VERCEL_ENV } from "@/lib/env";
-
-const previewAuthDisabled = ["1", "true", "yes", "on"].includes(
-  (PREVIEW_AUTH_DISABLED ?? "").toLowerCase(),
-);
-const isPreviewOrLocal = VERCEL_ENV === "preview" || VERCEL_ENV === "development" || !VERCEL_ENV;
+import { isPreviewOrLocal, previewAuthDisabled, PREVIEW_AUTH_PASSWORD } from "@/lib/env";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
@@ -23,7 +18,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               password: { label: "Password", type: "password" },
             },
             authorize: async (credentials) => {
-              if (!isPreviewOrLocal) return null;
               if (!previewAuthDisabled) {
                 const expected = PREVIEW_AUTH_PASSWORD;
                 if (!expected || credentials?.password !== expected) return null;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,11 @@
 import "server-only";
 import { z } from "zod";
 
+/** Parse a boolean-ish env flag: "1" | "true" | "yes" | "on" (case-insensitive) → true. */
+function isTruthyFlag(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
 const envSchema = z
   .object({
     DATABASE_URL: z
@@ -30,10 +35,11 @@ const envSchema = z
     SENTRY_CAPTURE_WARNINGS: z.string().trim().optional(),
   })
   .superRefine((value, ctx) => {
-    const previewAuthDisabled = ["1", "true", "yes", "on"].includes(
-      (value.PREVIEW_AUTH_DISABLED ?? "").toLowerCase(),
-    );
-    if (value.VERCEL_ENV === "preview" && !previewAuthDisabled && !value.PREVIEW_AUTH_PASSWORD) {
+    if (
+      value.VERCEL_ENV === "preview" &&
+      !isTruthyFlag(value.PREVIEW_AUTH_DISABLED) &&
+      !value.PREVIEW_AUTH_PASSWORD
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["PREVIEW_AUTH_PASSWORD"],
@@ -88,3 +94,14 @@ export const {
   SENTRY_AUTH_TOKEN,
   SENTRY_CAPTURE_WARNINGS,
 } = env;
+
+/**
+ * Credentials/preview login is offered in Vercel preview deployments and any
+ * non-Vercel context (local dev, CI). Centralized here so the login page and the
+ * NextAuth Credentials provider share one gate and can't drift.
+ */
+export const isPreviewOrLocal =
+  VERCEL_ENV === "preview" || VERCEL_ENV === "development" || !VERCEL_ENV;
+
+/** When set, preview login skips the password check (passwordless preview). */
+export const previewAuthDisabled = isTruthyFlag(PREVIEW_AUTH_DISABLED);


### PR DESCRIPTION
## Summary

Targeted dead-code / unreachable-code cleanup on the preview-auth surface.

- **Remove unreachable guard** — `if (!isPreviewOrLocal) return null` in the NextAuth Credentials `authorize` callback can never be false: the provider is only constructed inside the `isPreviewOrLocal ? [Credentials({...})] : []` branch, so inside `authorize` the gate is always true.
- **Dedupe the preview-auth gate** — the `["1","true","yes","on"].includes(...)` flag parse plus the `isPreviewOrLocal` / `previewAuthDisabled` predicates were each computed in three places (`env.ts`, `auth.ts`, `login/page.tsx`). Centralized into two `src/lib/env.ts` exports backed by a private `isTruthyFlag` helper, so the login page and the NextAuth provider share one source of truth and can't drift.
- **Login page hygiene** — stops reading `process.env` directly (per the "import from `@/lib/env`" convention) and drops the redundant `showPreviewLogin` alias.

## Behavior

No behavior change. The password-gated preview login path is fully preserved — only the always-true guard and the duplicated computations were removed.

## Not touched (deliberate)

- `logger.ts`'s separate `SENTRY_CAPTURE_WARNINGS` flag parse — different domain; the logger intentionally stays decoupled from the throwing `env` module.
- `public/sw.js` (knip false positive — registered via string path in `layout.tsx`).

## Checks

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)