### PR TITLE
[codex] validate imported locale

### DIFF
--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -9,8 +9,10 @@ import {
   OPTION_TYPES,
   GOAL_SCOPES,
 } from "./enums";
+import { SUPPORTED_LOCALES } from "@/i18n/config";
 
 const OCC_SHAPE = /^[A-Z][A-Z0-9.\-]{0,5}\d{6}[CP]\d{8}$/;
+const supportedLocaleSchema = z.enum(SUPPORTED_LOCALES);
 
 export const createAccountSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
@@ -105,7 +107,7 @@ export const deleteHoldingSchema = z.object({
 
 export const updateSettingsSchema = z.object({
   baseCurrency: z.string().length(3).optional(),
-  locale: z.enum(["en-US", "zh-TW"]).optional(),
+  locale: supportedLocaleSchema.optional(),
 });
 
 export const updateSnapshotAnnotationSchema = z.object({
@@ -334,7 +336,7 @@ export const dataImportSchema = z.object({
   settings: z
     .object({
       baseCurrency: z.string().length(3),
-      locale: z.string(),
+      locale: supportedLocaleSchema,
     })
     .optional()
     .nullable(),

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -9,6 +9,7 @@ import {
   createGoalSchema,
   createStockWatchItemSchema,
   updateSnapshotAnnotationSchema,
+  dataImportSchema,
 } from "@/lib/validators";
 
 // Locks in the E6 validator hardening (positive quantities, immutable
@@ -204,5 +205,17 @@ describe("updateSnapshotAnnotationSchema", () => {
   it("enforces label and note length limits", () => {
     expect(updateSnapshotAnnotationSchema.safeParse({ label: "x".repeat(81) }).success).toBe(false);
     expect(updateSnapshotAnnotationSchema.safeParse({ note: "x".repeat(501) }).success).toBe(false);
+  });
+});
+
+describe("dataImportSchema", () => {
+  it("rejects an imported settings locale outside supported locales", () => {
+    const result = dataImportSchema.safeParse({
+      version: "1.2",
+      settings: { baseCurrency: "USD", locale: "fr-FR" },
+      accounts: [],
+    });
+
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed
- Reused the app's `SUPPORTED_LOCALES` tuple in validator schemas.
- Restricted `dataImportSchema.settings.locale` to `en-US` or `zh-TW`.
- Added a unit regression test that rejects an imported unsupported locale.

## Why
Imported settings previously accepted any locale string, and the import route writes that value to the `NEXT_LOCALE` cookie after validation. Invalid locale imports should fail validation and return the existing 400 validation path.

## Validation
- `pnpm vitest run tests/unit/validators.test.ts` failed before the fix with `fr-FR` accepted.
- `pnpm vitest run tests/unit/validators.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`