### PR TITLE
[codex] Improve mobile heatmap snapshot details

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ To enable automation, deploy to Vercel and set all environment variables in your
 Vercel preview deployments use a **separate Neon branch** so they never touch production data:
 
 - Set `DATABASE_URL` with two scopes in Vercel → Settings → Environment Variables: one for **Production** (prod Neon branch) and one for **Preview** (a dedicated `preview` Neon branch). If your `DATABASE_URL` is managed by the Neon-Vercel integration, configure the per-environment branch mapping inside the integration UI instead.
-- The Vercel build runs `pnpm run build:vercel`, which runs `prisma migrate deploy` followed by `next build`. The migrate step is skipped when no files under `prisma/migrations/` changed since `VERCEL_GIT_PREVIOUS_SHA` (set `FORCE_PRISMA_MIGRATE_DEPLOY=1` to override; `SKIP_PRISMA_MIGRATE_DEPLOY=1` skips it unconditionally).
+- The Vercel build runs `pnpm run build:vercel`, which runs the idempotent `prisma migrate deploy` command before `next build`. Migration failures stop the deployment so a build cannot be published against a stale schema. `SKIP_PRISMA_MIGRATE_DEPLOY=1` remains an explicit emergency escape hatch.
 - CI / local `pnpm build` is plain `next build` and does **not** require a database.
 
 ## 💹 Net Worth History & Currency Normalization

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -628,7 +628,11 @@
     "snapshotLabel": {
       "addSnapshotAction": "Add label for {date}",
       "editSnapshotAction": "Edit label for {date}",
-      "title": "Snapshot label",
+      "addNoteAction": "Add note for {date}",
+      "editNoteAction": "Edit note for {date}",
+      "addNote": "Add note",
+      "editNote": "Edit note",
+      "title": "Snapshot details",
       "label": "Label",
       "labelPlaceholder": "Bonus paid",
       "labelCount": "{count}/80",
@@ -638,8 +642,8 @@
       "cancel": "Cancel",
       "save": "Save",
       "saving": "Saving...",
-      "toastSaved": "Snapshot label saved",
-      "toastFailed": "Failed to save snapshot label"
+      "toastSaved": "Snapshot details saved",
+      "toastFailed": "Failed to save snapshot details"
     },
     "emptyTitle": "No history yet",
     "emptyDesc": "Net worth is captured once a day as a snapshot. After your first one, your trend, activity calendar, and full ledger appear here. Snapshots run automatically each day; you can also trigger one now from the dashboard.",
@@ -685,7 +689,10 @@
       }
     },
     "activityYear": "{year} activity",
+    "netWorth": "Net worth",
+    "change": "Change",
     "selectedSnapshot": "Selected snapshot",
+    "clearSnapshotSelection": "Clear snapshot selection",
     "legendLoss": "Loss",
     "legendGain": "Gain"
   },

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -685,6 +685,7 @@
       }
     },
     "activityYear": "{year} activity",
+    "selectedSnapshot": "Selected snapshot",
     "legendLoss": "Loss",
     "legendGain": "Gain"
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -685,6 +685,7 @@
       }
     },
     "activityYear": "{year} 年活動",
+    "selectedSnapshot": "已選取快照",
     "legendLoss": "下跌",
     "legendGain": "上漲"
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -628,7 +628,11 @@
     "snapshotLabel": {
       "addSnapshotAction": "為 {date} 加上標籤",
       "editSnapshotAction": "編輯 {date} 的標籤",
-      "title": "快照標籤",
+      "addNoteAction": "為 {date} 加上備註",
+      "editNoteAction": "編輯 {date} 的備註",
+      "addNote": "新增備註",
+      "editNote": "編輯備註",
+      "title": "快照詳細資料",
       "label": "標籤",
       "labelPlaceholder": "收到獎金",
       "labelCount": "{count}/80",
@@ -638,8 +642,8 @@
       "cancel": "取消",
       "save": "儲存",
       "saving": "儲存中...",
-      "toastSaved": "快照標籤已儲存",
-      "toastFailed": "儲存快照標籤失敗"
+      "toastSaved": "快照詳細資料已儲存",
+      "toastFailed": "儲存快照詳細資料失敗"
     },
     "emptyTitle": "尚無歷史記錄",
     "emptyDesc": "每日擷取一次淨值快照。第一份快照完成後，您的趨勢、活動月曆和完整分類帳就會顯示在此處。快照每日自動執行，您也可以立即從儀表板手動觸發。",
