### PR TITLE
fix(settings): 44px mobile touch targets + accessible chip contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,7 @@
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-primary-ink: var(--primary-ink);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -115,6 +116,11 @@
      Defined once: lazy var() substitution re-resolves per cascaded theme/schema. */
   --gain-ink: color-mix(in oklab, var(--gain), var(--foreground) 30%);
   --loss-ink: color-mix(in oklab, var(--loss), var(--foreground) 30%);
+  /* Same treatment for the brand primary when it carries small chip/body text on
+     a faint primary tint (freshness + privacy badges): the raw --primary clears
+     3:1 as a pill fill but dips below 4.5:1 as 11px text on the near-white canvas,
+     worst on the lighter schemas (amber, emerald). Re-resolves per theme/schema. */
+  --primary-ink: color-mix(in oklab, var(--primary), var(--foreground) 30%);
   --app-icon-gradient-start: #34d399;
   --app-icon-gradient-end: #065f46;
 

--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -251,7 +251,7 @@ export function DataManagement() {
                 variant="outline"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isImporting}
-                className="w-full min-w-[200px]"
+                className="h-11 md:h-8 w-full min-w-[200px]"
               >
                 {isImporting ? (
                   <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
@@ -365,7 +365,9 @@ export function DataManagement() {
                   value={confirmation}
                   onChange={(event) => setConfirmation(event.target.value)}
                   autoComplete="off"
+                  autoCapitalize="characters"
                   aria-describedby="replace-confirmation-help"
+                  className="h-11 md:h-9"
                 />
                 <p id="replace-confirmation-help" className="text-xs text-muted-foreground">
                   {t("typeToConfirmHelp", { confirmation: CONFIRMATION_TEXT })}
@@ -374,13 +376,19 @@ export function DataManagement() {
             </div>
           )}
           <DialogFooter>
-            <Button variant="outline" onClick={resetImportSelection} disabled={isImporting}>
+            <Button
+              variant="outline"
+              onClick={resetImportSelection}
+              disabled={isImporting}
+              className="h-11 md:h-8"
+            >
               {t("cancel")}
             </Button>
             <Button
               variant="destructive"
               onClick={handleImport}
               disabled={!confirmationMatches || isImporting}
+              className="h-11 md:h-8"
             >
               {isImporting ? (
                 <Loader2Icon className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
@@ -419,7 +427,7 @@ export function DataManagement() {
                 setImportError(null);
                 resetImportSelection();
               }}
-              className="w-full sm:w-auto"
+              className="h-11 md:h-8 w-full sm:w-auto"
             >
               {t("close")}
             </Button>
@@ -442,10 +450,16 @@ export function DataManagement() {
             {t("importSuccessNextStep")}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => window.location.reload()}>
+            <Button
+              variant="outline"
+              onClick={() => window.location.reload()}
+              className="h-11 md:h-8"
+            >
               {t("stayInSettings")}
             </Button>
-            <Button onClick={() => window.location.assign("/")}>{t("reviewDashboard")}</Button>
+            <Button onClick={() => window.location.assign("/")} className="h-11 md:h-8">
+              {t("reviewDashboard")}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/settings/privacy-security.tsx
+++ b/src/components/settings/privacy-security.tsx
@@ -81,7 +81,7 @@ export function PrivacySecurity({ userEmail, signOutAction }: PrivacySecurityPro
             </div>
             <Badge
               variant="secondary"
-              className="self-start bg-primary/10 text-primary dark:bg-primary/15"
+              className="self-start bg-primary/10 text-primary-ink dark:bg-primary/15"
             >
               {t("privacy.privateByDefault")}
             </Badge>
@@ -102,7 +102,7 @@ export function PrivacySecurity({ userEmail, signOutAction }: PrivacySecurityPro
                   <Badge
                     variant="secondary"
                     className={
-                      privacyMode ? "bg-primary/10 text-primary dark:bg-primary/15" : undefined
+                      privacyMode ? "bg-primary/10 text-primary-ink dark:bg-primary/15" : undefined
                     }
                   >
                     {privacyMode ? t("privacy.balancesHidden") : t("privacy.balancesVisible")}
@@ -118,7 +118,7 @@ export function PrivacySecurity({ userEmail, signOutAction }: PrivacySecurityPro
               variant="outline"
               onClick={togglePrivacyMode}
               aria-pressed={privacyMode}
-              className="w-full sm:w-auto sm:min-w-[150px]"
+              className="h-11 md:h-8 w-full sm:w-auto sm:min-w-[150px]"
             >
               {privacyMode ? t("privacy.showBalances") : t("privacy.hideBalances")}
             </Button>
@@ -139,7 +139,11 @@ export function PrivacySecurity({ userEmail, signOutAction }: PrivacySecurityPro
               </div>
             </div>
             <form action={signOutAction} className="w-full sm:w-auto">
-              <Button type="submit" variant="outline" className="w-full sm:min-w-[150px]">
+              <Button
+                type="submit"
+                variant="outline"
+                className="h-11 md:h-8 w-full sm:min-w-[150px]"
+              >
                 <LogOutIcon className="mr-2 size-4" aria-hidden="true" />
                 {t("signOut")}
               </Button>
@@ -164,7 +168,7 @@ export function PrivacySecurity({ userEmail, signOutAction }: PrivacySecurityPro
               onClick={handleExport}
               disabled={isExporting}
               aria-busy={isExporting}
-              className="w-full sm:w-auto sm:min-w-[150px]"
+              className="h-11 md:h-8 w-full sm:w-auto sm:min-w-[150px]"
             >
               {isExporting ? (
                 <Loader2Icon className="mr-2 size-4 animate-spin" aria-hidden="true" />

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -100,7 +100,7 @@ function CurrencyPicker({
         variant="outline"
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
-        className="h-9 w-full justify-between gap-3 sm:w-[240px]"
+        className="h-11 md:h-9 w-full justify-between gap-3 sm:w-[240px]"
       >
         <span className="min-w-0 truncate text-left font-normal">
           {formatCurrencyLabel(selectedCurrency)}
@@ -270,7 +270,10 @@ export function SettingsForm({
               </div>
               <div className="flex items-center gap-2 sm:w-auto w-full">
                 <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
-                  <SelectTrigger id="language-select" className="flex-1 sm:flex-none sm:w-[200px]">
+                  <SelectTrigger
+                    id="language-select"
+                    className="min-h-11 md:min-h-0 flex-1 sm:flex-none sm:w-[200px]"
+                  >
                     <SelectValue>{t(`languages.${locale}`)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
@@ -363,7 +366,7 @@ export function SettingsForm({
                 type="button"
                 onClick={savePreferences}
                 disabled={saving || !preferencesChanged}
-                className="w-full sm:w-auto sm:min-w-[150px]"
+                className="h-11 md:h-8 w-full sm:w-auto sm:min-w-[150px]"
               >
                 {saving ? (
                   <RefreshCw className="mr-2 size-4 animate-spin" aria-hidden="true" />
@@ -418,7 +421,7 @@ export function SettingsForm({
                 title={
                   coolingDown ? t("toast.refreshCooldown", { seconds: secondsLeft }) : undefined
                 }
-                className="w-full sm:w-auto min-w-[150px]"
+                className="h-11 md:h-8 w-full sm:w-auto min-w-[150px]"
               >
                 <RefreshCw className={`mr-2 size-4 ${refreshing ? "animate-spin" : ""}`} />
                 {refreshing ? t("settings.refreshing") : t("settings.btnRefreshMarketData")}

--- a/src/components/ui/freshness-badge.tsx
+++ b/src/components/ui/freshness-badge.tsx
@@ -84,7 +84,7 @@ export function FreshnessBadge({
     ? "border-warning/35 bg-warning/10 text-warning"
     : kind === "snapshot"
       ? "border-border/70 bg-muted/30"
-      : "border-primary/25 bg-primary/5 text-primary";
+      : "border-primary/25 bg-primary/5 text-primary-ink";
 
   return (
     <span


### PR DESCRIPTION
## What

Mobile-focused fixes to the **Settings tab**, driven by an `impeccable` audit/critique pass.

### 1. 44px touch targets on mobile
Settings controls shipped at 32–36px on mobile (`Button`/`Select` default `h-8`, currency `h-9`) — below the 44px target the tab's **own** density toggle (`min-h-[44px]`) and color swatches (`w-11 h-11`) already use. Every interactive control is now ≥44px on mobile while keeping the compact desktop sizes:

- Buttons → `h-11 md:h-8` (currency picker `h-11 md:h-9`)
- Language `SelectTrigger` → `min-h-11 md:min-h-0` (a `min-height` floor, since its `data-[size]:h-8` outranks a plain `h-11`)
- `Input` (REPLACE confirm) → `h-11 md:h-9`

Covers currency, language, save, refresh, privacy toggle, sign out, export, import, and the destructive import-confirm/error/success dialog buttons.

### 2. Accessible chip contrast
Added a **`--primary-ink`** token (`color-mix(in oklab, var(--primary), var(--foreground) 30%)` — the same treatment the codebase already uses for `--gain-ink`/`--loss-ink`) and registered `--color-primary-ink` in `@theme`. The freshness badges and privacy badges now use `text-primary-ink` instead of `text-primary`: the raw `--primary` clears 3:1 as a pill fill but dips below 4.5:1 as ~11px text on the near-white canvas, worst on the lighter schemas (amber, emerald). Re-resolves per theme/schema.

## Why
WCAG 2.5.8 / Apple HIG touch-target guidance + PRODUCT.md mobile principles; WCAG 1.4.3 text contrast across all six color schemas.

## Verification
- Visual: captured before/after at **390px, amber schema, light mode** (worst case) via Preview Login on a local mobile viewport.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all pass (also enforced by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)