### PR TITLE
fix(settings): align section titles on desktop, unify field controls

### DIFF
--- a/src/app/(main)/settings/loading.tsx
+++ b/src/app/(main)/settings/loading.tsx
@@ -2,161 +2,200 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function SettingsLoading() {
   return (
-    <div className="space-y-10 max-w-2xl pb-16">
+    <div className="space-y-8 max-w-2xl lg:max-w-6xl pb-16">
+      {/* Page title */}
       <Skeleton className="h-10 md:h-9 w-28 rounded-lg" />
 
-      {/* Preferences section */}
-      <div className="space-y-3 w-full">
-        <Skeleton className="h-6 w-36" />
-        <div className="rounded-lg border overflow-hidden">
-          {/* Currency row */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="space-y-1">
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-3.5 w-56" />
-            </div>
-            <Skeleton className="h-9 w-full sm:w-[240px]" />
-          </div>
-          {/* Language row */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="space-y-1">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-3.5 w-48" />
-            </div>
-            <Skeleton className="h-9 w-full sm:w-[200px]" />
-          </div>
-          {/* Density row */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="space-y-1">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-3.5 w-40" />
-            </div>
-            <Skeleton className="h-9 w-40 rounded-lg" />
-          </div>
-          {/* Color schema row */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
-            <div className="space-y-1">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-3.5 w-44" />
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              {[...Array(6)].map((_, i) => (
-                <Skeleton key={i} className="w-11 h-11 rounded-full" />
-              ))}
-            </div>
-          </div>
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-3 bg-muted/20">
-            <Skeleton className="h-4 w-72 max-w-full" />
-            <Skeleton className="h-9 w-full sm:w-[150px]" />
-          </div>
-        </div>
-      </div>
-
-      {/* Synchronization section */}
-      <div className="space-y-3 w-full">
-        <Skeleton className="h-6 w-40" />
-        <div className="rounded-lg border overflow-hidden">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
-            <div className="space-y-2">
+      {/* 2×3 section grid — mirrors page.tsx layout exactly */}
+      <div className="grid gap-8 lg:grid-cols-2 lg:auto-rows-min lg:items-start lg:gap-x-10 lg:gap-y-10">
+        {/* Col 1 Row 1 — Preferences */}
+        <div className="space-y-3 lg:col-start-1 lg:row-start-1">
+          <Skeleton className="h-6 w-36" />
+          <div className="rounded-xl border overflow-hidden">
+            {/* Currency */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
               <div className="space-y-1">
-                <Skeleton className="h-4 w-28" />
-                <Skeleton className="h-3.5 w-64" />
-              </div>
-              <div className="flex gap-2">
-                <Skeleton className="h-6 w-32 rounded-full" />
-                <Skeleton className="h-6 w-32 rounded-full" />
-              </div>
-            </div>
-            <Skeleton className="h-9 w-full sm:w-[150px]" />
-          </div>
-        </div>
-      </div>
-
-      {/* Privacy and security */}
-      <div className="space-y-3 w-full">
-        <Skeleton className="h-6 w-44" />
-        <div className="rounded-lg border overflow-hidden">
-          <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 border-b bg-muted/20 p-4">
-            <div className="flex gap-3">
-              <Skeleton className="size-8 rounded-lg" />
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-36" />
-                <Skeleton className="h-3.5 w-72 max-w-full" />
-              </div>
-            </div>
-            <Skeleton className="h-5 w-28 rounded-full" />
-          </div>
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="flex gap-3">
-              <Skeleton className="size-8 rounded-lg" />
-              <div className="space-y-2">
                 <Skeleton className="h-4 w-28" />
                 <Skeleton className="h-3.5 w-56" />
               </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[240px] rounded-lg" />
             </div>
-            <Skeleton className="h-8 w-full sm:w-[150px]" />
-          </div>
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="flex gap-3">
-              <Skeleton className="size-8 rounded-lg" />
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-36" />
-                <Skeleton className="h-3.5 w-64" />
+            {/* Language */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-3.5 w-48" />
+              </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[240px] rounded-lg" />
+            </div>
+            {/* Density */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-3.5 w-44" />
+              </div>
+              <Skeleton className="h-9 w-full sm:w-40 rounded-lg" />
+            </div>
+            {/* Appearance / Theme */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3.5 w-52" />
+              </div>
+              <Skeleton className="h-9 w-full sm:w-44 rounded-lg" />
+            </div>
+            {/* Color Schema */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3.5 w-48" />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {[...Array(6)].map((_, i) => (
+                  <Skeleton key={i} className="w-11 h-11 rounded-full" />
+                ))}
               </div>
             </div>
-            <Skeleton className="h-8 w-full sm:w-[150px]" />
+            {/* Save footer */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-3 bg-muted/20">
+              <Skeleton className="h-4 w-64 max-w-full" />
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[150px] rounded-lg" />
+            </div>
           </div>
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
-            <div className="flex gap-3">
-              <Skeleton className="size-8 rounded-lg" />
+        </div>
+
+        {/* Col 1 Row 2 — Synchronization */}
+        <div className="space-y-3 lg:col-start-1 lg:row-start-2">
+          <Skeleton className="h-6 w-40" />
+          <div className="rounded-xl border overflow-hidden">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
               <div className="space-y-2">
-                <Skeleton className="h-4 w-28" />
+                <div className="space-y-1">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3.5 w-64" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-6 w-32 rounded-full" />
+                  <Skeleton className="h-6 w-32 rounded-full" />
+                </div>
+              </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[150px] rounded-lg" />
+            </div>
+          </div>
+        </div>
+
+        {/* Col 1 Row 3 — Version */}
+        <div className="space-y-3 lg:col-start-1 lg:row-start-3">
+          <Skeleton className="h-6 w-20" />
+          <div className="rounded-xl border overflow-hidden">
+            <div className="p-4 space-y-4">
+              <div className="flex items-end justify-between gap-3">
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-8 w-24 rounded-md" />
+                </div>
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <div className="rounded-md bg-muted/30 p-4 space-y-2">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-3.5 w-full" />
+                <Skeleton className="h-3.5 w-5/6" />
+                <Skeleton className="h-3.5 w-4/5" />
+              </div>
+              <Skeleton className="h-4 w-28 rounded-sm" />
+            </div>
+          </div>
+        </div>
+
+        {/* Col 2 Row 1 — Privacy & Security */}
+        <div className="space-y-3 lg:col-start-2 lg:row-start-1">
+          <Skeleton className="h-6 w-44" />
+          <div className="rounded-xl border overflow-hidden">
+            {/* Summary row */}
+            <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 border-b bg-muted/20 p-4">
+              <div className="flex gap-3">
+                <Skeleton className="size-8 rounded-lg shrink-0" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-36" />
+                  <Skeleton className="h-3.5 w-64 max-w-full" />
+                </div>
+              </div>
+              <Skeleton className="h-5 w-28 rounded-full shrink-0" />
+            </div>
+            {/* Privacy mode */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="flex gap-3">
+                <Skeleton className="size-8 rounded-lg shrink-0" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3.5 w-52" />
+                </div>
+              </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[150px] rounded-lg" />
+            </div>
+            {/* Signed in */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="flex gap-3">
+                <Skeleton className="size-8 rounded-lg shrink-0" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-36" />
+                  <Skeleton className="h-3.5 w-60" />
+                </div>
+              </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[150px] rounded-lg" />
+            </div>
+            {/* Export backup */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 border-b gap-4">
+              <div className="flex gap-3">
+                <Skeleton className="size-8 rounded-lg shrink-0" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3.5 w-56" />
+                </div>
+              </div>
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[150px] rounded-lg" />
+            </div>
+            {/* Your data */}
+            <div className="flex gap-3 p-4">
+              <Skeleton className="size-8 rounded-lg shrink-0" />
+              <div className="space-y-1.5">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-3.5 w-72 max-w-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Col 2 Row 2 — Data Management */}
+        <div className="space-y-3 lg:col-start-2 lg:row-start-2">
+          <Skeleton className="h-6 w-40" />
+          <div className="rounded-xl border overflow-hidden">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-20" />
                 <Skeleton className="h-3.5 w-60" />
               </div>
-            </div>
-            <Skeleton className="h-8 w-full sm:w-[150px]" />
-          </div>
-          <div className="flex gap-3 p-4">
-            <Skeleton className="size-8 rounded-lg" />
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-3.5 w-72 max-w-full" />
+              <Skeleton className="h-11 md:h-8 w-full sm:w-[200px] rounded-lg" />
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Data management */}
-      <div className="space-y-3 w-full">
-        <Skeleton className="h-6 w-40" />
-        <div className="rounded-lg border overflow-hidden">
-          {/* Import row */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between p-4 gap-4">
-            <div className="space-y-1">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-3.5 w-64" />
+        {/* Col 2 Row 3 — Add to Home Screen */}
+        <div className="space-y-3 lg:col-start-2 lg:row-start-3">
+          <Skeleton className="h-6 w-40" />
+          <div className="rounded-xl border overflow-hidden">
+            <div className="p-4 space-y-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-44" />
+                <Skeleton className="h-3.5 w-full" />
+              </div>
+              <div className="space-y-2 bg-muted/30 p-4 rounded-md">
+                <Skeleton className="h-3.5 w-4/5" />
+                <Skeleton className="h-3.5 w-full" />
+                <Skeleton className="h-3.5 w-3/4" />
+                <Skeleton className="h-3.5 w-5/6" />
+              </div>
             </div>
-            <Skeleton className="h-9 w-full sm:w-[200px]" />
-          </div>
-        </div>
-      </div>
-
-      {/* Install app card */}
-      <div className="space-y-3 w-full">
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-6 w-36" />
-        </div>
-        <div className="rounded-lg border overflow-hidden p-4 space-y-4">
-          <div className="space-y-1">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-3.5 w-full" />
-          </div>
-          <div className="space-y-2 bg-muted/30 p-4 rounded-md">
-            <Skeleton className="h-3.5 w-4/5" />
-            <Skeleton className="h-3.5 w-full" />
-            <Skeleton className="h-3.5 w-3/4" />
-            <Skeleton className="h-3.5 w-5/6" />
           </div>
         </div>
       </div>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -38,19 +38,20 @@ async function SettingsContent() {
       <div className="space-y-8 max-w-2xl lg:max-w-6xl pb-16 animate-in fade-in duration-200">
         <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
-        {/* Single column on mobile; on desktop the tall preferences form sits
-            beside a stack of the shorter cards so wide monitors aren't a narrow
-            column floating in empty space. items-start keeps columns independent.
-            At xl+ the Version and Install cards pair up in a 2-col sub-grid so
-            the right column doesn't have a long tail of narrow single-row cards. */}
-        <div className="grid gap-8 lg:grid-cols-2 lg:items-start lg:gap-x-10 lg:gap-y-10">
+        {/* Single column on mobile. On desktop a 2x3 section grid: each section
+            is placed explicitly so its title sits on a shared row line across
+            both columns (Preferences↔Privacy, Synchronization↔Data Management,
+            Version↔Install). auto-rows-min + items-start anchor every section to
+            its row top so the titles align. SettingsForm uses lg:contents so its
+            two inner sections become direct grid items. */}
+        <div className="grid gap-8 lg:grid-cols-2 lg:auto-rows-min lg:items-start lg:gap-x-10 lg:gap-y-10">
           <SettingsForm
             currentCurrency={settings.baseCurrency}
             currentLocale={settings.locale}
             lastPriceUpdate={latestPrice?.updatedAt?.toISOString() ?? null}
             lastExchangeRateUpdate={latestExchangeRate?.updatedAt?.toISOString() ?? null}
           />
-          <div className="space-y-8 lg:space-y-10">
+          <div className="lg:col-start-2 lg:row-start-1">
             <PrivacySecurity
               userEmail={session.user.email}
               signOutAction={async () => {
@@ -58,15 +59,15 @@ async function SettingsContent() {
                 await signOut({ redirectTo: "/login" });
               }}
             />
-            {/* Utility cluster: tighter internal spacing, visually subordinate
-                to Privacy & Security above. Version + Install pair at xl+. */}
-            <div className="space-y-5">
-              <DataManagement />
-              <div className="grid gap-5 xl:grid-cols-2 xl:items-start">
-                <VersionCard />
-                <InstallAppCard />
-              </div>
-            </div>
+          </div>
+          <div className="lg:col-start-2 lg:row-start-2">
+            <DataManagement />
+          </div>
+          <div className="lg:col-start-1 lg:row-start-3">
+            <VersionCard />
+          </div>
+          <div className="lg:col-start-2 lg:row-start-3">
+            <InstallAppCard />
           </div>
         </div>
       </div>

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -101,7 +101,7 @@ function CurrencyPicker({
         variant="outline"
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
-        className="h-11 md:h-9 w-full justify-between gap-3 sm:w-[240px]"
+        className="h-11 md:h-8 w-full justify-between gap-3 sm:w-[240px]"
       >
         <span className="min-w-0 truncate text-left font-normal">
           {formatCurrencyLabel(selectedCurrency)}
@@ -244,9 +244,9 @@ export function SettingsForm({
   }
 
   return (
-    <div className="space-y-8 w-full">
+    <div className="space-y-8 w-full lg:space-y-0 lg:contents">
       {/* PREFERENCES SECTION */}
-      <section className="space-y-3">
+      <section className="space-y-3 lg:col-start-1 lg:row-start-1">
         <h3 className="text-lg font-semibold text-foreground">{t("settings.preferencesTitle")}</h3>
         <Card className="overflow-hidden p-0">
           <CardContent className="p-0">
@@ -273,7 +273,7 @@ export function SettingsForm({
                 <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
                   <SelectTrigger
                     id="language-select"
-                    className="min-h-11 md:min-h-0 flex-1 sm:flex-none sm:w-[200px]"
+                    className="h-11 md:h-8 flex-1 sm:flex-none sm:w-[240px]"
                   >
                     <SelectValue>{t(`languages.${locale}`)}</SelectValue>
                   </SelectTrigger>
@@ -391,7 +391,7 @@ export function SettingsForm({
       </section>
 
       {/* SYNCHRONIZATION SECTION */}
-      <section className="space-y-3">
+      <section className="space-y-3 lg:col-start-1 lg:row-start-2">
         <h3 className="text-lg font-semibold text-foreground">
           {t("settings.synchronizationTitle")}
         </h3>


### PR DESCRIPTION
## What

Desktop polish for the Settings page.

- **Aligned section titles across columns.** The two desktop columns previously flowed independently (`items-start`), so only the top titles lined up. Replaced them with an explicit `lg:grid-cols-2` 2×3 section grid where each section is placed by `col-start`/`row-start`, so every title sits on a shared row line: Preferences ↔ Privacy & Security, Synchronization ↔ Restore from backup, Version ↔ Add to Home Screen. `SettingsForm` uses `lg:contents` so its two inner sections become direct grid items.
- **Unified the Preferences field controls.** The Currency picker was 36px tall / 240px wide while the Language select was 32px / 200px; every other control on the page is 32px. Both now share 32px height and 240px width (mobile keeps 44px touch targets), so they read as one tidy column.

## Verification

Measured live at 1440px: section titles share exact Y-coordinates per row (92 / 717 / 961); both fields now 32px × 240px at the same left edge. Mobile layout unchanged (single column, same order).

`pnpm typecheck`, `pnpm prettier --check`, and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)