### PR TITLE
fix(fx): defer first-use exchange-rate warm with Next 16 after()

### DIFF
--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from "next/cache";
+import { after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createHoldingSchema, updateHoldingSchema, deleteHoldingSchema } from "@/lib/validators";
 import { fetchStockPrices, fetchCryptoPrices } from "@/lib/services/price-service";
@@ -138,7 +139,7 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
   }
 
   invalidateUserCaches(userId);
-  if (holding.currency) void maybeWarmExchangeRate(holding.currency);
+  if (holding.currency) after(() => maybeWarmExchangeRate(holding.currency));
   return ok(holding, { status: 201 });
 });
 

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from "next/cache";
+import { after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createAccountSchema } from "@/lib/validators";
 import { ok, failure, validationError } from "@/lib/api-responses";
@@ -85,6 +86,6 @@ export const POST = withAuth(async (request, _ctx, userId) => {
     },
   });
   invalidateUserCaches(userId);
-  void maybeWarmExchangeRate(account.currency);
+  after(() => maybeWarmExchangeRate(account.currency));
   return ok(account, { status: 201 });
 });

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from "next/cache";
+import { after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { updateSettingsSchema } from "@/lib/validators";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
@@ -48,8 +49,9 @@ export const PATCH = withAuth(async (request, _ctx, userId) => {
   // If the base currency changed, the cached net-worth summary for this
   // user is stale (values are denominated in the old currency).
   if (parsed.data.baseCurrency !== undefined) {
+    const baseCurrency = parsed.data.baseCurrency;
     revalidateTag(`net-worth:${userId}`, { expire: 0 });
-    void maybeWarmExchangeRate(parsed.data.baseCurrency);
+    after(() => maybeWarmExchangeRate(baseCurrency));
   }
 
   const response = ok(settings);


### PR DESCRIPTION
## Problem

Three API write routes that can introduce a brand-new currency started the exchange-rate "warm" as a fire-and-forget promise and then returned the response:

- `src/app/api/accounts/route.ts` — `void maybeWarmExchangeRate(account.currency)`
- `src/app/api/accounts/[id]/holdings/route.ts` — `if (holding.currency) void maybeWarmExchangeRate(holding.currency)`
- `src/app/api/settings/route.ts` — `void maybeWarmExchangeRate(parsed.data.baseCurrency)`

On Vercel's serverless Node runtime, work that runs after the response is sent can be frozen or killed, so that promise is **not guaranteed to finish**. `maybeWarmExchangeRate` only fetches the first time a currency is used (no existing `ExchangeRate` row). If the warm is dropped, that currency has no FX rates and net-worth for those accounts falls back to **rate 1** (wrong by the FX factor) until the next daily cron or a manual refresh.

## Fix

Replace each fire-and-forget `void` with Next 16's `after(() => ...)` (`import { after } from "next/server"`). `after` schedules the callback to run **after** the response is sent while guaranteeing the platform awaits its completion — the idiomatic fix for this response-vs-background-work race. It keeps the ~1.2s FX fetch off the write's critical path without risking a dropped warm.

The change is surgical: only the `void X(...)` → `after(() => X(...))` swap plus the import in each file. `maybeWarmExchangeRate` already has its own try/catch (logs `rates.warm.failed`), so the callback won't throw — no extra error handling added.

One incidental: in `settings/route.ts` the narrowed `baseCurrency` is captured into a `const` so the deferred closure keeps its `string` type (the lazily-evaluated `after` callback otherwise loses the inline narrowing on the mutable property, failing `tsc`).

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm format:check` — pass
- `pnpm test:unit` — 123 passed (16 files); these routes aren't in the unit suite, confirmed no regression
- Confirmed `after` is exported from `next/server` and documented for Route Handlers (read `node_modules/next/dist/docs/01-app/03-api-reference/04-functions/after.md`)

The `after` runtime behavior is serverless-specific and not exercised locally; verification is the documented one-line swap plus the full static/test suite above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)