### PR TITLE
test(services): add Vitest unit suite for service layer (E22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,27 @@ jobs:
           key: deps-${{ runner.os }}-node22-${{ hashFiles('package-lock.json', 'prisma/schema.prisma') }}-v2
       - run: npm run typecheck
 
+  unit:
+    name: Unit tests
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body || '', '[skip ci]')
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - name: Restore deps cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            src/generated/prisma
+            ~/.cache/prisma
+          key: deps-${{ runner.os }}-node22-${{ hashFiles('package-lock.json', 'prisma/schema.prisma') }}-v2
+      - run: npm run test:unit
+
   build:
     name: Build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, '[skip ci]')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ ANALYZE=true npm run build  # Build with @next/bundle-analyzer HTML reports
 npm run lint         # Run ESLint
 
 # Database
+npm run db:up        # Start local PostgreSQL via docker-compose (recommended for dev — avoids Neon compute costs; then `npx prisma db push`)
+npm run db:down      # Stop the local PostgreSQL container
 npx prisma generate                                # Regenerate Prisma client after schema changes (also runs automatically via `postinstall` after `npm install`)
 npx prisma migrate dev --name <description>        # Author a new migration locally (commits to prisma/migrations/)
 npx prisma migrate deploy                          # Apply pending migrations against $DATABASE_URL (run by build:vercel on Vercel)
@@ -47,6 +49,13 @@ npx prisma migrate resolve --applied <migration>   # One-shot baseline: mark a m
 npx prisma db push                                 # Quick prototype-only schema sync — bypasses migration history; commit a migrate dev before merging
 npx prisma db push --force-reset                    # Reset local DB (drops all tables, recreates schema directly, bypassing migration history)
 npx prisma studio                                  # Open Prisma Studio GUI
+
+# Dead-code detection
+npx knip             # Find unused files/exports/deps (config: knip.json; shadcn ui/ primitives are ignored)
+
+# Unit tests (Vitest) — pure service-layer logic, no DB/env needed
+npm run test:unit        # Run the unit suite once (tests/unit/)
+npm run test:unit:watch  # Watch mode
 
 # E2E tests (Playwright)
 npm run test:e2e         # Run Playwright suite headless
@@ -98,9 +107,11 @@ src/
 │   │   ├── page.tsx            # Dashboard
 │   │   ├── accounts/           # Accounts list + [id] detail
 │   │   ├── analysis/           # Analysis tab (charts: assets/liabilities, cash flow, movers)
+│   │   ├── goals/              # Net worth goals & milestones
 │   │   ├── history/            # Net worth history view
 │   │   ├── projections/        # FIRE/retirement projection page
-│   │   └── settings/           # User settings
+│   │   ├── settings/           # User settings
+│   │   └── stocks/             # Stock watchlist / tracker
 │   └── api/
 │       ├── auth/[...nextauth]/ # NextAuth handlers
 │       ├── accounts/           # CRUD for accounts
@@ -108,13 +119,16 @@ src/
 │       ├── accounts/[id]/transactions/      # HoldingTransaction CRUD
 │       ├── accounts/[id]/cash-transactions/ # CashTransaction CRUD
 │       ├── exchange-rates/     # Fetch + refresh exchange rates
+│       ├── goals/              # Goals CRUD
 │       ├── options/chain/      # Options chain data (Yahoo Finance)
 │       ├── prices/refresh/     # Manual price refresh trigger
 │       ├── snapshots/          # Net worth snapshot history
 │       ├── search/             # Holding symbol search (Yahoo Finance)
 │       ├── settings/           # User settings API
+│       ├── stocks/             # Stock watchlist CRUD + quote + refresh
+│       ├── _metrics/vitals/    # Web Vitals ingestion
 │       └── cron/snapshot/      # Daily cron job (requires CRON_SECRET bearer token)
-├── hooks/                      # Client hooks (use-chart-animation, use-count-up)
+├── hooks/                      # Client hooks (use-chart-animation, use-count-up, use-is-mobile, use-refresh-cooldown, …)
 └── proxy.ts                    # Server-side proxy module (used by service layer)
 ```
 
@@ -183,6 +197,14 @@ Config entry point: `src/i18n/request.ts` (loaded by `next.config.ts` via `creat
 - Stocks/ETFs/bonds: Yahoo Finance 2
 - Crypto: Yahoo Finance 2 first, then CoinGecko API (free tier, no key) as fallback
 - Prices are cached in the `PriceCache` table (keyed by symbol)
+- All Yahoo calls go through the shared lazily-instantiated client in `src/lib/services/yahoo-client.ts` (`getYahooClient()`) — never instantiate `yahoo-finance2` directly
+
+**Manual refresh throttling** (see `docs/REFRESH_THROTTLING_PLAN.md`):
+
+- `src/lib/refresh-policy.ts` — isomorphic TTL constants (`PRICE_REFRESH_TTL_MS`, `FX_REFRESH_TTL_MS`, `CLIENT_REFRESH_COOLDOWN_MS`) shared by server freshness gates and the client cooldown so the two layers can't drift
+- `src/lib/refresh-client.ts` — client-side entry point for every "refresh market data" surface (dashboard button, pull-to-refresh, settings); module-level cooldown + `refresh:cooldown` event
+- `src/hooks/use-refresh-cooldown.ts` — React hook over that cooldown state
+- The server enforces its own freshness gate (skips external fetches for recently-cached symbols/rates) and per-user rate limits regardless of client behavior; throttled responses carry `Retry-After`
 
 **Exchange rates** (`src/lib/services/exchange-rate-service.ts`):
 
