### PR TITLE
feat(analysis): tidy mobile Analysis tab (v0.8.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -97,8 +97,10 @@ export function AnalysisView({
   const { density } = useDensity();
   const isMobile = useIsMobile();
   const isCompact = density === "compact";
-  // Keep side-by-side gaps equal to the vertical rhythm between stacked rows.
-  const gridGapClass = isCompact ? "gap-3" : "gap-6";
+  // On mobile the two charts in a section stack and read as one group, so the gap
+  // between them stays tighter than the gap between sections (set below). Desktop
+  // lays them side-by-side, where the wider gap matches the column rhythm.
+  const gridGapClass = isCompact ? "gap-3" : "gap-4 xl:gap-6";
   const stackGapClass = isCompact ? "space-y-3" : "space-y-6";
   const [range, setRange] = usePersistedRange<RangeLabel>(
     "analysis-view",
@@ -272,8 +274,8 @@ export function AnalysisView({
             value={range}
             onValueChange={setRange}
             aria-label={t("title")}
-            className="bg-background/80 dark:bg-card/70 ring-1 ring-border/50 backdrop-blur-md"
-            itemClassName="px-3 py-2 sm:px-2 sm:py-1"
+            className="flex-nowrap bg-background/80 dark:bg-card/70 ring-1 ring-border/50 backdrop-blur-md"
+            itemClassName="px-2 py-1.5 sm:px-2 sm:py-1"
           />
         </div>
 
@@ -310,19 +312,18 @@ export function AnalysisView({
               </Card>
             </section>
 
-            {/* Secondary analysis is grouped by question: movement first, then composition. */}
-            <div className={isCompact ? "space-y-3" : "space-y-4"}>
+            {/* Secondary analysis is grouped by question: movement first, then composition.
+                On mobile the sections separate more than the charts within them (gridGapClass),
+                so each question reads as its own group; desktop keeps them tighter. */}
+            <div className={isCompact ? "space-y-3" : "space-y-6 xl:space-y-4"}>
               <section
                 aria-label={`${t("monthlyChange")} / ${t("cashFlow")}`}
                 className={isCompact ? "space-y-2" : "space-y-3"}
               >
                 <div className="flex flex-wrap items-end justify-between gap-2">
                   <div>
-                    <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <h2 className="text-lg font-semibold tracking-tight text-foreground">
                       {t("movementSectionTitle")}
-                      <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                        {activeRangeLabel}
-                      </span>
                     </h2>
                     <p className="text-xs text-muted-foreground">{t("movementSectionSubtitle")}</p>
                   </div>
@@ -347,11 +348,8 @@ export function AnalysisView({
               >
                 <div className="flex flex-wrap items-end justify-between gap-2">
                   <div>
-                    <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <h2 className="text-lg font-semibold tracking-tight text-foreground">
                       {t("compositionSectionTitle")}
-                      <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                        {activeRangeLabel}
-                      </span>
                     </h2>
                     <p className="text-xs text-muted-foreground">
                       {t("compositionSectionSubtitle")}

--- a/src/components/analysis/chart-empty-state.tsx
+++ b/src/components/analysis/chart-empty-state.tsx
@@ -38,7 +38,7 @@ export function ChartEmptyState({
     >
       <Icon className="size-6 text-muted-foreground/50" strokeWidth={1.5} aria-hidden />
       <p className="max-w-[34ch] text-pretty text-sm text-muted-foreground">{message}</p>
-      {hint && <p className="max-w-[34ch] text-pretty text-xs text-muted-foreground/70">{hint}</p>}
+      {hint && <p className="max-w-[34ch] text-pretty text-xs text-muted-foreground">{hint}</p>}
     </div>
   );
 }

--- a/src/components/analysis/kpi-tiles.tsx
+++ b/src/components/analysis/kpi-tiles.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { ArrowDownRight, ArrowUpRight, CalendarDays, Info } from "lucide-react";
+import { ArrowDownRight, ArrowUpRight, CalendarDays, ChevronDown, Info } from "lucide-react";
 import { formatCurrency } from "@/lib/currencies";
 import { useCountUp } from "@/hooks/use-count-up";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { cn } from "@/lib/utils";
 import type { AnalysisKpis } from "@/lib/services/analysis-service";
 import { formatMonthLabel } from "@/lib/services/analysis-service";
@@ -192,7 +193,7 @@ function MetricRow({
       }`}
     >
       <div className="min-w-0">
-        <div className="text-xs font-medium leading-tight text-muted-foreground/90">{title}</div>
+        <div className="text-xs font-medium leading-tight text-muted-foreground">{title}</div>
         {subtitle && (
           <div className="mt-0.5 text-[11px] leading-tight tabular-nums text-muted-foreground">
             {subtitle}
@@ -218,6 +219,7 @@ export function KpiTiles({ kpis, baseCurrency, locale, rangeLabel }: Props) {
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const isCompact = density === "compact";
+  const isMobile = useIsMobile();
 
   const bestSub =
     privacyMode || !kpis.best ? undefined : formatMonthLabel(kpis.best.monthKey, locale);
@@ -237,6 +239,47 @@ export function KpiTiles({ kpis, baseCurrency, locale, rangeLabel }: Props) {
     privacyMode || kpis.ytdPct === null
       ? null
       : `${kpis.ytdPct >= 0 ? "+" : ""}${kpis.ytdPct.toFixed(1)}%`;
+
+  const metricRows = (
+    <div className="mt-1 divide-y divide-border/60">
+      <MetricRow
+        title={t("avgMonthly")}
+        amount={kpis.avgMonthlyDelta}
+        currency={baseCurrency}
+        privacyMode={privacyMode}
+        tone={privacyMode ? "neutral" : toneFor(kpis.avgMonthlyDelta)}
+        isCompact={isCompact}
+      />
+      <MetricRow
+        title={bestTitle}
+        amount={kpis.best ? kpis.best.deltaNetWorth : null}
+        currency={baseCurrency}
+        privacyMode={privacyMode}
+        subtitle={bestSub}
+        tone={privacyMode ? "neutral" : kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"}
+        isCompact={isCompact}
+      />
+      <MetricRow
+        title={worstTitle}
+        amount={kpis.worst ? kpis.worst.deltaNetWorth : null}
+        currency={baseCurrency}
+        privacyMode={privacyMode}
+        subtitle={worstSub}
+        tone={privacyMode ? "neutral" : kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"}
+        isCompact={isCompact}
+      />
+    </div>
+  );
+
+  const methodologyBox = (
+    <div className="flex items-start gap-2 rounded-md bg-muted/50 px-2.5 py-2 text-xs leading-snug text-muted-foreground">
+      <Info className="mt-0.5 size-3.5 shrink-0 text-foreground/50" aria-hidden />
+      <div className="min-w-0">
+        <div className="font-medium text-foreground">{t("methodologyShortTitle")}</div>
+        <p className="mt-0.5">{t("kpiMethodology", { range: rangeLabel })}</p>
+      </div>
+    </div>
+  );
 
   return (
     <div className={cn("flex h-full min-w-0 flex-col", isCompact ? "gap-3" : "gap-4")}>
@@ -278,61 +321,43 @@ export function KpiTiles({ kpis, baseCurrency, locale, rangeLabel }: Props) {
         />
       </section>
 
-      <section
-        className={cn("min-w-0 border-t border-border/70", isCompact ? "pt-2.5" : "pt-3")}
-        aria-label={t("selectedRangeMetrics", { range: rangeLabel })}
-      >
-        <div className="flex min-w-0 items-baseline justify-between gap-3">
-          <div className="text-xs font-semibold text-foreground">
-            {t("selectedRangeMetrics", { range: rangeLabel })}
-          </div>
-          <div className="text-[11px] font-medium text-muted-foreground">
-            {t("rangeDistribution")}
-          </div>
-        </div>
-        <div className="mt-1 divide-y divide-border/60">
-          <MetricRow
-            title={t("avgMonthly")}
-            amount={kpis.avgMonthlyDelta}
-            currency={baseCurrency}
-            privacyMode={privacyMode}
-            tone={privacyMode ? "neutral" : toneFor(kpis.avgMonthlyDelta)}
-            isCompact={isCompact}
-          />
-          <MetricRow
-            title={bestTitle}
-            amount={kpis.best ? kpis.best.deltaNetWorth : null}
-            currency={baseCurrency}
-            privacyMode={privacyMode}
-            subtitle={bestSub}
-            tone={
-              privacyMode ? "neutral" : kpis.best ? toneFor(kpis.best.deltaNetWorth) : "neutral"
-            }
-            isCompact={isCompact}
-          />
-          <MetricRow
-            title={worstTitle}
-            amount={kpis.worst ? kpis.worst.deltaNetWorth : null}
-            currency={baseCurrency}
-            privacyMode={privacyMode}
-            subtitle={worstSub}
-            tone={
-              privacyMode ? "neutral" : kpis.worst ? toneFor(kpis.worst.deltaNetWorth) : "neutral"
-            }
-            isCompact={isCompact}
-          />
-        </div>
-      </section>
+      {/* On mobile the lead YTD metric above is the headline; the range
+          distribution and methodology fold away so the card doesn't dominate
+          the scroll before the charts. Desktop (the side rail) shows it all. */}
+      {isMobile ? (
+        <details className="group/kpi min-w-0 border-t border-border/70 pt-2.5">
+          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span className="text-xs font-semibold text-foreground">
+              {t("selectedRangeMetrics", { range: rangeLabel })}
+            </span>
+            <ChevronDown
+              className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open/kpi:rotate-180"
+              aria-hidden
+            />
+          </summary>
+          {metricRows}
+          <div className="mt-3 border-t border-border/70 pt-3">{methodologyBox}</div>
+        </details>
+      ) : (
+        <>
+          <section
+            className={cn("min-w-0 border-t border-border/70", isCompact ? "pt-2.5" : "pt-3")}
+            aria-label={t("selectedRangeMetrics", { range: rangeLabel })}
+          >
+            <div className="flex min-w-0 items-baseline justify-between gap-3">
+              <div className="text-xs font-semibold text-foreground">
+                {t("selectedRangeMetrics", { range: rangeLabel })}
+              </div>
+              <div className="text-[11px] font-medium text-muted-foreground">
+                {t("rangeDistribution")}
+              </div>
+            </div>
+            {metricRows}
+          </section>
 
-      <div className="mt-auto border-t border-border/70 pt-3">
-        <div className="flex items-start gap-2 rounded-md bg-muted/50 px-2.5 py-2 text-xs leading-snug text-muted-foreground">
-          <Info className="mt-0.5 size-3.5 shrink-0 text-foreground/50" aria-hidden />
-          <div className="min-w-0">
-            <div className="font-medium text-foreground">{t("methodologyShortTitle")}</div>
-            <p className="mt-0.5">{t("kpiMethodology", { range: rangeLabel })}</p>
-          </div>
-        </div>
-      </div>
+          <div className="mt-auto border-t border-border/70 pt-3">{methodologyBox}</div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/analysis/top-movers-list.tsx
+++ b/src/components/analysis/top-movers-list.tsx
@@ -78,7 +78,7 @@ export const TopMoversList = memo(function TopMoversList({ movers, baseCurrency 
                         })}
                       </div>
                       {/* Mobile-only: collapsed start→end summary, hidden once columns appear */}
-                      <div className="sm:hidden text-[11px] text-muted-foreground/80 tabular-nums mt-0.5">
+                      <div className="sm:hidden text-[11px] text-muted-foreground tabular-nums mt-0.5">
                         {privacyMode
                           ? "***"
                           : `${formatCurrency(m.startValue, baseCurrency)} → ${formatCurrency(m.endValue, baseCurrency)}`}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,48 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.8.7",
+    date: "2026-06-24",
+    summary: {
+      "en-US": "Tidier Analysis tab on mobile.",
+      "zh-TW": "行動版分析頁面更整潔。",
+    },
+    changes: [
+      {
+        type: "improved",
+        text: {
+          "en-US":
+            "On mobile, the Analysis summary now shows the year-to-date headline up front and folds the range breakdown and methodology behind a tap, so the charts are reachable with less scrolling.",
+          "zh-TW":
+            "行動版的分析摘要現在優先顯示今年迄今的重點數字，並將區間明細與計算說明收合於點按之後，讓圖表更快可見、減少捲動。",
+        },
+      },
+      {
+        type: "improved",
+        text: {
+          "en-US":
+            "Refined spacing and heading hierarchy on the mobile Analysis tab so each section reads as its own group.",
+          "zh-TW": "調整行動版分析頁面的間距與標題層級，讓每個區段更像獨立群組。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "The Analysis time-range selector no longer wraps onto two rows on small screens.",
+          "zh-TW": "分析頁面的時間範圍選擇器在小螢幕上不再換成兩行。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US": "Muted helper text on the Analysis tab now meets WCAG AA contrast.",
+          "zh-TW": "分析頁面的次要說明文字現已符合 WCAG AA 對比標準。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.8.6",
     date: "2026-06-21",
     summary: {


### PR DESCRIPTION
## Summary
Mobile polish for the Analysis tab (`/analysis`).

- Time-range selector stays on a single row on small screens (no more two-row wrap).
- KPI summary on mobile leads with the year-to-date headline and folds the range breakdown + methodology into a native `<details>` disclosure, so charts are reachable with less scrolling. Desktop side-rail unchanged.
- Fixed inverted type hierarchy: section headers (Movement / Composition) now sit a step above their chart-card titles.
- Tightened mobile spacing rhythm so the two charts within a section group more tightly than the sections do from each other.
- Removed opacity-reduced muted text (`/70`, `/80`) so helper copy meets WCAG AA (base `muted-foreground` on background = 4.71:1).

Changelog + version bumped to 0.8.7.

## Test plan
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all pass.
- Verify on a mobile viewport: range selector is one row; KPI disclosure opens/closes; section headers outrank chart titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxsY9dyNQnCfiecxfLo3oz
