### PR TITLE
Fix ledger atomicity and cron cache invalidation

### DIFF
--- a/docs/ENHANCEMENT_PLAN.md
+++ b/docs/ENHANCEMENT_PLAN.md
@@ -20,6 +20,31 @@ Impact: 🔴 data risk / security / launch blocker · 🟡 meaningful · 🟢 po
 
 ---
 
+## 2026-06-17 module audit addendum
+
+Fresh module-by-module audit: [`MODULE_ENHANCEMENT_AUDIT_2026-06-17.md`](./MODULE_ENHANCEMENT_AUDIT_2026-06-17.md).
+
+Automated baseline is clean (`format:check`, `lint`, `typecheck`,
+`test:unit`, and `build` all pass), but the audit found live issues that should
+take priority over the older "completed" Tier 0 wording below:
+
+1. ✅ P0 ledger atomicity implemented in this PR: cash transaction create,
+   account balance edit, and holding transaction edit/delete now use stronger
+   transaction/delta write contracts.
+2. ✅ P0 cron cache consistency implemented in this PR: expired option sweeps
+   now invalidate net-worth before same-run snapshots.
+3. P1 validation/dedupe gaps: transaction pagination, snapshot range params,
+   goal scope references, and projection same-day snapshot dedupe need focused
+   fixes.
+4. P1/P2 client/tooling hardening: undo-delete can double-commit, option-chain
+   fetches need cancellation, Sentry config emits a deprecation warning, and
+   the vitals endpoint needs a body cap.
+
+Use the addendum as the current next-work queue, then reconcile stale statuses
+in `BUGS.md`, `CODE_QUALITY.md`, and `ROADMAP.md` as fixes land.
+
+---
+
 ## Tier 0 — Data integrity & correctness (completed; keep as regression log)
 
 Small fixes; every one was a verified live bug with user-visible consequences.

