### PR TITLE
[codex] Sync heatmap snapshot selection

### DIFF
--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -160,11 +160,13 @@ export function TrendChart({
   baseCurrency = "USD",
   hideRangeFilter = false,
   footer,
+  onSnapshotDateChange,
 }: {
   snapshots: SnapshotData[];
   baseCurrency?: string;
   hideRangeFilter?: boolean;
   footer?: ReactNode;
+  onSnapshotDateChange?: (date: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width: containerWidth, height: containerHeight } = useContainerSize(containerRef);
@@ -173,7 +175,6 @@ export function TrendChart({
   const t = useTranslations("trendChart");
   const { privacyMode } = usePrivacyMode();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
-  const { handlers: crosshairHandlers } = useChartCrosshair();
   const shouldReduceMotion = useReducedMotion();
   const rangeFadeTransition = shouldReduceMotion
     ? { duration: 0 }
@@ -218,6 +219,18 @@ export function TrendChart({
       netWorthPct: ((snapshot.netWorth - firstNetWorth) / Math.abs(firstNetWorth)) * 100,
     }));
   }, [filtered, isPercentMode]);
+
+  const handleActiveSnapshotChange = useCallback(
+    (index: number | string) => {
+      const activeIndex = Number(index);
+      if (!Number.isInteger(activeIndex)) return;
+
+      const snapshot = chartData[activeIndex];
+      if (snapshot) onSnapshotDateChange?.(snapshot.date);
+    },
+    [chartData, onSnapshotDateChange],
+  );
+  const { handlers: crosshairHandlers } = useChartCrosshair(handleActiveSnapshotChange);
 
   const periodChange = useMemo(() => {
     if (filtered.length < 2) return null;

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -72,13 +72,21 @@ type GridDay = {
 type Props = {
   snapshots: SnapshotRow[];
   baseCurrency: string;
+  selectedDate?: string | null;
+  onSelectedDateChange?: (date: string) => void;
   labels?: {
     netWorth: string;
     change: string;
   };
 };
 
-export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
+export function HistoryHeatmap({
+  snapshots,
+  baseCurrency,
+  selectedDate,
+  onSelectedDateChange,
+  labels,
+}: Props) {
   const format = useFormatter();
   const t = useTranslations("history");
   const { privacyMode } = usePrivacyMode();
@@ -92,8 +100,9 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
     maxNeg,
     weeksToShow,
     currentYear,
-    todayColIndex,
+    selectedColIndex,
     todayString,
+    activeDateString,
   } = useMemo(() => {
     // 1. Sort snapshots chronologically (oldest first) to easily calculate deltas
     const sortedSnapshots = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
@@ -109,21 +118,28 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       snapshotMap.set(snap.date, { ...snap, change });
     }
 
-    // 3. Determine end date (Saturday on or after Dec 31st of current year)
+    // 3. Show the year containing the selected snapshot. The latest snapshot is
+    // the default, while inspecting an older trend point moves the heatmap with it.
     const today = utcToday();
     const todayString = utcDateString(today);
-    const currentYear = today.getUTCFullYear();
+    const activeDateString = selectedDate ?? sortedSnapshots.at(-1)?.date ?? todayString;
+    const activeDate = calendarDateFromString(activeDateString);
+    const currentYear = Number.isNaN(activeDate.getTime())
+      ? today.getUTCFullYear()
+      : activeDate.getUTCFullYear();
+
+    // 4. Determine end date (Saturday on or after Dec 31st of the active year)
     const dec31 = calendarDate(currentYear, 11, 31);
     const dayOfWeekEnd = dec31.getUTCDay(); // 0 = Sunday, 6 = Saturday
     const daysToAddToReachSaturday = 6 - dayOfWeekEnd;
     const endDate = addUtcDays(dec31, daysToAddToReachSaturday);
 
-    // 4. Determine start date (Sunday on or before Jan 1st of current year)
+    // 5. Determine start date (Sunday on or before Jan 1st of the active year)
     const jan1 = calendarDate(currentYear, 0, 1);
     const dayOfWeekStart = jan1.getUTCDay();
     const startDate = addUtcDays(jan1, -dayOfWeekStart);
 
-    // 5. Calculate total days to show
+    // 6. Calculate total days to show
     const daysToShow = Math.round((endDate.getTime() - startDate.getTime()) / DAY_MS) + 1;
     const weeksToShow = daysToShow / 7;
 
@@ -175,9 +191,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       });
     }
 
-    // Column index of the current week, used to seed the initial scroll position
-    const todayDayOffset = Math.round((today.getTime() - startDate.getTime()) / DAY_MS);
-    const todayColIndex = Math.floor(todayDayOffset / 7);
+    // Column index of the selected week, used to keep the inspected day visible.
+    const selectedDayOffset = Math.round((activeDate.getTime() - startDate.getTime()) / DAY_MS);
+    const selectedColIndex = Number.isNaN(selectedDayOffset)
+      ? 0
+      : Math.floor(selectedDayOffset / 7);
 
     return {
       gridDays: days,
@@ -186,10 +204,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       maxNeg: Math.abs(maxNegativeChange),
       weeksToShow,
       currentYear,
-      todayColIndex,
+      selectedColIndex,
       todayString,
+      activeDateString,
     };
-  }, [snapshots, format]);
+  }, [snapshots, format, selectedDate]);
 
   // Transpose the flat array into 7 rows (Sunday–Saturday)
   const rows = useMemo(() => {
@@ -215,14 +234,14 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const dismissTooltip = useCallback(() => setTooltip(null), []);
 
-  // On mount, position the scroll so today sits near the right edge of the visible window.
-  // This shows recent activity immediately without requiring the user to scroll on mobile.
+  // Keep the selected week near the right edge so trend-chart inspection remains
+  // visible on narrow screens, including when selection crosses into another year.
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
-    const targetLeft = (todayColIndex - 8) * COL_WIDTH;
+    const targetLeft = (selectedColIndex - 8) * COL_WIDTH;
     el.scrollLeft = Math.max(0, targetLeft);
-  }, [todayColIndex]);
+  }, [selectedColIndex]);
 
   const showTooltipAtElement = (day: GridDay, element: HTMLElement) => {
     const rect = element.getBoundingClientRect();
@@ -347,6 +366,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
 
                     const canShowDetails = day.hasSnapshot && !day.isFuture;
                     const isToday = day.dateString === todayString;
+                    const isSelected = day.dateString === activeDateString;
 
                     const dateLabel = format.dateTime(calendarDateFromString(day.dateString), {
                       dateStyle: "medium",
@@ -401,8 +421,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                         role="gridcell"
                         aria-colindex={cIdx + 1}
                         aria-label={isToday ? `${cellLabel}, today` : cellLabel}
-                        aria-selected={tooltip?.day.dateString === day.dateString}
+                        aria-selected={isSelected}
                         tabIndex={canShowDetails ? 0 : -1}
+                        onClick={
+                          canShowDetails ? () => onSelectedDateChange?.(day.dateString) : undefined
+                        }
                         onPointerEnter={
                           canShowDetails
                             ? (e) => {
@@ -424,7 +447,10 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                         }
                         onFocus={
                           canShowDetails
-                            ? (e) => showTooltipAtElement(day, e.currentTarget)
+                            ? (e) => {
+                                onSelectedDateChange?.(day.dateString);
+                                showTooltipAtElement(day, e.currentTarget);
+                              }
                             : undefined
                         }
                         onBlur={canShowDetails ? () => setTooltip(null) : undefined}
@@ -436,8 +462,9 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                           canShowDetails &&
                             "cursor-pointer transition-transform hover:scale-125 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
                           bgClass,
-                          // Neutral ink ring marks today: orientation, not a gain/loss signal.
-                          isToday && "ring-1 ring-foreground/60 dark:ring-foreground/70",
+                          // Neutral ink ring tracks the snapshot being inspected without
+                          // competing with the gain/loss fill.
+                          isSelected && "ring-1 ring-foreground/60 dark:ring-foreground/70",
                         )}
                       />
                     );

--- a/src/components/history/history-view.tsx
+++ b/src/components/history/history-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useFormatter, useTranslations } from "next-intl";
 import { AlertTriangle } from "lucide-react";
 import { TrendChart } from "@/components/dashboard/trend-chart";
