### PR TITLE
[codex] reduce fluid active cpu usage

### DIFF
--- a/docs/FLUID_CPU_PLAN_2026-06.md
+++ b/docs/FLUID_CPU_PLAN_2026-06.md
@@ -14,9 +14,9 @@ least 1h of headroom, without changing the user-facing refresh cadence or
 upgrading plans.
 
 Fluid Active CPU is CPU time spent executing code, not wall-clock time waiting on
-external HTTP or database I/O. The highest-value levers are reducing unused RSC
-renders, avoiding duplicate auth work, and preventing cache invalidations that
-force cold recomputation.
+external HTTP or database I/O. The highest-value levers in this branch are
+avoiding duplicate auth work and preventing cache invalidations that force cold
+recomputation.
 
 ## Current Evidence
 
@@ -57,22 +57,7 @@ Additional findings:
 
 ## Implemented Changes
 
-### 1. Reduce unused page renders from navigation prefetch
-
-- Authenticated desktop sidebar links use `prefetch={false}` to disable automatic
-  production viewport prefetch.
-- Intent prefetch stays enabled only for lighter routes: `/`, `/accounts`,
-  `/goals`, `/stocks`, and `/settings`.
-- Heavier routes skip intent prefetch: `/analysis`, `/projections`, and
-  `/history`.
-- Focus-triggered prefetch was removed so keyboard navigation does not warm every
-  route.
-- Mobile touch prefetch follows the same light-route allow-list.
-
-Expected effect: fewer unused Vercel Function renders and fewer Proxy executions
-from sidebar links that were visible but never clicked.
-
-### 2. Avoid duplicate page-layer JWT decode
+### 1. Avoid duplicate page-layer JWT decode
 
 - Proxy validates the session cookie once through NextAuth.
 - After validation, Proxy overwrites internal auth headers and forwards only the
@@ -87,7 +72,7 @@ from sidebar links that were visible but never clicked.
 Expected effect: authenticated page renders skip the second JWT decode while
 preserving the database existence check and stale-session fallback.
 
-### 3. Gate market-data cache invalidation on actual value changes
+### 2. Gate market-data cache invalidation on actual value changes
 
 - Price refresh results report both `updated` rows and `changed` rows.
 - Exchange-rate refresh results report both `updated` forward rates and
@@ -103,7 +88,7 @@ preserving the database existence check and stale-session fallback.
 Expected effect: daily cron and manual refreshes no longer force cached reads to
 recompute when external providers return the same values.
 
-### 4. Add DB-backed FX freshness for cold Fluid instances
+### 3. Add DB-backed FX freshness for cold Fluid instances
 
 - Manual FX refresh first checks the in-process freshness map.
 - On cold instances, it now checks the latest persisted `ExchangeRate.updatedAt`
@@ -142,11 +127,6 @@ npm run test:unit
 
 Manual checks:
 
-- Load the authenticated dashboard in production mode and confirm the sidebar
-  does not prefetch every authenticated route on first paint.
-- Hover light sidebar routes and confirm only the hovered route is prefetched.
-- Click `/analysis`, `/projections`, and `/history` and confirm navigation still
-  works.
 - Run the snapshot cron twice with unchanged market data. The second run should
   log `cron.revalidate.gate` with `pricesChanged: 0` and `ratesChanged: 0`, and
   should skip broad market-data revalidation.
@@ -165,8 +145,6 @@ Success criteria:
 - Do not add a keep-warm ping. It spends Fluid Active CPU without user value.
 - Do not move functions away from `sin1` unless the database region changes.
 - Do not trust client-supplied auth headers in route handlers or Server Actions.
-- Do not re-enable broad automatic prefetch for authenticated dashboard
-  navigation without new CPU evidence that the cost is acceptable.
 - Do not switch to database sessions as a CPU fix; it would add per-render DB
   work.
 - Do not upgrade plans as the first fix; reduce avoidable CPU before buying more

--- a/docs/FLUID_CPU_PLAN_2026-06.md
+++ b/docs/FLUID_CPU_PLAN_2026-06.md
@@ -1,225 +1,173 @@
-# Fluid Active-CPU Reduction Plan — 2026-06-13 re-audit
+# Fluid Active CPU Reduction Plan - June 2026
 
-_Continuation of `docs/PLATFORM.md` § "Fluid CPU Optimization" (P1–P9). That
-section's plan was written 2026-05-17; most of its top items have since shipped
-(P3, P4, P5, P8 ✅; P1 matcher tightened; P2 firewall documented). This re-audit
-re-reads the live Vercel project and the current code, then re-prioritizes the
-**remaining** levers around what actually burns Active CPU today._
+Last updated: 2026-06-14
+
+This document consolidates the 2026-06-13 re-audit with the 2026-06-14
+implementation plan. It supersedes the standalone
+`docs/FLUID_ACTIVE_CPU_REDUCTION_PLAN.md` draft.
 
 ## Goal
 
-The project is on the Vercel **Hobby (Free)** plan, which includes **4 hours of
-Fluid Active CPU per month**. Usage is approaching that cap. Target: keep monthly
-billed Active CPU comfortably under the included allowance with no UX regression.
+The project runs on Vercel Hobby, which includes 4h of Fluid Active CPU per
+month. The target is to keep the rolling forecast below 3h/month, leaving at
+least 1h of headroom, without changing the user-facing refresh cadence or
+upgrading plans.
 
-> **Active CPU ≠ wall-clock.** Fluid bills _CPU time actually spent executing_,
-> not time spent waiting on I/O. External HTTP waits (Yahoo / CoinGecko / FX
-> providers) and idle DB round-trips are largely **not** billed. The levers that
-> move the needle are therefore (a) reducing CPU-bound work — RSC render,
-> JSON/Decimal math, JWT crypto, SDK init — and (b) reducing how often that work
-> is forced to run cold.
+Fluid Active CPU is CPU time spent executing code, not wall-clock time waiting on
+external HTTP or database I/O. The highest-value levers are reducing unused RSC
+renders, avoiding duplicate auth work, and preventing cache invalidations that
+force cold recomputation.
 
-## Live evidence (Vercel MCP, 2026-06-13)
+## Current Evidence
 
-Project `prj_soY30S7ki1x38gmeZXCancJD1PVA` (`asset-tracker`, team
-`team_ImEsp9hzYaqzaPz5VmE6LTiW`), production, latest deploy
-`dpl_9DAEKtrfPKx6a1S5XQtxNKkkLnJe`.
+Vercel Usage for May 15-Jun 14, 2026 showed:
 
