### PR TITLE
fix(ledger): guard cash-transaction DELETE with optimistic lock

### DIFF
--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -286,14 +286,36 @@ export const DELETE = withAuth<TxCtx>(async (_request, { params }, userId) => {
       return failure("Transaction not found", 404);
     }
 
-    const delta = calculateBalanceDelta({ type: cashTx.type, amount: Number(cashTx.amount) }, null);
-    await prisma.$transaction([
-      prisma.account.update({
-        where: { id: accountId },
-        data: { cashBalance: { increment: delta } },
-      }),
-      prisma.cashTransaction.delete({ where: { id: transactionId } }),
-    ]);
+    // Guard the delete on the values the balance delta was measured against
+    // (same optimistic-lock contract as the cash PATCH / holding paths) so a
+    // DELETE racing an edit can't apply a stale balance delta against a row
+    // another request already changed.
+    try {
+      await prisma.$transaction(async (tx) => {
+        const result = await tx.cashTransaction.deleteMany({
+          where: { id: transactionId, type: cashTx.type, amount: cashTx.amount },
+        });
+        if (result.count !== 1) {
+          throw new StaleCashTransactionError();
+        }
+        const delta = calculateBalanceDelta(
+          { type: cashTx.type, amount: Number(cashTx.amount) },
+          null,
+        );
+        if (delta !== 0) {
+          await tx.account.update({
+            where: { id: accountId },
+            data: { cashBalance: { increment: delta } },
+          });
+        }
+      });
+    } catch (error) {
+      if (error instanceof StaleCashTransactionError) {
+        return failure("Transaction changed while deleting; please retry", 409);
+      }
+      throw error;
+    }
+
     invalidateAccountCaches(userId);
     return ok({ ok: true });
   }


### PR DESCRIPTION
## Problem

In the transaction DELETE handler (`src/app/api/accounts/[id]/transactions/[transactionId]/route.ts`), the **cash branch** applied its balance delta unconditionally, computed from a row read *before* the transaction:

```ts
const delta = calculateBalanceDelta({ type: cashTx.type, amount: Number(cashTx.amount) }, null);
await prisma.$transaction([
  prisma.account.update({ ... cashBalance: { increment: delta } }),
  prisma.cashTransaction.delete({ where: { id: transactionId } }),
]);
```

Every sibling ledger path guards the row write on the values the delta was measured against and only applies the delta when exactly one row was written:
- **holding PATCH/DELETE** → `deleteMany({ where: { id, type, quantity } })`, throw if `count !== 1`
- **cash PATCH** → `updateMany({ where: { id, type, amount } })`, throw `StaleCashTransactionError` if `count !== 1` (its comment explains why)

The cash DELETE was the only one without this guard.

### Failure case (DELETE racing a PATCH on the same row)

1. Row = `DEPOSIT 100`. Both DELETE and PATCH read it.
2. PATCH changes amount → `300` (guarded, succeeds), increments balance by `+200`.
3. DELETE decrements balance by the **stale** `-100`, deletes the now-`300` row.
4. Correct net change for removing this deposit is `-100`; actual is `+200 − 100 = +100`. **Balance ends up off by 200, with no ledger row to explain it.**

(The plain double-DELETE race was already safe — the second `delete`-by-id throws `P2025` and rolls back.)

## Fix

Mirror the existing pattern — interactive transaction, `deleteMany` guarded on `(id, type, amount)`, `StaleCashTransactionError` → 409 on `count !== 1`, balance delta applied only inside the same transaction when the guarded delete succeeded.

## Verification

`pnpm typecheck` clean, `pnpm test:unit` → 123 passed. (API routes need a DB and aren't in the unit suite; this change is a direct mirror of three already-shipped guarded paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)