### PR TITLE
fix(mobile): light-mode gain/loss AA contrast (v0.8.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -535,7 +535,7 @@ export function AccountsList({
                       <tr className="bg-[var(--gain)]/8">
                         <td
                           colSpan={8}
-                          className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-[var(--gain)]"
+                          className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-[var(--gain-ink)]"
                         >
                           {t("accountsList.assets")}
                         </td>
@@ -565,7 +565,7 @@ export function AccountsList({
                       <tr className="bg-[var(--loss)]/8">
                         <td
                           colSpan={8}
-                          className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-[var(--loss)]"
+                          className="px-4 py-2 text-xs font-semibold uppercase tracking-widest text-[var(--loss-ink)]"
                         >
                           {t("accountsList.liabilities")}
                         </td>
@@ -1131,13 +1131,13 @@ function MobileSummaryStrip({
       <div className="flex items-center gap-4">
         <div>
           <p className="text-xs text-muted-foreground">{t("accountsList.assets")}</p>
-          <p className="font-semibold tabular-nums text-[var(--gain)]">
+          <p className="font-semibold tabular-nums text-[var(--gain-ink)]">
             {privacyMode ? HIDDEN : formatCurrency(totalAssets, baseCurrency, true)}
           </p>
         </div>
         <div>
           <p className="text-xs text-muted-foreground">{t("accountsList.liabilities")}</p>
-          <p className="font-semibold tabular-nums text-[var(--loss)]">
+          <p className="font-semibold tabular-nums text-[var(--loss-ink)]">
             {privacyMode ? HIDDEN : formatCurrency(totalLiabilities, baseCurrency, true)}
           </p>
         </div>

--- a/src/components/analysis/analysis-empty-state.tsx
+++ b/src/components/analysis/analysis-empty-state.tsx
@@ -30,7 +30,7 @@ export function AnalysisEmptyState({ hasAccounts }: { hasAccounts: boolean }) {
               {t("preview.trendSubtitle")}
             </p>
           </div>
-          <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+          <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-[var(--primary-ink)]">
             {t("preview.range")}
           </span>
         </div>

--- a/src/components/analysis/attribution-chart.tsx
+++ b/src/components/analysis/attribution-chart.tsx
@@ -65,7 +65,9 @@ function AttributionTooltip({
         value={
           privacyMode ? "***" : `${mktSign}${formatCurrency(item.marketPerformance, baseCurrency)}`
         }
-        valueClassName={item.marketPerformance >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+        valueClassName={
+          item.marketPerformance >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
+        }
       />
       <div className="pt-1.5 mt-1.5 border-t border-border/40">
         <ChartTooltipRow
@@ -73,7 +75,9 @@ function AttributionTooltip({
           value={
             privacyMode ? "***" : `${totalSign}${formatCurrency(item.totalDelta, baseCurrency)}`
           }
-          valueClassName={item.totalDelta >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+          valueClassName={
+            item.totalDelta >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
+          }
         />
       </div>
     </ChartTooltipContainer>
@@ -255,7 +259,7 @@ export const AttributionChart = memo(function AttributionChart({ items, baseCurr
                 <div className="text-muted-foreground">{t("attrMarket")}</div>
                 <div
                   className={`tabular-nums font-medium mt-0.5 ${
-                    totalMarket >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"
+                    totalMarket >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
                   }`}
                 >
                   {totalMarket >= 0 ? "+" : ""}
@@ -266,7 +270,7 @@ export const AttributionChart = memo(function AttributionChart({ items, baseCurr
                 <div className="text-muted-foreground">{t("tooltipChange")}</div>
                 <div
                   className={`tabular-nums font-medium mt-0.5 ${
-                    totalDelta >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"
+                    totalDelta >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
                   }`}
                 >
                   {totalDelta >= 0 ? "+" : ""}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -68,7 +68,9 @@ function CashFlowTooltip({
         value={
           privacyMode ? "***" : `${marketSign}${formatCurrency(b.marketPerformance, baseCurrency)}`
         }
-        valueClassName={b.marketPerformance >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+        valueClassName={
+          b.marketPerformance >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
+        }
       />
       <div className="pt-1.5 mt-1.5 border-t border-border/40">
         <ChartTooltipRow
@@ -76,7 +78,9 @@ function CashFlowTooltip({
           value={
             privacyMode ? "***" : `${deltaSign}${formatCurrency(b.deltaNetWorth, baseCurrency)}`
           }
-          valueClassName={b.deltaNetWorth >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+          valueClassName={
+            b.deltaNetWorth >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
+          }
         />
       </div>
     </ChartTooltipContainer>

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -40,11 +40,14 @@ function CountUpMoney({ amount, currency }: { amount: number; currency: string }
 function DirectionCaret({ tone, className }: { tone: Tone; className?: string }) {
   if (tone === "positive")
     return (
-      <ArrowUpRight className={`text-[var(--gain)] shrink-0 ${className ?? ""}`} aria-hidden />
+      <ArrowUpRight className={`text-[var(--gain-ink)] shrink-0 ${className ?? ""}`} aria-hidden />
     );
   if (tone === "negative")
     return (
-      <ArrowDownRight className={`text-[var(--loss)] shrink-0 ${className ?? ""}`} aria-hidden />
+      <ArrowDownRight
+        className={`text-[var(--loss-ink)] shrink-0 ${className ?? ""}`}
+        aria-hidden
+      />
     );
   return null;
 }
@@ -79,7 +82,7 @@ function MoneyValue({
           : isCompact
             ? "text-xs"
             : "text-sm",
-        tone === "negative" ? "text-[var(--loss)]" : "text-foreground",
+        tone === "negative" ? "text-[var(--loss-ink)]" : "text-foreground",
       )}
     >
       <DirectionCaret
@@ -124,9 +127,9 @@ function LeadMetric({
   const tone: Tone = privacyMode || amount === null ? "neutral" : toneFor(amount);
   const pillClass =
     tone === "negative"
-      ? "bg-[var(--loss)]/10 text-[var(--loss)]"
+      ? "bg-[var(--loss)]/10 text-[var(--loss-ink)]"
       : tone === "positive"
-        ? "bg-[var(--gain)]/10 text-[var(--gain)]"
+        ? "bg-[var(--gain)]/10 text-[var(--gain-ink)]"
         : "bg-muted text-muted-foreground";
 
   return (

--- a/src/components/analysis/monthly-change-chart.tsx
+++ b/src/components/analysis/monthly-change-chart.tsx
@@ -73,7 +73,9 @@ function ChangeTooltip({
           value={
             privacyMode ? pct : `${sign}${formatCurrency(b.deltaNetWorth, baseCurrency)} (${pct})`
           }
-          valueClassName={b.deltaNetWorth >= 0 ? "text-[var(--gain)]" : "text-[var(--loss)]"}
+          valueClassName={
+            b.deltaNetWorth >= 0 ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]"
+          }
         />
       </div>
     </ChartTooltipContainer>

--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -108,7 +108,7 @@ export const TopMoversList = memo(function TopMoversList({ movers, baseCurrency 
                         </Badge>
                       </div>
                       <div
-                        className={`text-xs tabular-nums mt-0.5 ${isPositive ? "text-[var(--gain)]/80" : "text-[var(--loss)]/80"}`}
+                        className={`text-xs tabular-nums mt-0.5 ${isPositive ? "text-[var(--gain-ink)]/80" : "text-[var(--loss-ink)]/80"}`}
                       >
                         {privacyMode ? "***" : pct}
                       </div>

--- a/src/components/dashboard/accounts-summary.tsx
+++ b/src/components/dashboard/accounts-summary.tsx
@@ -112,9 +112,9 @@ export function AccountsSummary({ summary }: { summary: NetWorthSummary }) {
   const renderGroup = (accounts: typeof summary.accounts, isAsset: boolean) => {
     const totalDisplay = isAsset ? summary.totalAssets : summary.totalLiabilities;
     const label = isAsset ? t("common.asset").toUpperCase() : t("common.liability").toUpperCase();
-    const accentClass = isAsset ? "text-[var(--gain)]" : "text-[var(--loss)]";
+    const accentClass = isAsset ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]";
     const dotClass = isAsset ? "bg-[var(--gain)]" : "bg-[var(--loss)]";
-    const totalAccentClass = isAsset ? "text-[var(--gain)]" : "text-[var(--loss)]";
+    const totalAccentClass = isAsset ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]";
 
     return (
       <div>

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -126,7 +126,8 @@ export function NetWorthCard({
       : null;
 
   const isPositive = delta !== null && delta >= 0;
-  const deltaColor = delta === null ? "" : isPositive ? "text-[var(--gain)]" : "text-[var(--loss)]";
+  const deltaColor =
+    delta === null ? "" : isPositive ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]";
   const bgDeltaColor =
     delta === null ? "" : isPositive ? "bg-[var(--gain)]/10" : "bg-[var(--loss)]/10";
   const deltaSign = delta !== null && delta > 0 ? "+" : "";
@@ -212,7 +213,7 @@ export function NetWorthCard({
           className={`${isCompact ? "p-2.5 sm:p-3" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}
         >
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
-            <Wallet className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-[var(--gain)] shrink-0" />
+            <Wallet className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-[var(--gain-ink)] shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">
               {t("totalAssets")}
             </p>
@@ -221,7 +222,7 @@ export function NetWorthCard({
             amount={totalAssets}
             currency={baseCurrency}
             privacy={privacyMode}
-            className="relative text-lg sm:text-2xl font-semibold text-[var(--gain)] mt-1 whitespace-nowrap tabular-nums truncate"
+            className="relative text-lg sm:text-2xl font-semibold text-[var(--gain-ink)] mt-1 whitespace-nowrap tabular-nums truncate"
           />
           {!isCompact && (
             <CompositionMeter
@@ -240,7 +241,7 @@ export function NetWorthCard({
           className={`${isCompact ? "p-2.5 sm:p-3" : "p-4 sm:p-6"} h-full flex flex-col justify-center min-w-0`}
         >
           <div className="flex items-center gap-1.5 sm:gap-2 mb-1 whitespace-nowrap overflow-hidden">
-            <TrendingDown className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-[var(--loss)] shrink-0" />
+            <TrendingDown className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-[var(--loss-ink)] shrink-0" />
             <p className="text-xs sm:text-sm font-medium text-muted-foreground truncate">
               {t("totalLiabilities")}
             </p>
@@ -249,7 +250,7 @@ export function NetWorthCard({
             amount={totalLiabilities}
             currency={baseCurrency}
             privacy={privacyMode}
-            className="relative text-lg sm:text-2xl font-semibold text-[var(--loss)] mt-1 whitespace-nowrap tabular-nums truncate"
+            className="relative text-lg sm:text-2xl font-semibold text-[var(--loss-ink)] mt-1 whitespace-nowrap tabular-nums truncate"
           />
           {!isCompact && (
             <CompositionMeter

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -264,8 +264,8 @@ export function TrendChart({
               aria-hidden={privacyMode || undefined}
               className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold tabular-nums ${
                 periodChange.delta >= 0
-                  ? "bg-[var(--gain)]/10 text-[var(--gain)]"
-                  : "bg-[var(--loss)]/10 text-[var(--loss)]"
+                  ? "bg-[var(--gain)]/10 text-[var(--gain-ink)]"
+                  : "bg-[var(--loss)]/10 text-[var(--loss-ink)]"
               }`}
             >
               {privacyMode ? (

--- a/src/components/dashboard/watchlist-card.tsx
+++ b/src/components/dashboard/watchlist-card.tsx
@@ -91,8 +91,8 @@ function WatchlistRow({ stock }: { stock: SerializedTrackedStock }) {
               className={cn(
                 "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-[13px] font-semibold tabular-nums leading-none",
                 isGain
-                  ? "bg-[var(--gain)]/15 text-[var(--gain)]"
-                  : "bg-[var(--loss)]/15 text-[var(--loss)]",
+                  ? "bg-[var(--gain)]/15 text-[var(--gain-ink)]"
+                  : "bg-[var(--loss)]/15 text-[var(--loss-ink)]",
               )}
             >
               <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden="true" />

--- a/src/components/goals/goals-onboarding.tsx
+++ b/src/components/goals/goals-onboarding.tsx
@@ -21,7 +21,7 @@ export function GoalsOnboarding({ onAdd }: GoalsOnboardingProps) {
               {t("preview.cardSubtitle")}
             </p>
           </div>
-          <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+          <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-[var(--primary-ink)]">
             {t("preview.status")}
           </span>
         </div>
@@ -54,7 +54,7 @@ export function GoalsOnboarding({ onAdd }: GoalsOnboardingProps) {
         <div className="space-y-3">
           {["netWorth", "assets", "account"].map((key, index) => (
             <div key={key} className="flex items-center gap-3 rounded-lg bg-card/70 p-3">
-              <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 text-xs font-semibold text-primary">
+              <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 text-xs font-semibold text-[var(--primary-ink)]">
                 {index + 1}
               </span>
               <div className="min-w-0 flex-1 space-y-1">

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -55,7 +55,7 @@ function ReorderGoalItem({ data }: { data: GoalWithProgress }) {
       <Target className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
       <p className="min-w-0 flex-1 truncate text-sm font-medium">{data.goal.name}</p>
       {data.isCompleted ? (
-        <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[var(--gain)]/15 px-2 py-0.5 text-xs font-semibold text-[var(--gain)]">
+        <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[var(--gain)]/15 px-2 py-0.5 text-xs font-semibold text-[var(--gain-ink)]">
           <CheckCircle2 className="h-3 w-3 shrink-0" aria-hidden />
           {t("completed")}
         </span>

--- a/src/components/history/daily-change-chart.tsx
+++ b/src/components/history/daily-change-chart.tsx
@@ -92,8 +92,8 @@ function DailyChangeTooltip({
             isZero
               ? "text-muted-foreground"
               : isPositive
-                ? "text-[var(--gain)]"
-                : "text-[var(--loss)]"
+                ? "text-[var(--gain-ink)]"
+                : "text-[var(--loss-ink)]"
           }
         />
       )}

--- a/src/components/history/history-heatmap.tsx
+++ b/src/components/history/history-heatmap.tsx
@@ -678,9 +678,9 @@ export function HistoryHeatmap({ snapshots, baseCurrency, labels }: Props) {
                     className={cn(
                       "font-medium tabular-nums whitespace-nowrap",
                       tooltip.day.change > 0
-                        ? "text-[var(--gain)]"
+                        ? "text-[var(--gain-ink)]"
                         : tooltip.day.change < 0
-                          ? "text-[var(--loss)]"
+                          ? "text-[var(--loss-ink)]"
                           : "text-muted-foreground",
                     )}
                   >

--- a/src/components/history/history-summary.tsx
+++ b/src/components/history/history-summary.tsx
@@ -127,7 +127,7 @@ export function HistorySummary({ snapshots, baseCurrency, className }: Props) {
     format.dateTime(new Date(dateStr + "T00:00:00"), { month: "short", day: "numeric" });
 
   const tone = (value: number) =>
-    value > 0 ? "text-[var(--gain)]" : value < 0 ? "text-[var(--loss)]" : "text-foreground";
+    value > 0 ? "text-[var(--gain-ink)]" : value < 0 ? "text-[var(--loss-ink)]" : "text-foreground";
 
   return (
     <Card className={cn(className)}>
@@ -150,7 +150,7 @@ export function HistorySummary({ snapshots, baseCurrency, className }: Props) {
           <span
             className={cn(
               "mt-1 text-xs tabular-nums",
-              stats.atHigh ? "text-[var(--gain)]" : "text-[var(--loss)]",
+              stats.atHigh ? "text-[var(--gain-ink)]" : "text-[var(--loss-ink)]",
             )}
           >
             {stats.atHigh
@@ -202,14 +202,14 @@ export function HistorySummary({ snapshots, baseCurrency, className }: Props) {
             style={{ "--i": 5 } as CSSProperties}
             label={t("bestDay")}
             value={stats.best ? signedMoney(stats.best.value) : "—"}
-            valueClass={stats.best ? "text-[var(--gain)]" : "text-muted-foreground"}
+            valueClass={stats.best ? "text-[var(--gain-ink)]" : "text-muted-foreground"}
             sub={stats.best ? shortDate(stats.best.date) : undefined}
           />
           <Stat
             style={{ "--i": 6 } as CSSProperties}
             label={t("worstDay")}
             value={stats.worst ? signedMoney(stats.worst.value) : "—"}
-            valueClass={stats.worst ? "text-[var(--loss)]" : "text-muted-foreground"}
+            valueClass={stats.worst ? "text-[var(--loss-ink)]" : "text-muted-foreground"}
             sub={stats.worst ? shortDate(stats.worst.date) : undefined}
           />
 
@@ -219,9 +219,9 @@ export function HistorySummary({ snapshots, baseCurrency, className }: Props) {
             label={t("upDownDays")}
             value={
               <>
-                <span className="text-[var(--gain)]">{stats.upDays}</span>
+                <span className="text-[var(--gain-ink)]">{stats.upDays}</span>
                 <span className="text-muted-foreground"> / </span>
-                <span className="text-[var(--loss)]">{stats.downDays}</span>
+                <span className="text-[var(--loss-ink)]">{stats.downDays}</span>
               </>
             }
           />

--- a/src/components/history/history-table.tsx
+++ b/src/components/history/history-table.tsx
@@ -161,9 +161,9 @@ export function HistoryTable({ snapshots, baseCurrency }: Props) {
                               className={cn(
                                 "text-xs tabular-nums mt-0.5",
                                 changePositive
-                                  ? "text-[var(--gain)]"
+                                  ? "text-[var(--gain-ink)]"
                                   : changeNegative
-                                    ? "text-[var(--loss)]"
+                                    ? "text-[var(--loss-ink)]"
                                     : "text-muted-foreground",
                               )}
                             >

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -530,8 +530,8 @@ function StockRow({
                 className={cn(
                   "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
                   isGain
-                    ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
-                    : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
+                    ? "bg-[var(--gain)]/15 text-[var(--gain-ink)] ring-[var(--gain)]/25"
+                    : "bg-[var(--loss)]/15 text-[var(--loss-ink)] ring-[var(--loss)]/25",
                 )}
               >
                 <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
@@ -567,8 +567,8 @@ function StockRow({
                   className={cn(
                     "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
                     isGain
-                      ? "bg-[var(--gain)]/15 text-[var(--gain)] ring-[var(--gain)]/25"
-                      : "bg-[var(--loss)]/15 text-[var(--loss)] ring-[var(--loss)]/25",
+                      ? "bg-[var(--gain)]/15 text-[var(--gain-ink)] ring-[var(--gain)]/25"
+                      : "bg-[var(--loss)]/15 text-[var(--loss-ink)] ring-[var(--loss)]/25",
                   )}
                 >
                   <DirectionIcon className="h-4 w-4 shrink-0" />
@@ -675,8 +675,8 @@ function ReorderStockItem({ stock }: { stock: SerializedTrackedStock }) {
           className={cn(
             "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 font-mono text-xs font-semibold tabular-nums leading-none",
             isGain
-              ? "bg-[var(--gain)]/15 text-[var(--gain)]"
-              : "bg-[var(--loss)]/15 text-[var(--loss)]",
+              ? "bg-[var(--gain)]/15 text-[var(--gain-ink)]"
+              : "bg-[var(--loss)]/15 text-[var(--loss-ink)]",
           )}
         >
           <DirectionIcon className="h-3 w-3 shrink-0" aria-hidden />

--- a/src/components/stocks/stocks-onboarding.tsx
+++ b/src/components/stocks/stocks-onboarding.tsx
@@ -10,7 +10,7 @@ interface StocksOnboardingProps {
 }
 
 const rows = [
-  { symbol: "AAPL", tone: "bg-primary/12 text-primary", gain: true },
+  { symbol: "AAPL", tone: "bg-primary/12 text-[var(--primary-ink)]", gain: true },
   { symbol: "NVDA", tone: "bg-chart-2/12 text-chart-2", gain: true },
   { symbol: "TSM", tone: "bg-chart-3/12 text-chart-3", gain: false },
 ] as const;
@@ -28,7 +28,7 @@ export function StocksOnboarding({ onAdd }: StocksOnboardingProps) {
               {t("preview.watchlistSubtitle")}
             </p>
           </div>
-          <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+          <span className="shrink-0 whitespace-nowrap rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-[var(--primary-ink)]">
             {t("preview.manual")}
           </span>
         </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -13,8 +13,8 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
-        gain: "bg-[color-mix(in_oklch,var(--gain)_18%,transparent)] text-[var(--gain)]",
-        loss: "bg-[color-mix(in_oklch,var(--loss)_18%,transparent)] text-[var(--loss)]",
+        gain: "bg-[color-mix(in_oklch,var(--gain)_18%,transparent)] text-[var(--gain-ink)]",
+        loss: "bg-[color-mix(in_oklch,var(--loss)_18%,transparent)] text-[var(--loss-ink)]",
         warning: "bg-[color-mix(in_oklch,var(--warning)_18%,transparent)] text-[var(--warning)]",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,25 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.8.5",
+    date: "2026-06-21",
+    summary: {
+      "en-US": "Sharper mobile legibility in light mode.",
+      "zh-TW": "淺色模式下行動版更清晰易讀。",
+    },
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Gain, loss, and accent values now meet WCAG AA contrast in light mode — green and blue figures on cards are easier to read in bright light.",
+          "zh-TW":
+            "淺色模式下的漲跌與重點數值現已符合 WCAG AA 對比標準，卡片上的綠色與藍色數字在強光下更易閱讀。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.8.4",
     date: "2026-06-21",
     summary: {


### PR DESCRIPTION
## Summary

- Sweeps `text-[var(--gain)]` / `text-[var(--loss)]` / `text-primary` (on tinted backgrounds) to their `--ink` counterparts (`--gain-ink`, `--loss-ink`, `--primary-ink`) across 20 components — these tokens are `color-mix(in oklab, var(--gain/loss/primary), var(--foreground) 30%)` and hit WCAG AA (≥4.5:1) in light mode where the raw gain/loss greens were failing
- Also adds `shrink-0 whitespace-nowrap` to the "Manual record" badge in `stocks-onboarding.tsx` to prevent wrapping at narrow widths
- Releases as v0.8.5 (rebased onto v0.8.4 which landed the avatar fix)

## Test plan

- [x] Light mode: gain (green) and loss (red/blue) values on dashboard, accounts, analysis, history, goals, stocks pages are visibly readable
- [x] Dark mode: colors unchanged (ink tokens are darker in dark mode, which already passed)
- [ ] Stocks onboarding "Manual record" badge does not wrap on narrow screens
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jdh3VPqTAMivNaRHUAz2w