### PR TITLE
feat(mobile): sliding tab-bar pill + list entrance stagger

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -443,6 +443,29 @@
   animation-delay: calc(var(--i, 0) * 45ms);
 }
 
+/* ─── Mobile list entrance ────────────────────────────────────────────────────
+   Grouped mobile lists (accounts rows, the stock watchlist) settle in as a
+   sibling stagger when the screen mounts, so a list reads as arriving rather than
+   appearing all at once. Transform/opacity only, one-shot, `backwards` fill holds
+   the from-state through the per-row delay then reverts to the natural state so
+   row hover/press transitions keep working. The caller caps `--i` (see
+   STAGGER_CAP in the list components) so a long list never grows a slow tail. */
+@keyframes list-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.stagger-rise {
+  animation: list-row-in var(--duration-normal) var(--ease-out-expo) backwards;
+  animation-delay: calc(var(--i, 0) * 45ms);
+}
+
 /* Decorative, continuously-looping effects must not run when the user has
    asked for reduced motion (WCAG 2.3.3) — the mesh stays as a static wash. */
 @media (prefers-reduced-motion: reduce) {
@@ -461,7 +484,8 @@
     animation: none;
   }
   .history-cell-in,
-  .history-rise-in {
+  .history-rise-in,
+  .stagger-rise {
     animation: none;
   }
   /* tw-animate-css ships no reduced-motion guard of its own, so the dashboard's

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -60,6 +60,10 @@ const QuickAddHolding = dynamic(() => import("./quick-add-holding").then((m) => 
 
 const HIDDEN = "***";
 
+// Cap the per-row entrance stagger so a long mobile list never grows a slow tail:
+// rows past this index all share the final delay (8 × 45ms = 360ms) and land together.
+const STAGGER_CAP = 8;
+
 const CATEGORY_ICONS: Record<string, LucideIcon> = {
   BANK: Landmark,
   BROKERAGE: BriefcaseBusiness,
@@ -652,10 +656,11 @@ export function AccountsList({
                     {t("accountsList.assets")}
                   </h3>
                   <div className="rounded-xl border overflow-hidden divide-y divide-border/60">
-                    {assets.map((account) => (
+                    {assets.map((account, index) => (
                       <MobileAccountRow
                         key={account.id}
                         account={account}
+                        index={index}
                         priceMap={priceMap}
                         ratesMap={ratesMap}
                         baseCurrency={baseCurrency}
@@ -676,10 +681,11 @@ export function AccountsList({
                     {t("accountsList.liabilities")}
                   </h3>
                   <div className="rounded-xl border overflow-hidden divide-y divide-border/60">
-                    {liabilities.map((account) => (
+                    {liabilities.map((account, index) => (
                       <MobileAccountRow
                         key={account.id}
                         account={account}
+                        index={index}
                         priceMap={priceMap}
                         ratesMap={ratesMap}
                         baseCurrency={baseCurrency}
@@ -1142,6 +1148,7 @@ function MobileSummaryStrip({
 
 function MobileAccountRow({
   account,
+  index,
   priceMap,
   ratesMap,
   baseCurrency,
@@ -1152,6 +1159,7 @@ function MobileAccountRow({
   isUpdating,
 }: {
   account: SerializedAccountWithHoldings;
+  index: number;
   priceMap: Record<string, number>;
   ratesMap: Record<string, number>;
   baseCurrency: string;
@@ -1176,7 +1184,10 @@ function MobileAccountRow({
   const isBank = account.category === "BANK";
 
   return (
-    <div className="relative group">
+    <div
+      className="relative group motion-safe:stagger-rise"
+      style={{ "--i": Math.min(index, STAGGER_CAP) } as React.CSSProperties}
+    >
       <Link href={`/accounts/${account.id}`} prefetch={false} transitionTypes={["nav-forward"]}>
         <div
           className={`flex items-center gap-3 ${isCompact ? "px-4 py-2.5" : "px-4 py-3.5"} bg-card hover:bg-muted/40 active:bg-muted/60 transition-colors`}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -24,7 +24,14 @@ import { usePrivacyMode } from "./privacy-mode-context";
 import { useTranslations } from "next-intl";
 import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
 import { hapticTick } from "@/lib/haptics";
-import { useCallback, useEffect, useSyncExternalStore, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+} from "react";
 import { AppIcon } from "./app-icon";
 
 const SIDEBAR_STORAGE_KEY = "asset-tracker:sidebar-collapsed";
@@ -265,6 +272,61 @@ export function MobileNav() {
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];
 
+  const resolveActive = (href: string) =>
+    isPending
+      ? href === "/"
+        ? optimisticHref === "/"
+        : (optimisticHref?.startsWith(href) ?? false)
+      : href === "/"
+        ? pathname === "/"
+        : pathname.startsWith(href);
+
+  // The active "pill" is a single shared element that glides between tabs instead
+  // of each button toggling its own background. We measure the active button's box
+  // and translate the pill there; only `transform` is transitioned (the buttons are
+  // equal-width, so width/height stay constant). `animate` gates the transition on
+  // for one frame after the first measurement so the pill places itself on mount
+  // without sliding in from the left edge. routes not in the tab bar (e.g. /history)
+  // leave activeIndex at -1, hiding the pill.
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [indicator, setIndicator] = useState<{
+    x: number;
+    w: number;
+    y: number;
+    h: number;
+  } | null>(null);
+  const [animate, setAnimate] = useState(false);
+  const activeIndex = navItems.findIndex((item) => resolveActive(item.href));
+
+  useEffect(() => {
+    const measure = () => {
+      const btn = activeIndex >= 0 ? itemRefs.current[activeIndex] : null;
+      if (!btn) {
+        setIndicator(null);
+        return;
+      }
+      setIndicator({
+        x: btn.offsetLeft,
+        w: btn.offsetWidth,
+        y: btn.offsetTop,
+        h: btn.offsetHeight,
+      });
+    };
+    measure();
+    const nav = itemRefs.current[0]?.parentElement;
+    if (!nav) return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(nav);
+    return () => ro.disconnect();
+  }, [activeIndex]);
+
+  useEffect(() => {
+    if (indicator && !animate) {
+      const id = requestAnimationFrame(() => setAnimate(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [indicator, animate]);
+
   return (
     <nav
       className={cn(
@@ -272,18 +334,34 @@ export function MobileNav() {
         hidden && "translate-y-[calc(100%+1.75rem+env(safe-area-inset-bottom))]",
       )}
     >
-      {navItems.map((item) => {
-        const isActive = isPending
-          ? item.href === "/"
-            ? optimisticHref === "/"
-            : (optimisticHref?.startsWith(item.href) ?? false)
-          : item.href === "/"
-            ? pathname === "/"
-            : pathname.startsWith(item.href);
+      {/* Sliding active-tab pill — sits behind the buttons. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute left-0 top-0 rounded-full bg-primary/15 dark:bg-primary/20",
+          animate &&
+            "transition-[transform,opacity] duration-[280ms] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+        )}
+        style={
+          indicator
+            ? {
+                width: indicator.w,
+                height: indicator.h,
+                transform: `translate(${indicator.x}px, ${indicator.y}px)`,
+                opacity: 1,
+              }
+            : { opacity: 0 }
+        }
+      />
+      {navItems.map((item, i) => {
+        const isActive = resolveActive(item.href);
         const Icon = item.icon;
         return (
           <button
             key={item.href}
+            ref={(el) => {
+              itemRefs.current[i] = el;
+            }}
             type="button"
             onTouchStart={() => {
               if (!isActive) router.prefetch(item.href);
@@ -304,7 +382,7 @@ export function MobileNav() {
               className={cn(
                 "flex w-full h-full flex-col items-center justify-center gap-0.5 px-1 py-1 rounded-full text-[10px] font-medium tracking-tight normal-case transition-colors motion-normal",
                 isActive
-                  ? "text-primary font-semibold bg-primary/15 dark:bg-primary/20"
+                  ? "text-primary font-semibold"
                   : "text-muted-foreground group-hover:text-foreground",
               )}
             >

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useState, type CSSProperties } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { Reorder, useDragControls } from "framer-motion";
@@ -365,12 +365,18 @@ function StockForm({
   );
 }
 
+// Cap the per-row entrance stagger so a long watchlist never grows a slow tail:
+// rows past this index share the final delay and land together.
+const STAGGER_CAP = 8;
+
 function StockRow({
   stock,
+  index,
   onEdit,
   onDelete,
 }: {
   stock: SerializedTrackedStock;
+  index: number;
   onEdit: (stock: SerializedTrackedStock) => void;
   onDelete: (stock: SerializedTrackedStock) => void;
 }) {
@@ -472,8 +478,9 @@ function StockRow({
   return (
     <Card
       size="sm"
+      style={{ "--i": Math.min(index, STAGGER_CAP) } as CSSProperties}
       className={cn(
-        "overflow-visible transition-colors md:py-2",
+        "overflow-visible transition-colors md:py-2 motion-safe:stagger-rise",
         hasDirection
           ? isGain
             ? "border-[var(--gain)]/35 bg-[var(--gain)]/5 hover:border-[var(--gain)]/60 hover:bg-[var(--gain)]/8"
@@ -910,10 +917,11 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
         <ManageOrderList draft={draft} onReorder={setDraft} />
       ) : (
         <div className="space-y-3 md:space-y-2">
-          {stocks.map((stock) => (
+          {stocks.map((stock, index) => (
             <StockRow
               key={stock.id}
               stock={stock}
+              index={index}
               onEdit={(nextStock) => {
                 setEditingStock(nextStock);
                 setFormOpen(true);


### PR DESCRIPTION
## Summary

Two purposeful motion additions to the mobile experience (`/impeccable animate` on mobile usage). The existing mobile system was already mature (hide-on-scroll chrome, large-title sync, iOS tab-pop, route view-transitions, pull-to-refresh, bottom-sheet forms), so this fills the two genuine gaps rather than re-animating polished surfaces.

### 1. Sliding active-tab pill (`MobileNav`)
The bottom tab bar previously toggled a `bg-primary/15` background on each button independently. Now a single shared pill measures the active button's box and `translate()`s between tabs:
- **Transform-only** transition (buttons are equal-width `flex-1`, so width/height stay constant), `280ms` `--ease-out-expo` — confident glide, no bounce.
- An `animate` flag gates the transition on one frame *after* first measurement, so the pill places itself on mount instead of sliding in from the left edge.
- Follows the **optimistic** active state, so it starts gliding the instant you tap (before navigation resolves).
- `ResizeObserver` re-measures on layout/orientation changes; routes outside the tab bar (e.g. `/history`) hide it via `opacity: 0`. `motion-reduce:transition-none` keeps it placed but static for reduced-motion users.

### 2. List/card entrance stagger
- New reusable `.stagger-rise` utility (`list-row-in` keyframe: 8px rise + fade, `backwards` fill, `--i × 45ms` delay) mirroring the existing `history-rise-in` convention, added to the `prefers-reduced-motion` guard.
- Applied to the **mobile accounts list** (was fully static) and the **stock watchlist**, each capped at `STAGGER_CAP = 8` so a long list lands together rather than dragging a slow tail.
- Holdings list left untouched — it already animates entrance via framer-motion.

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all pass.
- Verified in a real 390×844 mobile viewport against the worktree dev server with seeded data: the pill sits under Dashboard at rest, glides toward Accounts mid-tap, and both lists render with the entrance applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)