--- a/docs/MODULE_ENHANCEMENT_AUDIT_2026-06-17.md
+++ b/docs/MODULE_ENHANCEMENT_AUDIT_2026-06-17.md
@@ -1,0 +1,221 @@
+# Module Enhancement Audit - 2026-06-17
+
+This audit re-checks the current codebase module by module against the local
+Next.js 16.2.2 docs in `node_modules/next/dist/docs/` and the existing
+trackers in `docs/`. It is intentionally source-grounded: every live issue
+below points at the current file and line where the risk still exists.
+
+Automated baseline:
+
+- `pnpm format:check` passed.
+- `pnpm lint` passed.
+- `pnpm typecheck` passed.
+- `pnpm test:unit` passed: 12 files, 107 tests.
+- `pnpm build` passed. Build output still reports the Sentry `disableLogger`
+  deprecation warning from `next.config.ts`.
+
+Implementation update in this PR:
+
+- P0 items A1, A2, A3, and C1 are now implemented with focused route/cron
+  regression coverage. Remaining open findings start at A4, H1, P1, G1, U1,
+  and the P2 hardening/schema cleanup queue below.
+
+Severity guide:
+
+- P0: correctness, data integrity, or stale financial output.
+- P1: broken/500-prone edge cases or misleading UX.
+- P2: hardening, maintainability, stale docs, or coverage gaps.
+
+## Executive Plan
+
+1. Fix ledger atomicity first: cash transaction create, account balance edit,
+   and holding transaction edit/delete must commit ledger rows and account or
+   holding totals as one write contract.
+2. Normalize route input validation: reject invalid `limit`, `page`, `from`,
+   `to`, and scoped goal references with 400 responses instead of letting
+   invalid values flow into Prisma/raw SQL.
+3. Remove duplicated snapshot-dedupe logic from projections by reusing the
+   history tie-break convention: target currency wins, then latest `createdAt`.
+4. Harden cron cache invalidation so option expiry invalidates net-worth before
+   same-run snapshots are created.
+5. Close the smaller UI/tooling gaps: undo-delete double commit, option-chain
+   fetch cleanup, Sentry deprecation, auth-adapter typing, metrics body cap.
+6. Add focused regression tests for every P0/P1 fix, then clean stale tracker
+   statuses in `BUGS.md`, `CODE_QUALITY.md`, and `ROADMAP.md`.
+
+## Module Findings
+
+### Accounts and Ledger
+
+Status: P0 ledger issues resolved in this PR; live P1 issues remain.
+
+- P0 A1 - Resolved in this PR. Manual cash transaction creation now wraps the
+  `CashTransaction` insert and `Account.cashBalance` increment in one
+  `prisma.$transaction`, with route coverage confirming both writes go through
+  the transaction path.
+- P0 A2 - Resolved in this PR. Manual account balance edits now create the
+  cash EDIT row and update the account inside one transaction. The optional
+  balance-edit note is validated by `updateAccountSchema` and stripped from
+  the account update payload before Prisma sees it.
+- P0 A3 - Resolved in this PR. Holding transaction edit/delete now uses guarded
+  `updateMany`/`deleteMany` row-state checks plus atomic holding
+  `increment`/`decrement` writes. Negative decrements return 400, stale
+  concurrent edits return 409, and successful mutations invalidate account,
+  net-worth, and history caches as before.
+- P1 A4 - Transaction pagination can pass `NaN` to raw SQL. `limit` and `page`
+  are parsed with `Number(...)` in
+  `src/app/api/accounts/[id]/transactions/route.ts:49` and `:78`. Values such
+  as `?limit=abc` or `?page=abc` become `NaN`, then flow into `LIMIT`/`OFFSET`.
+  Plan: add a Zod query schema using `z.coerce.number().int().min().max()` and
+  return `validationError` for invalid params.
+- P1 A5 - Account DELETE may surface a Prisma 500 instead of a 404.
+  `src/app/api/accounts/[id]/route.ts:60` deletes by `{ id, userId }` without a
+  missing-row guard. Plan: use `deleteMany({ where: { id, userId } })` and
+  return 404 when `count === 0`, matching the stock/recurring delete pattern.
+
+### History and Snapshots API
+
+Status: live P1 issue found.
+
+- P1 H1 - Snapshot range params are not validated. `src/app/api/snapshots/route.ts:12`
+  and `:13` convert arbitrary `from`/`to` strings with `new Date(...)`; invalid
+  dates can reach Prisma. `currency` at `:9` is also unconstrained. Plan: add a
+  Zod query schema for ISO dates and three-letter currency codes; reject
+  invalid ranges with 400 and add a small route-handler test.
+
+### Cron and Snapshot Creation
+
+Status: P0 cache-consistency issue resolved in this PR.
+
+- P0 C1 - Resolved in this PR. The expired-option sweep now feeds a
+  `structuralChanged` cache-invalidation gate, so both `accounts` and
+  `net-worth` are revalidated before same-run snapshots are created even when
+  prices, rates, and recurring materializers did not change.
+
+### Projections
+
+Status: live P1 issue found.
+
+- P1 P1 - Projection dedupe can keep an older same-day snapshot. History uses a
+  deterministic duplicate rule, but `src/lib/services/projection-service.ts:43`
+  only replaces when no row exists or the candidate matches the target base
+  currency. Two same-currency snapshots on the same day can leave the earlier
+  one in projections. Plan: extract/share the history dedupe helper or mirror
+  its target-currency-then-latest-`createdAt` rule; add a projection-service
+  regression test.
+
+### Goals
+
+Status: live P1 issue found.
+
+- P1 G1 - Goal scope references are accepted without semantic validation.
+  `src/lib/validators.ts:268`-`:275` allows any `scopeRefId`; create/update in
+  `src/app/api/goals/route.ts:31`-`:38` and
+  `src/app/api/goals/[id]/route.ts:22`-`:28` persist it without checking that
+  `ACCOUNT` references belong to the user or that `CATEGORY` references are
+  valid categories. Plan: validate scope/ref pairs server-side before writes:
+  `ACCOUNT` must exist for `userId`, `CATEGORY` must be an `AccountCategory`,
+  and `NET_WORTH`/`ASSETS_ONLY` should clear `scopeRefId`.
+
+### Settings and Data Management
+
+Status: no new import/export correctness issue found; existing account deletion
+gap remains.
+
+- P2 S1 - True account deletion is still the missing privacy/GDPR piece already
+  tracked as E16. Export and replace-import are present, bounded, validated, and
+  transactional; deleting the `User` row plus a confirm UI remains pending.
+- P2 S2 - Locale-change reload still uses an unmanaged timeout in
+  `src/components/settings/settings-form.tsx`. Plan: track the timeout id and
+  clear it on unmount, or replace the full reload with a routed locale refresh
+  once the i18n flow supports it.
+
+### UI and Shared Client Utilities
+
+Status: live P1/P2 issues found.
+
+- P1 U1 - Undo delete can commit twice. `src/lib/undo-delete.ts:28` and `:31`
+  both call `onCommit()` when the toast closes and only guard the undo path.
+  If Sonner fires both callbacks for one close, the DELETE can be issued twice.
+  Plan: add a `committed` flag and route both callbacks through one `commitOnce`.
+- P2 U2 - Option-chain fetches can set state after unmount.
+  `src/components/accounts/option-builder.tsx:113`-`:135` and `:147`-`:160`
+  fetch without an `AbortController` or mounted guard. Plan: add cancellation
+  for initial and expiration-specific chain loads; keep failed-expiration state
+  updates behind the same guard.
+- P2 U3 - A few visible/accessibility strings remain hardcoded in client
+  chrome and quick-add flows. Plan: move sidebar/mobile privacy labels and the
+  remaining quick-add manual-search strings into `messages/en-US.json` and
+  `messages/zh-TW.json`.
+
+### Auth, Observability, and Platform
+
+Status: live P2 issues found.
+
+- P2 O1 - Sentry build config uses a deprecated option. `pnpm build` warns that
+  `disableLogger` is deprecated; the option is set at `next.config.ts:151`.
+  Plan: migrate to the current Sentry/Next config option
+  (`webpack.treeshake.removeDebugLogging` where supported) or remove it if
+  Turbopack does not support the replacement.
+- P2 O2 - The custom auth adapter still relies on explicit `any` casts.
+  `src/lib/auth-adapter.ts:7`-`:26` suppresses the adapter boundary. Plan:
+  type the override against Auth.js `Adapter` and Prisma generated inputs so
+  provider-account changes fail at compile time.
+- P2 O3 - The vitals endpoint reads an unbounded body. `_metrics/vitals`
+  calls `request.text()` at `src/app/api/_metrics/vitals/route.ts:6` without a
+  size cap or rate limit, unlike the CSP report route. Plan: mirror the CSP
+  report body cap and add a small anonymous rate limit.
+
+### Database and Schema
+
+Status: live P2 schema cleanup items remain.
+
+- P2 D1 - `ExchangeRate` keeps both a synthetic `id` primary key and a unique
+  `(fromCurrency, toCurrency)` pair at `prisma/schema.prisma:245`-`:252`.
+  Plan: migrate to the currency pair as the primary key or document why the
+  synthetic key is required.
+- P2 D2 - `Goal.scopeRefId` is a free string at
+  `prisma/schema.prisma:286`-`:287`; this matches mixed scopes but needs the
+  server-side validation in G1 and preferably a comment documenting the
+  invariant.
+- P2 D3 - Cost-basis schema work is still blocked on `price`/`fee` for
+  `HoldingTransaction`; keep E25 as the keystone migration before P&L/tax-lot
+  features.
+
+### Tests and CI
+
+Status: baseline is good; targeted gaps remain.
+
+- P1 T1 - Add tests for A4/H1/P1/G1. A1/A2/A3/C1 now have focused unit
+  coverage in this PR; the remaining live P1 items still need regression tests
+  when implemented.
+- P2 T2 - Playwright coverage still does not exercise projections, history
+  ranges, settings import/export round trip, or undo-delete double-close
+  behavior. Add focused E2E specs after the P0 fixes.
+- P2 T3 - Docs-only changes are intentionally ignored by CI. For audit docs,
+  run `pnpm format:check` locally before merging because GitHub will not check
+  Markdown-only edits under the current workflow path filters.
+
+## Modules With No New Blocking Issue Found
+
+The audit did not find a new blocking issue in these modules beyond items
+already listed above or in the existing long-term roadmap:
+
+- Dashboard rendering and pull-to-refresh composition.
+- Analysis service pure aggregation helpers.
+- Stock watch CRUD, reorder, quote, and refresh routes.
+- Search route and option-chain route-handler validation/rate limiting.
+- Recurring cash and recurring investment materializers.
+- Health endpoint and CSP report endpoint.
+- i18n request setup and root App Router file conventions.
+
+## Exit Criteria
+
+Consider this audit closed when:
+
+- P0 items A1, A2, A3, and C1 are fixed and covered by tests.
+- P1 items A4, A5, H1, P1, G1, and U1 are fixed and covered by tests.
+- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit`, and
+  `pnpm build` all pass without a new warning.
+- Existing docs are reconciled so stale open items do not contradict the live
+  code state.

--- a/src/app/api/accounts/[id]/cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/cash-transactions/route.ts
@@ -19,14 +19,18 @@ export const POST = withAuth(
     const account = await prisma.account.findUnique({ where: { id, userId } });
     if (!account) return failure("Account not found", 404);
 
-    const transaction = await prisma.cashTransaction.create({
-      data: { accountId: id, type, amount, note },
-    });
-
     const delta = calculateBalanceDelta(null, { type, amount });
-    await prisma.account.update({
-      where: { id },
-      data: { cashBalance: { increment: delta } },
+    const transaction = await prisma.$transaction(async (tx) => {
+      const created = await tx.cashTransaction.create({
+        data: { accountId: id, type, amount, note },
+      });
+
+      await tx.account.update({
+        where: { id },
+        data: { cashBalance: { increment: delta } },
+      });
+
+      return created;
     });
 
     revalidateTag(`accounts:${userId}`, { expire: 0 });

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -32,25 +32,29 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const existingAccount = await prisma.account.findUnique({ where: { id, userId } });
   if (!existingAccount) return failure("Not found", 404);
 
-  // If cashBalance is being updated to a new value, log it as an EDIT transaction
-  if (parsed.data.cashBalance !== undefined) {
-    const diff = new Decimal(parsed.data.cashBalance).minus(existingAccount.cashBalance);
-    if (!diff.isZero()) {
-      await prisma.cashTransaction.create({
-        data: {
-          accountId: id,
-          type: "EDIT",
-          amount: diff,
-          note: body.note || `Manual balance update (${diff.isNegative() ? "" : "+"}${diff})`,
-        },
-      });
+  const { note, ...accountData } = parsed.data;
+  const account = await prisma.$transaction(async (tx) => {
+    // If cashBalance is being updated to a new value, log it as an EDIT transaction.
+    if (accountData.cashBalance !== undefined) {
+      const diff = new Decimal(accountData.cashBalance).minus(existingAccount.cashBalance);
+      if (!diff.isZero()) {
+        await tx.cashTransaction.create({
+          data: {
+            accountId: id,
+            type: "EDIT",
+            amount: diff,
+            note: note || `Manual balance update (${diff.isNegative() ? "" : "+"}${diff})`,
+          },
+        });
+      }
     }
-  }
 
-  const account = await prisma.account.update({
-    where: { id, userId },
-    data: parsed.data,
+    return tx.account.update({
+      where: { id, userId },
+      data: accountData,
+    });
   });
+
   invalidateUserCaches(userId);
   return ok(account);
 });

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -13,6 +13,8 @@ function invalidateUserCaches(userId: string) {
   revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
+class StaleAccountError extends Error {}
+
 export const GET = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
   const account = await prisma.account.findUnique({
@@ -33,27 +35,51 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   if (!existingAccount) return failure("Not found", 404);
 
   const { note, ...accountData } = parsed.data;
-  const account = await prisma.$transaction(async (tx) => {
-    // If cashBalance is being updated to a new value, log it as an EDIT transaction.
-    if (accountData.cashBalance !== undefined) {
-      const diff = new Decimal(accountData.cashBalance).minus(existingAccount.cashBalance);
-      if (!diff.isZero()) {
-        await tx.cashTransaction.create({
-          data: {
-            accountId: id,
-            type: "EDIT",
-            amount: diff,
-            note: note || `Manual balance update (${diff.isNegative() ? "" : "+"}${diff})`,
-          },
+  // A manual balance edit logs the difference as an EDIT cash transaction. The
+  // diff must be measured against the balance we actually write over, so the
+  // write is guarded on that prior balance: if a concurrent cash mutation moved
+  // it between our read and the commit, we reject with 409 rather than letting
+  // the EDIT row desync from the stored cashBalance.
+  const nextBalance = accountData.cashBalance;
+  const balanceChanging =
+    nextBalance !== undefined && !new Decimal(nextBalance).equals(existingAccount.cashBalance);
+
+  let account;
+  try {
+    account = await prisma.$transaction(async (tx) => {
+      if (!balanceChanging) {
+        return tx.account.update({
+          where: { id, userId },
+          data: accountData,
         });
       }
-    }
 
-    return tx.account.update({
-      where: { id, userId },
-      data: accountData,
+      const diff = new Decimal(nextBalance!).minus(existingAccount.cashBalance);
+      await tx.cashTransaction.create({
+        data: {
+          accountId: id,
+          type: "EDIT",
+          amount: diff,
+          note: note || `Manual balance update (${diff.isNegative() ? "" : "+"}${diff})`,
+        },
+      });
+
+      const result = await tx.account.updateMany({
+        where: { id, userId, cashBalance: existingAccount.cashBalance },
+        data: accountData,
+      });
+      if (result.count !== 1) {
+        throw new StaleAccountError();
+      }
+
+      return tx.account.findUniqueOrThrow({ where: { id } });
     });
-  });
+  } catch (error) {
+    if (error instanceof StaleAccountError) {
+      return failure("Account changed while updating; please retry", 409);
+    }
+    throw error;
+  }
 
   invalidateUserCaches(userId);
   return ok(account);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from "next/cache";
+import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
 import {
@@ -21,22 +22,31 @@ function invalidateAccountCaches(userId: string) {
 
 class NegativeHoldingQuantityError extends Error {}
 class StaleHoldingTransactionError extends Error {}
+class StaleCashTransactionError extends Error {}
 
 async function applyHoldingQuantityDelta(
   tx: Pick<typeof prisma, "holding">,
   holdingId: string,
   delta: number,
 ) {
-  if (delta > 0) {
+  // Snap the float delta to the column's Decimal(18, 8) scale before handing it
+  // to Prisma. A raw `number` delta produced by float arithmetic (e.g. 0.1 + 0.2
+  // = 0.30000000000000004) would otherwise drift the stored quantity away from
+  // its transaction ledger and, worse, spuriously trip the `gte` guard below
+  // when closing an exact-quantity position. CLAUDE.md: never hand a raw
+  // `number` to Prisma for monetary/quantity values.
+  const change = new Decimal(delta.toFixed(8));
+
+  if (change.gt(0)) {
     await tx.holding.update({
       where: { id: holdingId },
-      data: { quantity: { increment: delta } },
+      data: { quantity: { increment: change } },
     });
     return;
   }
 
-  if (delta < 0) {
-    const decrement = Math.abs(delta);
+  if (change.lt(0)) {
+    const decrement = change.abs();
     const result = await tx.holding.updateMany({
       where: { id: holdingId, quantity: { gte: decrement } },
       data: { quantity: { decrement } },
@@ -158,30 +168,53 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
     if (amountError) return failure(amountError, 400);
 
     // Balance adjustment and transaction update commit atomically so a
-    // failure can't leave the cash balance out of sync with the ledger.
-    const updatedTx = await prisma.$transaction(async (tx) => {
-      // Recompute balance delta whenever amount or type changes.
-      if (data.amount !== undefined || data.type !== undefined) {
-        const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
-        const delta = calculateBalanceDelta(oldTx, nextCashTx);
-        if (delta !== 0) {
-          await tx.account.update({
-            where: { id: accountId },
-            data: { cashBalance: { increment: delta } },
-          });
+    // failure can't leave the cash balance out of sync with the ledger. The
+    // row write is guarded on the values the delta was measured against (the
+    // same optimistic-lock contract as the holding path), so two concurrent
+    // edits can't each apply their own balance delta on top of a row only one
+    // of them actually wrote.
+    let updatedTx;
+    try {
+      updatedTx = await prisma.$transaction(async (tx) => {
+        const result = await tx.cashTransaction.updateMany({
+          where: {
+            id: transactionId,
+            type: cashTx.type,
+            amount: cashTx.amount,
+          },
+          data: {
+            ...(data.amount !== undefined && { amount: data.amount }),
+            ...(data.type !== undefined && { type: data.type }),
+            ...(data.note !== undefined && { note: data.note }),
+            ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
+          },
+        });
+        if (result.count !== 1) {
+          throw new StaleCashTransactionError();
         }
-      }
 
-      return tx.cashTransaction.update({
-        where: { id: transactionId },
-        data: {
-          ...(data.amount !== undefined && { amount: data.amount }),
-          ...(data.type !== undefined && { type: data.type }),
-          ...(data.note !== undefined && { note: data.note }),
-          ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
-        },
+        // Recompute balance delta whenever amount or type changes.
+        if (data.amount !== undefined || data.type !== undefined) {
+          const oldTx = { type: cashTx.type, amount: Number(cashTx.amount) };
+          const delta = calculateBalanceDelta(oldTx, nextCashTx);
+          if (delta !== 0) {
+            await tx.account.update({
+              where: { id: accountId },
+              data: { cashBalance: { increment: delta } },
+            });
+          }
+        }
+
+        return tx.cashTransaction.findUniqueOrThrow({
+          where: { id: transactionId },
+        });
       });
-    });
+    } catch (error) {
+      if (error instanceof StaleCashTransactionError) {
+        return failure("Transaction changed while updating; please retry", 409);
+      }
+      throw error;
+    }
 
     invalidateAccountCaches(userId);
     return ok(updatedTx);

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -19,6 +19,34 @@ function invalidateAccountCaches(userId: string) {
   revalidateTag(`history:${userId}`, { expire: 0 });
 }
 
+class NegativeHoldingQuantityError extends Error {}
+class StaleHoldingTransactionError extends Error {}
+
+async function applyHoldingQuantityDelta(
+  tx: Pick<typeof prisma, "holding">,
+  holdingId: string,
+  delta: number,
+) {
+  if (delta > 0) {
+    await tx.holding.update({
+      where: { id: holdingId },
+      data: { quantity: { increment: delta } },
+    });
+    return;
+  }
+
+  if (delta < 0) {
+    const decrement = Math.abs(delta);
+    const result = await tx.holding.updateMany({
+      where: { id: holdingId, quantity: { gte: decrement } },
+      data: { quantity: { decrement } },
+    });
+    if (result.count !== 1) {
+      throw new NegativeHoldingQuantityError();
+    }
+  }
+}
+
 export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
   const { id: accountId, transactionId } = await params;
 
@@ -62,29 +90,42 @@ export const PATCH = withAuth<TxCtx>(async (request, { params }, userId) => {
       { type: holdingTx.type, quantity: Number(holdingTx.quantity) },
       { type: nextType, quantity: nextQuantity },
     );
-    const nextHoldingQty = Number(holdingTx.holding.quantity) + holdingDelta;
-    if (nextHoldingQty < 0) {
-      return failure("Holding quantity cannot be negative", 400);
-    }
 
-    const updatedTx = await prisma.$transaction(async (tx) => {
-      if (holdingDelta !== 0) {
-        await tx.holding.update({
-          where: { id: holdingTx.holding.id },
-          data: { quantity: nextHoldingQty },
+    let updatedTx;
+    try {
+      updatedTx = await prisma.$transaction(async (tx) => {
+        const result = await tx.holdingTransaction.updateMany({
+          where: {
+            id: transactionId,
+            type: holdingTx.type,
+            quantity: holdingTx.quantity,
+          },
+          data: {
+            ...(data.quantity !== undefined && { quantity: nextQuantity }),
+            ...(data.type !== undefined && { type: data.type }),
+            ...(data.note !== undefined && { note: data.note }),
+            ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
+          },
         });
-      }
+        if (result.count !== 1) {
+          throw new StaleHoldingTransactionError();
+        }
 
-      return tx.holdingTransaction.update({
-        where: { id: transactionId },
-        data: {
-          ...(data.quantity !== undefined && { quantity: nextQuantity }),
-          ...(data.type !== undefined && { type: data.type }),
-          ...(data.note !== undefined && { note: data.note }),
-          ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
-        },
+        await applyHoldingQuantityDelta(tx, holdingTx.holding.id, holdingDelta);
+
+        return tx.holdingTransaction.findUniqueOrThrow({
+          where: { id: transactionId },
+        });
       });
-    });
+    } catch (error) {
+      if (error instanceof NegativeHoldingQuantityError) {
+        return failure("Holding quantity cannot be negative", 400);
+      }
+      if (error instanceof StaleHoldingTransactionError) {
+        return failure("Transaction changed while updating; please retry", 409);
+      }
+      throw error;
+    }
 
     invalidateAccountCaches(userId);
     return ok(updatedTx);
@@ -172,18 +213,32 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
       { type: holdingTx.type, quantity: Number(holdingTx.quantity) },
       null,
     );
-    const nextHoldingQty = Number(holdingTx.holding.quantity) + holdingDelta;
-    if (nextHoldingQty < 0) {
-      return failure("Holding quantity cannot be negative", 400);
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const result = await tx.holdingTransaction.deleteMany({
+          where: {
+            id: transactionId,
+            type: holdingTx.type,
+            quantity: holdingTx.quantity,
+          },
+        });
+        if (result.count !== 1) {
+          throw new StaleHoldingTransactionError();
+        }
+
+        await applyHoldingQuantityDelta(tx, holdingTx.holding.id, holdingDelta);
+      });
+    } catch (error) {
+      if (error instanceof NegativeHoldingQuantityError) {
+        return failure("Holding quantity cannot be negative", 400);
+      }
+      if (error instanceof StaleHoldingTransactionError) {
+        return failure("Transaction changed while deleting; please retry", 409);
+      }
+      throw error;
     }
 
-    await prisma.$transaction([
-      prisma.holding.update({
-        where: { id: holdingTx.holding.id },
-        data: { quantity: nextHoldingQty },
-      }),
-      prisma.holdingTransaction.delete({ where: { id: transactionId } }),
-    ]);
     invalidateAccountCaches(userId);
     return ok({ ok: true });
   }

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: Request) {
     // 0. Sweep expired option contracts so the snapshot doesn't include them
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);
+    let expiredOptionsChanged = false;
     const expiredOptions = await prisma.holding.findMany({
       where: {
         assetType: "OPTION",
@@ -65,7 +66,7 @@ export async function GET(request: Request) {
           data: { quantity: 0 },
         }),
       ]);
-      revalidateTag("accounts", "max");
+      expiredOptionsChanged = true;
     }
 
     // 1. Warm the ExchangeRate cache (so render paths never need to fetch
@@ -125,10 +126,11 @@ export async function GET(request: Request) {
     // New recurring cash/buy rows changed balances + holdings → net-worth +
     // accounts must drop even when prices/rates were unchanged (otherwise list
     // pages and the snapshot below would read stale data).
-    if (ratesChanged > 0 || priceResult.changed > 0 || recurringChanged) {
+    const structuralChanged = expiredOptionsChanged || recurringChanged;
+    if (ratesChanged > 0 || priceResult.changed > 0 || structuralChanged) {
       revalidateTag("net-worth", "max");
     }
-    if (recurringChanged) {
+    if (structuralChanged) {
       revalidateTag("accounts", "max");
     }
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -24,6 +24,7 @@ export const updateAccountSchema = createAccountSchema
   .extend({
     isActive: z.boolean(),
     isPinned: z.boolean(),
+    note: z.string().max(500).optional().nullable(),
   })
   .partial();
 

--- a/tests/unit/account-ledger-routes.test.ts
+++ b/tests/unit/account-ledger-routes.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  account: null as Record<string, unknown> | null,
+  cashTx: null as Record<string, unknown> | null,
+  holdingTx: null as Record<string, unknown> | null,
+  holdingTransactionUpdateManyCount: 1,
+  holdingTransactionDeleteManyCount: 1,
+  holdingUpdateManyCount: 1,
+  calls: [] as Array<{ op: string; args?: Record<string, unknown> }>,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/api-handler", () => ({
+  withAuth:
+    (handler: (req: Request, ctx: unknown, userId: string) => Promise<Response>) =>
+    (req: Request, ctx: unknown) =>
+      handler(req, ctx, "user1"),
+}));
+
+vi.mock("@/lib/prisma", () => {
+  const prisma = {
+    account: {
+      findUnique: vi.fn(async () => h.account),
+      update: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "account.update", args });
+        return { id: "acc1", ...(args.data as Record<string, unknown>) };
+      }),
+    },
+    cashTransaction: {
+      findUnique: vi.fn(async () => h.cashTx),
+      create: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "cashTransaction.create", args });
+        return { id: "cash-new", ...(args.data as Record<string, unknown>) };
+      }),
+      update: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "cashTransaction.update", args });
+        return { id: "cash1", ...(args.data as Record<string, unknown>) };
+      }),
+      delete: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "cashTransaction.delete", args });
+        return { id: "cash1" };
+      }),
+    },
+    holding: {
+      update: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "holding.update", args });
+        return { id: "holding1" };
+      }),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "holding.updateMany", args });
+        return { count: h.holdingUpdateManyCount };
+      }),
+    },
+    holdingTransaction: {
+      findUnique: vi.fn(async () => h.holdingTx),
+      findUniqueOrThrow: vi.fn(async () => ({ id: "holdtx1", quantity: 15, type: "BUY" })),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "holdingTransaction.updateMany", args });
+        return { count: h.holdingTransactionUpdateManyCount };
+      }),
+      deleteMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "holdingTransaction.deleteMany", args });
+        return { count: h.holdingTransactionDeleteManyCount };
+      }),
+    },
+    $transaction: vi.fn(async (work: unknown) => {
+      h.calls.push({ op: "$transaction" });
+      if (Array.isArray(work)) return Promise.all(work);
+      return (work as (tx: typeof prisma) => Promise<unknown>)(prisma);
+    }),
+  };
+  return { prisma };
+});
+
+const params = (id = "acc1", transactionId = "tx1") => ({
+  params: Promise.resolve({ id, transactionId }),
+});
+
+const jsonRequest = (method: string, body: Record<string, unknown>) =>
+  new Request("http://unit.test", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+
+describe("account ledger routes", () => {
+  beforeEach(() => {
+    h.account = { id: "acc1", userId: "user1", cashBalance: 10 };
+    h.cashTx = null;
+    h.holdingTx = null;
+    h.holdingTransactionUpdateManyCount = 1;
+    h.holdingTransactionDeleteManyCount = 1;
+    h.holdingUpdateManyCount = 1;
+    h.calls = [];
+  });
+
+  it("creates a manual cash transaction and balance increment in one transaction", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/cash-transactions/route");
+
+    const response = await POST(jsonRequest("POST", { type: "DEPOSIT", amount: 100 }), {
+      params: Promise.resolve({ id: "acc1" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(h.calls[0].op).toBe("$transaction");
+    expect(h.calls.find((call) => call.op === "cashTransaction.create")?.args?.data).toMatchObject({
+      accountId: "acc1",
+      type: "DEPOSIT",
+      amount: 100,
+    });
+    expect(h.calls.find((call) => call.op === "account.update")?.args?.data).toEqual({
+      cashBalance: { increment: 100 },
+    });
+  });
+
+  it("records manual account balance edits atomically and strips note from account data", async () => {
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+
+    const response = await PATCH(
+      jsonRequest("PATCH", { cashBalance: 25, note: "opening correction" }),
+      { params: Promise.resolve({ id: "acc1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(h.calls[0].op).toBe("$transaction");
+    const edit = h.calls.find((call) => call.op === "cashTransaction.create")?.args?.data as
+      | Record<string, unknown>
+      | undefined;
+    expect(edit).toMatchObject({
+      accountId: "acc1",
+      type: "EDIT",
+      note: "opening correction",
+    });
+    expect(Number(edit?.amount)).toBe(15);
+    expect(h.calls.find((call) => call.op === "account.update")?.args?.data).toEqual({
+      cashBalance: 25,
+    });
+  });
+
+  it("applies holding edit quantity changes with atomic deltas", async () => {
+    h.holdingTx = {
+      id: "tx1",
+      type: "BUY",
+      quantity: 10,
+      holding: { id: "holding1", accountId: "acc1", quantity: 10 },
+    };
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 15 }), params());
+
+    expect(response.status).toBe(200);
+    expect(
+      h.calls.find((call) => call.op === "holdingTransaction.updateMany")?.args?.where,
+    ).toMatchObject({
+      id: "tx1",
+      type: "BUY",
+      quantity: 10,
+    });
+    expect(h.calls.find((call) => call.op === "holding.update")?.args?.data).toEqual({
+      quantity: { increment: 5 },
+    });
+  });
+
+  it("rolls back stale holding edits before applying the holding delta", async () => {
+    h.holdingTransactionUpdateManyCount = 0;
+    h.holdingTx = {
+      id: "tx1",
+      type: "BUY",
+      quantity: 10,
+      holding: { id: "holding1", accountId: "acc1", quantity: 10 },
+    };
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 15 }), params());
+
+    expect(response.status).toBe(409);
+    expect(h.calls.some((call) => call.op === "holding.update")).toBe(false);
+    expect(h.calls.some((call) => call.op === "holding.updateMany")).toBe(false);
+  });
+
+  it("deletes holding transactions with a guarded decrement", async () => {
+    h.holdingTx = {
+      id: "tx1",
+      type: "BUY",
+      quantity: 7,
+      holding: { id: "holding1", accountId: "acc1", quantity: 7 },
+    };
+    const { DELETE } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await DELETE(new Request("http://unit.test", { method: "DELETE" }), params());
+
+    expect(response.status).toBe(200);
+    expect(
+      h.calls.find((call) => call.op === "holdingTransaction.deleteMany")?.args?.where,
+    ).toMatchObject({
+      id: "tx1",
+      type: "BUY",
+      quantity: 7,
+    });
+    expect(h.calls.find((call) => call.op === "holding.updateMany")?.args).toEqual({
+      where: { id: "holding1", quantity: { gte: 7 } },
+      data: { quantity: { decrement: 7 } },
+    });
+  });
+});

--- a/tests/unit/account-ledger-routes.test.ts
+++ b/tests/unit/account-ledger-routes.test.ts
@@ -4,6 +4,8 @@ const h = vi.hoisted(() => ({
   account: null as Record<string, unknown> | null,
   cashTx: null as Record<string, unknown> | null,
   holdingTx: null as Record<string, unknown> | null,
+  accountUpdateManyCount: 1,
+  cashTransactionUpdateManyCount: 1,
   holdingTransactionUpdateManyCount: 1,
   holdingTransactionDeleteManyCount: 1,
   holdingUpdateManyCount: 1,
@@ -25,13 +27,19 @@ vi.mock("@/lib/prisma", () => {
   const prisma = {
     account: {
       findUnique: vi.fn(async () => h.account),
+      findUniqueOrThrow: vi.fn(async () => h.account),
       update: vi.fn(async (args: Record<string, unknown>) => {
         h.calls.push({ op: "account.update", args });
         return { id: "acc1", ...(args.data as Record<string, unknown>) };
       }),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "account.updateMany", args });
+        return { count: h.accountUpdateManyCount };
+      }),
     },
     cashTransaction: {
       findUnique: vi.fn(async () => h.cashTx),
+      findUniqueOrThrow: vi.fn(async () => ({ id: "cash1", ...(h.cashTx ?? {}) })),
       create: vi.fn(async (args: Record<string, unknown>) => {
         h.calls.push({ op: "cashTransaction.create", args });
         return { id: "cash-new", ...(args.data as Record<string, unknown>) };
@@ -39,6 +47,10 @@ vi.mock("@/lib/prisma", () => {
       update: vi.fn(async (args: Record<string, unknown>) => {
         h.calls.push({ op: "cashTransaction.update", args });
         return { id: "cash1", ...(args.data as Record<string, unknown>) };
+      }),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.calls.push({ op: "cashTransaction.updateMany", args });
+        return { count: h.cashTransactionUpdateManyCount };
       }),
       delete: vi.fn(async (args: Record<string, unknown>) => {
         h.calls.push({ op: "cashTransaction.delete", args });
@@ -92,6 +104,8 @@ describe("account ledger routes", () => {
     h.account = { id: "acc1", userId: "user1", cashBalance: 10 };
     h.cashTx = null;
     h.holdingTx = null;
+    h.accountUpdateManyCount = 1;
+    h.cashTransactionUpdateManyCount = 1;
     h.holdingTransactionUpdateManyCount = 1;
     h.holdingTransactionDeleteManyCount = 1;
     h.holdingUpdateManyCount = 1;
@@ -136,9 +150,22 @@ describe("account ledger routes", () => {
       note: "opening correction",
     });
     expect(Number(edit?.amount)).toBe(15);
-    expect(h.calls.find((call) => call.op === "account.update")?.args?.data).toEqual({
-      cashBalance: 25,
+    const accountWrite = h.calls.find((call) => call.op === "account.updateMany")?.args as
+      | { where?: Record<string, unknown>; data?: Record<string, unknown> }
+      | undefined;
+    expect(accountWrite?.where).toMatchObject({ id: "acc1", userId: "user1", cashBalance: 10 });
+    expect(accountWrite?.data).toEqual({ cashBalance: 25 });
+  });
+
+  it("rejects a manual balance edit when the balance changed concurrently (409)", async () => {
+    h.accountUpdateManyCount = 0;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { cashBalance: 25 }), {
+      params: Promise.resolve({ id: "acc1" }),
     });
+
+    expect(response.status).toBe(409);
   });
 
   it("applies holding edit quantity changes with atomic deltas", async () => {
@@ -160,9 +187,10 @@ describe("account ledger routes", () => {
       type: "BUY",
       quantity: 10,
     });
-    expect(h.calls.find((call) => call.op === "holding.update")?.args?.data).toEqual({
-      quantity: { increment: 5 },
-    });
+    const holdingWrite = h.calls.find((call) => call.op === "holding.update")?.args?.data as {
+      quantity: { increment: unknown };
+    };
+    expect(Number(holdingWrite.quantity.increment)).toBe(5);
   });
 
   it("rolls back stale holding edits before applying the holding delta", async () => {
@@ -201,9 +229,42 @@ describe("account ledger routes", () => {
       type: "BUY",
       quantity: 7,
     });
-    expect(h.calls.find((call) => call.op === "holding.updateMany")?.args).toEqual({
-      where: { id: "holding1", quantity: { gte: 7 } },
-      data: { quantity: { decrement: 7 } },
+    const deleteWrite = h.calls.find((call) => call.op === "holding.updateMany")?.args as {
+      where: { id: string; quantity: { gte: unknown } };
+      data: { quantity: { decrement: unknown } };
+    };
+    expect(deleteWrite.where.id).toBe("holding1");
+    expect(Number(deleteWrite.where.quantity.gte)).toBe(7);
+    expect(Number(deleteWrite.data.quantity.decrement)).toBe(7);
+  });
+
+  it("edits a cash transaction with a guarded balance delta", async () => {
+    h.cashTx = { id: "tx1", accountId: "acc1", type: "DEPOSIT", amount: 100 };
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", amount: 150 }), params());
+
+    expect(response.status).toBe(200);
+    expect(
+      h.calls.find((call) => call.op === "cashTransaction.updateMany")?.args?.where,
+    ).toMatchObject({
+      id: "tx1",
+      type: "DEPOSIT",
+      amount: 100,
     });
+    expect(h.calls.find((call) => call.op === "account.update")?.args?.data).toEqual({
+      cashBalance: { increment: 50 },
+    });
+  });
+
+  it("rejects a stale cash transaction edit with 409", async () => {
+    h.cashTx = { id: "tx1", accountId: "acc1", type: "DEPOSIT", amount: 100 };
+    h.cashTransactionUpdateManyCount = 0;
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", amount: 150 }), params());
+
+    expect(response.status).toBe(409);
+    expect(h.calls.some((call) => call.op === "account.update")).toBe(false);
   });
 });

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  events: [] as string[],
+  expiredOptions: [] as Array<{ id: string; quantity: number }>,
+}));
+
+vi.mock("@/lib/env", () => ({
+  CRON_SECRET: "test-secret",
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn((tag: string) => {
+    h.events.push(`revalidate:${tag}`);
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+
+vi.mock("@/lib/sentry-cron", () => ({
+  startSnapshotCronCheckIn: vi.fn(() => "check-in"),
+  finishSnapshotCronCheckIn: vi.fn(),
+}));
+
+vi.mock("@/lib/services/exchange-rate-service", () => ({
+  refreshExchangeRates: vi.fn(async () => ({ updated: 0, changed: 0 })),
+}));
+
+vi.mock("@/lib/services/price-service", () => ({
+  refreshAllPrices: vi.fn(async () => ({ updated: 0, changed: 0 })),
+}));
+
+vi.mock("@/lib/services/recurring-cash-service", () => ({
+  materializeDueRecurringTransactions: vi.fn(async () => ({ created: 0, rulesProcessed: 0 })),
+}));
+
+vi.mock("@/lib/services/recurring-investment-service", () => ({
+  materializeDueInvestments: vi.fn(async () => ({ created: 0, rulesProcessed: 0 })),
+}));
+
+vi.mock("@/lib/services/snapshot-service", () => ({
+  createSnapshot: vi.fn(async () => {
+    h.events.push("snapshot");
+    return { id: "snapshot1" };
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => {
+  const prisma = {
+    cronRun: {
+      create: vi.fn(async () => ({ id: "cron1" })),
+      update: vi.fn(async () => ({})),
+    },
+    holding: {
+      findMany: vi.fn(async () => h.expiredOptions),
+      updateMany: vi.fn(async () => ({ count: h.expiredOptions.length })),
+    },
+    holdingTransaction: {
+      createMany: vi.fn(async () => ({ count: h.expiredOptions.length })),
+    },
+    account: {
+      findMany: vi.fn(async () => []),
+    },
+    setting: {
+      findMany: vi.fn(async () => []),
+    },
+    user: {
+      findMany: vi.fn(async () => [{ id: "user1", appSettings: { baseCurrency: "USD" } }]),
+    },
+    $transaction: vi.fn(async (work: unknown) => {
+      if (Array.isArray(work)) return Promise.all(work);
+      return (work as (tx: typeof prisma) => Promise<unknown>)(prisma);
+    }),
+  };
+  return { prisma };
+});
+
+describe("snapshot cron route", () => {
+  beforeEach(() => {
+    h.events = [];
+    h.expiredOptions = [];
+  });
+
+  it("invalidates net worth before snapshot creation when options expire", async () => {
+    h.expiredOptions = [{ id: "holding1", quantity: 2 }];
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(h.events).toContain("revalidate:accounts");
+    expect(h.events).toContain("revalidate:net-worth");
+    expect(h.events.indexOf("revalidate:net-worth")).toBeLessThan(h.events.indexOf("snapshot"));
+  });
+});

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   createHoldingSchema,
+  updateAccountSchema,
   updateHoldingSchema,
   updateTransactionSchema,
   createCashTransactionSchema,
@@ -11,6 +12,20 @@ import {
 
 // Locks in the E6 validator hardening (positive quantities, immutable
 // assetType, per-type transaction unions, OCC option shape, ISO datetimes).
+
+describe("updateAccountSchema", () => {
+  it("accepts a bounded manual balance edit note", () => {
+    const result = updateAccountSchema.safeParse({ cashBalance: 125, note: "opening correction" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.note).toBe("opening correction");
+    }
+  });
+
+  it("rejects an oversized manual balance edit note", () => {
+    expect(updateAccountSchema.safeParse({ note: "x".repeat(501) }).success).toBe(false);
+  });
+});
 
 describe("createHoldingSchema", () => {
   const base = { symbol: "aapl", name: "Apple", quantity: 10, assetType: "STOCK" as const };


### PR DESCRIPTION
## Summary
- Wrap manual cash transaction creation and manual account balance edits in Prisma transactions.
- Apply holding transaction edits/deletes with guarded row-state checks plus atomic holding quantity deltas.
- Revalidate net-worth before snapshot creation when expired options are swept.
- Add focused route/cron validator coverage and update the enhancement audit docs.

## Verification
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test:unit
- pnpm build

Note: pnpm build still emits the pre-existing Sentry disableLogger deprecation warning tracked in the audit docs.