-| Query (7-day window, production)    | Result                                                               |
-| ----------------------------------- | -------------------------------------------------------------------- |
-| `source=edge-middleware`, all paths | **2 logs** — both `GET /` → 302 (self/bot)                           |
-| `source=serverless`                 | **0 logs**                                                           |
-| all sources, no filter              | **14 logs** — `/privacy` ×10 (one-second burst), `/login` ×2, `/` ×2 |
-| `query=snapshot` (cron evidence)    | **0 logs** in window                                                 |
-| `get_project.live`                  | **`false`**                                                          |
+| Source                 |      Usage | Share |
+| ---------------------- | ---------: | ----: |
+| Vercel Functions       |     1h 28m | 68.8% |
+| Proxy / middleware     |     40m 9s | 31.2% |
+| Total Fluid Active CPU | 2h 8m / 4h | 53.7% |
 
-**Headline:** real request volume is effectively zero. The bot-probe storm that
-dominated the 2026-05-17 audit (33 edge-middleware hits, `/wp-admin`, `/cmd_sco`)
-is **gone** — the tightened matcher (P1) and firewall rules (P2) are working. With
-human + bot request traffic this low, **per-request optimization can no longer be
-the main lever.** Whatever is consuming the 4-hour budget runs _independently of
-request volume_:
+Additional findings:
 
-1. The **daily cron** (`/api/cron/snapshot`, `30 21 * * *`) and, more importantly,
-   the **cold cache rebuilds it forces** by invalidating global cache tags.
-2. **Deploy-driven cache resets.** Vercel's `cacheComponents`/ISR cache is
-   per-deployment. `list_deployments` shows a very high cadence — ~20 deploys in
-   the recent window, multiple **production** deploys per hour during active dev.
-   Every production deploy discards the warm render cache, so the next visit to
-   each PPR route cold-renders its dynamic holes (Active CPU). With near-zero
-   traffic there is never a warm cache to amortize that cost across.
-3. The **`/api/health` DB probe** (`SELECT 1` + two `findFirst`s per call) if an
-   external uptime monitor polls it on a tight interval — a 24/7 drip that can
-   dwarf a once-a-day cron.
+- Runtime logs sampled from production show clustered authenticated page renders
+  across `/`, `/accounts`, `/goals`, `/stocks`, `/analysis`, `/projections`,
+  `/settings`, and `/history`.
+- Logs also show repeated slow `User.findUnique` auth existence checks.
+- Observability Plus is not enabled, so route-level Vercel metrics are
+  unavailable on Hobby.
+- The latest production deployment runs Vercel Functions in `sin1`, matching the
+  Neon Singapore region. A region change is not part of this plan.
+- The earlier 2026-06-13 audit also found that the May bot-probe storm had been
+  reduced by the matcher and firewall work, so this plan keeps bot defenses in
+  place but focuses on app-origin CPU.
 
-Caveat: Hobby log retention is short and the MCP row cap (100) under-samples, so
-the cron's daily fire likely rolled out of the window rather than not firing
-(the `CronRun` audit table is the authoritative record — see C1).
+## Status Of Existing P/C Items
 
-## What already shipped (P-series recap)
+| Item  | Lever                                                             | Status                     |
+| ----- | ----------------------------------------------------------------- | -------------------------- |
+| P1/P2 | Middleware matcher and firewall rules for bot/junk paths          | Done                       |
+| P3    | Static public `/login`, `/privacy`, `/terms` flow                 | Done                       |
+| P4    | Anonymous no-session fast path before NextAuth                    | Done                       |
+| P5    | Unified user-scoped `/api/refresh`                                | Done                       |
+| P6/C2 | Gate cron cache invalidation on actual market-data changes        | Implemented in this branch |
+| P7/C6 | Reduce page-layer duplicate auth work with a trusted Proxy header | Implemented in this branch |
+| P8    | Singleton Yahoo client                                            | Done                       |
+| P9/C7 | Keep-warm pinger                                                  | Rejected                   |
 
-| Item | Lever                                             | Status (2026-06-13)                                      |
-| ---- | ------------------------------------------------- | -------------------------------------------------------- |
-| P1   | Tighten middleware matcher (skip bot/junk paths)  | ✅ Live in `src/proxy.ts` matcher                        |
-| P2   | Vercel Firewall / WAF rules                       | ✅ Documented (`docs/firewall_rules.json`) — verify live |
-| P3   | Statically serve `/login` `/privacy` `/terms`     | ✅ Done                                                  |
-| P4   | Skip JWT decode for anonymous (no session cookie) | ✅ Done — `hasSessionCookie()` fast path in `proxy.ts`   |
-| P5   | Collapse refresh into one user-scoped function    | ✅ Done — `POST /api/refresh`, dirty-gated invalidation  |
-| P6   | **Gate the cron's `revalidateTag` on "changed"**  | ❌ **Not done** — cron still invalidates unconditionally |
-| P7   | RSC double-auth dedup (trusted header)            | ⏸️ Deferred                                              |
-| P8   | Singleton `yahoo-finance2` client                 | ✅ Done — `yahoo-client.ts`                              |
-| P9   | Keep-warm pinger                                  | 🚫 Intentionally not shipped                             |
+## Implemented Changes
 
-## Prioritized plan (C-series)
+### 1. Reduce unused page renders from navigation prefetch
 
-Ordered by expected Active-CPU saved given the traffic-independent profile above.
+- Authenticated desktop sidebar links use `prefetch={false}` to disable automatic
+  production viewport prefetch.
+- Intent prefetch stays enabled only for lighter routes: `/`, `/accounts`,
+  `/goals`, `/stocks`, and `/settings`.
+- Heavier routes skip intent prefetch: `/analysis`, `/projections`, and
+  `/history`.
+- Focus-triggered prefetch was removed so keyboard navigation does not warm every
+  route.
+- Mobile touch prefetch follows the same light-route allow-list.
 
-### C1 — Measure Active CPU at the source before cutting (prerequisite)
+Expected effect: fewer unused Vercel Function renders and fewer Proxy executions
+from sidebar links that were visible but never clicked.
 
-**Why first:** the runtime _request_ logs (above) prove the cost is **not** in
-request volume, so optimizing request paths blind would chase the wrong thing.
-We need per-source attribution before spending effort.
+### 2. Avoid duplicate page-layer JWT decode
 
