### PR TITLE
fix(stocks): prevent add-stock dialog overflow with long names

### DIFF
--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -233,7 +233,7 @@ function StockForm({
   }
 
   const form = (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="min-w-0 space-y-4">
       {editing && selected ? (
         <div className="rounded-lg border bg-muted/40 p-3">
           <div className="flex items-center gap-2">
@@ -245,7 +245,7 @@ function StockForm({
           <p className="mt-1 truncate text-sm text-muted-foreground">{selected.name}</p>
         </div>
       ) : selected ? (
-        <div className="flex items-center justify-between rounded-lg border bg-muted/40 p-3">
+        <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 p-3">
           <div className="min-w-0">
             <Label className="text-xs text-muted-foreground">{t("selectedStock")}</Label>
             <div className="mt-1 flex items-center gap-2">
@@ -256,7 +256,13 @@ function StockForm({
             </div>
             <p className="mt-1 truncate text-sm text-muted-foreground">{selected.name}</p>
           </div>
-          <Button type="button" variant="ghost" size="sm" onClick={() => setSelected(null)}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0 whitespace-nowrap"
+            onClick={() => setSelected(null)}
+          >
             {t("changeStock")}
           </Button>
         </div>


### PR DESCRIPTION
## What broke

In the watchlist "Add stock" dialog (desktop), selecting a stock with a long name caused a grid-blowout: the content spilled outside the dialog's right edge. The dialog renders inside `DialogContent`, which is a CSS grid capped at `sm:max-w-sm`. The `<form>` was a grid child with the default `min-width: auto`, so it refused to shrink below its content and the inner `truncate` could never clamp the long name.

Mobile was unaffected because it uses a `Drawer` with a plain block wrapper rather than the grid.

## The fix

- Add `min-w-0` to the `<form>` so it can shrink to its grid track and let the inner `truncate` clamp the stock name.
- Add `gap-3` to the selected-stock flex row and `shrink-0 whitespace-nowrap` to the "Change stock" button so it stays on one line once the name truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)