### PR TITLE
fix(stocks): map duplicate add (P2002) to 409 instead of 500

### DIFF
--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { createStockWatchItemSchema } from "@/lib/validators";
@@ -47,19 +48,30 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   });
   const nextSortOrder = (_max.sortOrder ?? -1) + 1;
 
-  const item = await prisma.stockWatchItem.create({
-    data: {
-      userId,
-      symbol: quote.symbol,
-      name: quote.name || parsed.data.name,
-      exchange: quote.exchange || parsed.data.exchange,
-      currency: quote.currency || parsed.data.currency,
-      recordPrice: parsed.data.recordPrice,
-      recordDate: new Date(`${parsed.data.recordDate}T00:00:00.000Z`),
-      note: parsed.data.note?.trim() || null,
-      sortOrder: nextSortOrder,
-    },
-  });
+  let item;
+  try {
+    item = await prisma.stockWatchItem.create({
+      data: {
+        userId,
+        symbol: quote.symbol,
+        name: quote.name || parsed.data.name,
+        exchange: quote.exchange || parsed.data.exchange,
+        currency: quote.currency || parsed.data.currency,
+        recordPrice: parsed.data.recordPrice,
+        recordDate: new Date(`${parsed.data.recordDate}T00:00:00.000Z`),
+        note: parsed.data.note?.trim() || null,
+        sortOrder: nextSortOrder,
+      },
+    });
+  } catch (error) {
+    // Concurrent duplicate adds can both pass the findUnique pre-checks, then
+    // the second create violates the userId_symbol unique index (P2002).
+    // Map that race to the same 409 the pre-checks return.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return failure("This stock is already tracked.", 409);
+    }
+    throw error;
+  }
 
   await tryWarmStockPrice(item.symbol);
   invalidateStockWatchCaches(userId);


### PR DESCRIPTION
## Problem

`POST /api/stocks` has a check-then-create TOCTOU race. The handler does `findUnique({ where: { userId_symbol } })` and returns a 409 ("This stock is already tracked.") if a row exists, then later calls `create(...)`. Two concurrent POSTs of the same symbol can both pass the existence check before either row exists; the second `create` then violates the `userId_symbol` unique index, throwing Prisma `P2002`, which bubbles up as a **500 instead of a clean 409**.

No data corruption — the unique index already prevents the duplicate row — just the wrong status on a double-submit race.

## Fix

Keep the existing fast-path `findUnique` checks (common case + canonical-symbol case). Additionally wrap **only** the `create` in a try/catch that maps `Prisma.PrismaClientKnownRequestError` with `code === "P2002"` to the same `failure("This stock is already tracked.", 409)` the pre-checks return. Any other error is rethrown. The warm/invalidate/return success path is unchanged.

Surgical: only the POST handler `create` wrapping plus the `Prisma` import (imported the way the repo already does in `src/app/api/settings/data/route.ts`).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — all pass (also enforced by the husky pre-push hook on push).
- `pnpm test:unit` — 123 passed (16 files); this route isn't in the unit suite.
- Functional: ran a throwaway Vitest against the local Docker Postgres (`asset_app`) using the same `PrismaPg` adapter the app uses — created a `StockWatchItem`, attempted a second `create` with the same `(userId, symbol)`, asserted the caught error had `code === "P2002"` and the handler's mapping logic returned `409`. Passed; scratch rows/test removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)