### PR TITLE
refactor(accounts): dedupe input mask + enum lists; declare @sentry/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@prisma/adapter-pg": "^7.6.0",
         "@prisma/client": "^7.6.0",
         "@radix-ui/react-slot": "^1.2.5",
+        "@sentry/core": "^10.57.0",
         "@sentry/nextjs": "^10.57.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
     "@radix-ui/react-slot": "^1.2.5",
+    "@sentry/core": "^10.57.0",
     "@sentry/nextjs": "^10.57.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -108,14 +108,18 @@ export function AccountDetail({
 
   const shouldReduceMotion = useReducedMotion();
 
-  const holdingsWithValue: HoldingWithPrice[] = account.holdings.map((h) => {
-    const price = priceMap[h.symbol] ?? null;
-    const hc = h.currency || "USD";
-    const rate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
-    const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
-    const marketValue = price !== null ? price * h.quantity * multiplier * rate : null;
-    return { ...h, currentPrice: price, marketValue };
-  });
+  const holdingsWithValue: HoldingWithPrice[] = useMemo(
+    () =>
+      account.holdings.map((h) => {
+        const price = priceMap[h.symbol] ?? null;
+        const hc = h.currency || "USD";
+        const rate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
+        const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
+        const marketValue = price !== null ? price * h.quantity * multiplier * rate : null;
+        return { ...h, currentPrice: price, marketValue };
+      }),
+    [account.holdings, account.currency, priceMap, ratesMap],
+  );
 
   const totalHoldingsValue = holdingsWithValue.reduce((sum, h) => sum + (h.marketValue ?? 0), 0);
 

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -15,23 +15,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CURRENCIES } from "@/lib/currencies";
+import { maskAmountInput } from "@/lib/amount-input";
+import { ACCOUNT_CATEGORIES } from "@/lib/enums";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useDiscardGuard } from "@/hooks/use-discard-guard";
 import { DiscardConfirmDialog } from "@/components/discard-confirm-dialog";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
