### PR TITLE
fix(holdings): optimistic-lock guard on holding PATCH quantity write

### DIFF
--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,5 +1,6 @@
 import { revalidateTag } from "next/cache";
 import { after } from "next/server";
+import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema, deleteHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
@@ -10,6 +11,8 @@ import { parseOccSymbol, formatOptionLabel, OptionError } from "@/lib/options";
 import { log } from "@/lib/logger";
 
 type IdCtx = { params: Promise<{ id: string }> };
+
+class StaleHoldingError extends Error {}
 
 function invalidateUserCaches(userId: string) {
   revalidateTag(`accounts:${userId}`, { expire: 0 });
@@ -169,27 +172,49 @@ export const PATCH = withAuth<IdCtx>(async (request, _ctx, userId) => {
     return failure("Quantity must be positive", 400);
   }
 
-  // Update and EDIT audit log commit together — a failed update must not
-  // leave a phantom EDIT transaction behind.
-  const holding = await prisma.$transaction(async (tx) => {
-    const updated = await tx.holding.update({ where: { id }, data });
+  // A manual quantity edit logs the difference as an EDIT holding transaction.
+  // The diff must be measured against the quantity we actually write over, so
+  // the write is guarded on that prior quantity: if a concurrent mutation moved
+  // it between our read and the commit, we reject with 409 rather than letting
+  // the EDIT row desync from the stored quantity. Update and EDIT audit log
+  // commit together — a failed update must not leave a phantom EDIT behind.
+  const quantityChanging =
+    data.quantity !== undefined && !new Decimal(data.quantity).equals(existing.quantity);
 
-    if (data.quantity !== undefined) {
-      const diff = data.quantity - Number(existing.quantity);
-      if (diff !== 0) {
-        await tx.holdingTransaction.create({
-          data: {
-            holdingId: id,
-            type: "EDIT",
-            quantity: diff,
-            note: `Quantity changed from ${Number(existing.quantity)} to ${data.quantity}`,
-          },
-        });
+  let holding;
+  try {
+    holding = await prisma.$transaction(async (tx) => {
+      if (!quantityChanging) {
+        return tx.holding.update({ where: { id }, data });
       }
-    }
 
-    return updated;
-  });
+      const diff = new Decimal(data.quantity!).minus(existing.quantity);
+      await tx.holdingTransaction.create({
+        data: {
+          holdingId: id,
+          type: "EDIT",
+          quantity: diff,
+          note: `Quantity changed from ${existing.quantity} to ${data.quantity}`,
+        },
+      });
+
+      const result = await tx.holding.updateMany({
+        where: { id, quantity: existing.quantity },
+        data,
+      });
+      if (result.count !== 1) {
+        throw new StaleHoldingError();
+      }
+
+      return tx.holding.findUniqueOrThrow({ where: { id } });
+    });
+  } catch (error) {
+    if (error instanceof StaleHoldingError) {
+      return failure("Holding changed while updating; please retry", 409);
+    }
+    throw error;
+  }
+
   invalidateUserCaches(userId);
   return ok(holding);
 });


### PR DESCRIPTION
## What

Adds an optimistic-lock guard to the **holding PATCH** handler (`src/app/api/accounts/[id]/holdings/route.ts`) so a manual quantity edit can't desync its EDIT audit row from the stored quantity under concurrent edits, and computes the EDIT diff with `Decimal` per the project invariant (never hand a raw JS number to Prisma for monetary/quantity values).

## Why

The previous handler read the current quantity, then unconditionally ran `holding.update` and created an `EDIT` `holdingTransaction` whose `diff` was measured against that read. If a concurrent mutation moved the quantity between the read and the commit, the EDIT row would record a diff against a stale baseline — desyncing the audit trail from the stored quantity. The diff was also computed as `data.quantity - Number(existing.quantity)`, handing a raw JS number into the transaction row.

## How

Mirrors the existing guard in the account PATCH manual-balance path (`src/app/api/accounts/[id]/route.ts`) and the sibling holding-transaction routes:

- New `class StaleHoldingError extends Error {}`.
- `quantityChanging = data.quantity !== undefined && !new Decimal(data.quantity).equals(existing.quantity)`.
- Name/assetType-only edits keep the plain unguarded `tx.holding.update`.
- Quantity edits compute `diff = new Decimal(data.quantity!).minus(existing.quantity)`, write the EDIT row with that `Decimal`, then guard the write with `tx.holding.updateMany({ where: { id, quantity: existing.quantity }, data })` and throw `StaleHoldingError` if `result.count !== 1`.
- The `$transaction` is wrapped in try/catch; `StaleHoldingError` → `failure("Holding changed while updating; please retry", 409)`, everything else rethrows.

Surgical: only the PATCH handler, the new import, and the new error class changed. POST/GET/DELETE and `invalidateUserCaches` untouched.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — all pass.
- `pnpm test:unit` — 123/123 pass (this route is not in the service-layer unit suite; nothing regressed).
- Functional happy-path + edge paths exercised against a live local Postgres with a throwaway script replicating the exact transaction logic: happy edit (10→15) returns the updated row with one EDIT row, diff `5`; the stale path (write guarded on a stale baseline) rolls back, leaving the quantity unchanged and no phantom EDIT row, returning the 409-equivalent; a no-op (unchanged) quantity writes no EDIT row. The true concurrent 409 is hard to trigger deterministically, but the `updateMany` count-guard rollback is verified and is pattern-equivalent to the account-PATCH guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)