### PR TITLE
fix(accounts): return 404 (not 500) when deleting a missing account

### DIFF
--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -87,7 +87,11 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
 
 export const DELETE = withAuth<IdCtx>(async (_request, { params }, userId) => {
   const { id } = await params;
-  await prisma.account.delete({ where: { id, userId } });
+  // Ownership folded into the write (mirrors the holdings / recurring DELETE
+  // pattern) so a missing or non-owned account returns 404 instead of throwing
+  // an unhandled P2025 -> 500.
+  const { count } = await prisma.account.deleteMany({ where: { id, userId } });
+  if (count === 0) return failure("Not found", 404);
   invalidateUserCaches(userId);
   return ok({ ok: true });
 });


### PR DESCRIPTION
## Problem

`DELETE /api/accounts/[id]` used `prisma.account.delete({ where: { id, userId } })`. When the account is missing or not owned by the requesting user, `delete` throws an unhandled `P2025` → the handler returns **500** for what is really a **client error**.

Every sibling DELETE handler folds ownership into a `deleteMany` + count check and returns **404**:
- `holdings` route → `deleteMany({ where: { id, account: { userId } } })`, 404 on `count === 0`
- `recurring-cash-transactions/[recurringId]` → same pattern
- `recurring-investments/[recurringId]` → same pattern

This account DELETE was the lone outlier.

## Fix

```ts
const { count } = await prisma.account.deleteMany({ where: { id, userId } });
if (count === 0) return failure("Not found", 404);
```

Surgical, one-handler change that aligns this route with the established pattern.

## Verification

`pnpm typecheck` + `pnpm lint` + `pnpm format:check` clean, `pnpm test:unit` → 123 passed. (API routes need a DB and aren't in the unit suite; this is a direct mirror of three already-shipped sibling handlers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)