### PR TITLE
Fix silent balance-save failure and dedupe numeric input formatting

### DIFF
--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -161,16 +161,27 @@ export function AccountDetail({
     : filteredSortedHoldings.slice(0, 20);
 
   async function saveBalance(newBalance: number, note?: string) {
-    await fetch(`/api/accounts/${account.id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cashBalance: newBalance, note }),
-    });
-    setRefreshTrigger((prev) => prev + 1);
-    toast.success(t("accountDetail.balanceUpdated"));
-    startTransition(() => {
-      router.refresh();
-    });
+    try {
+      const res = await fetch(`/api/accounts/${account.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cashBalance: newBalance, note }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error?.message || t("accountDetail.updateFailed"));
+      }
+
+      setRefreshTrigger((prev) => prev + 1);
+      toast.success(t("accountDetail.balanceUpdated"));
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t("accountDetail.updateFailed"));
+      throw error;
+    }
   }
 
   async function handleNameSave() {

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CURRENCIES } from "@/lib/currencies";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { ACCOUNT_CATEGORIES } from "@/lib/enums";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useDiscardGuard } from "@/hooks/use-discard-guard";
@@ -83,13 +83,13 @@ export function AccountForm({
       setCashBalanceError("");
       return;
     }
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed)) {
       setCashBalanceError(t("accountForm.invalidAmount", { defaultValue: "Invalid amount" }));
       return;
     }
     setCashBalanceError("");
-    setCashBalance(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(parsed));
+    setCashBalance(formatAmountInput(parsed, 2));
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -105,7 +105,7 @@ export function AccountForm({
           type,
           category,
           currency,
-          cashBalance: parseFloat(cashBalance.replace(/,/g, "")) || 0,
+          cashBalance: parseAmountInput(cashBalance) || 0,
         }),
       });
 