-- Read **Vercel → Project → Usage → Active CPU** and record the current rolling
-  30-day total and the daily trend in `docs/LOG.md` as the baseline.
-- Read **Vercel → Observability → Functions** to see which function
-  (`/api/cron/snapshot`, RSC route render, `/api/health`, `/api/refresh`)
-  accounts for the most Active CPU.
-- Pull cron cost directly from the audit table: the `CronRun` rows already record
-  `durationMs` per run (`src/app/api/cron/snapshot/route.ts`). Query the last 30
-  rows to get average + max cron wall time, and cross-check against Active CPU.
-- Confirm whether anything polls `/api/health` (uptime monitor, Sentry, external
-  checker) and at what interval — this single number may explain the budget.
+- Proxy validates the session cookie once through NextAuth.
+- After validation, Proxy overwrites internal auth headers and forwards only the
+  trusted user id to the app render.
+- Page auth reads that server-written header first, then confirms the user still
+  exists in the database.
+- Client-supplied `x-asset-user-id` and `x-asset-auth-source` headers are
+  stripped before Proxy forwards the request.
+- API routes keep their existing `withAuth` flow and do not trust the Proxy
+  header.
 
-**Effort:** 30–45 min, no code. **Output:** a baseline + the one or two functions
-that dominate, which tells us which of C2–C6 actually matters.
+Expected effect: authenticated page renders skip the second JWT decode while
+preserving the database existence check and stale-session fallback.
 
-### C2 — Gate the cron's global cache invalidation on actual change (was P6)
+### 3. Gate market-data cache invalidation on actual value changes
 
-**Effect: High, and the highest-confidence code lever.** `/api/cron/snapshot`
-today calls, _every single day regardless of whether anything moved_:
+- Price refresh results report both `updated` rows and `changed` rows.
+- Exchange-rate refresh results report both `updated` forward rates and
+  `changed` persisted rows.
+- Cron logs `cron.revalidate.gate` with prices/rates updated and changed counts.
+- Cron only revalidates broad `prices`, `prices:crypto`, `exchange-rates`, and
+  `net-worth` tags when values actually changed.
+- Manual refresh and stock-watch refresh use `changed` for cache busting and
+  client `router.refresh()` decisions.
+- Snapshot and per-user history invalidation still run after snapshot rows are
+  written.
 
-```
-revalidateTag("exchange-rates", "max")
-revalidateTag("net-worth", "max")
-revalidateTag("prices", "max")
-revalidateTag("prices:crypto", "max")
-revalidateTag("snapshots", "max")
-revalidateTag(`history:${user.id}`, "max")   // per user
-```
+Expected effect: daily cron and manual refreshes no longer force cached reads to
+recompute when external providers return the same values.
 
-Each global invalidation forces the **next** render of every cached RSC read
-(`/`, `/analysis`, `/history`, `/settings`, `/accounts`) to cold-rebuild — the
-exact expensive Active-CPU work we want to avoid. The manual `/api/refresh` route
-**already** solved this with dirty-gating (`pricesDirty`/`ratesDirty` from the
-service result); the cron never got the same treatment.
+### 4. Add DB-backed FX freshness for cold Fluid instances
 
-- File: `src/app/api/cron/snapshot/route.ts`.
-- Capture `refreshAllPrices()`'s `updated` count and the per-currency
-  `refreshExchangeRates` results (they already return `{ updated, ... }`).
-- Only `revalidateTag("prices"|"prices:crypto", "max")` when prices updated > 0;
-  only `revalidateTag("exchange-rates", "max")` when any rate updated > 0; only
-  invalidate `net-worth` when either changed.
-- For `snapshots` / `history:${user.id}`: compare each user's new snapshot total
-  against the prior snapshot and skip invalidation when it's within an epsilon
-  (e.g. `< 0.01` base-currency) **and** no option contracts expired that day.
-- Keep the always-on invalidation only for the option-expiry branch (it already
-  guards on `expiredOptions.length > 0`).
+- Manual FX refresh first checks the in-process freshness map.
+- On cold instances, it now checks the latest persisted `ExchangeRate.updatedAt`
+  for the base currency before calling external FX APIs.
+- Cron still uses `force: true`, because snapshots should be based on the latest
+  available rates.
 
-**Pros:** removes a guaranteed daily cold-rebuild of every cached route on days
-when nothing moved (weekends, holidays, flat markets). Reuses a pattern already
-proven in `/api/refresh`. **Cons:** a missed invalidation could surface a stale
-number for up to 24 h — mitigate by keeping the epsilon tight and leaving the
-cheap per-user `history` invalidation on whenever a snapshot row was actually
-written.
+Expected effect: cold or newly scaled Fluid instances skip unnecessary external
+FX fetches when the database already has fresh rates.
 
-### C3 — Cut production deploy cadence (process, not code)
+## Remaining Operational Checks
 
-**Effect: High, given the observed cadence.** Multiple production deploys per
-hour each discard the per-deployment render cache; with ~0 traffic there's no
-warm reuse, so every route re-pays cold-render Active CPU on its first
-post-deploy hit. The fix is to deploy to **production** less often:
+These are not required before merging the code changes, but they should be used
+to confirm the source of any remaining Fluid Active CPU after deployment.
 
