### PR TITLE
refactor(observability): simplify Sentry dashboard setup script

### DIFF
--- a/scripts/setup-sentry-monitoring.mjs
+++ b/scripts/setup-sentry-monitoring.mjs
@@ -78,14 +78,15 @@ function dashboardWidget(spec, layout) {
   return {
     title,
     displayType,
-    // Sentry defaults un-typed widgets to the errors dataset; p95(transaction.duration)
-    // only resolves on the transactions dataset, so latency widgets must opt out.
+    // Defaults to the errors dataset; widgets that need transaction-duration
+    // metrics pass widgetType: "spans" (the transactions dataset is deprecated
+    // under Sentry EAP) — see the p95 latency specs below.
     widgetType,
     interval: "5m",
     limit: 10,
     layout: {
-      minH: layout.h,
       ...layout,
+      minH: layout.h,
     },
     queries: [
       {
@@ -351,15 +352,15 @@ async function main() {
   // PUT replaces the existing dashboard's widget set with the current spec (the
   // widgets carry no id, so Sentry recreates them); POST creates it on first run.
   // Without the update branch a re-run would no-op against a stale dashboard.
-  const dashboard = existingDashboard
-    ? await sentryFetch(`/organizations/${org}/dashboards/${existingDashboard.id}/`, {
-        method: "PUT",
-        body: JSON.stringify(dashboardPayload(projectInfo.id)),
-      })
-    : await sentryFetch(`/organizations/${org}/dashboards/`, {
-        method: "POST",
-        body: JSON.stringify(dashboardPayload(projectInfo.id)),
-      });
+  const dashboard = await sentryFetch(
+    existingDashboard
+      ? `/organizations/${org}/dashboards/${existingDashboard.id}/`
+      : `/organizations/${org}/dashboards/`,
+    {
+      method: existingDashboard ? "PUT" : "POST",
+      body: JSON.stringify(dashboardPayload(projectInfo.id)),
+    },
+  );
 
   const alertResults = [];
   if (alertActions.length === 0) {


### PR DESCRIPTION
## What

`/simplify` cleanups for `scripts/setup-sentry-monitoring.mjs`. All three are **behavior-preserving** — the emitted Sentry dashboard payload is structurally identical (verified via dry-run; no live re-apply needed).

1. **Collapse the duplicated PUT/POST branch** in `main()` into a single `sentryFetch` call that derives only path + method — previously two near-identical arms each repeated `JSON.stringify(dashboardPayload(...))`.
2. **Fix a stale comment** in `dashboardWidget`: it described `p95(transaction.duration)` / the transactions dataset, but the specs use `p95(span.duration)` with `widgetType: "spans"` (the transactions dataset is deprecated under Sentry EAP). The stale comment could lead a maintainer to "fix" the specs backward.
3. **Reorder** `layout: { minH, ...layout }` → `{ ...layout, minH: layout.h }` so `minH` reads as a default rather than a spread-overridable key.

## Why

Came out of a `/simplify` review (4 parallel agents: reuse / simplification / efficiency / altitude). Findings deliberately **skipped**: the `columns`/`aggregates` `.includes("(")` derivation (payload-sensitive), parallelizing two pre-existing GETs (out of scope, marginal for a one-shot script), and generalizing the `h:2` KPI-row override (over-engineering for a 19-item static config).

## Stacking

> ⚠️ **Stacked on top of [#433](https://github.com/mike840609/asset_tracker/pull/433).** Base branch is `claude/competent-euclid-38123d`, not `master` — this only refactors code introduced in #433 (the PUT/POST update path, the `dashboardWidget` comment). **Merge #433 first**, then rebase/retarget this onto `master`.

## Verification

`node --check`, `format:check`, and the dry-run all pass; pre-push hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)