### PR TITLE
[workaround] Proxy Google avatar through first-party route to survive ad blockers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -1,0 +1,62 @@
+import { getSession } from "@/lib/auth-session";
+import { log } from "@/lib/logger";
+
+// First-party avatar proxy.
+//
+// Google profile pictures are hosted on lh3.googleusercontent.com. Loading them
+// directly as a third-party <img> is unreliable in the field: privacy browsers
+// and ad blockers (Brave Shields, uBlock, etc.) block requests to Google-owned
+// hosts as trackers, so the avatar silently fails ("provisional headers shown",
+// no response) even though the image itself returns 200 server-side.
+//
+// Proxying through our own origin makes the browser issue a same-origin request
+// to /api/avatar, which those blockers leave alone. The upstream URL is taken
+// from the authenticated session — never from a client-supplied parameter — so
+// this can't be abused as an open image proxy / SSRF vector.
+
+// Only Google's avatar CDN is ever proxied. Anything else 404s.
+const ALLOWED_HOSTS = new Set(["lh3.googleusercontent.com"]);
+
+export async function GET(): Promise<Response> {
+  const session = await getSession();
+  const imageUrl = session?.user?.image;
+  if (!imageUrl) return new Response(null, { status: 404 });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(imageUrl);
+  } catch {
+    return new Response(null, { status: 404 });
+  }
+  if (parsed.protocol !== "https:" || !ALLOWED_HOSTS.has(parsed.hostname)) {
+    return new Response(null, { status: 404 });
+  }
+
+  try {
+    // Omit the referrer so Google's CDN serves the image without origin leakage.
+    const upstream = await fetch(parsed.toString(), {
+      headers: { Accept: "image/*" },
+      referrerPolicy: "no-referrer",
+    });
+    if (!upstream.ok || !upstream.body) {
+      log.warn("Avatar proxy upstream failed", { status: upstream.status });
+      return new Response(null, { status: 404 });
+    }
+
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        "Content-Type": upstream.headers.get("content-type") ?? "image/jpeg",
+        // Per-user image behind auth: cache privately, with a short TTL so a
+        // changed Google photo is picked up within the hour.
+        "Cache-Control": "private, max-age=3600",
+      },
+    });
+  } catch (error) {
+    log.error("Avatar proxy fetch error", {
+      error: error instanceof Error ? error.message : String(error),
+      __error: error,
+    });
+    return new Response(null, { status: 404 });
+  }
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -214,14 +214,15 @@ export function Sidebar({
           {!collapsed &&
             (userImage && !avatarError ? (
               <img
-                src={userImage}
+                // Served through our own origin (/api/avatar) rather than the raw
+                // Google URL: privacy browsers / ad blockers (Brave Shields, etc.)
+                // block third-party requests to googleusercontent.com, so a direct
+                // <img src> silently fails. The proxy resolves the avatar from the
+                // session server-side, keeping the request same-origin.
+                src="/api/avatar"
                 width={28}
                 height={28}
                 alt={userName ?? "User avatar"}
-                // Google's image CDN returns 429/403 when a referrer is sent
-                // (the app's Referrer-Policy leaks the origin otherwise), which
-                // is what breaks the avatar. Strip the referrer on this request.
-                referrerPolicy="no-referrer"
                 onError={() => setAvatarError(true)}
                 className="h-7 w-7 rounded-full"
               />

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,25 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.8.5",
+    date: "2026-06-21",
+    summary: {
+      "en-US": "Google profile avatars now load reliably behind ad blockers.",
+      "zh-TW": "Google 個人頭像現在即使在廣告攔截器下也能可靠載入。",
+    },
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Sidebar avatar: Google profile pictures are now served through the app's own origin instead of loaded directly from Google. Privacy browsers and ad blockers (e.g. Brave Shields) block third-party requests to Google's image host, which left the avatar broken even after the earlier referrer fix.",
+          "zh-TW":
+            "側邊欄頭像：Google 個人頭像改由應用程式自身網域提供，而非直接向 Google 載入。隱私瀏覽器與廣告攔截器（如 Brave Shields）會封鎖對 Google 圖片主機的第三方請求，導致先前的來源修正後頭像仍然破圖。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.8.4",
     date: "2026-06-21",
     summary: {


### PR DESCRIPTION
## Description

Follow-up to #475. The earlier `referrerPolicy="no-referrer"` fix was correct but insufficient — the Google profile avatar still fails to load in the sidebar for some users.

**Root cause:** privacy browsers and ad blockers (Brave Shields, uBlock, etc.) block third-party requests to `lh3.googleusercontent.com` outright (Google-owned hosts are treated as trackers). The avatar `<img>` request never reaches the network — DevTools shows "Provisional headers are shown" with no response — even though the image itself returns `200` + a valid JPEG when fetched server-side. No referrer/header change can fix this because the browser refuses to send the request.

**Fix:** serve the avatar through the app's own origin so the browser makes a *same-origin* request that ad blockers leave alone.

### Changes

- **New route `src/app/api/avatar/route.ts`** — resolves the avatar URL from the authenticated session (never a client-supplied parameter), fetches it server-side from Google, and streams it back. Safety:
  - URL comes from the session, not a query param → not an open proxy / no SSRF
  - Upstream host allowlisted to `lh3.googleusercontent.com`
  - On any upstream failure → `404`, so the existing `onError` fallback to the version link still works
  - `Cache-Control: private, max-age=3600` so repeated renders don't re-hit Google
- **`sidebar.tsx`** — the avatar `<img>` now points at `/api/avatar` instead of the raw Google URL. The "googleusercontent.com" string no longer appears in any URL the browser sees, so filter lists can't match it.
- **Version bump** — v0.8.5 + changelog entry (bilingual).

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Verified the avatar URL returns `200` + JPEG server-side regardless of referrer/UA (confirming the failure is client-side blocking)
- [x] `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all pass
- [x] Fallback to the version link preserved when the proxy 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012N25MC4iiMNTh1uHBWCZvD)_