@@ -685,7 +689,10 @@
       }
     },
     "activityYear": "{year} 年活動",
+    "netWorth": "淨資產",
+    "change": "變化",
     "selectedSnapshot": "已選取快照",
+    "clearSnapshotSelection": "清除快照選取",
     "legendLoss": "下跌",
     "legendGain": "上漲"
   },

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 
-function run(command, args, { allowFailure = false } = {}) {
+function run(command, args) {
   const result = spawnSync(command, args, {
     stdio: "inherit",
     shell: process.platform === "win32",
@@ -11,49 +11,22 @@ function run(command, args, { allowFailure = false } = {}) {
     throw result.error;
   }
 
-  if (result.status !== 0 && !allowFailure) {
+  if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
 
   return result.status ?? 1;
 }
 
-// Skip `prisma migrate deploy` when this commit range touched no migration
-// files. Falls open (runs migrate) on any uncertainty: missing previous SHA,
-// shallow clone that can't reach it, or git failure.
-function migrationsChanged() {
-  if (process.env.FORCE_PRISMA_MIGRATE_DEPLOY === "1") return true;
-
-  const prevSha = process.env.VERCEL_GIT_PREVIOUS_SHA;
-  if (!prevSha) return true;
-
-  const reachable = spawnSync("git", ["cat-file", "-e", prevSha], { stdio: "ignore" });
-  if (reachable.status !== 0) return true;
-
-  const diff = spawnSync(
-    "git",
-    ["diff", "--name-only", `${prevSha}...HEAD`, "--", "prisma/migrations"],
-    { encoding: "utf8" },
-  );
-  if (diff.status !== 0) return true;
-
-  return diff.stdout.trim().length > 0;
-}
-
-const shouldAttemptMigrate = process.env.SKIP_PRISMA_MIGRATE_DEPLOY !== "1" && migrationsChanged();
-
-if (shouldAttemptMigrate) {
-  const migrateStatus = run("prisma", ["migrate", "deploy"], { allowFailure: true });
-
-  if (migrateStatus !== 0) {
-    console.warn("\n[build:vercel] prisma migrate deploy failed; continuing with Next.js build.");
-    console.warn("[build:vercel] Set SKIP_PRISMA_MIGRATE_DEPLOY=1 to skip migration entirely.\n");
-  }
+// `prisma migrate deploy` is idempotent and must run before every deployment.
+// A previous optimization skipped this step when the current commit did not
+// add migration files and allowed migration failures to continue. That could
+// publish a healthy-looking deployment against a stale schema, leaving every
+// data-backed Server Component to fail at runtime.
+if (process.env.SKIP_PRISMA_MIGRATE_DEPLOY !== "1") {
+  run("prisma", ["migrate", "deploy"]);
 } else {
-  console.log(
-    "[build:vercel] No migration files changed since previous deploy — skipping prisma migrate deploy.",
-  );
-  console.log("[build:vercel] Set FORCE_PRISMA_MIGRATE_DEPLOY=1 to force it.\n");
+  console.warn("[build:vercel] SKIP_PRISMA_MIGRATE_DEPLOY=1 — skipping database migrations.\n");
 }
 
 // Always (re)generate the Prisma client before building. We can't rely on the

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo, useRef, useState, useEffect, useSyncExternalStore } from "react";
+import { useMemo, useRef, useState, useEffect, useSyncExternalStore, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { motion, useReducedMotion } from "framer-motion";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useDensity } from "@/components/layout/density-context";
 import { cn } from "@/lib/utils";
 import { HistoryView } from "@/components/history/history-view";
@@ -79,6 +80,10 @@ function pickDefaultRange(snapshots: NormalizedSnapshot[]): RangeLabel {
   return "YTD";
 }
 
+function MountedAnalysis({ show, children }: { show: boolean; children: ReactNode }) {
+  return show ? <div>{children}</div> : null;
+}
+
 export function AnalysisView({
   snapshots,
   cashFlowData,
@@ -91,6 +96,7 @@ export function AnalysisView({
   const t = useTranslations("analysis");
   const tNav = useTranslations("nav");
   const { density } = useDensity();
+  const isMobile = useIsMobile();
   const isCompact = density === "compact";
   // Keep side-by-side gaps equal to the vertical rhythm between stacked rows.
   const gridGapClass = isCompact ? "gap-3" : "gap-6";
@@ -234,6 +240,8 @@ export function AnalysisView({
   const [override, setOverride] = useState<"analysis" | "history" | null>(null);
   const activeTab: "analysis" | "history" =
     override ?? (hash === "#history" ? "history" : "analysis");
+  const showAnalysis = !isMobile || activeTab === "analysis";
+  const showHistory = isMobile && activeTab === "history";
 
   const handleTabChange = (tab: "analysis" | "history") => {
     setOverride(tab);
@@ -265,8 +273,9 @@ export function AnalysisView({
         aria-label={tNav("analysis")}
       />
 
-      {/* Analysis tab content — always visible on desktop, conditional on mobile */}
-      <div className={activeTab === "history" ? "hidden md:block" : "block"}>
+      {/* Do not mount charts inside a display:none tab. Recharts measures its
+          container on mount, so hidden lazy charts otherwise initialize at 0×0. */}
+      <MountedAnalysis show={showAnalysis}>
         {/* Sentinel: when this scrolls off-screen the range bar is stuck */}
         <div ref={sentinelRef} className="h-px -mt-px" aria-hidden />
         {/* Range selector — floats as a compact pill while scrolling */}
@@ -385,12 +394,10 @@ export function AnalysisView({
             <TopMoversList movers={topMovers} baseCurrency={baseCurrency} />
           </motion.div>
         )}
-      </div>
+      </MountedAnalysis>
 
       {/* History tab content — mobile only */}
-      {activeTab === "history" && (
-        <HistoryView snapshots={snapshots} baseCurrency={baseCurrency} className="md:hidden" />
-      )}
+      {showHistory && <HistoryView snapshots={snapshots} baseCurrency={baseCurrency} />}
     </div>
   );
 }

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -6,6 +6,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { formatCurrency } from "@/lib/currencies";
+import { hapticTick } from "@/lib/haptics";
 
 const CELL_PX = 10;
 const GAP_PX = 4;
@@ -83,7 +84,9 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   const t = useTranslations("history");
   const { privacyMode } = usePrivacyMode();
   const [tooltip, setTooltip] = useState<{ day: GridDay; x: number; y: number } | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const tooltipLabels = labels ?? { netWorth: "Net Worth", change: "Change" };
+  const activePointerType = useRef<string | null>(null);
 
   const {
     gridDays,
@@ -203,6 +206,11 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
     }
     return result;
   }, [gridDays, weeksToShow]);
+
+  const selectedDay = useMemo(
+    () => gridDays.find((day) => day.dateString === selectedDate),
+    [gridDays, selectedDate],
+  );
 
   const daysOfWeek = useMemo(
     () =>
@@ -347,6 +355,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
 
                     const canShowDetails = day.hasSnapshot && !day.isFuture;
                     const isToday = day.dateString === todayString;
+                    const isSelected = day.dateString === selectedDate;
 
                     const dateLabel = format.dateTime(calendarDateFromString(day.dateString), {
                       dateStyle: "medium",
@@ -401,8 +410,43 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                         role="gridcell"
                         aria-colindex={cIdx + 1}
                         aria-label={isToday ? `${cellLabel}, today` : cellLabel}
-                        aria-selected={tooltip?.day.dateString === day.dateString}
+                        aria-selected={isSelected}
                         tabIndex={canShowDetails ? 0 : -1}
+                        onPointerDown={
+                          canShowDetails
+                            ? (e) => {
+                                activePointerType.current = e.pointerType;
+                              }
+                            : undefined
+                        }
+                        onPointerUp={
+                          canShowDetails
+                            ? () => {
+                                activePointerType.current = null;
+                              }
+                            : undefined
+                        }
+                        onPointerCancel={
+                          canShowDetails
+                            ? () => {
+                                activePointerType.current = null;
+                              }
+                            : undefined
+                        }
+                        onClick={
+                          canShowDetails
+                            ? () => {
+                                // A click only becomes a persistent selection in the
+                                // single-column mobile layout. Touch-generated clicks are
+                                // naturally cancelled when the user scrolls the calendar.
+                                if (window.matchMedia("(max-width: 767px)").matches) {
+                                  if (selectedDate !== day.dateString) hapticTick();
+                                  setSelectedDate(day.dateString);
+                                  setTooltip(null);
+                                }
+                              }
+                            : undefined
+                        }
                         onPointerEnter={
                           canShowDetails
                             ? (e) => {
@@ -424,7 +468,12 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                         }
                         onFocus={
                           canShowDetails
-                            ? (e) => showTooltipAtElement(day, e.currentTarget)
+                            ? (e) => {
+                                // Touch focus is followed by the persistent mobile detail
+                                // panel. Keep the floating tooltip for keyboard navigation.
+                                if (!activePointerType.current)
+                                  showTooltipAtElement(day, e.currentTarget);
+                              }
                             : undefined
                         }
                         onBlur={canShowDetails ? () => setTooltip(null) : undefined}
@@ -434,10 +483,14 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                           // Only the year-to-date fills in; the blank future months stay put.
                           !day.isFuture && "history-cell-in",
                           canShowDetails &&
-                            "cursor-pointer transition-transform hover:scale-125 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1",
+                            "cursor-pointer transition-[transform,box-shadow] duration-150 ease-[var(--ease-out-expo)] hover:scale-125 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-1 motion-reduce:transition-none",
                           bgClass,
+                          isSelected &&
+                            "relative z-10 scale-150 ring-2 ring-primary ring-offset-2 ring-offset-card",
                           // Neutral ink ring marks today: orientation, not a gain/loss signal.
-                          isToday && "ring-1 ring-foreground/60 dark:ring-foreground/70",
+                          isToday &&
+                            !isSelected &&
+                            "ring-1 ring-foreground/60 dark:ring-foreground/70",
                         )}
                       />
                     );
@@ -448,6 +501,69 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
           </div>
         </div>
       </div>
+
+      {selectedDay && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="mt-3 rounded-lg bg-muted/45 px-3 py-2.5 ring-1 ring-foreground/10 animate-in fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none md:hidden"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold text-foreground">
+                {format.dateTime(calendarDateFromString(selectedDay.dateString), {
+                  dateStyle: "medium",
+                  timeZone: CALENDAR_TIME_ZONE,
+                })}
+              </p>
+              {!privacyMode && selectedDay.label && (
+                <p className="mt-0.5 truncate text-[11px] font-medium text-foreground/80">
+                  {selectedDay.label}
+                </p>
+              )}
+            </div>
+            <span className="shrink-0 rounded-full bg-primary/10 px-2 py-1 text-[10px] font-medium text-primary-ink">
+              {t("selectedSnapshot")}
+            </span>
+          </div>
+
+          <div className="mt-2 flex items-end justify-between gap-4 border-t border-border/50 pt-2">
+            <div className="min-w-0">
+              <p className="text-[10px] text-muted-foreground">{tooltipLabels.netWorth}</p>
+              <p className="mt-0.5 truncate text-sm font-semibold tabular-nums text-foreground">
+                {privacyMode ? "***" : formatCurrency(selectedDay.netWorth!, baseCurrency)}
+              </p>
+            </div>
+            {selectedDay.change !== null && (
+              <div className="shrink-0 text-right">
+                <p className="text-[10px] text-muted-foreground">{tooltipLabels.change}</p>
+                <p
+                  className={cn(
+                    "mt-0.5 text-sm font-semibold tabular-nums",
+                    selectedDay.change > 0
+                      ? "text-[var(--gain-ink)]"
+                      : selectedDay.change < 0
+                        ? "text-[var(--loss-ink)]"
+                        : "text-muted-foreground",
+                  )}
+                >
+                  {privacyMode
+                    ? "***"
+                    : (selectedDay.change >= 0 ? "+" : "") +
+                      formatCurrency(selectedDay.change, baseCurrency)}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {!privacyMode && selectedDay.note && (
+            <p className="mt-2 line-clamp-3 border-t border-border/50 pt-2 text-[11px] leading-relaxed text-muted-foreground">
+              {selectedDay.note}
+            </p>
+          )}
+        </div>
+      )}
 
       {typeof document !== "undefined" &&
         tooltip &&

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -3,8 +3,10 @@
 import { useCallback, useMemo, useState, useRef, useEffect, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import { useFormatter, useTranslations } from "next-intl";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { SnapshotLabelDialog } from "@/components/history/snapshot-label-dialog";
 import { formatCurrency } from "@/lib/currencies";
 import { hapticTick } from "@/lib/haptics";
 
@@ -59,6 +61,7 @@ type SnapshotRow = {
 };
 
 type GridDay = {
+  id?: string;
   date: Date;
   dateString: string;
   hasSnapshot: boolean;
@@ -85,7 +88,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   const { privacyMode } = usePrivacyMode();
   const [tooltip, setTooltip] = useState<{ day: GridDay; x: number; y: number } | null>(null);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const tooltipLabels = labels ?? { netWorth: "Net Worth", change: "Change" };
+  const tooltipLabels = labels ?? { netWorth: t("netWorth"), change: t("change") };
   const activePointerType = useRef<string | null>(null);
 
   const {
@@ -166,6 +169,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       }
 
       days.push({
+        id: snapData?.id,
         date: current,
         dateString,
         hasSnapshot: !!snapData,
@@ -208,7 +212,8 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
   }, [gridDays, weeksToShow]);
 
   const selectedDay = useMemo(
-    () => gridDays.find((day) => day.dateString === selectedDate),
+    () =>
+      gridDays.find((day) => day.dateString === selectedDate && day.hasSnapshot && !day.isFuture),
     [gridDays, selectedDate],
   );
 
@@ -264,6 +269,18 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
       window.removeEventListener("orientationchange", dismissTooltip);
     };
   }, [dismissTooltip, tooltip]);
+
+  // Persistent selection is a mobile-only alternative to the floating tooltip.
+  // Clear it when the layout becomes desktop so it cannot reappear after a resize.
+  useEffect(() => {
+    const desktopLayout = window.matchMedia("(min-width: 768px)");
+    const clearDesktopSelection = (event: MediaQueryListEvent) => {
+      if (event.matches) setSelectedDate(null);
+    };
+
+    desktopLayout.addEventListener("change", clearDesktopSelection);
+    return () => desktopLayout.removeEventListener("change", clearDesktopSelection);
+  }, []);
 
   return (
     <div
@@ -355,7 +372,7 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
 
                     const canShowDetails = day.hasSnapshot && !day.isFuture;
                     const isToday = day.dateString === todayString;
-                    const isSelected = day.dateString === selectedDate;
+                    const isSelected = canShowDetails && day.dateString === selectedDate;
 
                     const dateLabel = format.dateTime(calendarDateFromString(day.dateString), {
                       dateStyle: "medium",
@@ -440,8 +457,10 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                                 // single-column mobile layout. Touch-generated clicks are
                                 // naturally cancelled when the user scrolls the calendar.
                                 if (window.matchMedia("(max-width: 767px)").matches) {
-                                  if (selectedDate !== day.dateString) hapticTick();
-                                  setSelectedDate(day.dateString);
+                                  hapticTick();
+                                  setSelectedDate((current) =>
+                                    current === day.dateString ? null : day.dateString,
+                                  );
                                   setTooltip(null);
                                 }
                               }
@@ -504,40 +523,47 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
 
       {selectedDay && (
         <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className="mt-3 rounded-lg bg-muted/45 px-3 py-2.5 ring-1 ring-foreground/10 animate-in fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none md:hidden"
+          role="region"
+          aria-label={t("selectedSnapshot")}
+          className="mt-3 animate-in rounded-lg bg-muted/45 px-3 py-3 ring-1 ring-foreground/10 fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none md:hidden"
         >
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="text-xs font-semibold text-foreground">
+              <p className="text-sm font-semibold text-foreground">
                 {format.dateTime(calendarDateFromString(selectedDay.dateString), {
                   dateStyle: "medium",
                   timeZone: CALENDAR_TIME_ZONE,
                 })}
               </p>
               {!privacyMode && selectedDay.label && (
-                <p className="mt-0.5 truncate text-[11px] font-medium text-foreground/80">
+                <p className="mt-0.5 truncate text-xs font-medium text-foreground/80">
                   {selectedDay.label}
                 </p>
               )}
             </div>
-            <span className="shrink-0 rounded-full bg-primary/10 px-2 py-1 text-[10px] font-medium text-primary-ink">
-              {t("selectedSnapshot")}
-            </span>
+            <button
+              type="button"
+              aria-label={t("clearSnapshotSelection")}
+              className="-mr-1 -mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:bg-foreground/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 active:bg-foreground/10"
+              onClick={() => {
+                hapticTick();
+                setSelectedDate(null);
+              }}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </button>
           </div>
 
-          <div className="mt-2 flex items-end justify-between gap-4 border-t border-border/50 pt-2">
+          <div className="mt-2.5 flex items-end justify-between gap-4 border-t border-border/50 pt-2.5">
             <div className="min-w-0">
-              <p className="text-[10px] text-muted-foreground">{tooltipLabels.netWorth}</p>
+              <p className="text-xs text-muted-foreground">{tooltipLabels.netWorth}</p>
               <p className="mt-0.5 truncate text-sm font-semibold tabular-nums text-foreground">
                 {privacyMode ? "***" : formatCurrency(selectedDay.netWorth!, baseCurrency)}
               </p>
             </div>
             {selectedDay.change !== null && (
               <div className="shrink-0 text-right">
-                <p className="text-[10px] text-muted-foreground">{tooltipLabels.change}</p>
+                <p className="text-xs text-muted-foreground">{tooltipLabels.change}</p>
                 <p
                   className={cn(
                     "mt-0.5 text-sm font-semibold tabular-nums",
@@ -558,10 +584,37 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
           </div>
 
           {!privacyMode && selectedDay.note && (
-            <p className="mt-2 line-clamp-3 border-t border-border/50 pt-2 text-[11px] leading-relaxed text-muted-foreground">
+            <p className="mt-2.5 line-clamp-3 border-t border-border/50 pt-2.5 text-xs leading-relaxed text-muted-foreground">
               {selectedDay.note}
             </p>
           )}
+          {!privacyMode && selectedDay.id && (
+            <div className="mt-2.5 border-t border-border/50 pt-2">
+              <SnapshotLabelDialog
+                snapshot={{
+                  id: selectedDay.id,
+                  date: selectedDay.dateString,
+                  label: selectedDay.label,
+                  note: selectedDay.note,
+                }}
+                trigger="note"
+                className="-ml-2"
+              />
+            </div>
+          )}
+          <span className="sr-only" aria-live="polite">
+            {t("selectedSnapshot")}: {tooltipLabels.netWorth},{" "}
+            {privacyMode ? "***" : formatCurrency(selectedDay.netWorth!, baseCurrency)}
+            {selectedDay.change !== null && (
+              <>
+                ; {tooltipLabels.change},{" "}
+                {privacyMode
+                  ? "***"
+                  : (selectedDay.change >= 0 ? "+" : "") +
+                    formatCurrency(selectedDay.change, baseCurrency)}
+              </>
+            )}
+          </span>
         </div>
       )}
 

--- a/src/components/history/snapshot-label-dialog.tsx
+++ b/src/components/history/snapshot-label-dialog.tsx
@@ -3,7 +3,7 @@
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
-import { Tag } from "lucide-react";
+import { NotebookPen, Tag } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -24,9 +24,10 @@ export type SnapshotLabelTarget = {
 type Props = {
   snapshot: SnapshotLabelTarget;
   className?: string;
+  trigger?: "icon" | "note";
 };
 
-export function SnapshotLabelDialog({ snapshot, className }: Props) {
+export function SnapshotLabelDialog({ snapshot, className, trigger = "icon" }: Props) {
   const router = useRouter();
   const t = useTranslations("history.snapshotLabel");
   const format = useFormatter();
@@ -77,9 +78,11 @@ export function SnapshotLabelDialog({ snapshot, className }: Props) {
     dateStyle: "medium",
   });
   const hasLabel = Boolean(snapshot?.label);
-  const triggerLabel = t(hasLabel ? "editSnapshotAction" : "addSnapshotAction", {
-    date: snapshotDate,
-  });
+  const hasNote = Boolean(snapshot?.note);
+  const triggerLabel =
+    trigger === "note"
+      ? t(hasNote ? "editNoteAction" : "addNoteAction", { date: snapshotDate })
+      : t(hasLabel ? "editSnapshotAction" : "addSnapshotAction", { date: snapshotDate });
 
   const form = (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -127,14 +130,21 @@ export function SnapshotLabelDialog({ snapshot, className }: Props) {
       <Button
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size={trigger === "note" ? "sm" : "icon-sm"}
         onClick={() => handleOpenChange(true)}
         disabled={saving}
         aria-label={triggerLabel}
         title={triggerLabel}
         className={cn("text-muted-foreground hover:text-foreground", className)}
       >
-        <Tag className="size-3.5" aria-hidden="true" />
+        {trigger === "note" ? (
+          <>
+            <NotebookPen className="size-3.5" aria-hidden="true" />
+            {t(hasNote ? "editNote" : "addNote")}
+          </>
+        ) : (
+          <Tag className="size-3.5" aria-hidden="true" />
+        )}
       </Button>
 
       {isMobile ? (


### PR DESCRIPTION
## Summary

- add persistent mobile heatmap snapshot selection with readable, localized details
- add an Add note / Edit note action that reuses the responsive snapshot details drawer
- clear stale selection on desktop transitions and improve accessible selection announcements
- avoid mounting Recharts charts inside hidden analysis/history tabs
- run Vercel database migrations before builds and fail deployments on migration errors

## Why

Touch users previously lost the hover tooltip immediately and could not act on a selected snapshot. The analysis history deep link also mounted lazy charts inside a hidden tab, causing repeated zero-dimension Recharts warnings.

## Impact

Mobile users can select a heatmap cell, inspect its values, add or edit a note, and dismiss the selection. English and Traditional Chinese labels are localized. Analysis and history charts now mount only when their responsive surface is visible.

## Validation

- Prettier
- ESLint (0 errors; existing skill-script warnings remain)
- TypeScript
- Vitest: 115 tests passed
- mobile browser verification at 390×844
- direct `/analysis#history`, analysis/history tab switching, and desktop chart layout verified with no hidden responsive charts or zero-dimension warnings