-- Land feature work on preview branches (already happening) but **batch merges to
-  `master`** so production redeploys a few times a day rather than a few times an
-  hour.
-- Optionally gate production deploys behind tags/releases (Vercel → Git →
-  "Production Branch" + ignored-build step) so only intentional releases hit prod.
-- Preview deployments have their own (separate) usage and don't share the prod
-  cache, so this is specifically about the `master` → production cadence.
-
-**Pros:** directly reduces the number of cold-cache windows. No code risk.
-**Cons:** slower prod feedback loop; purely a workflow change, so it needs owner
-buy-in rather than a PR.
-
-### C4 — Right-size the `/api/health` probe and its polling
-
-**Effect: Medium–High if it's polled frequently; otherwise negligible.** Each
-call runs `SELECT 1` + `netWorthSnapshot.findFirst` + `cronRun.findFirst`
-(`src/app/api/health/route.ts`). At a 1-minute uptime-monitor interval that's
-~43k invocations/month of real (if small) DB + JSON Active CPU — plausibly larger
-than the once-daily cron.
-
-- Confirm the polling source and interval in C1 first.
-- Split **liveness** (cheap, no DB — return `{ ok: true }`) from **readiness**
-  (the DB probe). Point the high-frequency uptime monitor at liveness only.
-- Or relax the monitor interval to 5–15 min, which is plenty for a personal app.
-- Or cache the readiness DB probe result for ~60 s so bursts collapse to one query.
-
-### C5 — Verify Sentry tracing is OFF in production
-
-**Effect: Low–Medium, near-zero effort.** Server-side tracing adds per-request
-CPU. The code defaults correctly to `tracesSampleRate: 0`
-(`src/instrumentation.ts`), but that's overridable by `SENTRY_TRACES_SAMPLE_RATE`.
-
-- Confirm in Vercel → Project → Settings → Environment Variables that
-  `SENTRY_TRACES_SAMPLE_RATE` and `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` are
-  **unset or `0`** in production, and that no `profilesSampleRate` is configured.
-- Error capture (`captureException`/`captureMessage`) stays on — it's event-driven
-  and cheap. Only continuous tracing/profiling is the concern.
-
-### C6 — RSC double-auth dedup (was P7) — keep deferred until C1 says otherwise
-
-Middleware decodes the JWT, then `getSession()` decodes it again per render. This
-only matters once **human navigation volume returns**; at current traffic it's
-noise. Revisit only if C1's per-function breakdown shows authenticated RSC render
-(JWT crypto) is a top consumer. The trusted-header approach also carries a
-spoofing-surface caveat (documented in PLATFORM.md P7) — not worth the risk for a
-non-measurable gain today.
-
-### C7 — Do NOT add a keep-warm pinger (reaffirms P9)
-
-A warmer spends Active CPU to avoid cold starts — the opposite of the goal when
-traffic is near zero. Leave cold starts as-is; C2–C4 reduce total work instead.
-
-## Recommended execution order
-
-1. **C1** — read Vercel Usage + Observability + `CronRun.durationMs`; identify the
-   dominant function and confirm whether `/api/health` is being polled. _(no code)_
-2. **C2** — port the `/api/refresh` dirty-gating into the cron. _(one PR, this branch)_
-3. **C4** — fix `/api/health` polling/shape if C1 shows it's hot.
-4. **C3** — agree a production-deploy batching policy. _(workflow)_
-5. **C5** — one-time env-var check.
-6. Re-measure after ~3–7 days; only then consider **C6**.
+- Record the new rolling 30-day Vercel Usage baseline in `docs/LOG.md` after the
+  next production deploy.
+- Review Vercel Usage for 24-72 hours and compare the daily run rate against the
+  May 15-Jun 14 baseline.
+- Confirm whether anything polls `/api/health`, and reduce the interval or split
+  liveness/readiness if it is frequent.
+- Confirm production Sentry tracing/profiling env vars are unset or `0`.
+- Keep production deploys batched where possible, because each production deploy
+  resets deployment-local render caches.
 
 ## Verification
 
-After C2 ships, wait for two cron fires (one on a flat-market day) then:
+Run before deploy:
 
-- **Vercel → Usage → Active CPU:** confirm the daily Active-CPU step-down vs. the
-  C1 baseline; record in `docs/LOG.md`.
-- **Cron correctness:** on a day prices _did_ move, confirm the dashboard shows
-  fresh numbers within the cron window (no stale-number regression from C2's
-  gating). On a flat day, confirm `CronRun` still wrote a row but the cache tags
-  were _not_ invalidated (add a `log.info("cron.revalidate.skipped")` to assert).
-- **Functional smoke:** `npm run test:e2e` smoke spec green; manual sign-in →
-  dashboard → click Refresh → numbers update.
+```bash
+npm run format:check
+npm run lint
+npm run typecheck
+npm run test:unit
+```
 
-## Out of scope (intentionally skipped)
+Manual checks:
 
-- Migrating off Hobby — the owner wants to stay on Free.
-- Switching to database sessions — would _increase_ per-render CPU.
-- Edge runtime for API routes — blocked by `cacheComponents` (PLATFORM.md V8) and
-  most routes need Prisma (Node-only).
-- Lowering snapshot frequency below daily — daily granularity is a product
-  requirement; C2 removes the waste without touching cadence.
+- Load the authenticated dashboard in production mode and confirm the sidebar
+  does not prefetch every authenticated route on first paint.
+- Hover light sidebar routes and confirm only the hovered route is prefetched.
+- Click `/analysis`, `/projections`, and `/history` and confirm navigation still
+  works.
+- Run the snapshot cron twice with unchanged market data. The second run should
+  log `cron.revalidate.gate` with `pricesChanged: 0` and `ratesChanged: 0`, and
+  should skip broad market-data revalidation.
+- Send a request with forged `x-asset-user-id` and confirm it does not
+  authenticate without a valid session cookie.
+
+Success criteria:
+
+- The 24-72 hour post-deploy Fluid Active CPU run rate drops by at least 35%.
+- The rolling monthly forecast stays below 3h.
+- Signed-out redirects, signed-in dashboard access, manual refresh, and daily
+  snapshot creation keep working.
+
+## Do Not Do
+
+- Do not add a keep-warm ping. It spends Fluid Active CPU without user value.
+- Do not move functions away from `sin1` unless the database region changes.
+- Do not trust client-supplied auth headers in route handlers or Server Actions.
+- Do not re-enable broad automatic prefetch for authenticated dashboard
+  navigation without new CPU evidence that the cost is acceptable.
+- Do not switch to database sessions as a CPU fix; it would add per-render DB
+  work.
+- Do not upgrade plans as the first fix; reduce avoidable CPU before buying more
+  quota.

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -85,15 +85,25 @@ export async function GET(request: Request) {
     log.info("cron.prices.refresh");
     // force: snapshots must be computed from current rates; the manual-refresh
     // freshness gate doesn't apply to the cron.
-    await Promise.all([
-      ...[...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true })),
+    const [rateResults, priceResult] = await Promise.all([
+      Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true }))),
       refreshAllPrices(),
     ]);
+    const ratesUpdated = rateResults.reduce((sum, result) => sum + result.updated, 0);
+    const ratesChanged = rateResults.reduce((sum, result) => sum + result.changed, 0);
+    log.info("cron.revalidate.gate", {
+      pricesUpdated: priceResult.updated,
+      pricesChanged: priceResult.changed,
+      ratesUpdated,
+      ratesChanged,
+    });
     // "max" is the cacheComponents revalidation scope required by Next.js 16 cacheComponents: true