-
-const CATEGORY_KEYS = [
-  "BANK",
-  "BROKERAGE",
-  "CRYPTO_WALLET",
-  "PROPERTY",
-  "VEHICLE",
-  "CREDIT_CARD",
-  "LOAN",
-  "MORTGAGE",
-  "OTHER",
-] as const;
 
 export function AccountForm({
   open,
@@ -80,16 +70,10 @@ export function AccountForm({
   );
 
   function handleCashBalanceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
+    const next = maskAmountInput(e.target.value);
+    if (next === null) return;
     setCashBalanceError("");
-    if (!raw) {
-      setCashBalance("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setCashBalance(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    setCashBalance(next);
   }
 
   function handleCashBalanceBlur() {
@@ -179,7 +163,7 @@ export function AccountForm({
               <SelectValue>{t(`categories.${category}`)}</SelectValue>
             </SelectTrigger>
             <SelectContent>
-              {CATEGORY_KEYS.map((key) => (
+              {ACCOUNT_CATEGORIES.map((key) => (
                 <SelectItem key={key} value={key}>
                   {t(`categories.${key}`)}
                 </SelectItem>
@@ -189,64 +173,42 @@ export function AccountForm({
         </div>
       </div>
 
-      {category === "BROKERAGE" || category === "CRYPTO_WALLET" ? (
-        <div className="space-y-2">
-          <Label htmlFor={currencyId}>{t("accountForm.labelCurrency")}</Label>
-          <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
-            <SelectTrigger id={currencyId}>
-              <SelectValue>
-                {(() => {
-                  const c = CURRENCIES.find((c) => c.code === currency);
-                  return c ? `${c.code} (${c.symbol})` : currency;
-                })()}
-              </SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              {CURRENCIES.map((c) => (
-                <SelectItem key={c.code} value={c.code}>
-                  {c.code} ({c.symbol})
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      ) : (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor={currencyId}>{t("accountForm.labelCurrency")}</Label>
-            <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
-              <SelectTrigger id={currencyId}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {CURRENCIES.map((c) => (
-                  <SelectItem key={c.code} value={c.code}>
-                    {c.code} ({c.symbol})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      <div className="space-y-2">
+        <Label htmlFor={currencyId}>{t("accountForm.labelCurrency")}</Label>
+        <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
+          <SelectTrigger id={currencyId}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CURRENCIES.map((c) => (
+              <SelectItem key={c.code} value={c.code}>
+                {c.code} ({c.symbol})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-          <div className="space-y-2">
-            <Label htmlFor={cashId}>{t("accountForm.labelCashBalance")}</Label>
-            <Input
-              id={cashId}
-              type="text"
-              inputMode="decimal"
-              value={cashBalance}
-              onChange={handleCashBalanceChange}
-              onBlur={handleCashBalanceBlur}
-              aria-invalid={!!cashBalanceError}
-              aria-describedby={cashBalanceError ? `${cashId}-error` : undefined}
-            />
-            {cashBalanceError && (
-              <p id={`${cashId}-error`} className="text-xs text-destructive" role="alert">
-                {cashBalanceError}
-              </p>
-            )}
-          </div>
-        </>
+      {/* Brokerage/crypto value comes from holdings, so only cash accounts edit a balance here. */}
+      {category !== "BROKERAGE" && category !== "CRYPTO_WALLET" && (
+        <div className="space-y-2">
+          <Label htmlFor={cashId}>{t("accountForm.labelCashBalance")}</Label>
+          <Input
+            id={cashId}
+            type="text"
+            inputMode="decimal"
+            value={cashBalance}
+            onChange={handleCashBalanceChange}
+            onBlur={handleCashBalanceBlur}
+            aria-invalid={!!cashBalanceError}
+            aria-describedby={cashBalanceError ? `${cashId}-error` : undefined}
+          />
+          {cashBalanceError && (
+            <p id={`${cashId}-error`} className="text-xs text-destructive" role="alert">
+              {cashBalanceError}
+            </p>
+          )}
+        </div>
       )}
 
       <div className="flex justify-end gap-2 pt-2">

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import type { SerializedHolding } from "@/lib/types";
 
 import { getOptionDisplay } from "@/lib/options";
+import { maskAmountInput } from "@/lib/amount-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -49,15 +50,8 @@ export function EditHoldingDialog({
   const optionDisplay = getOptionDisplay(holding);
 
   function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    const next = maskAmountInput(e.target.value);
+    if (next !== null) setQuantity(next);
   }
 
   function handleQuantityBlur() {
@@ -95,11 +89,6 @@ export function EditHoldingDialog({
       toast.error(
         isOption ? "Quantity must be 0 or greater" : "Quantity must be a positive number",
       );
-      setLoading(false);
-      return;
-    }
-    if (!isOption && parsedQty <= 0) {
-      toast.error("Quantity must be a positive number");
       setLoading(false);
       return;
     }

--- a/src/components/accounts/holding-form.tsx
+++ b/src/components/accounts/holding-form.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
 import { OptionBuilder } from "./option-builder";
+import { maskAmountInput } from "@/lib/amount-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -53,16 +54,10 @@ export function HoldingForm({
   const [quantityError, setQuantityError] = useState("");
 
   function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
+    const next = maskAmountInput(e.target.value);
+    if (next === null) return;
     setQuantityError("");
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    setQuantity(next);
   }
 
   function handleQuantityBlur() {

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -6,6 +6,7 @@ import { Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { formatCurrency, formatNumber } from "@/lib/currencies";
+import { maskAmountInput } from "@/lib/amount-input";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
 interface InlineBalanceEditorProps {
@@ -34,16 +35,10 @@ export function InlineBalanceEditor({
   const { privacyMode } = usePrivacyMode();
 
   function handleBalanceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
+    const next = maskAmountInput(e.target.value);
+    if (next === null) return;
     setError("");
-    if (!raw) {
-      setBalance("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setBalance(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    setBalance(next);
   }
 
   function handleBalanceBlur() {

--- a/src/components/accounts/quick-add-holding.tsx
+++ b/src/components/accounts/quick-add-holding.tsx
@@ -25,10 +25,13 @@ import { DiscardConfirmDialog } from "@/components/discard-confirm-dialog";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
+import { maskAmountInput } from "@/lib/amount-input";
+import { HOLDING_ASSET_TYPES } from "@/lib/enums";
 
 const OptionBuilder = dynamic(() => import("./option-builder").then((m) => m.OptionBuilder));
 
-const ASSET_TYPE_KEYS = ["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OTHER"] as const;
+// OPTION has its own tab/builder, so the stock form offers every other asset type.
+const ASSET_TYPE_KEYS = HOLDING_ASSET_TYPES.filter((k) => k !== "OPTION");
 
 const ASSET_TYPE_TO_CATEGORY: Record<string, string> = {
   STOCK: "BROKERAGE",
@@ -77,16 +80,10 @@ export function QuickAddHolding({
   const [quantityError, setQuantityError] = useState("");
 
   function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
+    const next = maskAmountInput(e.target.value);
+    if (next === null) return;
     setQuantityError("");
-    if (!raw) {
-      setQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    setQuantity(next);
   }
 
   function handleQuantityBlur() {

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatQuantity } from "@/lib/currencies";
+import { maskAmountInput } from "@/lib/amount-input";
 import type { SerializedTransaction } from "@/lib/types";
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -175,15 +176,8 @@ export function TransactionHistory({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   function handleEditQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setEditQuantity("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setEditQuantity(decPart !== undefined ? `${formatted}.${decPart}` : formatted);
+    const next = maskAmountInput(e.target.value);
+    if (next !== null) setEditQuantity(next);
   }
 
   function handleEditQuantityBlur() {

--- a/src/lib/amount-input.ts
+++ b/src/lib/amount-input.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for comma-masked numeric text inputs (cash balances, quantities,
+ * cost bases). Several account/holding forms render amounts as the user types with
+ * thousands separators; these keep that masking and the inverse parse in one place
+ * so the fiddly regex doesn't drift between copies.
+ */
+
+/**
+ * Live thousands-separator mask for a numeric input value. Strips any existing
+ * grouping commas, rejects non-numeric input by returning `null` (the caller
+ * should ignore that keystroke and leave state unchanged), and otherwise regroups
+ * the integer part while preserving an in-progress decimal (e.g. "1234." → "1,234.").
+ */
+export function maskAmountInput(value: string): string | null {
+  const raw = value.replace(/,/g, "");
+  if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return null;
+  if (!raw) return "";
+  const [intPart, decPart] = raw.split(".");
+  const formatted = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return decPart !== undefined ? `${formatted}.${decPart}` : formatted;
+}
+
+/** Parse a comma-masked amount input value into a number (`NaN` if blank/invalid). */
+export function parseAmountInput(value: string): number {
+  return parseFloat(value.replace(/,/g, ""));
+}


### PR DESCRIPTION
## Summary

Code-hygiene cleanup from a `/simplify` pass over `src/components/accounts/`, plus a dependency-declaration fix surfaced by `knip`. No behavior changes.

### Accounts simplification
- **Shared input mask** — extracted the copy-pasted thousands-separator handler (strip commas → validate → split decimal → regroup regex) into `src/lib/amount-input.ts` (`maskAmountInput` / `parseAmountInput`). Six account/holding form handlers each re-implemented it identically; now they call the shared helper. `option-builder` keeps its own integer-only variant (different validation), by design.
- **`account-form`** — maps the shared `ACCOUNT_CATEGORIES` enum instead of a hand-copied category list; collapses the ternary that duplicated the entire currency `<Select>` + `CURRENCIES.map` into one Select plus a conditional cash-balance field.
- **`quick-add-holding`** — derives its asset-type list from `HOLDING_ASSET_TYPES` (minus `OPTION`) instead of a hardcoded array.
- **`edit-holding-dialog`** — removes an unreachable quantity-validation branch (the prior `< Number.MIN_VALUE` guard already rejected non-positive non-option quantities with the same toast).
- **`account-detail`** — memoizes `holdingsWithValue`; its unstable reference was defeating the downstream `sortedHoldings` `useMemo`, re-running the sort on every keystroke/state change.

### Dependency fix
- Declares `@sentry/core` as a direct dependency (`^10.57.0`, matching `@sentry/nextjs`). It's imported directly in `src/lib/sentry-config.ts` but was only resolved transitively — flagged by `knip` as unlisted. Hand-edited `package.json` + lockfile (no `npm install`) to avoid a local-npm-11 lockfile rewrite that would break CI's `npm ci`.

## Test plan
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npx knip` — no longer reports the unlisted `@sentry/core` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)