### PR TITLE
fix(cache): tag rate-dependent cached reads with exchange-rates

### DIFF
--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -130,6 +130,7 @@ export async function getNormalizedHistory(
   cacheTag("snapshots");
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
 
   const fromDate = new Date();
@@ -160,6 +161,7 @@ export async function getCurrentYearNormalizedHistory(
   cacheTag("snapshots");
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
 
   const now = new Date();
@@ -215,6 +217,7 @@ async function fetchFullHistoryCached(
   cacheTag("snapshots");
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
 
   const [snapshotsRaw, allRatesMap] = await Promise.all([
@@ -260,6 +263,7 @@ export async function getSnapshotReconciliationWarning(
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
   cacheTag(`net-worth:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("minutes");
 
   const [latestSnapshot, currentSummary, allRatesMap] = await Promise.all([
@@ -411,6 +415,7 @@ export async function getAccountMonthlyCashFlow(
   "use cache";
   cacheTag(`accounts:${userId}`);
   cacheTag(`history:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
 
   const [accounts, allRatesMap, firstSnapshot] = await Promise.all([

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -219,6 +219,7 @@ async function getCachedNetWorthSummaryInner(
   "use cache";
   cacheTag("net-worth");
   cacheTag(`net-worth:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
   return computeNetWorthSummary(userId, baseCurrency);
 }

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -20,6 +20,7 @@ export async function getProjectionData(
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
   cacheTag(`accounts:${userId}`);
+  cacheTag("exchange-rates");
   cacheLife("hours");
 
   const [snapshotsRaw, accountsRaw, allRatesMap] = await Promise.all([

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -82,13 +82,17 @@ const h = vi.hoisted(() => ({
   prices: [] as { symbol: string; price: number; currency: string }[],
   rates: new Map<string, number>(),
   warnings: [] as { msg: string; meta: unknown }[],
+  tags: [] as string[],
 }));
 
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   return { ...actual, cache: <T>(fn: T): T => fn };
 });
-vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("next/cache", () => ({
+  cacheTag: (tag: string) => h.tags.push(tag),
+  cacheLife: () => {},
+}));
 vi.mock("@/lib/logger", () => ({
   log: {
     info: () => {},
@@ -141,6 +145,17 @@ describe("getCachedNetWorthSummary (two-pass valuation)", () => {
       { currency: "USD", value: 3000 },
       { currency: "TWD", value: 100 },
     ]);
+  });
+
+  it("tags the cached read with exchange-rates so a warmed FX rate invalidates it", async () => {
+    h.tags = [];
+    h.rates = new Map([["USD_TWD", 30]]);
+    h.prices = [];
+    h.accounts = [account({ id: "A", type: "ASSET", currency: "USD", cashBalance: 100 })];
+
+    await getCachedNetWorthSummary("u1", "USD");
+
+    expect(h.tags).toContain("exchange-rates");
   });
 
   it("falls back to rate 1 and warns for an unresolvable currency", async () => {


### PR DESCRIPTION
## The bug

Cached reads that compute values using **current** exchange rates were tagged `net-worth` / `snapshots` / per-user tags, but **not** `exchange-rates`.

`maybeWarmExchangeRate` (the first-use FX warm path) only calls `revalidateTag("exchange-rates")`. So when a freshly-warmed rate landed, those cached results were **not** invalidated — net worth kept showing a new-currency account at the **rate-1 fallback** until `cacheLife("hours")` lapsed or another mutation busted `net-worth`.

`/api/refresh` and cron already bust `net-worth` on rate change; the first-use warm path was the gap.

## The fix

Add `cacheTag("exchange-rates")` to every `"use cache"` function that reads exchange rates at current rates (verified each calls `getAllExchangeRates()` / `resolveRate()`), placed alongside the existing `cacheTag(...)` calls before `cacheLife(...)`. Now any `exchange-rates` revalidation — including the warm — invalidates them.

Surgical: no query logic, signature, or other changes.

### Functions tagged
- `net-worth-service.ts` → `getCachedNetWorthSummaryInner` (primary — dashboard net worth)
- `projection-service.ts` → `getProjectionData`
- `history-service.ts` → `getNormalizedHistory`, `getCurrentYearNormalizedHistory`, `fetchFullHistoryCached`, `getSnapshotReconciliationWarning`, `getAccountMonthlyCashFlow`

## Tests

Extended the net-worth unit test: `cacheTag` is now spied (via the existing `next/cache` mock) and asserted to be called with `"exchange-rates"`.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm format:check` ✅
- `pnpm test:unit` ✅ (16 files, 124 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)