-    revalidateTag("exchange-rates", "max");
-    revalidateTag("net-worth", "max");
-    revalidateTag("prices", "max");
-    revalidateTag("prices:crypto", "max");
+    if (ratesChanged > 0) revalidateTag("exchange-rates", "max");
+    if (priceResult.changed > 0) {
+      revalidateTag("prices", "max");
+      revalidateTag("prices:crypto", "max");
+    }
+    if (ratesChanged > 0 || priceResult.changed > 0) revalidateTag("net-worth", "max");
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -43,6 +43,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   ]);
 
   const ratesUpdated = rateResults.reduce((sum, r) => sum + r.updated, 0);
+  const ratesChanged = rateResults.reduce((sum, r) => sum + r.changed, 0);
   const ratesSkippedFresh = rateResults.filter((r) => r.skippedFresh).length;
   // Any base whose external fetch failed (vs. skipped-fresh) means the user
   // may be looking at stale conversions — surface it so the client can warn.
@@ -62,8 +63,8 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   // src/app/api/accounts/route.ts: per-user tags expire immediately so this
   // user's next read is fresh; global tags (shared by all users) revalidate
   // with "max" (stale-while-revalidate) to avoid cross-user blocking reads.
-  const pricesDirty = priceResult.updated > 0;
-  const ratesDirty = ratesUpdated > 0;
+  const pricesDirty = priceResult.changed > 0;
+  const ratesDirty = ratesChanged > 0;
   if (pricesDirty) {
     revalidateTag("prices", "max");
     revalidateTag("prices:crypto", "max");
@@ -82,11 +83,13 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   return ok({
     prices: {
       updated: priceResult.updated,
+      changed: priceResult.changed,
       skippedFresh: priceResult.skippedFresh,
       retryAfterSeconds: priceResult.retryAfterSeconds,
     },
     rates: {
       updated: ratesUpdated,
+      changed: ratesChanged,
       skippedFresh: ratesSkippedFresh,
       retryAfterSeconds: ratesRetryAfterSeconds,
       fetchFailed: ratesFetchFailed,

--- a/src/components/dashboard/dashboard-actions.tsx
+++ b/src/components/dashboard/dashboard-actions.tsx
@@ -40,7 +40,7 @@ export function DashboardActions({
           toast.success(t("refreshSuccess", { count: outcome.prices }));
           if (outcome.ratesFetchFailed) toast.warning(t("ratesRefreshFailed"));
           setClientRefreshAt(new Date().toISOString());
-          router.refresh();
+          if (outcome.changed > 0) router.refresh();
           break;
         case "fresh":
           if (outcome.ratesFetchFailed) {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -104,19 +104,14 @@ export function Sidebar({
   }, [toggleCollapsed]);
 
   const navItems = [
-    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard, prefetchOnIntent: true },
-    { label: t("nav.accounts"), href: "/accounts", icon: Copy, prefetchOnIntent: true },
-    { label: t("nav.goals"), href: "/goals", icon: Target, prefetchOnIntent: true },
-    { label: t("nav.stocks"), href: "/stocks", icon: ChartCandlestick, prefetchOnIntent: true },
-    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3, prefetchOnIntent: false },
-    {
-      label: t("nav.projections"),
-      href: "/projections",
-      icon: TrendingUp,
-      prefetchOnIntent: false,
-    },
-    { label: t("nav.history"), href: "/history", icon: History, prefetchOnIntent: false },
-    { label: t("nav.settings"), href: "/settings", icon: Settings, prefetchOnIntent: true },
+    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
+    { label: t("nav.accounts"), href: "/accounts", icon: Copy },
+    { label: t("nav.goals"), href: "/goals", icon: Target },
+    { label: t("nav.stocks"), href: "/stocks", icon: ChartCandlestick },
+    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3 },
+    { label: t("nav.projections"), href: "/projections", icon: TrendingUp },
+    { label: t("nav.history"), href: "/history", icon: History },
+    { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
   return (
@@ -172,10 +167,8 @@ export function Sidebar({
             <Link
               key={item.href}
               href={item.href}
-              prefetch={false}
-              onMouseEnter={() => {
-                if (item.prefetchOnIntent) router.prefetch(item.href);
-              }}
+              onMouseEnter={() => router.prefetch(item.href)}
+              onFocus={() => router.prefetch(item.href)}
               title={collapsed ? item.label : undefined}
               className={cn(
                 "group relative flex items-center rounded-lg py-2.5 text-sm font-medium transition-all motion-fast",
@@ -265,11 +258,11 @@ export function MobileNav() {
   const [optimisticHref, setOptimisticHref] = useState<string | null>(null);
 
   const navItems = [
-    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard, prefetchOnIntent: true },
-    { label: t("nav.accounts"), href: "/accounts", icon: Copy, prefetchOnIntent: true },
-    { label: t("nav.plan"), href: "/goals", icon: Target, prefetchOnIntent: true },
-    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3, prefetchOnIntent: false },
-    { label: t("nav.settings"), href: "/settings", icon: Settings, prefetchOnIntent: true },
+    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
+    { label: t("nav.accounts"), href: "/accounts", icon: Copy },
+    { label: t("nav.plan"), href: "/goals", icon: Target },
+    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3 },
+    { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
   return (
@@ -293,7 +286,7 @@ export function MobileNav() {
             key={item.href}
             type="button"
             onTouchStart={() => {
-              if (!isActive && item.prefetchOnIntent) router.prefetch(item.href);
+              if (!isActive) router.prefetch(item.href);
             }}
             onClick={() => {
               if (isActive) return;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -104,14 +104,19 @@ export function Sidebar({
   }, [toggleCollapsed]);
 
   const navItems = [
-    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
-    { label: t("nav.accounts"), href: "/accounts", icon: Copy },
-    { label: t("nav.goals"), href: "/goals", icon: Target },
-    { label: t("nav.stocks"), href: "/stocks", icon: ChartCandlestick },
-    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3 },
-    { label: t("nav.projections"), href: "/projections", icon: TrendingUp },
-    { label: t("nav.history"), href: "/history", icon: History },
-    { label: t("nav.settings"), href: "/settings", icon: Settings },
+    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard, prefetchOnIntent: true },
+    { label: t("nav.accounts"), href: "/accounts", icon: Copy, prefetchOnIntent: true },
+    { label: t("nav.goals"), href: "/goals", icon: Target, prefetchOnIntent: true },
+    { label: t("nav.stocks"), href: "/stocks", icon: ChartCandlestick, prefetchOnIntent: true },
+    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3, prefetchOnIntent: false },
+    {
+      label: t("nav.projections"),
+      href: "/projections",
+      icon: TrendingUp,
+      prefetchOnIntent: false,
+    },
+    { label: t("nav.history"), href: "/history", icon: History, prefetchOnIntent: false },
+    { label: t("nav.settings"), href: "/settings", icon: Settings, prefetchOnIntent: true },
   ];
 
   return (
@@ -167,8 +172,10 @@ export function Sidebar({
             <Link
               key={item.href}
               href={item.href}
-              onMouseEnter={() => router.prefetch(item.href)}
-              onFocus={() => router.prefetch(item.href)}
+              prefetch={false}
+              onMouseEnter={() => {
+                if (item.prefetchOnIntent) router.prefetch(item.href);
+              }}
               title={collapsed ? item.label : undefined}
               className={cn(
                 "group relative flex items-center rounded-lg py-2.5 text-sm font-medium transition-all motion-fast",
@@ -258,11 +265,11 @@ export function MobileNav() {
   const [optimisticHref, setOptimisticHref] = useState<string | null>(null);
 
   const navItems = [
-    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard },
-    { label: t("nav.accounts"), href: "/accounts", icon: Copy },
-    { label: t("nav.plan"), href: "/goals", icon: Target },
-    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3 },
-    { label: t("nav.settings"), href: "/settings", icon: Settings },
+    { label: t("nav.dashboard"), href: "/", icon: LayoutDashboard, prefetchOnIntent: true },
+    { label: t("nav.accounts"), href: "/accounts", icon: Copy, prefetchOnIntent: true },
+    { label: t("nav.plan"), href: "/goals", icon: Target, prefetchOnIntent: true },
+    { label: t("nav.analysis"), href: "/analysis", icon: BarChart3, prefetchOnIntent: false },
+    { label: t("nav.settings"), href: "/settings", icon: Settings, prefetchOnIntent: true },
   ];
 
   return (
@@ -286,7 +293,7 @@ export function MobileNav() {
             key={item.href}
             type="button"
             onTouchStart={() => {
-              if (!isActive) router.prefetch(item.href);
+              if (!isActive && item.prefetchOnIntent) router.prefetch(item.href);
             }}
             onClick={() => {
               if (isActive) return;

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -769,15 +769,18 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
         return;
       }
       if (!res.ok) throw new Error("refresh failed");
-      const { data }: { data: { updated: number; skippedFresh?: number } } = await res.json();
+      const { data }: { data: { updated: number; changed?: number; skippedFresh?: number } } =
+        await res.json();
       startCooldown(Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000));
       if (data.updated === 0 && (data.skippedFresh ?? 0) > 0) {
         toast.info(t("alreadyFresh"));
         return;
       }
       toast.success(t("refreshSuccess", { count: data.updated }));
-      window.dispatchEvent(new CustomEvent("prices:refreshed"));
-      startTransition(() => router.refresh());
+      if ((data.changed ?? data.updated) > 0) {
+        window.dispatchEvent(new CustomEvent("prices:refreshed"));
+        startTransition(() => router.refresh());
+      }
     } catch {
       toast.error(t("refreshFailed"));
     } finally {

--- a/src/lib/auth-headers.ts
+++ b/src/lib/auth-headers.ts
@@ -1,0 +1,3 @@
+export const AUTH_USER_ID_HEADER = "x-asset-user-id";
+export const AUTH_SOURCE_HEADER = "x-asset-auth-source";
+export const AUTH_SOURCE_PROXY = "proxy";

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,15 +1,38 @@
 import "server-only";
 import { cache } from "react";
+import { headers } from "next/headers";
 import { auth } from "@/auth";
-import { userExists } from "@/lib/auth-user";
+import { AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY, AUTH_USER_ID_HEADER } from "@/lib/auth-headers";
+import { getAuthUser, userExists } from "@/lib/auth-user";
+
+type AppSession = {
+  user?: {
+    id?: string;
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+} | null;
+
+async function getTrustedProxyUserId(): Promise<string | null> {
+  const requestHeaders = await headers();
+  if (requestHeaders.get(AUTH_SOURCE_HEADER) !== AUTH_SOURCE_PROXY) return null;
+  const userId = requestHeaders.get(AUTH_USER_ID_HEADER);
+  return userId && userId.trim() ? userId : null;
+}
 
 /**
- * Cached auth() wrapper — deduplicates the auth call within a single
- * React server render. The middleware already calls auth() once; this
- * ensures the page-level call reuses the same result instead of
- * decoding the JWT a second time.
+ * Cached session wrapper. Proxy validates the JWT once and forwards only a
+ * server-written user id header; normal page renders can then skip a second
+ * JWT decode while still confirming the user exists in the database.
  */
-export const getSession = cache(async () => {
+export const getSession = cache(async (): Promise<AppSession> => {
+  const proxyUserId = await getTrustedProxyUserId();
+  if (proxyUserId) {
+    const user = await getAuthUser(proxyUserId);
+    return user ? { user } : null;
+  }
+
   const session = await auth();
   if (!session?.user?.id) return session;
 

--- a/src/lib/auth-user.ts
+++ b/src/lib/auth-user.ts
@@ -1,11 +1,17 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
 
+export async function getAuthUser(userId: string) {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, email: true, image: true },
+  });
+}
+
 export async function userExists(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true },
   });
-
   return Boolean(user);
 }

--- a/src/lib/refresh-client.ts
+++ b/src/lib/refresh-client.ts
@@ -15,7 +15,7 @@ import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
 export type RefreshOutcome =
   // `ratesFetchFailed` marks a degraded success: prices refreshed (or were
   // fresh) but the external FX fetch failed, so conversions may use stale rates.
-  | { status: "updated"; prices: number; rates: number; ratesFetchFailed: boolean }
+  | { status: "updated"; prices: number; rates: number; changed: number; ratesFetchFailed: boolean }
   | { status: "fresh"; retryAfterSeconds: number; ratesFetchFailed: boolean }
   | { status: "cooldown"; retryAfterSeconds: number }
   | { status: "error" };
@@ -43,6 +43,7 @@ function parseRetryAfterSeconds(res: Response): number {
 
 type RefreshPayload = {
   updated?: number;
+  changed?: number;
   skippedFresh?: number | boolean;
   retryAfterSeconds?: number | null;
   fetchFailed?: boolean;
@@ -74,6 +75,7 @@ export async function refreshMarketData(): Promise<RefreshOutcome> {
 
     const pricesUpdated = priceData.updated ?? 0;
     const ratesUpdated = ratesData.updated ?? 0;
+    const changed = (priceData.changed ?? pricesUpdated) + (ratesData.changed ?? ratesUpdated);
     const anySkipped = Boolean(priceData.skippedFresh) || Boolean(ratesData.skippedFresh);
     const ratesFetchFailed = Boolean(ratesData.fetchFailed);
 
@@ -92,7 +94,13 @@ export async function refreshMarketData(): Promise<RefreshOutcome> {
     }
 
     window.dispatchEvent(new CustomEvent("prices:refreshed"));
-    return { status: "updated", prices: pricesUpdated, rates: ratesUpdated, ratesFetchFailed };
+    return {
+      status: "updated",
+      prices: pricesUpdated,
+      rates: ratesUpdated,
+      changed,
+      ratesFetchFailed,
+    };
   } catch {
     return { status: "error" };
   }

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -7,6 +7,8 @@ import { log, withTiming } from "@/lib/logger";
 
 export type RefreshRatesResult = {
   updated: number;
+  /** Persisted rows whose rate changed compared with the previous value. */
+  changed: number;
   /** True when the base currency's rates were fresh and no fetch happened. */
   skippedFresh: boolean;
   /** When the rates become stale again; null unless skippedFresh. */
@@ -27,6 +29,25 @@ const RATE_FETCH_TIMEOUT_MS = 1200;
 // staleness check costs no DB read (same warm-instance pattern as
 // lib/rate-limit.ts). Cold starts simply refresh once and re-prime it.
 const lastRateRefreshAt = new Map<string, number>();
+
+function decimalChangedAtDbScale(current: unknown, next: number): boolean {
+  const currentNumber = Number(current);
+  return (
+    !Number.isFinite(currentNumber) ||
+    !Number.isFinite(next) ||
+    currentNumber.toFixed(8) !== next.toFixed(8)
+  );
+}
+
+async function getPersistedFreshRefreshAt(baseCurrency: string): Promise<Date | null> {
+  const result = await prisma.exchangeRate.aggregate({
+    where: { fromCurrency: baseCurrency },
+    _max: { updatedAt: true },
+  });
+  const refreshedAt = result._max.updatedAt;
+  if (!refreshedAt || Date.now() - refreshedAt.getTime() >= FX_REFRESH_TTL_MS) return null;
+  return refreshedAt;
+}
 
 /**
  * Cache Components read of all exchange rates.
@@ -195,10 +216,26 @@ export async function refreshExchangeRates(
     log.info("rates.refresh.skipped_fresh", { base: baseCurrency });
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: true,
       nextRefreshAt: new Date(last + FX_REFRESH_TTL_MS).toISOString(),
       fetchFailed: false,
     };
+  }
+
+  if (!opts.force) {
+    const persistedRefreshAt = await getPersistedFreshRefreshAt(baseCurrency);
+    if (persistedRefreshAt) {
+      lastRateRefreshAt.set(baseCurrency, persistedRefreshAt.getTime());
+      log.info("rates.refresh.skipped_fresh_db", { base: baseCurrency });
+      return {
+        updated: 0,
+        changed: 0,
+        skippedFresh: true,
+        nextRefreshAt: new Date(persistedRefreshAt.getTime() + FX_REFRESH_TTL_MS).toISOString(),
+        fetchFailed: false,
+      };
+    }
   }
 
   const rates = await fetchExchangeRates(baseCurrency);
@@ -207,7 +244,13 @@ export async function refreshExchangeRates(
   if (entries.length === 0) {
     // Genuine failure/timeout (lastRateRefreshAt deliberately NOT stamped,
     // so the next call retries immediately).
-    return { updated: 0, skippedFresh: false, nextRefreshAt: null, fetchFailed: true };
+    return {
+      updated: 0,
+      changed: 0,
+      skippedFresh: false,
+      nextRefreshAt: null,
+      fetchFailed: true,
+    };
   }
 
   const rows: [id: string, fromCurrency: string, toCurrency: string, rate: number][] = [];
@@ -226,6 +269,16 @@ export async function refreshExchangeRates(
   // (e.g. base=USD and base=TWD both upsert USD_TWD and TWD_USD), and
   // multi-row upserts taking the same locks in different orders can deadlock.
   rows.sort(([a], [b]) => (a < b ? -1 : 1));
+
+  const currentRows = await prisma.exchangeRate.findMany({
+    where: { id: { in: rows.map(([id]) => id) } },
+    select: { id: true, rate: true },
+  });
+  const currentById = new Map(currentRows.map((row) => [row.id, row]));
+  const changed = rows.reduce((count, [id, _fromCurrency, _toCurrency, rate]) => {
+    const current = currentById.get(id);
+    return current === undefined || decimalChangedAtDbScale(current.rate, rate) ? count + 1 : count;
+  }, 0);
 
   const params: unknown[] = [];
   const placeholders = rows.map(([id, fromCurrency, toCurrency, rate]) => {
@@ -246,5 +299,11 @@ export async function refreshExchangeRates(
   lastRateRefreshAt.set(baseCurrency, Date.now());
   // `updated` counts fetched (forward) rates only — it feeds the user-facing
   // "N rates updated" toast; counting derived inverse rows would double it.
-  return { updated: entries.length, skippedFresh: false, nextRefreshAt: null, fetchFailed: false };
+  return {
+    updated: entries.length,
+    changed,
+    skippedFresh: false,
+    nextRefreshAt: null,
+    fetchFailed: false,
+  };
 }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -10,6 +10,8 @@ const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 
 export type RefreshPricesResult = {
   updated: number;
+  /** Persisted rows whose price/currency changed compared with the previous value. */
+  changed: number;
   /** Symbols skipped because their cached price was younger than the TTL. */
   skippedFresh: number;
   errors: string[];
@@ -22,6 +24,15 @@ export type RefreshPricesOptions = {
   /** Bypass the freshness gate (cron path — snapshots need current prices). */
   force?: boolean;
 };
+
+function decimalChangedAtDbScale(current: unknown, next: number): boolean {
+  const currentNumber = Number(current);
+  return (
+    !Number.isFinite(currentNumber) ||
+    !Number.isFinite(next) ||
+    currentNumber.toFixed(8) !== next.toFixed(8)
+  );
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -262,6 +273,7 @@ export async function refreshPricesForStockSymbols(
   if (uniqueSymbols.length === 0) {
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: 0,
       errors: [],
       nextRefreshAt: null,
@@ -281,6 +293,7 @@ async function refreshPricesForHoldings(
   if (holdings.length === 0) {
     return {
       updated: 0,
+      changed: 0,
       skippedFresh: 0,
       errors: [],
       nextRefreshAt: null,
@@ -320,6 +333,7 @@ async function refreshPricesForHoldings(
           : null;
         return {
           updated: 0,
+          changed: 0,
           skippedFresh,
           errors: [],
           nextRefreshAt: nextRefreshAt?.toISOString() ?? null,
@@ -339,6 +353,7 @@ async function refreshPricesForHoldings(
 
   const errors: string[] = [];
   let updated = 0;
+  let changed = 0;
 
   const [stockPrices, cryptoPrices] = await Promise.all([
     fetchStockPrices(stockSymbols),
@@ -349,10 +364,31 @@ async function refreshPricesForHoldings(
 
   const entries = [...allPrices];
   if (entries.length === 0) {
-    return { updated: 0, skippedFresh, errors: [], nextRefreshAt: null, retryAfterSeconds: null };
+    return {
+      updated: 0,
+      changed: 0,
+      skippedFresh,
+      errors: [],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
   }
 
   try {
+    const currentRows = await prisma.priceCache.findMany({
+      where: { symbol: { in: entries.map(([symbol]) => symbol) } },
+      select: { symbol: true, price: true, currency: true },
+    });
+    const currentBySymbol = new Map(currentRows.map((row) => [row.symbol, row]));
+    const pendingChanged = entries.reduce((count, [symbol, { price, currency }]) => {
+      const current = currentBySymbol.get(symbol);
+      return current === undefined ||
+        current.currency !== currency ||
+        decimalChangedAtDbScale(current.price, price)
+        ? count + 1
+        : count;
+    }, 0);
+
     const params: unknown[] = [];
     const placeholders = entries.map(([symbol, { price, currency }]) => {
       const base = params.length;
@@ -369,10 +405,11 @@ async function refreshPricesForHoldings(
       ...params,
     );
     updated = entries.length;
-    revalidateTag("prices", "max");
+    changed = pendingChanged;
+    if (changed > 0) revalidateTag("prices", "max");
   } catch (error) {
     errors.push(`Bulk upsert failed: ${String(error)}`);
   }
 
-  return { updated, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
+  return { updated, changed, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
 }

--- a/src/lib/services/stock-watch-service.ts
+++ b/src/lib/services/stock-watch-service.ts
@@ -186,7 +186,7 @@ export async function refreshTrackedStockPrices(userId: string) {
   });
   const result = await refreshPricesForStockSymbols(stocks.map((stock) => stock.symbol));
   // Skip the cache bust when nothing changed (e.g. everything was fresh).
-  if (result.updated > 0) invalidateStockWatchCaches(userId);
+  if (result.changed > 0) invalidateStockWatchCaches(userId);
   return result;
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import authConfig from "./auth.config";
+import { AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY, AUTH_USER_ID_HEADER } from "@/lib/auth-headers";
 import { SESSION_COOKIE_NAMES } from "@/lib/auth-cookies";
 import { getClientIp } from "@/lib/rate-limit";
 import { NextResponse } from "next/server";
@@ -11,6 +12,29 @@ const PUBLIC_ROUTES = ["/login", "/privacy", "/terms"];
 
 function hasSessionCookie(req: NextRequest): boolean {
   return SESSION_COOKIE_NAMES.some((name) => req.cookies.has(name));
+}
+
+function requestHeadersForApp(req: NextRequest, userId?: string): Headers {
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.delete(AUTH_USER_ID_HEADER);
+  requestHeaders.delete(AUTH_SOURCE_HEADER);
+
+  if (userId) {
+    requestHeaders.set(AUTH_USER_ID_HEADER, userId);
+    requestHeaders.set(AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY);
+  }
+
+  return requestHeaders;
+}
+
+function nextResponse(req: NextRequest, userId?: string): NextResponse {
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeadersForApp(req, userId),
+    },
+  });
+  setLocaleCookie(req, response);
+  return response;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,20 +73,18 @@ function _authRateLimit(request: Request): Response | null {
 }
 // ---------------------------------------------------------------------------
 
-// On first visit (no locale cookie), detect from Accept-Language and set cookie
-function localeCookieResponse(req: NextRequest): NextResponse | undefined {
+// On first visit (no locale cookie), detect from Accept-Language and set cookie.
+function setLocaleCookie(req: NextRequest, response: NextResponse): void {
   const localeCookie = req.cookies.get("NEXT_LOCALE")?.value;
-  if (localeCookie) return undefined;
+  if (localeCookie) return;
 
   const acceptLanguage = req.headers.get("accept-language") ?? "";
   const locale = acceptLanguage.toLowerCase().includes("zh") ? "zh-TW" : "en-US";
-  const response = NextResponse.next();
   response.cookies.set("NEXT_LOCALE", locale, {
     path: "/",
     maxAge: 60 * 60 * 24 * 365,
     sameSite: "lax",
   });
-  return response;
 }
 
 // Slow path: a session cookie is present, so pay the JWT decode to validate it.
@@ -82,7 +104,7 @@ const authMiddleware = auth((req) => {
     return Response.redirect(newUrl);
   }
 
-  return localeCookieResponse(req);
+  return nextResponse(req, req.auth?.user?.id);
 });
 
 export default function middleware(req: NextRequest, event: NextFetchEvent) {
@@ -100,7 +122,7 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
     if (!PUBLIC_ROUTES.includes(req.nextUrl.pathname)) {
       return Response.redirect(new URL("/login", req.nextUrl.origin));
     }
-    return localeCookieResponse(req);
+    return nextResponse(req);
   }
 
   // NextAuth types the wrapped handler for route-handler contexts too, so the


### PR DESCRIPTION
## Summary

- Add a trusted Proxy-to-page auth header fast path to avoid duplicate page-layer JWT decode while keeping API auth unchanged.
- Track `changed` counts for price and FX refreshes, then gate cron/manual invalidation and client refreshes on actual value changes.
- Add DB-backed FX freshness checks for cold Fluid instances and consolidate the June Fluid CPU plan doc.

## Why

Vercel Usage for May 15-Jun 14 showed 2h 8m / 4h Fluid Active CPU, with most usage split across Vercel Functions and Proxy/middleware. Production logs showed clustered authenticated page renders and repeated auth existence checks, so this reduces duplicate auth work and cache invalidations that force cold recomputation. Sidebar prefetch behavior is intentionally unchanged in this PR.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`