### PR TITLE
fix(search): treat Yahoo 4xx as non-errors, keep them out of Sentry

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,7 +1,7 @@
 import { unstable_cache } from "next/cache";
 import { ok, failure } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
-import { getYahooClient } from "@/lib/services/yahoo-client";
+import { getYahooClient, getYahooErrorStatus } from "@/lib/services/yahoo-client";
 import { log } from "@/lib/logger";
 
 type SearchResult = {
@@ -142,8 +142,19 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
-    // Distinct from an empty 200: signals an upstream failure so the client can
-    // show "search unavailable" instead of a misleading "no results".
+    const status = getYahooErrorStatus(error);
+    if (status !== undefined && status >= 400 && status < 500) {
+      // Expected client-driven 4xx, not a server fault: a malformed query
+      // (e.g. mid-composition Bopomofo yielding a 400 "Invalid Search Query")
+      // or a transient upstream rate-limit (429). Keep it out of Sentry —
+      // log.warn is breadcrumb-only — and return empty results so the UI shows
+      // "no matches" rather than an error. Not cached: a 429 is transient.
+      log.warn("search.yahoo_4xx", { query, status, error: String(error) });
+      return ok([] as SearchResult[]);
+    }
+    // Genuine upstream failure (5xx / network / timeout): distinct from an
+    // empty 200 so the client can show "search unavailable" instead of a
+    // misleading "no results". Captured so real outages stay visible.
     log.error("search.failed", { query, error: String(error) });
     return failure("Search is temporarily unavailable. Please try again.", 502);
   }

--- a/src/lib/services/yahoo-client.ts
+++ b/src/lib/services/yahoo-client.ts
@@ -22,3 +22,18 @@ let clientPromise: ReturnType<typeof load> | null = null;
 export function getYahooClient() {
   return (clientPromise ??= load());
 }
+
+/**
+ * Extract the upstream HTTP status from a yahoo-finance2 error, when it carries
+ * one. `BadRequestError` corresponds to a 400; `HTTPError` sets a numeric `code`
+ * to the response status (see the lib's yahooFinanceFetch). Returns undefined
+ * for network/timeout/validation errors that have no HTTP status — callers
+ * should treat those as genuine failures. Lets call sites distinguish an
+ * expected client-driven 4xx (malformed query, rate-limit) from a real outage.
+ */
+export function getYahooErrorStatus(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  if (error.name === "BadRequestError") return 400;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "number" ? code : undefined;
+}

--- a/tests/unit/yahoo-client.test.ts
+++ b/tests/unit/yahoo-client.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+
+// yahoo-client imports `server-only` (aliased in vitest.config) and only
+// dynamically imports yahoo-finance2 inside load(), so importing the module
+// for the pure helper never pulls in the Node-only lib.
+const { getYahooErrorStatus } = await import("@/lib/services/yahoo-client");
+
+// Fabricate errors the way yahoo-finance2 shapes them (see its lib/errors.ts +
+// yahooFinanceFetch.ts): BadRequestError carries only a name; HTTPError sets a
+// numeric `code` to the upstream response status.
+function badRequestError(message: string): Error {
+  const error = new Error(message);
+  error.name = "BadRequestError";
+  return error;
+}
+
+function httpError(message: string, code: number): Error {
+  const error = new Error(message) as Error & { code: number };
+  error.name = "HTTPError";
+  error.code = code;
+  return error;
+}
+
+describe("getYahooErrorStatus", () => {
+  it("maps BadRequestError to 400", () => {
+    expect(getYahooErrorStatus(badRequestError("Invalid Search Query"))).toBe(400);
+  });
+
+  it("returns the HTTPError status code (e.g. 429 rate-limit)", () => {
+    expect(getYahooErrorStatus(httpError("Edge: Too Many Requests", 429))).toBe(429);
+  });
+
+  it("returns the HTTPError status code for upstream 5xx", () => {
+    expect(getYahooErrorStatus(httpError("Service Unavailable", 503))).toBe(503);
+  });
+
+  it("returns undefined for a network/timeout error with no status", () => {
+    expect(getYahooErrorStatus(new Error("fetch failed"))).toBeUndefined();
+  });
+
+  it("returns undefined for non-Error values", () => {
+    expect(getYahooErrorStatus("boom")).toBeUndefined();
+    expect(getYahooErrorStatus(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **ASTT-N** (`search.failed`) — the search endpoint was reporting normal user input as production Sentry errors.

`/api/search` caught **every** error from Yahoo and did `log.error("search.failed", …)` (→ `Sentry.captureMessage`) + returned `502`. But Yahoo **4xx** responses aren't server faults:
- **400 `Invalid Search Query`** — produced by malformed/incomplete input. The live event was query `"ˇㄉㄢ"` — a user mid-composition in **Bopomofo/注音**.
- **429 `Too Many Requests`** — a transient upstream rate-limit.

Both were surfacing as captured Sentry errors for ordinary typing.

## Changes

- New `getYahooErrorStatus()` helper in `yahoo-client.ts` that classifies a `yahoo-finance2` error's upstream HTTP status (`BadRequestError` → 400; `HTTPError` carries `response.status` on `.code`; network/timeout/validation → `undefined`).
- `/api/search` now branches on it:
  - **4xx** → `log.warn("search.yahoo_4xx", …)` (breadcrumb-only, **not** captured by Sentry) + empty `200` so the UI shows "no matches"; not cached, since a 429 is transient.
  - **5xx / network / timeout** → unchanged: `log.error("search.failed", …)` + `502`, so genuine outages stay visible and the client can still distinguish "search broken" from "no results".

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- `pnpm test:unit` — 99 passing (+5: classifier across `BadRequestError`, `HTTPError` 4xx/5xx, network errors, non-Error values)

## Context

Follow-up to #447 (Frankfurter 404 noise, merged). Same noise-reduction pattern: an expected client/upstream condition should be a breadcrumb, not a captured production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)