--- a/src/components/accounts/edit-holding-dialog.tsx
+++ b/src/components/accounts/edit-holding-dialog.tsx
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 import type { SerializedHolding } from "@/lib/types";
 
 import { getOptionDisplay } from "@/lib/options";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -38,9 +38,7 @@ export function EditHoldingDialog({
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [quantity, setQuantity] = useState(() =>
-    new Intl.NumberFormat("en-US", {
-      maximumFractionDigits: holding.assetType === "OPTION" ? 0 : 6,
-    }).format(Number(holding.quantity)),
+    formatAmountInput(Number(holding.quantity), holding.assetType === "OPTION" ? 0 : 6),
   );
   const [name, setName] = useState(holding.name);
   const [assetType, setAssetType] = useState<
@@ -57,13 +55,9 @@ export function EditHoldingDialog({
   function handleQuantityBlur() {
     const val = quantity.replace(/,/g, "");
     if (!val) return;
-    const parsed = isOption ? parseInt(val, 10) : parseFloat(val);
+    const parsed = isOption ? parseInt(val, 10) : parseAmountInput(val);
     if (isNaN(parsed)) return;
-    setQuantity(
-      isOption
-        ? new Intl.NumberFormat("en-US").format(parsed)
-        : new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed),
-    );
+    setQuantity(isOption ? formatAmountInput(parsed, 0) : formatAmountInput(parsed, 6));
   }
 
   function handleOpen(isOpen: boolean) {
@@ -83,7 +77,7 @@ export function EditHoldingDialog({
     e.preventDefault();
     setLoading(true);
 
-    const parsedQty = parseFloat(quantity.replace(/,/g, ""));
+    const parsedQty = parseAmountInput(quantity);
     const minAllowed = isOption ? 0 : Number.MIN_VALUE;
     if (isNaN(parsedQty) || parsedQty < minAllowed) {
       toast.error(

--- a/src/components/accounts/holding-form.tsx
+++ b/src/components/accounts/holding-form.tsx
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
 import { OptionBuilder } from "./option-builder";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 
 const ASSET_TYPES = [
   { value: "STOCK", label: "Stock" },
@@ -66,13 +66,13 @@ export function HoldingForm({
       setQuantityError("");
       return;
     }
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed) || parsed <= 0) {
       setQuantityError("Invalid quantity");
       return;
     }
     setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
+    setQuantity(formatAmountInput(parsed, 6));
   }
 
   function selectResult(result: SearchResult) {
@@ -141,7 +141,7 @@ export function HoldingForm({
     await postHolding({
       symbol,
       name,
-      quantity: parseFloat(quantity.replace(/,/g, "")),
+      quantity: parseAmountInput(quantity),
       assetType,
       currency,
     });
@@ -151,7 +151,7 @@ export function HoldingForm({
   const canSubmit =
     (tickerSelected || (manualMode && symbol && name)) &&
     !!quantity &&
-    parseFloat(quantity.replace(/,/g, "")) > 0;
+    parseAmountInput(quantity) > 0;
 
   // Dirty once the user has picked/typed a ticker, named it, or set a quantity.
   const isDirty = !!symbol || !!quantity || name.trim() !== "";

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -6,7 +6,7 @@ import { Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { formatCurrency, formatNumber } from "@/lib/currencies";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 
 interface InlineBalanceEditorProps {
@@ -47,13 +47,13 @@ export function InlineBalanceEditor({
       setError("");
       return;
     }
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed)) {
       setError("Invalid amount");
       return;
     }
     setError("");
-    setBalance(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(parsed));
+    setBalance(formatAmountInput(parsed, 2));
   }
 
   async function handleSave() {
@@ -65,7 +65,7 @@ export function InlineBalanceEditor({
       return;
     }
 
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed)) {
       setError("Invalid amount");
       return;
@@ -78,6 +78,8 @@ export function InlineBalanceEditor({
       setBalance("");
       setNote("");
       setError("");
+    } catch {
+      // onSave surfaces its own error toast; keep the editor open with the entered value.
     } finally {
       setSaving(false);
     }

--- a/src/components/accounts/option-builder.tsx
+++ b/src/components/accounts/option-builder.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatAmountInput } from "@/lib/amount-input";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
 import {
@@ -99,7 +100,7 @@ export function OptionBuilder({ loading, onSubmit, onConfigure, onCancel }: Opti
       return;
     }
     setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US").format(parsed));
+    setQuantity(formatAmountInput(parsed, 0));
   }
 
   const [showSearch, setShowSearch] = useState(false);

--- a/src/components/accounts/quick-add-holding.tsx
+++ b/src/components/accounts/quick-add-holding.tsx
@@ -25,7 +25,7 @@ import { DiscardConfirmDialog } from "@/components/discard-confirm-dialog";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 import { HoldingSearch } from "./holding-search";
 import type { SearchResult } from "./holding-search";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { HOLDING_ASSET_TYPES } from "@/lib/enums";
 
 const OptionBuilder = dynamic(() => import("./option-builder").then((m) => m.OptionBuilder));
@@ -92,13 +92,13 @@ export function QuickAddHolding({
       setQuantityError("");
       return;
     }
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed) || parsed <= 0) {
       setQuantityError(t("quickAddHolding.invalidQuantity", { defaultValue: "Invalid quantity" }));
       return;
     }
     setQuantityError("");
-    setQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
+    setQuantity(formatAmountInput(parsed, 6));
   }
 
   function selectResult(result: SearchResult) {
@@ -183,7 +183,7 @@ export function QuickAddHolding({
         body: JSON.stringify({
           symbol,
           name,
-          quantity: parseFloat(quantity.replace(/,/g, "")),
+          quantity: parseAmountInput(quantity),
           assetType,
           currency,
         }),
@@ -216,7 +216,7 @@ export function QuickAddHolding({
   const canProceed =
     (tickerSelected || (manualMode && symbol && name)) &&
     !!quantity &&
-    parseFloat(quantity.replace(/,/g, "")) > 0;
+    parseAmountInput(quantity) > 0;
 
   const matchingAccounts = getMatchingAccounts();
   const targetCategory = ASSET_TYPE_TO_CATEGORY[assetType] || "BROKERAGE";
@@ -424,7 +424,7 @@ export function QuickAddHolding({
             </div>
             <p className="text-sm text-muted-foreground mt-0.5">
               {assetType === "OPTION"
-                ? `${name} · ${quantity} contract${parseFloat(quantity.replace(/,/g, "")) !== 1 ? "s" : ""}`
+                ? `${name} · ${quantity} contract${parseAmountInput(quantity) !== 1 ? "s" : ""}`
                 : t("quickAddHolding.sharesSummary", { name, quantity })}
             </p>
           </div>

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatQuantity } from "@/lib/currencies";
-import { maskAmountInput } from "@/lib/amount-input";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import type { SerializedTransaction } from "@/lib/types";
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -183,9 +183,9 @@ export function TransactionHistory({
   function handleEditQuantityBlur() {
     const val = editQuantity.replace(/,/g, "");
     if (!val) return;
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed)) return;
-    setEditQuantity(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(parsed));
+    setEditQuantity(formatAmountInput(parsed, 6));
   }
 
   const [transactions, setTransactions] = useState<SerializedTransaction[]>([]);
@@ -246,9 +246,7 @@ export function TransactionHistory({
   const handleEditClick = (t: SerializedTransaction) => {
     setEditingTx(t);
     setEditType(t.type);
-    setEditQuantity(
-      new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(t.quantity),
-    );
+    setEditQuantity(formatAmountInput(t.quantity, 6));
     setEditNote(t.note || "");
 
     // Format date for datetime-local input

--- a/src/components/goals/goal-form-dialog.tsx
+++ b/src/components/goals/goal-form-dialog.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CURRENCIES } from "@/lib/currencies";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { ACCOUNT_CATEGORIES } from "@/lib/enums";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { SerializedAccount, SerializedGoal } from "@/lib/types";
@@ -37,9 +38,7 @@ function initialState(editGoal: SerializedGoal | undefined, defaultCurrency: str
   if (editGoal) {
     return {
       name: editGoal.name,
-      targetAmount: new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(
-        Number(editGoal.targetAmount),
-      ),
+      targetAmount: formatAmountInput(Number(editGoal.targetAmount), 2),
       targetCurrency: editGoal.targetCurrency,
       targetDate: editGoal.targetDate ? editGoal.targetDate.slice(0, 10) : "",
       scope: editGoal.scope as GoalScope,
@@ -105,28 +104,21 @@ export function GoalFormDialog({
   const needsScopeRef = scope === "CATEGORY" || scope === "ACCOUNT";
 
   function handleTargetAmountChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setTargetAmount("");
-      return;
-    }
-    const [intPart, decPart] = raw.split(".");
-    const formattedInt = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setTargetAmount(decPart !== undefined ? `${formattedInt}.${decPart}` : formattedInt);
+    const next = maskAmountInput(e.target.value);
+    if (next !== null) setTargetAmount(next);
   }
 
   function handleTargetAmountBlur() {
     const val = targetAmount.replace(/,/g, "");
     if (!val) return;
-    const parsed = parseFloat(val);
+    const parsed = parseAmountInput(val);
     if (isNaN(parsed) || parsed <= 0) return;
-    setTargetAmount(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(parsed));
+    setTargetAmount(formatAmountInput(parsed, 2));
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const amount = parseFloat(targetAmount.replace(/,/g, ""));
+    const amount = parseAmountInput(targetAmount);
     if (!name.trim() || isNaN(amount) || amount <= 0) return;
     if (needsScopeRef && !scopeRefId) return;
 

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { formatCurrency, formatNumber, getCurrencySymbol } from "@/lib/currencies";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import { useCountUp } from "@/hooks/use-count-up";
@@ -168,36 +169,30 @@ function NumberInput({
   max?: number;
   prefix?: string;
 }) {
-  const [display, setDisplay] = useState(() =>
-    value === 0 ? "" : new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(value),
-  );
+  const [display, setDisplay] = useState(() => (value === 0 ? "" : formatAmountInput(value, 6)));
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value.replace(/,/g, "");
-    if (raw !== "" && !/^\d*\.?\d*$/.test(raw)) return;
-    if (!raw) {
-      setDisplay("");
+    const next = maskAmountInput(e.target.value);
+    if (next === null) return;
+    setDisplay(next);
+    if (!next) {
       onChange(0);
       return;
     }
-    const [intPart, decPart] = raw.split(".");
-    const formattedInt = (intPart || "").replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    setDisplay(decPart !== undefined ? `${formattedInt}.${decPart}` : formattedInt);
-    const parsed = parseFloat(raw);
+    const parsed = parseAmountInput(next);
     if (!isNaN(parsed)) {
       onChange(Math.max(min, max !== undefined ? Math.min(max, parsed) : parsed));
     }
   }
 
   function handleBlur() {
-    const raw = display.replace(/,/g, "");
-    const parsed = parseFloat(raw);
-    if (!raw || isNaN(parsed)) {
+    const parsed = parseAmountInput(display);
+    if (isNaN(parsed)) {
       setDisplay("");
       return;
     }
     const clamped = Math.max(min, max !== undefined ? Math.min(max, parsed) : parsed);
-    setDisplay(new Intl.NumberFormat("en-US", { maximumFractionDigits: 6 }).format(clamped));
+    setDisplay(formatAmountInput(clamped, 6));
   }
 
   return (

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -52,6 +52,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { StocksOnboarding } from "./stocks-onboarding";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { hapticTick } from "@/lib/haptics";
+import { formatAmountInput } from "@/lib/amount-input";
 import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
 import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
@@ -72,10 +73,6 @@ function parseMoney(value: string) {
   if (!normalized) return null;
   const parsed = Number(normalized);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function formatNumberInput(value: number) {
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 8 }).format(value);
 }
 
 function useFormatters() {
@@ -139,13 +136,15 @@ function StockForm({
         }
       : null,
   );
-  const [recordPrice, setRecordPrice] = useState(stock ? formatNumberInput(stock.recordPrice) : "");
+  const [recordPrice, setRecordPrice] = useState(
+    stock ? formatAmountInput(stock.recordPrice, 8) : "",
+  );
   const [recordDate, setRecordDate] = useState(stock?.recordDate ?? localToday());
   const [note, setNote] = useState(stock?.note ?? "");
   const [priceError, setPriceError] = useState("");
 
   const isDirty = editing
-    ? recordPrice !== formatNumberInput(stock.recordPrice) ||
+    ? recordPrice !== formatAmountInput(stock.recordPrice, 8) ||
       recordDate !== stock.recordDate ||
       note !== (stock.note ?? "")
     : !!selected || !!recordPrice || recordDate !== localToday() || note.trim().length > 0;
@@ -173,7 +172,7 @@ function StockForm({
         type: "STOCK",
         currency: data.currency,
       });
-      setRecordPrice(formatNumberInput(data.price));
+      setRecordPrice(formatAmountInput(data.price, 8));
       setPriceError("");
     } catch {
       toast.error(t("prefillFailed"));

--- a/src/lib/amount-input.ts
+++ b/src/lib/amount-input.ts
@@ -24,3 +24,12 @@ export function maskAmountInput(value: string): string | null {
 export function parseAmountInput(value: string): number {
   return parseFloat(value.replace(/,/g, ""));
 }
+
+/**
+ * Format a parsed number for display in a masked amount input (en-US thousands
+ * grouping). Mirrors the inverse of {@link maskAmountInput} for the blur/normalize
+ * step that re-renders a validated number with grouping separators.
+ */
+export function formatAmountInput(value: number, maxFractionDigits = 2): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: maxFractionDigits }).format(value);
+}

--- a/tests/unit/amount-input.test.ts
+++ b/tests/unit/amount-input.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
+
+describe("maskAmountInput", () => {
+  it("groups the integer part with thousands separators", () => {
+    expect(maskAmountInput("1234")).toBe("1,234");
+    expect(maskAmountInput("1234567")).toBe("1,234,567");
+  });
+
+  it("preserves an in-progress trailing decimal point", () => {
+    expect(maskAmountInput("1234.")).toBe("1,234.");
+    expect(maskAmountInput("1234.5")).toBe("1,234.5");
+  });
+
+  it("strips existing grouping commas before re-masking", () => {
+    expect(maskAmountInput("1,234,567")).toBe("1,234,567");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(maskAmountInput("")).toBe("");
+  });
+
+  it("returns null for non-numeric input so the keystroke can be ignored", () => {
+    expect(maskAmountInput("12a")).toBeNull();
+    expect(maskAmountInput("abc")).toBeNull();
+    expect(maskAmountInput("1.2.3")).toBeNull();
+  });
+});
+
+describe("parseAmountInput", () => {
+  it("strips commas and parses to a number", () => {
+    expect(parseAmountInput("1,234.5")).toBe(1234.5);
+    expect(parseAmountInput("1,000,000")).toBe(1000000);
+  });
+
+  it("returns NaN for blank or invalid input", () => {
+    expect(parseAmountInput("")).toBeNaN();
+    expect(parseAmountInput("abc")).toBeNaN();
+  });
+});
+
+describe("formatAmountInput", () => {
+  it("defaults to 2 fraction digits with thousands grouping", () => {
+    expect(formatAmountInput(1234.5)).toBe("1,234.5");
+    expect(formatAmountInput(1234.567)).toBe("1,234.57");
+  });
+
+  it("respects a custom maxFractionDigits", () => {
+    expect(formatAmountInput(1.123456789, 6)).toBe("1.123457");
+    expect(formatAmountInput(1.123456789, 8)).toBe("1.12345679");
+  });
+
+  it("formats integers with zero fraction digits", () => {
+    expect(formatAmountInput(1234, 0)).toBe("1,234");
+    expect(formatAmountInput(1234.9, 0)).toBe("1,235");
+  });
+
+  it("round-trips with parseAmountInput", () => {
+    expect(parseAmountInput(formatAmountInput(1234567.89, 2))).toBe(1234567.89);
+  });
+});


### PR DESCRIPTION
## Summary

Targeted bug-fix + refactor of `src/components/`. Rather than rewrite the whole directory, this focuses on the work that actually reduces bug risk: one genuine correctness bug plus removing cross-file duplication by reusing the existing `amount-input.ts` helpers.

## Changes

**1. Fix silent balance-save failure** (`accounts/account-detail.tsx`)
- `saveBalance()` fired the PATCH but never checked `res.ok` and had no `try/catch`, so editing a cash balance showed a **success toast and cleared the editor even when the server rejected the update**.
- It now mirrors the sibling `handleNameSave()`: checks `res.ok`, surfaces an error toast on failure, and re-throws.
- `inline-balance-editor.tsx` `handleSave` gets a matching `catch {}` so the editor stays open with the entered value on failure (and the toast isn't duplicated).

**2. Dedupe numeric input formatting**
- Nine form files inlined the same comma-mask → `parseFloat` → `Intl.NumberFormat(...).format()` logic.
- Added one small `formatAmountInput()` helper next to the existing `maskAmountInput`/`parseAmountInput` (the latter was previously unused — now actually used), and replaced the inline logic across `accounts/` (holding-form, inline-balance-editor, edit-holding-dialog, option-builder, account-form, quick-add-holding, transaction-history), `goals/goal-form-dialog`, `projections/projection-view`, and `stocks/stock-tracker-view`.
- Behavior preserved — same fraction digits, same validation/error strings.

**3. Tests**
- Added `tests/unit/amount-input.test.ts` covering mask/parse/format (grouping, in-progress decimals, null-on-invalid, fraction-digit handling, round-trip).

## Deliberately out of scope
Verified non-bugs left alone to keep the diff safe: the sidebar `key={isActive}` (intentional remount to replay the `ios-tab-pop` CSS animation), positional Recharts/`COLUMNS` keys, and a dubious negative-balance "validation" that would break overdrafts/liabilities.

## Verification
- `npm run test:unit` → 7 files, 69 tests pass
- `npm run format:check`, `npm run lint`, `npm run typecheck` → all clean (also enforced by the pre-push hook)

https://claude.ai/code/session_01CQAgPSZ2Un693xPG7TW9mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQAgPSZ2Un693xPG7TW9mt)_