@@ -40,6 +41,9 @@ export function HistoryView({
   const t = useTranslations("history");
   const format = useFormatter();
   const { privacyMode } = usePrivacyMode();
+  const [selectedSnapshotDate, setSelectedSnapshotDate] = useState<string | null>(
+    snapshots.at(-1)?.date ?? null,
+  );
 
   const firstSnapshot = snapshots[0];
   const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
@@ -118,10 +122,13 @@ export function HistoryView({
             snapshots={snapshots}
             baseCurrency={baseCurrency}
             hideRangeFilter={hideTrendRangeFilter}
+            onSnapshotDateChange={setSelectedSnapshotDate}
             footer={
               <HistoryHeatmap
                 snapshots={snapshots}
                 baseCurrency={baseCurrency}
+                selectedDate={selectedSnapshotDate}
+                onSelectedDateChange={setSelectedSnapshotDate}
                 labels={{ netWorth: t("colNetWorth"), change: t("colChange") }}
               />
             }

--- a/src/hooks/use-chart-crosshair.ts
+++ b/src/hooks/use-chart-crosshair.ts
@@ -3,15 +3,20 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { hapticTick } from "@/lib/haptics";
 
-export function useChartCrosshair() {
+type ActiveTooltipIndex = number | string;
+
+export function useChartCrosshair(
+  onActiveTooltipIndexChange?: (index: ActiveTooltipIndex) => void,
+) {
   const [isActive, setIsActive] = useState(false);
   const lastIndexRef = useRef<string | null>(null);
   const pressTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const onTouchStart = useCallback(
     (state: { activeTooltipIndex?: number | string | null } | null | undefined) => {
-      if (state?.activeTooltipIndex !== undefined) {
+      if (state?.activeTooltipIndex != null) {
         lastIndexRef.current = String(state.activeTooltipIndex);
+        onActiveTooltipIndexChange?.(state.activeTooltipIndex);
       }
       if (pressTimerRef.current) {
         clearTimeout(pressTimerRef.current);
@@ -22,22 +27,23 @@ export function useChartCrosshair() {
         hapticTick();
       }, 400);
     },
-    [],
+    [onActiveTooltipIndexChange],
   );
 
   const onTouchMove = useCallback(
     (state: { activeTooltipIndex?: number | string | null } | null | undefined) => {
       if (
-        state?.activeTooltipIndex !== undefined &&
+        state?.activeTooltipIndex != null &&
         String(state.activeTooltipIndex) !== lastIndexRef.current
       ) {
         lastIndexRef.current = String(state.activeTooltipIndex);
+        onActiveTooltipIndexChange?.(state.activeTooltipIndex);
         if (isActive) {
           hapticTick();
         }
       }
     },
-    [isActive],
+    [isActive, onActiveTooltipIndexChange],
   );
 
   const onTouchEnd = useCallback(() => {


### PR DESCRIPTION
## Summary

- keep the history heatmap outline synchronized with the snapshot inspected on the trend chart
- move the outline when a user taps or focuses a heatmap snapshot day
- show the selected snapshot's year and keep its week visible on narrow screens

## Why

The heatmap outline was tied to the current calendar day, while trend-chart and heatmap tooltip interactions maintained separate transient state. Inspecting an earlier snapshot therefore left the outline on the latest day and provided conflicting visual feedback.

This change lifts the selected snapshot date into the history view and shares it across both surfaces. The latest snapshot remains the default selection.

## Impact

Users can now see exactly which snapshot they are inspecting. Older-year trend selections also update the heatmap year instead of leaving the marker outside the visible grid.

## Validation

- browser verification for default, direct heatmap selection, and trend-driven selection
- no browser console errors
- `pnpm test:unit` (115 tests)
- `pnpm typecheck`
- ESLint
- Prettier