@@ -202,6 +224,10 @@ Config entry point: `src/i18n/request.ts` (loaded by `next.config.ts` via `creat
 - `snapshot-service.ts` — creates `NetWorthSnapshot` rows with the lossless per-account breakdown
 - `history-service.ts` — reads snapshots and renormalizes them on the fly into the user's current base currency
 - `analysis-service.ts` — backs the `/analysis` tab
+- `analysis-payload-service.ts` — `getCachedAnalysisPayload`: bundles the four `/analysis` history/cash-flow reads behind one `unstable_cache` entry
+- `goal-service.ts` — goals CRUD + progress computation against the cached net-worth summary (backs `/goals`)
+- `stock-watch-service.ts` — stock watchlist (`StockWatchItem`) reads/refresh (backs `/stocks`)
+- `yahoo-client.ts` — shared `yahoo-finance2` client singleton (see Price Pipeline above)
 - `projection-service.ts` — `getProjectionData` for FIRE/retirement projections (uses `"use cache"`)
 - `settings-service.ts` — user settings reads/writes
 - `balance.ts` — shared balance/value computation helpers
@@ -224,6 +250,13 @@ Config entry point: `src/i18n/request.ts` (loaded by `next.config.ts` via `creat
 
 `GET /api/cron/snapshot` — requires `Authorization: Bearer <CRON_SECRET>` header. Refreshes all prices, then creates `NetWorthSnapshot` records for every user. Scheduled in `vercel.json` at `30 21 * * *` (21:30 UTC daily); `maxDuration` is 60s and the function region is pinned to `sin1` to match the Neon database region. (Note: `README.md` still says "00:00 UTC" — `vercel.json` and this file are the source of truth.)
 
+### Unit Testing (Vitest)
+
+- Specs live in `tests/unit/` (config: `vitest.config.ts`). The suite targets the pure service-layer logic — net-worth two-pass valuation + missing-rate fallback, `resolveRate`, history normalize/dedupe, analysis aggregations, `types.ts` serializers, and `validators.ts` edge cases.
+- **No DB or env vars needed.** `vitest.config.ts` mirrors the `@/*` alias and aliases `server-only` to a stub (`tests/stubs/server-only.ts`) so server-only modules import in Node. DB/cache/logger modules are mocked per-file (`vi.mock`), and `resolveRate` stays real so the missing-rate path is genuinely exercised.
+- New service tests should follow the same pattern: test the real exported function, mock `@/lib/prisma` / `@/lib/logger` / `next/cache` (and React `cache()` where a `"use cache"` wrapper is in the path), and assert on the returned shape.
+- Runs in CI via the `unit` job in `.github/workflows/ci.yml`, alongside lint/typecheck on every PR.
+
 ### E2E Testing (Playwright)
 
 - Specs live in `tests/e2e/` (`smoke.spec.ts` is the entry; `global-setup.ts` / `global-teardown.ts` provision and tear down a dedicated test user so runs don't pollute real user data — see commit `3289e91`).
@@ -239,10 +272,13 @@ src/components/
 ├── accounts/     # Account detail, holding form, transaction history, inline editors
 ├── analysis/     # Analysis view, assets/liabilities chart, cash flow chart, movers list
 ├── dashboard/    # Net worth card, allocation chart, trend chart, accounts summary
+├── goals/        # Goal cards, goal form dialog, goals view + onboarding
 ├── history/      # History table, pull-to-refresh
 ├── layout/       # Sidebar, mobile header, theme provider/toggle
+├── onboarding/   # First-run empty-state surface (shared by feature onboardings)
 ├── projections/  # FIRE projection chart and view
-└── settings/     # Settings form
+├── settings/     # Settings form
+└── stocks/       # Stock tracker view + onboarding
 ```
 
 ### Key Conventions

--- a/README.md
+++ b/README.md
@@ -99,9 +99,16 @@ When you are done developing for the day, you can stop the database with `npm ru
 > [!TIP]
 > **Resetting the Local Database**: If you need to clear all data and rebuild the database schema from scratch, run `npx prisma db push --force-reset`. Avoid using `npx prisma migrate reset` locally, as the repository does not have a baseline migration file (it relies on `db push` for schema sync) and the command will fail.
 
-### 5. End-to-End Tests
+### 5. Tests
 
-A Playwright suite lives in `tests/e2e/`. The global setup provisions a dedicated test user so runs don't pollute real data.
+**Unit tests (Vitest).** A fast, DB-free suite lives in `tests/unit/`, covering the pure service-layer logic — net-worth two-pass valuation, exchange-rate resolution, history normalize/dedupe, analysis aggregations, serializers, and Zod validators. Server-only/DB modules are exercised through their real public functions with their dependencies mocked, so no database or env vars are needed.
+
+```bash
+npm run test:unit        # Run once (headless)
+npm run test:unit:watch  # Watch mode
+```
+
+**End-to-end tests (Playwright).** A suite lives in `tests/e2e/`. The global setup provisions a dedicated test user so runs don't pollute real data.
 
 ```bash
 npm run test:e2e         # Run headless
@@ -149,7 +156,7 @@ git worktree remove ../asset_tracker-<task-name>
 
 This repository uses a **light-vs-heavy CI split**:
 
-- **Pull requests**: run fast checks only (`lint`, `typecheck`).
+- **Pull requests**: run fast checks only (`format:check`, `lint`, `typecheck`, `test:unit`).
 - **Push to `master`** (production merge path): run heavy checks (`build`).
 - **Vercel preview deployments**: the Playwright `e2e` smoke suite runs against the live preview URL (`deployment_status` trigger; production deployments are skipped since they never render the preview-credentials login). Requires the `E2E_PASSWORD` repo secret to match `PREVIEW_AUTH_PASSWORD` on Vercel previews.
 - **Docs-only / markdown-only changes** on push are skipped via workflow `paths-ignore`.

--- a/docs/ENHANCEMENT_PLAN.md
+++ b/docs/ENHANCEMENT_PLAN.md
@@ -178,16 +178,23 @@ snapshotAgeMs, timestamp }` — no user data. `status` is `"ok"` (HTTP 200) when
 
 | ID  | Item                                                                | Effort | Impact | Source      |
 | --- | ------------------------------------------------------------------- | ------ | ------ | ----------- |
-| E22 | Vitest + first service-layer suite                                  | M      | 🔴     | ROADMAP S7  |
+| E22 | ✅ Vitest + first service-layer suite                               | M      | 🔴     | ROADMAP S7  |
 | E23 | E2E gaps: /projections, /history, settings import/export round-trip | M      | 🟡     | new (audit) |
 | E24 | ✅ Run `format:check` in PR CI; lint/typecheck are already gated    | XS     | 🟢     | new (audit) |
 
-- **E22** — Zero unit tests exist. First wave, all pure functions:
-  `net-worth-service` two-pass + missing-rate path · `exchange-rate-service`
-  `resolveRate` identity/inverse/cross · `history-service` normalize + dedupe
-  (locks in E2's fix) · `analysis-service` bucket aggregations ·
-  `types.ts` serializers (Decimal/Date stripping) · `validators.ts` edge cases
-  (locks in E6). A regression in net-worth math currently only surfaces in E2E.
+- **E22** — Done. Vitest 4 added (`npm run test:unit` / `:watch`; config in
+  `vitest.config.ts` with an `@/*` alias and a `server-only` stub at
+  `tests/stubs/server-only.ts` so server-only service modules import cleanly in
+  the Node test env). First wave landed under `tests/unit/` (56 tests, 6 files):
+  `net-worth-service` two-pass valuation + missing-rate fallback (real
+  `resolveRate`, mocked Prisma/rates, neutralized cache wrappers) ·
+  `exchange-rate-service` `resolveRate` identity/direct/inverse/USD-cross ·
+  `history-service` normalize + dedupe via `getFullNormalizedHistory` (locks in
+  E2's same-day tie-break) · `analysis-service` bucket/KPI/attribution/mover
+  aggregations · `types.ts` serializers (Decimal→number, Date→ISO) ·
+  `validators.ts` edge cases (locks in E6). CI runs them in a new `unit` job in
+  `.github/workflows/ci.yml`, mirroring the lint/typecheck jobs. Next:
+  E23 (E2E gaps).
 - **E23** — Playwright covers smoke/accounts/analysis/stocks/mobile; the
   pages with the most math (projections, history) and the riskiest mutation
   (data import) have no coverage. An import→export round-trip equality test
@@ -335,8 +342,9 @@ Recorded so future audits don't waste a cycle:
    (shipped — `/api/health`) + E18 (CronRun audit) + E19 (Sentry via logger).
    Failures now page you instead of hiding. E18's freshness alarm reuses the
    36 h window E17 already enforces; E19 only activates once a DSN is set.
-3. **Week 3 — lock it in:** E22 unit suite (+E23 E2E gaps), then revisit CSP
-   reports only if `/api/csp/report` surfaces real production violations.
+3. **Week 3 — lock it in:** E22 unit suite is shipped (Vitest service-layer
+   tests in CI); E23 E2E gaps are next, then revisit CSP reports only if
+   `/api/csp/report` surfaces real production violations.
 4. **Then the keystone:** E25 schema migration → F3 cost basis → F6/F8
    cashflow. From here the F-series order above takes over.
 5. **Continuous:** E34 on every Next upgrade; revisit E30 only after a Vercel

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ The existing `docs/` folder has trackers (PERFORMANCE, PLATFORM, UI*UX, CODE_QUA
 | S4                                 | Structured logger + Sentry across services (**do first** — F1)            | M      | 🔴     | ❌                   | Q5 / R17               |
 | S5                                 | `/api/health` endpoint (DB ping + freshness) (**do first** — F1)          | XS     | 🔴     | ❌                   | V12 / R12              |
 | S6                                 | Cron-run audit table + freshness alert (**do first** — F1)                | M      | 🔴     | ❌                   | V11 / R13              |
-| S7                                 | Vitest + service-layer test suite                                         | M      | 🔴     | ❌                   | Q1–Q4                  |
+| S7                                 | Vitest + service-layer test suite                                         | M      | 🔴     | ✅                   | Q1–Q4                  |
 | S8                                 | CSP header enforced + report endpoint                                     | M      | 🔴     | ✅                   | V14 / R2               |
 | S9                                 | GDPR data export + account deletion                                       | L      | 🔴     | ❌                   | R7 / R8                |
 | S10                                | Middleware returns JSON 401 for `/api/*`                                  | XS     | 🔴     | ❌                   | SUGGESTIONS 2026-05-11 |
@@ -111,16 +111,22 @@ Add `CronRun { id, name, startedAt, finishedAt, ok, error, durationMs }` to Pris
 
 #### S7 — Vitest + service-layer test suite
 
-**M | 🔴 | ❌ — closes Q1–Q4**
+**M | 🔴 | ✅ Done (2026-06-14) — closes Q1–Q4 (tracked as E22 in ENHANCEMENT_PLAN.md)**
 
-Add Vitest config + first wave of unit tests:
+Vitest 4 added (`npm run test:unit`); config in `vitest.config.ts` (`@/*` alias
 
-- `src/lib/services/net-worth-service.ts` — two-pass rate resolution, missing-rate path, mixed-currency totals
-- `src/lib/services/exchange-rate-service.ts` — identity, inverse, missing-pair lazy fetch
-- `src/lib/types.ts` — `serialize{Account,Holding,AccountWithHoldings}` Decimal/Date stripping
-- `src/lib/services/balance.ts` — account-value math
+- a `server-only` stub so server-only service modules import in the Node test
+  env). First wave under `tests/unit/` (56 tests, 6 files), run in CI by a new
+  `unit` job:
 
-Today only the Playwright smoke test exists. A regression in net-worth math would only surface in E2E — too late.
+* `src/lib/services/net-worth-service.ts` — two-pass valuation, missing-rate fallback, mixed-currency totals, option multiplier (real `resolveRate`, mocked Prisma/rates, neutralized cache wrappers)
+* `src/lib/services/exchange-rate-service.ts` — `resolveRate` identity / direct / inverse / USD-cross
+* `src/lib/services/history-service.ts` — normalize + same-day dedupe tie-break (locks in S-series E2 fix)
+* `src/lib/services/analysis-service.ts` — monthly buckets, KPIs, cash-flow split, category history, movers, attribution
+* `src/lib/types.ts` — `serialize{Account,Holding,AccountWithHoldings,Goal}` Decimal/Date stripping
+* `src/lib/validators.ts` — Zod edge cases (locks in E6: positive quantities, immutable assetType, OCC option shape, per-type unions)
+
+Follow-up: `src/lib/services/balance.ts` direct coverage + the E23 E2E gaps.
 
 #### S8 — CSP header
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,8 @@
         "lint-staged": "^17.0.3",
         "prettier": "^3.8.3",
         "sharp": "^0.34.5",
-        "tailwindcss": "^4"
+        "tailwindcss": "^4",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": "24.x"
@@ -2239,6 +2240,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -3425,6 +3436,312 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "28.0.1",
@@ -4966,6 +5283,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -5027,6 +5355,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -5732,6 +6067,129 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -6261,6 +6719,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -6567,6 +7035,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7629,8 +8107,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -8216,6 +8693,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -11079,9 +11566,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11583,6 +12070,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -12067,9 +12568,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -12086,7 +12587,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12836,6 +13337,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
@@ -13450,6 +13985,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -13589,6 +14131,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stacktrace-parser": {
@@ -14066,6 +14615,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -14077,9 +14633,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -14090,6 +14646,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -14706,6 +15272,196 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -14986,6 +15742,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "postinstall": "prisma generate",
     "setup:worktree": "node scripts/setup-worktree.mjs",
     "prepare": "husky",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
@@ -91,6 +93,7 @@
     "lint-staged": "^17.0.3",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "vitest": "^4.1.8"
   }
 }

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,4 @@
+// Test stub for the `server-only` package. The real module throws when
+// imported outside a React Server Component bundle; in Vitest we alias it here
+// so server-only service modules can be imported and unit-tested directly.
+export {};

--- a/tests/unit/analysis-service.test.ts
+++ b/tests/unit/analysis-service.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateMonthlyChange,
+  fillMonthRange,
+  computeKpis,
+  formatMonthLabel,
+  buildCashFlowBuckets,
+  aggregateCategoryHistory,
+  computePerformanceAttribution,
+  computeTopMovers,
+} from "@/lib/services/analysis-service";
+import type {
+  NormalizedSnapshot,
+  SnapshotBreakdown,
+  AccountMeta,
+} from "@/lib/services/history-service";
+import type { AccountMonthlyContribution } from "@/lib/services/history-service";
+
+function snap(
+  date: string,
+  netWorth: number,
+  assets = netWorth,
+  liabilities = 0,
+): NormalizedSnapshot {
+  return {
+    id: date,
+    date,
+    createdAt: `${date}T00:00:00.000Z`,
+    netWorth,
+    totalAssets: assets,
+    totalLiabilities: liabilities,
+    baseCurrency: "USD",
+  };
+}
+
+describe("aggregateMonthlyChange", () => {
+  it("returns [] for no snapshots", () => {
+    expect(aggregateMonthlyChange([])).toEqual([]);
+  });
+
+  it("groups by month and uses the last snapshot as the month end", () => {
+    const buckets = aggregateMonthlyChange([
+      snap("2026-01-05", 100),
+      snap("2026-01-20", 150),
+      snap("2026-02-10", 200),
+    ]);
+    expect(buckets).toHaveLength(2);
+    // First month has no prior baseline → start = its own first snapshot.
+    expect(buckets[0]).toMatchObject({
+      monthKey: "2026-01",
+      startNetWorth: 100,
+      endNetWorth: 150,
+      deltaNetWorth: 50,
+    });
+    // Second month's baseline is the prior month's last snapshot (150).
+    expect(buckets[1]).toMatchObject({
+      monthKey: "2026-02",
+      startNetWorth: 150,
+      endNetWorth: 200,
+      deltaNetWorth: 50,
+    });
+  });
+
+  it("yields null deltaPct when the baseline is zero", () => {
+    const buckets = aggregateMonthlyChange([snap("2026-01-05", 0), snap("2026-01-20", 100)]);
+    expect(buckets[0].deltaPct).toBeNull();
+  });
+});
+
+describe("fillMonthRange", () => {
+  it("pads missing months with isEmpty buckets", () => {
+    const real = aggregateMonthlyChange([snap("2026-01-05", 100), snap("2026-03-05", 300)]);
+    const filled = fillMonthRange(
+      real,
+      new Date(Date.UTC(2026, 0, 1)),
+      new Date(Date.UTC(2026, 2, 1)),
+    );
+    expect(filled.map((b) => b.monthKey)).toEqual(["2026-01", "2026-02", "2026-03"]);
+    expect(filled[1]).toMatchObject({ monthKey: "2026-02", isEmpty: true, deltaNetWorth: 0 });
+    expect(filled[0].isEmpty).toBe(false);
+  });
+});
+
+describe("computeKpis", () => {
+  it("returns the empty shape when there are no real buckets", () => {
+    expect(computeKpis([], [])).toEqual({
+      best: null,
+      worst: null,
+      avgMonthlyDelta: 0,
+      ytdDelta: 0,
+      ytdPct: null,
+    });
+  });
+
+  it("finds best/worst/avg and computes YTD against the prior-year baseline", () => {
+    const snapshots = [
+      snap("2025-12-31", 1000),
+      snap("2026-01-31", 1200),
+      snap("2026-02-28", 1100),
+    ];
+    const buckets = aggregateMonthlyChange(snapshots);
+    const kpis = computeKpis(buckets, snapshots);
+    expect(kpis.best?.monthKey).toBe("2026-01");
+    expect(kpis.worst?.monthKey).toBe("2026-02");
+    // YTD baseline = last prior-year snapshot (1000); latest = 1100.
+    expect(kpis.ytdDelta).toBe(100);
+    expect(kpis.ytdPct).toBeCloseTo(10);
+  });
+});
+
+describe("formatMonthLabel", () => {
+  it("formats a valid key", () => {
+    expect(formatMonthLabel("2026-04", "en-US")).toBe("Apr 2026");
+  });
+  it("falls back to the raw key when malformed", () => {
+    expect(formatMonthLabel("not-a-month")).toBe("not-a-month");
+  });
+});
+
+describe("buildCashFlowBuckets", () => {
+  it("splits net-worth change into contributions and market performance", () => {
+    const buckets = [
+      {
+        monthKey: "2026-01",
+        endDate: "2026-01",
+        startNetWorth: 0,
+        endNetWorth: 100,
+        totalAssets: 100,
+        totalLiabilities: 0,
+        deltaNetWorth: 100,
+        deltaPct: null,
+        isEmpty: false,
+      },
+    ];
+    const result = buildCashFlowBuckets(
+      buckets,
+      [{ monthKey: "2026-01", contributions: 60 }],
+      "en-US",
+    );
+    expect(result[0]).toMatchObject({
+      monthKey: "2026-01",
+      contributions: 60,
+      marketPerformance: 40,
+      deltaNetWorth: 100,
+    });
+  });
+
+  it("treats months with no contribution data as zero contribution", () => {
+    const buckets = [
+      {
+        monthKey: "2026-02",
+        endDate: "2026-02",
+        startNetWorth: 100,
+        endNetWorth: 90,
+        totalAssets: 90,
+        totalLiabilities: 0,
+        deltaNetWorth: -10,
+        deltaPct: null,
+        isEmpty: false,
+      },
+    ];
+    const result = buildCashFlowBuckets(buckets, [], "en-US");
+    expect(result[0]).toMatchObject({ contributions: 0, marketPerformance: -10 });
+  });
+});
+
+describe("aggregateCategoryHistory", () => {
+  const accounts: AccountMeta[] = [
+    { id: "a1", name: "Brokerage", category: "INVESTMENT" },
+    { id: "a2", name: "Savings", category: "CASH" },
+    { id: "a3", name: "401k", category: "INVESTMENT" },
+  ];
+
+  it("sums account values per category, keeping the last snapshot of each month", () => {
+    const snapshots: SnapshotBreakdown[] = [
+      { date: "2026-01-10", accountValues: { a1: 100, a2: 50, a3: 200 } },
+      { date: "2026-01-28", accountValues: { a1: 110, a2: 55, a3: 210 } },
+    ];
+    const points = aggregateCategoryHistory(snapshots, accounts);
+    expect(points).toHaveLength(1);
+    expect(points[0]).toMatchObject({ monthKey: "2026-01", INVESTMENT: 320, CASH: 55 });
+  });
+
+  it("returns [] when there are no snapshots", () => {
+    expect(aggregateCategoryHistory([], accounts)).toEqual([]);
+  });
+});
+
+describe("computeTopMovers", () => {
+  const accounts: AccountMeta[] = [
+    { id: "a1", name: "Brokerage", category: "INVESTMENT" },
+    { id: "a2", name: "Savings", category: "CASH" },
+  ];
+
+  it("ranks by absolute change and drops untouched accounts", () => {
+    const snapshots: SnapshotBreakdown[] = [
+      { date: "2026-01-01", accountValues: { a1: 100, a2: 1000 } },
+      { date: "2026-02-01", accountValues: { a1: 400, a2: 1010 } },
+    ];
+    const movers = computeTopMovers(snapshots, accounts);
+    expect(movers.map((m) => m.accountId)).toEqual(["a1", "a2"]);
+    expect(movers[0]).toMatchObject({ absoluteChange: 300, percentChange: 300 });
+  });
+
+  it("returns [] when fewer than two snapshots", () => {
+    expect(computeTopMovers([{ date: "2026-01-01", accountValues: { a1: 1 } }], accounts)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("computePerformanceAttribution", () => {
+  const accounts: AccountMeta[] = [{ id: "a1", name: "Brokerage", category: "INVESTMENT" }];
+
+  it("splits totalDelta into cash contribution and market performance", () => {
+    const snapshots: SnapshotBreakdown[] = [
+      { date: "2026-01-01", accountValues: { a1: 1000 } },
+      { date: "2026-03-01", accountValues: { a1: 1500 } },
+    ];
+    const cashFlows: AccountMonthlyContribution[] = [
+      { accountId: "a1", monthKey: "2025-12", contributions: 999 }, // before range — excluded
+      { accountId: "a1", monthKey: "2026-02", contributions: 200 },
+    ];
+    const items = computePerformanceAttribution(snapshots, accounts, cashFlows, "2026-01");
+    expect(items[0]).toMatchObject({
+      totalDelta: 500,
+      cashContribution: 200,
+      marketPerformance: 300,
+    });
+  });
+
+  it("returns [] when fewer than two snapshots", () => {
+    expect(computePerformanceAttribution([], accounts, [], "2026-01")).toEqual([]);
+  });
+});

--- a/tests/unit/exchange-rate-service.test.ts
+++ b/tests/unit/exchange-rate-service.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+
+// exchange-rate-service imports `server-only` (aliased in vitest.config),
+// `@/lib/prisma` (loads env + a real DB client) and `@/lib/logger`
+// (loads Sentry). resolveRate is pure, so we stub those import-time
+// dependencies and exercise the function against an in-memory rate map.
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  withTiming: <T>(_name: string, fn: () => T) => fn(),
+}));
+
+const { resolveRate } = await import("@/lib/services/exchange-rate-service");
+
+describe("resolveRate", () => {
+  it("returns 1 for an identity conversion", () => {
+    expect(resolveRate(new Map(), "USD", "USD")).toBe(1);
+  });
+
+  it("uses a direct rate when present", () => {
+    const map = new Map([["USD_TWD", 30]]);
+    expect(resolveRate(map, "USD", "TWD")).toBe(30);
+  });
+
+  it("inverts when only the reverse pair exists", () => {
+    const map = new Map([["USD_TWD", 30]]);
+    expect(resolveRate(map, "TWD", "USD")).toBeCloseTo(1 / 30);
+  });
+
+  it("derives a cross rate via USD", () => {
+    // TWD→EUR = (USD→EUR) / (USD→TWD) = 0.9 / 30
+    const map = new Map([
+      ["USD_TWD", 30],
+      ["USD_EUR", 0.9],
+    ]);
+    expect(resolveRate(map, "TWD", "EUR")).toBeCloseTo(0.9 / 30);
+  });
+
+  it("derives a cross rate using inverse USD legs", () => {
+    // Only TWD_USD and EUR_USD known → both legs inverted internally.
+    const map = new Map([
+      ["TWD_USD", 1 / 30],
+      ["EUR_USD", 1 / 0.9],
+    ]);
+    expect(resolveRate(map, "TWD", "EUR")).toBeCloseTo(0.9 / 30);
+  });
+
+  it("returns undefined when no path resolves the pair", () => {
+    const map = new Map([["USD_TWD", 30]]);
+    expect(resolveRate(map, "JPY", "GBP")).toBeUndefined();
+  });
+});

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Shared fixtures, hoisted so the vi.mock factories (which are themselves
+// hoisted above imports) can close over them.
+interface SnapshotRowFixture {
+  id: string;
+  date: Date;
+  createdAt: Date;
+  netWorth: number;
+  totalAssets: number;
+  totalLiabilities: number;
+  baseCurrency: string;
+}
+const h = vi.hoisted(() => ({
+  rows: [] as SnapshotRowFixture[],
+  rates: new Map<string, number>(),
+}));
+
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  withTiming: <T>(_name: string, fn: () => T) => fn(),
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: { netWorthSnapshot: { findMany: vi.fn(async () => h.rows) } },
+}));
+vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
+});
+
+const { getFullNormalizedHistory } = await import("@/lib/services/history-service");
+
+function row(
+  over: Partial<SnapshotRowFixture> & Pick<SnapshotRowFixture, "id" | "date">,
+): SnapshotRowFixture {
+  return {
+    createdAt: over.date,
+    netWorth: 100,
+    totalAssets: 100,
+    totalLiabilities: 0,
+    baseCurrency: "USD",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  h.rows = [];
+  h.rates = new Map<string, number>();
+});
+
+describe("getFullNormalizedHistory (normalize + dedupe — locks E2)", () => {
+  it("sorts ascending by date", async () => {
+    h.rows = [
+      row({ id: "b", date: new Date("2026-02-01T00:00:00.000Z") }),
+      row({ id: "a", date: new Date("2026-01-01T00:00:00.000Z") }),
+    ];
+    const result = await getFullNormalizedHistory("u1", "USD");
+    expect(result.map((s) => s.date)).toEqual(["2026-01-01", "2026-02-01"]);
+  });
+
+  it("prefers the snapshot whose baseCurrency matches the target on same-day collisions", async () => {
+    // The non-matching TWD row has the LATER createdAt, proving the
+    // currency-match tie-break outranks recency.
+    h.rows = [
+      row({
+        id: "usd",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T06:00:00.000Z"),
+        netWorth: 1000,
+        baseCurrency: "USD",
+      }),
+      row({
+        id: "twd",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T12:00:00.000Z"),
+        netWorth: 30000,
+        baseCurrency: "TWD",
+      }),
+    ];
+    h.rates = new Map([["USD_TWD", 30]]);
+    const result = await getFullNormalizedHistory("u1", "USD");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("usd");
+    expect(result[0].netWorth).toBe(1000);
+  });
+
+  it("breaks same-currency same-day ties by greatest createdAt", async () => {
+    h.rows = [
+      row({
+        id: "early",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T01:00:00.000Z"),
+        netWorth: 100,
+      }),
+      row({
+        id: "late",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T23:00:00.000Z"),
+        netWorth: 200,
+      }),
+    ];
+    const result = await getFullNormalizedHistory("u1", "USD");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("late");
+    expect(result[0].netWorth).toBe(200);
+  });
+
+  it("renormalizes a non-target-currency snapshot using the current rate map", async () => {
+    h.rows = [
+      row({
+        id: "twd",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        netWorth: 3000,
+        totalAssets: 3300,
+        totalLiabilities: 300,
+        baseCurrency: "TWD",
+      }),
+    ];
+    h.rates = new Map([["USD_TWD", 30]]); // TWD→USD = 1/30
+    const result = await getFullNormalizedHistory("u1", "USD");
+    expect(result[0].netWorth).toBeCloseTo(100);
+    expect(result[0].totalAssets).toBeCloseTo(110);
+    expect(result[0].totalLiabilities).toBeCloseTo(10);
+    expect(result[0].baseCurrency).toBe("USD");
+  });
+});

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Net-worth computation is exercised through its public cached entry point.
+// We neutralize the caching wrappers (React cache(), Next "use cache" tags)
+// and feed deterministic accounts / prices / rates through mocked Prisma and
+// exchange-rate reads. resolveRate stays real so the missing-rate fallback is
+// genuinely tested.
+
+const created = new Date("2026-01-01T00:00:00.000Z");
+
+interface HoldingFixture {
+  id: string;
+  accountId: string;
+  symbol: string;
+  name: string;
+  quantity: number;
+  currency: string;
+  assetType: string;
+  underlyingSymbol: null;
+  optionType: null;
+  strike: null;
+  expiration: null;
+  contractMultiplier: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+interface AccountFixture {
+  id: string;
+  userId: string;
+  name: string;
+  type: "ASSET" | "LIABILITY";
+  category: string;
+  currency: string;
+  cashBalance: number;
+  isActive: boolean;
+  isPinned: boolean;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+  holdings: HoldingFixture[];
+}
+
+function holding(
+  over: Partial<HoldingFixture> & Pick<HoldingFixture, "id" | "symbol">,
+): HoldingFixture {
+  return {
+    accountId: "acc",
+    name: over.symbol,
+    quantity: 1,
+    currency: "USD",
+    assetType: "STOCK",
+    underlyingSymbol: null,
+    optionType: null,
+    strike: null,
+    expiration: null,
+    contractMultiplier: null,
+    createdAt: created,
+    updatedAt: created,
+    ...over,
+  };
+}
+function account(
+  over: Partial<AccountFixture> & Pick<AccountFixture, "id" | "currency" | "type">,
+): AccountFixture {
+  return {
+    userId: "u1",
+    name: over.id,
+    category: "INVESTMENT",
+    cashBalance: 0,
+    isActive: true,
+    isPinned: false,
+    sortOrder: 0,
+    createdAt: created,
+    updatedAt: created,
+    holdings: [],
+    ...over,
+  };
+}
+
+const h = vi.hoisted(() => ({
+  accounts: [] as unknown[],
+  prices: [] as { symbol: string; price: number; currency: string }[],
+  rates: new Map<string, number>(),
+  warnings: [] as { msg: string; meta: unknown }[],
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, cache: <T>(fn: T): T => fn };
+});
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("@/lib/logger", () => ({
+  log: {
+    info: () => {},
+    warn: (msg: string, meta: unknown) => h.warnings.push({ msg, meta }),
+    error: () => {},
+    debug: () => {},
+  },
+  withTiming: <T>(_name: string, fn: () => T) => fn(),
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    account: { findMany: vi.fn(async () => h.accounts) },
+    priceCache: { findMany: vi.fn(async () => h.prices) },
+  },
+}));
+vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
+});
+
+const { getCachedNetWorthSummary } = await import("@/lib/services/net-worth-service");
+
+describe("getCachedNetWorthSummary (two-pass valuation)", () => {
+  it("prices holdings, converts currencies, and splits assets vs. liabilities", async () => {
+    h.warnings = [];
+    h.rates = new Map([["USD_TWD", 30]]); // TWD→USD = 1/30
+    h.prices = [{ symbol: "AAPL", price: 200, currency: "USD" }];
+    h.accounts = [
+      account({
+        id: "A",
+        type: "ASSET",
+        currency: "USD",
+        cashBalance: 1000,
+        holdings: [holding({ id: "h1", symbol: "AAPL", quantity: 10, currency: "USD" })],
+      }),
+      account({ id: "B", type: "ASSET", currency: "TWD", cashBalance: 3000 }),
+      account({ id: "C", type: "LIABILITY", currency: "USD", cashBalance: 500 }),
+    ];
+
+    const summary = await getCachedNetWorthSummary("u1", "USD");
+
+    // A: 1000 cash + (200 * 10) holding = 3000; B: 3000 TWD / 30 = 100.
+    expect(summary.totalAssets).toBeCloseTo(3100);
+    expect(summary.totalLiabilities).toBeCloseTo(500);
+    expect(summary.netWorth).toBeCloseTo(2600);
+    expect(summary.baseCurrency).toBe("USD");
+
+    // Currency exposure (assets only), sorted by base-currency value desc.
+    expect(summary.currencyExposure).toEqual([
+      { currency: "USD", value: 3000 },
+      { currency: "TWD", value: 100 },
+    ]);
+  });
+
+  it("falls back to rate 1 and warns for an unresolvable currency", async () => {
+    h.warnings = [];
+    h.rates = new Map([["USD_TWD", 30]]); // no EUR path
+    h.prices = [];
+    h.accounts = [account({ id: "D", type: "ASSET", currency: "EUR", cashBalance: 50 })];
+
+    const summary = await getCachedNetWorthSummary("u1", "USD");
+
+    // EUR is unresolvable → rate 1 → value passes through unchanged.
+    expect(summary.totalAssets).toBeCloseTo(50);
+    expect(summary.currencyExposure).toEqual([{ currency: "EUR", value: 50 }]);
+    expect(h.warnings.some((w) => w.msg === "rates.unresolved")).toBe(true);
+  });
+
+  it("leaves holdings unpriced (null market value) when no cached price exists", async () => {
+    h.warnings = [];
+    h.rates = new Map();
+    h.prices = []; // no AAPL price cached
+    h.accounts = [
+      account({
+        id: "A",
+        type: "ASSET",
+        currency: "USD",
+        cashBalance: 100,
+        holdings: [holding({ id: "h1", symbol: "AAPL", quantity: 10, currency: "USD" })],
+      }),
+    ];
+
+    const summary = await getCachedNetWorthSummary("u1", "USD");
+
+    // Only cash counts; the unpriced holding contributes nothing.
+    expect(summary.totalAssets).toBeCloseTo(100);
+    expect(summary.accounts[0].holdings[0].marketValue).toBeNull();
+  });
+
+  it("applies the option contract multiplier to market value", async () => {
+    h.warnings = [];
+    h.rates = new Map();
+    h.prices = [{ symbol: "AAPL240119C00150000", price: 5, currency: "USD" }];
+    h.accounts = [
+      account({
+        id: "A",
+        type: "ASSET",
+        currency: "USD",
+        cashBalance: 0,
+        holdings: [
+          holding({
+            id: "opt",
+            symbol: "AAPL240119C00150000",
+            quantity: 2,
+            currency: "USD",
+            assetType: "OPTION",
+            contractMultiplier: 100,
+          }),
+        ],
+      }),
+    ];
+
+    const summary = await getCachedNetWorthSummary("u1", "USD");
+
+    // 5 * 2 contracts * 100 multiplier = 1000.
+    expect(summary.totalAssets).toBeCloseTo(1000);
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  serializeAccount,
+  serializeHolding,
+  serializeAccountWithHoldings,
+  serializeGoal,
+} from "@/lib/types";
+
+// Minimal Decimal stand-in: Prisma's Decimal coerces via Number(), so any
+// object with a matching valueOf() exercises the same code path the
+// serializers rely on (Decimal → number).
+function decimal(value: number) {
+  return { valueOf: () => value, toString: () => String(value) };
+}
+
+type AccountInput = Parameters<typeof serializeAccount>[0];
+type HoldingInput = Parameters<typeof serializeHolding>[0];
+type GoalInput = Parameters<typeof serializeGoal>[0];
+
+const created = new Date("2026-01-02T03:04:05.000Z");
+const updated = new Date("2026-02-03T04:05:06.000Z");
+
+function accountFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "acc1",
+    userId: "user1",
+    name: "Brokerage",
+    type: "ASSET",
+    category: "INVESTMENT",
+    currency: "USD",
+    cashBalance: decimal(1234.56),
+    isActive: true,
+    isPinned: false,
+    sortOrder: 0,
+    createdAt: created,
+    updatedAt: updated,
+    ...overrides,
+  } as unknown as AccountInput;
+}
+
+function holdingFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "h1",
+    accountId: "acc1",
+    symbol: "AAPL",
+    name: "Apple",
+    quantity: decimal(10.5),
+    currency: "USD",
+    assetType: "STOCK",
+    underlyingSymbol: null,
+    optionType: null,
+    strike: null,
+    expiration: null,
+    contractMultiplier: null,
+    createdAt: created,
+    updatedAt: updated,
+    ...overrides,
+  } as unknown as HoldingInput;
+}
+
+describe("serializeAccount", () => {
+  it("coerces Decimal → number and Date → ISO string", () => {
+    const result = serializeAccount(accountFixture());
+    expect(result.cashBalance).toBe(1234.56);
+    expect(typeof result.cashBalance).toBe("number");
+    expect(result.createdAt).toBe("2026-01-02T03:04:05.000Z");
+    expect(result.updatedAt).toBe("2026-02-03T04:05:06.000Z");
+    // Passthrough fields are untouched.
+    expect(result.name).toBe("Brokerage");
+    expect(result.isActive).toBe(true);
+  });
+});
+
+describe("serializeHolding", () => {
+  it("coerces quantity/strike Decimals and date fields", () => {
+    const result = serializeHolding(
+      holdingFixture({ strike: decimal(150), expiration: new Date("2026-12-31T00:00:00.000Z") }),
+    );
+    expect(result.quantity).toBe(10.5);
+    expect(result.strike).toBe(150);
+    expect(result.expiration).toBe("2026-12-31T00:00:00.000Z");
+    expect(result.createdAt).toBe("2026-01-02T03:04:05.000Z");
+  });
+
+  it("passes through null/undefined option fields without coercion", () => {
+    const result = serializeHolding(holdingFixture());
+    expect(result.strike).toBeNull();
+    expect(result.expiration).toBeNull();
+    expect(result.underlyingSymbol).toBeNull();
+  });
+});
+
+describe("serializeAccountWithHoldings", () => {
+  it("serializes the account and each nested holding", () => {
+    const result = serializeAccountWithHoldings(
+      accountFixture({
+        holdings: [holdingFixture(), holdingFixture({ id: "h2", symbol: "MSFT" })],
+      }) as unknown as Parameters<typeof serializeAccountWithHoldings>[0],
+    );
+    expect(result.cashBalance).toBe(1234.56);
+    expect(result.holdings).toHaveLength(2);
+    expect(result.holdings[0].quantity).toBe(10.5);
+    expect(result.holdings[1].symbol).toBe("MSFT");
+    // Every holding date is a string, safe for the RSC → client boundary.
+    expect(typeof result.holdings[0].createdAt).toBe("string");
+  });
+});
+
+describe("serializeGoal", () => {
+  it("coerces targetAmount and dates, preserving null targetDate", () => {
+    const goal = {
+      id: "g1",
+      userId: "user1",
+      name: "House",
+      targetAmount: decimal(500000),
+      targetCurrency: "USD",
+      targetDate: null,
+      scope: "NET_WORTH",
+      scopeRefId: null,
+      sortOrder: 0,
+      createdAt: created,
+      updatedAt: updated,
+    } as unknown as GoalInput;
+    const result = serializeGoal(goal);
+    expect(result.targetAmount).toBe(500000);
+    expect(result.targetDate).toBeNull();
+    expect(result.createdAt).toBe("2026-01-02T03:04:05.000Z");
+  });
+
+  it("serializes a present targetDate to ISO", () => {
+    const result = serializeGoal({
+      id: "g2",
+      userId: "user1",
+      name: "Car",
+      targetAmount: decimal(40000),
+      targetCurrency: "USD",
+      targetDate: new Date("2027-01-01T00:00:00.000Z"),
+      scope: "NET_WORTH",
+      scopeRefId: null,
+      sortOrder: 1,
+      createdAt: created,
+      updatedAt: updated,
+    } as unknown as GoalInput);
+    expect(result.targetDate).toBe("2027-01-01T00:00:00.000Z");
+  });
+});

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  createHoldingSchema,
+  updateHoldingSchema,
+  updateTransactionSchema,
+  createCashTransactionSchema,
+  updateCashTransactionSchema,
+  createGoalSchema,
+  createStockWatchItemSchema,
+} from "@/lib/validators";
+
+// Locks in the E6 validator hardening (positive quantities, immutable
+// assetType, per-type transaction unions, OCC option shape, ISO datetimes).
+
+describe("createHoldingSchema", () => {
+  const base = { symbol: "aapl", name: "Apple", quantity: 10, assetType: "STOCK" as const };
+
+  it("uppercases the symbol and defaults currency to USD", () => {
+    const result = createHoldingSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.symbol).toBe("AAPL");
+      expect(result.data.currency).toBe("USD");
+    }
+  });
+
+  it("rejects a zero quantity", () => {
+    expect(createHoldingSchema.safeParse({ ...base, quantity: 0 }).success).toBe(false);
+  });
+
+  it("rejects a negative quantity", () => {
+    expect(createHoldingSchema.safeParse({ ...base, quantity: -1 }).success).toBe(false);
+  });
+
+  it("accepts an OPTION holding with a valid OCC symbol", () => {
+    const result = createHoldingSchema.safeParse({
+      symbol: "AAPL240119C00150000",
+      name: "AAPL Call",
+      quantity: 1,
+      assetType: "OPTION",
+    });
+    expect(result.success).toBe(true);
+    // contractMultiplier defaults to the OCC-standard 100.
+    if (result.success && result.data.assetType === "OPTION") {
+      expect(result.data.contractMultiplier).toBe(100);
+    }
+  });
+
+  it("rejects an OPTION holding whose symbol is not a valid OCC contract", () => {
+    const result = createHoldingSchema.safeParse({
+      symbol: "AAPL",
+      name: "AAPL Call",
+      quantity: 1,
+      assetType: "OPTION",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateHoldingSchema", () => {
+  it("allows a zero quantity (closing an option position)", () => {
+    expect(updateHoldingSchema.safeParse({ id: "h1", quantity: 0 }).success).toBe(true);
+  });
+
+  it("rejects a negative quantity", () => {
+    expect(updateHoldingSchema.safeParse({ id: "h1", quantity: -5 }).success).toBe(false);
+  });
+
+  it("refuses to convert a holding to OPTION via PATCH", () => {
+    expect(updateHoldingSchema.safeParse({ id: "h1", assetType: "OPTION" }).success).toBe(false);
+  });
+
+  it("permits switching between non-option asset types", () => {
+    expect(updateHoldingSchema.safeParse({ id: "h1", assetType: "ETF" }).success).toBe(true);
+  });
+});
+
+describe("updateTransactionSchema", () => {
+  it("rejects a non-positive quantity for BUY/SELL", () => {
+    expect(updateTransactionSchema.safeParse({ id: "t1", type: "BUY", quantity: 0 }).success).toBe(
+      false,
+    );
+    expect(
+      updateTransactionSchema.safeParse({ id: "t1", type: "SELL", quantity: -2 }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a zero adjustment for EDIT but allows non-zero", () => {
+    expect(updateTransactionSchema.safeParse({ id: "t1", type: "EDIT", quantity: 0 }).success).toBe(
+      false,
+    );
+    expect(
+      updateTransactionSchema.safeParse({ id: "t1", type: "EDIT", quantity: -3 }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a non-ISO createdAt", () => {
+    expect(updateTransactionSchema.safeParse({ id: "t1", createdAt: "2026-06-14" }).success).toBe(
+      false,
+    );
+    expect(
+      updateTransactionSchema.safeParse({ id: "t1", createdAt: "2026-06-14T00:00:00.000Z" })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("cash transaction schemas", () => {
+  it("requires a positive amount for DEPOSIT/WITHDRAWAL", () => {
+    expect(createCashTransactionSchema.safeParse({ type: "DEPOSIT", amount: 0 }).success).toBe(
+      false,
+    );
+    expect(createCashTransactionSchema.safeParse({ type: "WITHDRAWAL", amount: 100 }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects a zero EDIT adjustment but allows a negative one", () => {
+    expect(createCashTransactionSchema.safeParse({ type: "EDIT", amount: 0 }).success).toBe(false);
+    expect(createCashTransactionSchema.safeParse({ type: "EDIT", amount: -50 }).success).toBe(true);
+  });
+
+  it("enforces per-type amount rules on update", () => {
+    expect(
+      updateCashTransactionSchema.safeParse({ id: "c1", type: "DEPOSIT", amount: -1 }).success,
+    ).toBe(false);
+    expect(
+      updateCashTransactionSchema.safeParse({ id: "c1", type: "EDIT", amount: 0 }).success,
+    ).toBe(false);
+  });
+});
+
+describe("createGoalSchema", () => {
+  it("requires a positive target amount", () => {
+    expect(
+      createGoalSchema.safeParse({ name: "House", targetAmount: 0, scope: "NET_WORTH" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a malformed target date", () => {
+    expect(
+      createGoalSchema.safeParse({
+        name: "House",
+        targetAmount: 100,
+        scope: "NET_WORTH",
+        targetDate: "06/14/2026",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("createStockWatchItemSchema", () => {
+  const base = {
+    symbol: "tsla",
+    name: "Tesla",
+    recordPrice: 250,
+    recordDate: "2026-06-14",
+  };
+
+  it("uppercases the symbol and accepts a valid record date", () => {
+    const result = createStockWatchItemSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.symbol).toBe("TSLA");
+  });
+
+  it("rejects a non-positive record price", () => {
+    expect(createStockWatchItemSchema.safeParse({ ...base, recordPrice: 0 }).success).toBe(false);
+  });
+
+  it("rejects a malformed record date", () => {
+    expect(
+      createStockWatchItemSchema.safeParse({ ...base, recordDate: "2026/06/14" }).success,
+    ).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Unit-test config (E22). Runs the pure service-layer suites in tests/unit/.
+// E2E lives separately under tests/e2e/ and is driven by Playwright, so it is
+// explicitly excluded here.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+    globals: false,
+  },
+  resolve: {
+    alias: {
+      // Mirror the tsconfig `@/*` path alias for runtime resolution.
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      // The real `server-only` module throws outside an RSC bundle; stub it so
+      // server-only service modules can be imported in the Node test env.
+      "server-only": fileURLToPath(new URL("./tests/stubs/server-only.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Resolves **E22** in `docs/ENHANCEMENT_PLAN.md` (tracked as **S7** in `docs/ROADMAP.md`): _"Vitest + first service-layer suite."_ Until now only the Playwright E2E smoke suite existed, so a regression in net-worth math would only surface in E2E.

Adds **Vitest 4** plus the first wave of fast, DB-free unit tests for the pure service-layer logic — **56 tests across 6 files**.

## What's covered

- **net-worth-service** — two-pass valuation, missing-rate fallback (rate→1 + warn), mixed-currency totals, currency exposure, option contract multiplier
- **exchange-rate-service** — `resolveRate` identity / direct / inverse / USD-cross / unresolvable
- **history-service** — normalize + same-day dedupe tie-break via `getFullNormalizedHistory` (**locks in the E2 fix**)
- **analysis-service** — monthly buckets, KPIs/YTD, cash-flow split, category history, top movers, attribution
- **types.ts** — `serialize{Account,Holding,AccountWithHoldings,Goal}` (Decimal→number, Date→ISO)
- **validators.ts** — Zod edge cases (**locks in E6**: positive quantities, immutable `assetType`, OCC option shape, per-type unions, ISO datetimes)

## How it's wired

- `vitest.config.ts` mirrors the `@/*` alias and stubs `server-only` (`tests/stubs/server-only.ts`) so server-only modules import in Node. DB/cache/logger are mocked per-file with `vi.mock`; `resolveRate` stays **real** so the missing-rate path is genuinely exercised. No DB or env vars needed.
- Scripts: `npm run test:unit` / `test:unit:watch`.
- New `unit` job in `.github/workflows/ci.yml`, mirroring the lint/typecheck jobs on every PR.
- No production source files changed — server-only/DB modules are tested through their real public functions.

## Docs

- E22 ✅ in `ENHANCEMENT_PLAN.md`, S7 ✅ in `ROADMAP.md`
- `README.md` — new "Tests" section (Unit + E2E); CI policy line updated
- `CLAUDE.md` — unit-test commands + a "Unit Testing (Vitest)" architecture section. (Note: this file also carried pre-existing uncommitted doc-accuracy edits — knip, db commands, stocks/goals routes — which are included here.)

## Notes

- Vitest was installed with **npm 10.9.8** to keep `package-lock.json` CI-compatible (verified with a `npm@10.9.8 ci --dry-run`).
- Follow-ups (out of scope): `balance.ts` direct coverage and the E23 E2E gaps.

## Verification

`format:check`, `lint`, `typecheck` all clean; **56/56** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)