### PR TITLE
[codex] fix history heatmap date alignment

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -15,7 +15,10 @@ import {
   resolveRate,
 } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import { getNormalizedHistory } from "@/lib/services/history-service";
+import {
+  getCurrentYearNormalizedHistory,
+  getNormalizedHistory,
+} from "@/lib/services/history-service";
 import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
 import { TrendChartSection } from "@/components/dashboard/trend-chart-section";
@@ -265,22 +268,23 @@ async function GoalsMilestoneSection({
 /**
  * Trend chart + history heatmap — streams behind its Suspense boundary so the
  * dashboard shell never waits on snapshot history. getNormalizedHistory is
- * "use cache" with cacheLife("hours"), so the snapshot fetch — shared by
- * TrendChartSection and HistoryHeatmap — is a cache read on warm requests.
+ * "use cache" with cacheLife("hours"), so the chart stays on the fast 90-day
+ * window while the heatmap gets a year-to-date calendar window.
  */
 async function TrendSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
-  const [snapshots, t] = await Promise.all([
+  const [trendSnapshots, heatmapSnapshots, t] = await Promise.all([
     getNormalizedHistory(userId, baseCurrency),
+    getCurrentYearNormalizedHistory(userId, baseCurrency),
     getTranslations("dashboard"),
   ]);
 
   return (
     <TrendChartSection
       baseCurrency={baseCurrency}
-      snapshots={snapshots}
+      snapshots={trendSnapshots}
       footer={
         <>
-          <HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />
+          <HistoryHeatmap snapshots={heatmapSnapshots} baseCurrency={baseCurrency} />
           {/* Mobile-only entry point — History is a sub-tab of /analysis, so
               the tab bar gives it no scent. The trend chart is the preview;
               this names the destination. Desktop uses the sidebar route. */}

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -11,6 +11,7 @@ const CELL_PX = 10;
 const GAP_PX = 4;
 const COL_WIDTH = CELL_PX + GAP_PX;
 const CALENDAR_TIME_ZONE = "UTC";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function calendarDate(year: number, monthIndex: number, day: number) {
   return new Date(Date.UTC(year, monthIndex, day));
@@ -19,6 +20,22 @@ function calendarDate(year: number, monthIndex: number, day: number) {
 function calendarDateFromString(dateString: string) {
   const [year, month, day] = dateString.split("-").map(Number);
   return calendarDate(year, month - 1, day);
+}
+
+function utcToday() {
+  const now = new Date();
+  return calendarDate(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+}
+
+function addUtcDays(date: Date, days: number) {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+function utcDateString(date: Date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 // Fixed reference dates for day-of-week label generation
@@ -45,7 +62,7 @@ type GridDay = {
   netWorth?: number;
   change: number | null;
   isFuture: boolean;
-  isNextYear: boolean;
+  isOutsideYear: boolean;
 };
 
 type Props = {
@@ -64,105 +81,109 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   const [tooltip, setTooltip] = useState<{ day: GridDay; x: number; y: number } | null>(null);
   const tooltipLabels = labels ?? { netWorth: "Net Worth", change: "Change" };
 
-  const { gridDays, monthLabels, maxPos, maxNeg, weeksToShow, currentYear, todayColIndex } =
-    useMemo(() => {
-      // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
-      const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
+  const {
+    gridDays,
+    monthLabels,
+    maxPos,
+    maxNeg,
+    weeksToShow,
+    currentYear,
+    todayColIndex,
+    todayString,
+  } = useMemo(() => {
+    // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
+    const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
 
-      let maxPositiveChange = 0;
-      let maxNegativeChange = 0;
+    // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
+    const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
 
-      // 2. Create a lookup map of snapshot dates with pre-calculated changes (O(N))
-      const snapshotMap = new Map<string, SnapshotRow & { change: number | null }>();
+    for (let i = 0; i < sortedSnapshots.length; i++) {
+      const snap = sortedSnapshots[i]!;
+      const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
+      const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
 
-      for (let i = 0; i < sortedSnapshots.length; i++) {
-        const snap = sortedSnapshots[i]!;
-        const prevSnap = i > 0 ? sortedSnapshots[i - 1] : null;
-        const change = prevSnap ? snap.netWorth - prevSnap.netWorth : null;
+      snapshotMap.set(snap.date, { ...snap, change });
+    }
 
-        if (change !== null) {
-          if (change > maxPositiveChange) maxPositiveChange = change;
-          if (change < maxNegativeChange) maxNegativeChange = change;
-        }
+    // 3. Determine end date (Saturday on or after Dec 31st of current year)
+    const today = utcToday();
+    const todayString = utcDateString(today);
+    const currentYear = today.getUTCFullYear();
+    const dec31 = calendarDate(currentYear, 11, 31);
+    const dayOfWeekEnd = dec31.getUTCDay(); // 0 = Sunday, 6 = Saturday
+    const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
+    const endDate = addUtcDays(dec31, daysToAddToReachSaturday);
 
-        snapshotMap.set(snap.date, { ...snap, change });
-      }
+    // 4. Determine start date (Sunday on or before Jan 1st of current year)
+    const jan1 = calendarDate(currentYear, 0, 1);
+    const dayOfWeekStart = jan1.getUTCDay();
+    const startDate = addUtcDays(jan1, -dayOfWeekStart);
 
-      // 3. Determine end date (Saturday on or after Dec 31st of current year)
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      const currentYear = today.getFullYear();
-      const dec31 = new Date(currentYear, 11, 31);
-      const dayOfWeekEnd = dec31.getDay(); // 0 = Sunday, 6 = Saturday
-      const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
-      const endDate = new Date(dec31);
-      endDate.setDate(dec31.getDate() + daysToAddToReachSaturday);
+    // 5. Calculate total days to show
+    const daysToShow = Math.round((endDate.getTime() - startDate.getTime()) / DAY_MS) + 1;
+    const weeksToShow = daysToShow / 7;
 
-      // 4. Determine start date (Sunday on or before Jan 1st of current year)
-      const jan1 = new Date(currentYear, 0, 1);
-      const dayOfWeekStart = jan1.getDay();
-      const startDate = new Date(jan1);
-      startDate.setDate(jan1.getDate() - dayOfWeekStart);
+    const days: GridDay[] = [];
+    const mLabels: { col: number; label: string }[] = [];
+    let currentMonth = -1;
+    let maxPositiveChange = 0;
+    let maxNegativeChange = 0;
 
-      // 5. Calculate total days to show
-      const daysToShow =
-        Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-      const weeksToShow = daysToShow / 7;
+    for (let i = 0; i < daysToShow; i++) {
+      const current = addUtcDays(startDate, i);
 
-      const days: GridDay[] = [];
-      const mLabels: { col: number; label: string }[] = [];
-      let currentMonth = -1;
+      const year = current.getUTCFullYear();
+      const monthIndex = current.getUTCMonth();
+      const dateString = utcDateString(current);
 
-      for (let i = 0; i < daysToShow; i++) {
-        const current = new Date(startDate);
-        current.setDate(startDate.getDate() + i);
+      const snapData = snapshotMap.get(dateString);
+      const isFuture = current.getTime() > today.getTime();
+      const isOutsideYear = year !== currentYear;
+      const change = snapData?.change ?? null;
 
-        const year = current.getFullYear();
-        const month = String(current.getMonth() + 1).padStart(2, "0");
-        const day = String(current.getDate()).padStart(2, "0");
-        const dateString = `${year}-${month}-${day}`;
-
-        const snapData = snapshotMap.get(dateString);
-
-        // Track month boundaries for labels (only if we are still in the current year)
-        if (year === currentYear && current.getMonth() !== currentMonth && current.getDate() < 15) {
-          currentMonth = current.getMonth();
-          mLabels.push({
-            col: Math.floor(i / 7),
-            label: format.dateTime(calendarDate(year, current.getMonth(), 1), {
-              month: "short",
-              timeZone: CALENDAR_TIME_ZONE,
-            }),
-          });
-        }
-
-        days.push({
-          date: current,
-          dateString,
-          hasSnapshot: !!snapData,
-          netWorth: snapData?.netWorth,
-          change: snapData?.change ?? null,
-          isFuture: current > today,
-          isNextYear: year > currentYear,
+      // Track month boundaries for labels (only if we are still in the current year)
+      if (year === currentYear && monthIndex !== currentMonth && current.getUTCDate() < 15) {
+        currentMonth = monthIndex;
+        mLabels.push({
+          col: Math.floor(i / 7),
+          label: format.dateTime(calendarDate(year, monthIndex, 1), {
+            month: "short",
+            timeZone: CALENDAR_TIME_ZONE,
+          }),
         });
       }
 
-      // Column index of the current week, used to seed the initial scroll position
-      const todayDayOffset = Math.round(
-        (today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
-      );
-      const todayColIndex = Math.floor(todayDayOffset / 7);
+      if (!isFuture && !isOutsideYear && change !== null) {
+        if (change > maxPositiveChange) maxPositiveChange = change;
+        if (change < maxNegativeChange) maxNegativeChange = change;
+      }
 
-      return {
-        gridDays: days,
-        monthLabels: mLabels,
-        maxPos: maxPositiveChange,
-        maxNeg: Math.abs(maxNegativeChange),
-        weeksToShow,
-        currentYear,
-        todayColIndex,
-      };
-    }, [snapshots, format]);
+      days.push({
+        date: current,
+        dateString,
+        hasSnapshot: !!snapData,
+        netWorth: snapData?.netWorth,
+        change,
+        isFuture,
+        isOutsideYear,
+      });
+    }
+
+    // Column index of the current week, used to seed the initial scroll position
+    const todayDayOffset = Math.round((today.getTime() - startDate.getTime()) / DAY_MS);
+    const todayColIndex = Math.floor(todayDayOffset / 7);
+
+    return {
+      gridDays: days,
+      monthLabels: mLabels,
+      maxPos: maxPositiveChange,
+      maxNeg: Math.abs(maxNegativeChange),
+      weeksToShow,
+      currentYear,
+      todayColIndex,
+      todayString,
+    };
+  }, [snapshots, format]);
 
   // Transpose the flat array into 7 rows (Sunday–Saturday)
   const rows = useMemo(() => {
@@ -184,14 +205,6 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       ),
     [format],
   );
-
-  // "You are here" marker: the date the user orients around in the year grid.
-  const todayString = useMemo(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
-      d.getDate(),
-    ).padStart(2, "0")}`;
-  }, []);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const dismissTooltip = useCallback(() => setTooltip(null), []);
@@ -315,7 +328,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                 <div key={rIdx} role="row" aria-rowindex={rIdx + 1} className="flex gap-1">
                   {row.map((day, cIdx) => {
                     // Padding cells outside the current year — hide from AT
-                    if (!day || day.isNextYear) {
+                    if (!day || day.isOutsideYear) {
                       return (
                         <div
                           key={cIdx}

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -18,6 +18,16 @@ export interface NormalizedSnapshot {
 /** Default history window: last 90 days. Keeps the query fast for the dashboard. */
 const DEFAULT_HISTORY_DAYS = 90;
 
+const SNAPSHOT_SELECT = {
+  id: true,
+  date: true,
+  createdAt: true,
+  netWorth: true,
+  totalAssets: true,
+  totalLiabilities: true,
+  baseCurrency: true,
+} as const;
+
 interface SnapshotRow {
   id: string;
   date: Date;
@@ -111,21 +121,56 @@ export async function getNormalizedHistory(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId, date: { gte: fromDate } },
-      select: {
-        id: true,
-        date: true,
-        createdAt: true,
-        netWorth: true,
-        totalAssets: true,
-        totalLiabilities: true,
-        baseCurrency: true,
-      },
+      select: SNAPSHOT_SELECT,
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),
   ]);
 
   return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
+}
+
+/**
+ * Current-year history for the activity heatmap. Includes the latest snapshot
+ * before Jan 1, when present, so the first visible day can compute its delta
+ * the same way full-history views do.
+ */
+export async function getCurrentYearNormalizedHistory(
+  userId: string,
+  targetBaseCurrency: string,
+): Promise<NormalizedSnapshot[]> {
+  "use cache";
+  cacheTag("snapshots");
+  cacheTag("net-worth");
+  cacheTag(`history:${userId}`);
+  cacheLife("hours");
+
+  const now = new Date();
+  const yearStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+
+  const [currentYearRows, previousDateRow, allRatesMap] = await Promise.all([
+    prisma.netWorthSnapshot.findMany({
+      where: { userId, date: { gte: yearStart } },
+      select: SNAPSHOT_SELECT,
+      orderBy: { date: "asc" },
+    }),
+    prisma.netWorthSnapshot.findFirst({
+      where: { userId, date: { lt: yearStart } },
+      select: { date: true },
+      orderBy: { date: "desc" },
+    }),
+    getAllExchangeRates(),
+  ]);
+
+  const previousRows = previousDateRow
+    ? await prisma.netWorthSnapshot.findMany({
+        where: { userId, date: previousDateRow.date },
+        select: SNAPSHOT_SELECT,
+        orderBy: { createdAt: "asc" },
+      })
+    : [];
+
+  return normalizeSnapshots([...previousRows, ...currentYearRows], allRatesMap, targetBaseCurrency);
 }
 
 /**
@@ -158,15 +203,7 @@ async function fetchFullHistoryCached(
   const [snapshotsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId },
-      select: {
-        id: true,
-        date: true,
-        createdAt: true,
-        netWorth: true,
-        totalAssets: true,
-        totalLiabilities: true,
-        baseCurrency: true,
-      },
+      select: SNAPSHOT_SELECT,
       orderBy: { date: "asc" },
     }),
     getAllExchangeRates(),

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -13,6 +13,9 @@ interface SnapshotRowFixture {
 }
 const h = vi.hoisted(() => ({
   rows: [] as SnapshotRowFixture[],
+  currentYearRows: [] as SnapshotRowFixture[],
+  previousRows: [] as SnapshotRowFixture[],
+  previousDateRow: null as { date: Date } | null,
   rates: new Map<string, number>(),
 }));
 
@@ -22,14 +25,25 @@ vi.mock("@/lib/logger", () => ({
   withTiming: <T>(_name: string, fn: () => T) => fn(),
 }));
 vi.mock("@/lib/prisma", () => ({
-  prisma: { netWorthSnapshot: { findMany: vi.fn(async () => h.rows) } },
+  prisma: {
+    netWorthSnapshot: {
+      findMany: vi.fn(async (args?: { where?: { date?: Date | { gte?: Date } } }) => {
+        const dateWhere = args?.where?.date;
+        if (dateWhere instanceof Date) return h.previousRows;
+        if (dateWhere && "gte" in dateWhere) return h.currentYearRows;
+        return h.rows;
+      }),
+      findFirst: vi.fn(async () => h.previousDateRow),
+    },
+  },
 }));
 vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
   const actual = await importActual<typeof import("@/lib/services/exchange-rate-service")>();
   return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
 });
 
-const { getFullNormalizedHistory } = await import("@/lib/services/history-service");
+const { getCurrentYearNormalizedHistory, getFullNormalizedHistory } =
+  await import("@/lib/services/history-service");
 
 function row(
   over: Partial<SnapshotRowFixture> & Pick<SnapshotRowFixture, "id" | "date">,
@@ -45,7 +59,11 @@ function row(
 }
 
 beforeEach(() => {
+  vi.useRealTimers();
   h.rows = [];
+  h.currentYearRows = [];
+  h.previousRows = [];
+  h.previousDateRow = null;
   h.rates = new Map<string, number>();
 });
 
@@ -123,5 +141,37 @@ describe("getFullNormalizedHistory (normalize + dedupe — locks E2)", () => {
     expect(result[0].totalAssets).toBeCloseTo(110);
     expect(result[0].totalLiabilities).toBeCloseTo(10);
     expect(result[0].baseCurrency).toBe("USD");
+  });
+});
+
+describe("getCurrentYearNormalizedHistory", () => {
+  it("returns current-year snapshots plus the latest prior day for delta context", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
+
+    const priorDate = new Date("2025-12-31T00:00:00.000Z");
+    h.previousDateRow = { date: priorDate };
+    h.previousRows = [row({ id: "prior", date: priorDate, netWorth: 90 })];
+    h.currentYearRows = [
+      row({ id: "jan", date: new Date("2026-01-01T00:00:00.000Z"), netWorth: 100 }),
+      row({ id: "today", date: new Date("2026-06-14T00:00:00.000Z"), netWorth: 120 }),
+    ];
+
+    const result = await getCurrentYearNormalizedHistory("u1", "USD");
+
+    expect(result.map((s) => s.date)).toEqual(["2025-12-31", "2026-01-01", "2026-06-14"]);
+  });
+
+  it("returns only current-year snapshots when there is no prior history", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
+
+    h.currentYearRows = [
+      row({ id: "jan", date: new Date("2026-01-01T00:00:00.000Z"), netWorth: 100 }),
+    ];
+
+    const result = await getCurrentYearNormalizedHistory("u1", "USD");
+
+    expect(result.map((s) => s.date)).toEqual(["2026-01-01"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the dashboard/history activity heatmap mismatch by separating the dashboard trend data window from the heatmap data window and making the heatmap calendar UTC-stable.

## Root Cause

The dashboard Net Worth Trend footer reused the dashboard trend query, which only loads the latest 90 days. The History tab uses full history, so the same year heatmap could compute different cells and color intensity. The heatmap also mixed local `Date` getters with UTC-normalized snapshot dates, which could move the current-date ring to a different square near timezone boundaries.

## Changes

- Added a current-year normalized history fetch for the heatmap, including the latest prior snapshot for first-visible-day delta context.
- Kept the dashboard trend chart on the fast 90-day query while feeding its heatmap the current-year data.
- Updated the heatmap grid to compute today, week bounds, month labels, future state, and date keys with UTC calendar math.
- Added unit coverage for the new current-year history service behavior.

## Validation

- `npm run test:unit -- tests/unit/history-service.test.ts`
- `npm run typecheck`
- `npm run lint`
- Push hook: `npm run format:check && npm run lint && npm run typecheck`