### PR TITLE
[codex] make route rate limits durable

### DIFF
--- a/prisma/migrations/20260628000000_add_rate_limit_bucket/migration.sql
+++ b/prisma/migrations/20260628000000_add_rate_limit_bucket/migration.sql
@@ -1,0 +1,11 @@
+-- Durable route-handler rate limit buckets shared across serverless instances.
+CREATE TABLE "RateLimitBucket" (
+    "key" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "resetAt" TIMESTAMPTZ(3) NOT NULL,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "RateLimitBucket_pkey" PRIMARY KEY ("key")
+);
+
+CREATE INDEX "RateLimitBucket_resetAt_idx" ON "RateLimitBucket"("resetAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -252,6 +252,15 @@ model ExchangeRate {
   @@id([fromCurrency, toCurrency])
 }
 
+model RateLimitBucket {
+  key       String   @id
+  count     Int      @default(0)
+  resetAt   DateTime @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @db.Timestamptz(3)
+
+  @@index([resetAt])
+}
+
 model NetWorthSnapshot {
   id               String   @id @default(cuid())
   userId           String

--- a/src/app/api/exchange-rates/route.ts
+++ b/src/app/api/exchange-rates/route.ts
@@ -1,9 +1,11 @@
+import { connection } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { ok } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 
 export async function GET(request: Request) {
-  const limited = rateLimitCheckWithPrune(request, { limit: 30, prefix: "exchange-rates" });
+  await connection();
+  const limited = await rateLimitCheckWithPrune(request, { limit: 30, prefix: "exchange-rates" });
   if (limited) return limited;
 
   const rates = await prisma.exchangeRate.findMany({

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { log } from "@/lib/logger";
@@ -34,7 +35,8 @@ const FRESHNESS_MAX_AGE_MS = 36 * 60 * 60 * 1000;
 const SNAPSHOT_CRON_NAME = "snapshot";
 
 export async function GET(request: Request) {
-  const limited = rateLimitCheckWithPrune(request, { limit: 30, prefix: "health" });
+  await connection();
+  const limited = await rateLimitCheckWithPrune(request, { limit: 30, prefix: "health" });
   if (limited) return limited;
 
   const now = Date.now();

--- a/src/app/api/options/chain/route.ts
+++ b/src/app/api/options/chain/route.ts
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { ok } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { getYahooClient } from "@/lib/services/yahoo-client";
@@ -32,7 +33,8 @@ const slim = (arr: any[] | undefined): ChainContract[] =>
   }));
 
 export async function GET(request: Request) {
-  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "options-chain" });
+  await connection();
+  const limited = await rateLimitCheckWithPrune(request, { limit: 60, prefix: "options-chain" });
   if (limited) return limited;
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -16,7 +16,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   // Per-user (not per-IP): each call fans out to Yahoo/CoinGecko + the FX
   // source. The service-level freshness gates are the primary defense; this
   // just stops request loops from reaching the DB queries.
-  const limited = rateLimitCheckWithPrune(request, {
+  const limited = await rateLimitCheckWithPrune(request, {
     limit: 5,
     prefix: "market-refresh",
     key: userId,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { connection } from "next/server";
 import { ok, failure } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { getYahooClient, getYahooErrorStatus } from "@/lib/services/yahoo-client";
@@ -121,7 +122,8 @@ const cachedYahooSearch = unstable_cache(
 );
 
 export async function GET(request: Request) {
-  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "search" });
+  await connection();
+  const limited = await rateLimitCheckWithPrune(request, { limit: 60, prefix: "search" });
   if (limited) return limited;
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -268,7 +268,7 @@ export const GET = withAuth(async (_req, _ctx, userId) => {
 
 export const POST = withAuth(async (request, _ctx, userId) => {
   try {
-    const limited = rateLimitCheckWithPrune(request, {
+    const limited = await rateLimitCheckWithPrune(request, {
       limit: 5,
       prefix: "settings-import",
       key: userId,

--- a/src/app/api/stocks/quote/route.ts
+++ b/src/app/api/stocks/quote/route.ts
@@ -1,10 +1,12 @@
+import { connection } from "next/server";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure } from "@/lib/api-responses";
 import { rateLimitCheckWithPrune } from "@/lib/rate-limit";
 import { fetchEquityQuote, warmStockPrice } from "@/lib/services/stock-watch-service";
 
 export const GET = withAuth(async (request) => {
-  const limited = rateLimitCheckWithPrune(request, { limit: 60, prefix: "stocks-quote" });
+  await connection();
+  const limited = await rateLimitCheckWithPrune(request, { limit: 60, prefix: "stocks-quote" });
   if (limited) return limited;
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/stocks/refresh/route.ts
+++ b/src/app/api/stocks/refresh/route.ts
@@ -6,7 +6,7 @@ import { refreshTrackedStockPrices } from "@/lib/services/stock-watch-service";
 export const POST = withAuth(async (request, _ctx, userId) => {
   // Tighter than the quote endpoint: each call fans out to Yahoo for every
   // tracked symbol. Keyed per-user so a shared IP can't exhaust the budget.
-  const limited = rateLimitCheckWithPrune(request, {
+  const limited = await rateLimitCheckWithPrune(request, {
     limit: 10,
     prefix: "stocks-refresh",
     key: userId,

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -14,7 +14,7 @@ export function withAuth<Ctx = unknown>(
     if (!session?.user?.id) return failure("Unauthorized", 401);
     if (!(await userExists(session.user.id))) return failure("Unauthorized", 401);
     if (MUTATION_METHODS.has(req.method)) {
-      const limited = rateLimitCheckWithPrune(req, {
+      const limited = await rateLimitCheckWithPrune(req, {
         limit: 60,
         prefix: `mutation:${req.method}`,
         key: session.user.id,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,13 +1,15 @@
 /**
- * R3 — Sliding-window rate limiter (zero external dependencies).
+ * R3 — fixed-window route-handler rate limiter.
  *
- * Uses a module-level Map so the state is shared across requests that hit the
- * same warm serverless instance. On Vercel Node.js runtime this provides
- * meaningful per-IP throttling; cold starts reset the window, which is an
- * acceptable trade-off until Upstash / Vercel KV is wired in.
+ * Route handlers use a Prisma-backed bucket so limits are shared across
+ * serverless instances and survive cold starts. The write path is a single
+ * PostgreSQL upsert that increments or resets the bucket atomically.
+ *
+ * `getClientIp` intentionally stays dependency-free because `src/proxy.ts`
+ * imports it for the edge/proxy inline limiter.
  *
  * Usage:
- *   const limited = rateLimitCheckWithPrune(request, { limit: 60, windowMs: 60_000 });
+ *   const limited = await rateLimitCheckWithPrune(request, { limit: 60, windowMs: 60_000 });
  *   if (limited) return limited;          // 429 response
  */
 
@@ -25,13 +27,10 @@ interface RateLimitOptions {
   key?: string;
 }
 
-interface WindowEntry {
+interface RateLimitRow {
   count: number;
-  resetAt: number;
+  resetAt: Date;
 }
-
-// Module-level store — shared across warm invocations on the same instance.
-const store = new Map<string, WindowEntry>();
 
 /** Extract the best available IP from the request headers. */
 export function getClientIp(request: Request): string {
@@ -55,58 +54,121 @@ export function getClientIp(request: Request): string {
  *
  * @returns A 429 Response if the limit is exceeded, otherwise `null`.
  */
-function rateLimitCheck(request: Request, options: RateLimitOptions): Response | null {
+async function rateLimitCheck(
+  request: Request,
+  options: RateLimitOptions,
+): Promise<Response | null> {
   const { limit, windowMs = 60_000, prefix = "rl" } = options;
   const id = options.key ?? getClientIp(request);
   const key = `${prefix}:${id}`;
-  const now = Date.now();
+  const now = new Date();
+  const resetAt = new Date(now.getTime() + windowMs);
 
-  const entry = store.get(key);
+  try {
+    const rows = await incrementBucket(key, resetAt, now);
+    const entry = rows[0];
 
-  if (!entry || now >= entry.resetAt) {
-    // First request in window (or expired window) — initialise.
-    store.set(key, { count: 1, resetAt: now + windowMs });
+    if (!entry) {
+      throw new Error("Rate limit increment returned no rows");
+    }
+
+    if (entry.count > limit) {
+      return rateLimitedResponse(limit, entry.resetAt, now);
+    }
+
     return null;
-  }
-
-  entry.count += 1;
-
-  if (entry.count > limit) {
-    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-    return new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json",
-        "Retry-After": String(retryAfter),
-        "X-RateLimit-Limit": String(limit),
-        "X-RateLimit-Remaining": "0",
-        "X-RateLimit-Reset": String(Math.ceil(entry.resetAt / 1000)),
+  } catch (error) {
+    await logLimiterError(error);
+    return new Response(
+      JSON.stringify({ error: { message: "Rate limit is temporarily unavailable" } }),
+      {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": "5",
+        },
       },
-    });
+    );
   }
+}
 
-  return null;
+async function incrementBucket(key: string, resetAt: Date, now: Date): Promise<RateLimitRow[]> {
+  const { prisma } = await import("@/lib/prisma");
+
+  return prisma.$queryRawUnsafe<RateLimitRow[]>(
+    `
+      INSERT INTO "RateLimitBucket" ("key", "count", "resetAt", "updatedAt")
+      VALUES ($1, 1, $2, NOW())
+      ON CONFLICT ("key") DO UPDATE SET
+        "count" = CASE
+          WHEN "RateLimitBucket"."resetAt" <= $3 THEN 1
+          ELSE "RateLimitBucket"."count" + 1
+        END,
+        "resetAt" = CASE
+          WHEN "RateLimitBucket"."resetAt" <= $3 THEN $2
+          ELSE "RateLimitBucket"."resetAt"
+        END,
+        "updatedAt" = NOW()
+      RETURNING "count", "resetAt"
+    `,
+    key,
+    resetAt,
+    now,
+  );
+}
+
+function rateLimitedResponse(limit: number, resetAt: Date, now: Date): Response {
+  const retryAfter = Math.max(1, Math.ceil((resetAt.getTime() - now.getTime()) / 1000));
+  return new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+    status: 429,
+    headers: {
+      "Content-Type": "application/json",
+      "Retry-After": String(retryAfter),
+      "X-RateLimit-Limit": String(limit),
+      "X-RateLimit-Remaining": "0",
+      "X-RateLimit-Reset": String(Math.ceil(resetAt.getTime() / 1000)),
+    },
+  });
 }
 
 /**
- * Periodically prune expired entries to prevent unbounded Map growth.
+ * Periodically prune expired buckets to prevent unbounded table growth.
  * Called lazily on each check; runs at most once per minute.
  */
 let lastPruned = 0;
-function maybePrune() {
+async function maybePrune(): Promise<void> {
   const now = Date.now();
   if (now - lastPruned < 60_000) return;
   lastPruned = now;
-  for (const [key, entry] of store) {
-    if (now >= entry.resetAt) store.delete(key);
+
+  try {
+    const { prisma } = await import("@/lib/prisma");
+    await prisma.rateLimitBucket.deleteMany({
+      where: {
+        resetAt: {
+          lte: new Date(now),
+        },
+      },
+    });
+  } catch (error) {
+    await logLimiterError(error, "rate_limit.prune_failed");
+  }
+}
+
+async function logLimiterError(error: unknown, message = "rate_limit.check_failed"): Promise<void> {
+  try {
+    const { log } = await import("@/lib/logger");
+    log.error(message, { error: error instanceof Error ? error.message : String(error) });
+  } catch {
+    // Logging should never change rate-limit behavior.
   }
 }
 
 // Attach prune to the check function so callers don't need to think about it.
-export function rateLimitCheckWithPrune(
+export async function rateLimitCheckWithPrune(
   request: Request,
   options: RateLimitOptions,
-): Response | null {
-  maybePrune();
+): Promise<Response | null> {
+  await maybePrune();
   return rateLimitCheck(request, options);
 }

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type RateLimitRow = { count: number; resetAt: Date };
+
+const { prisma } = vi.hoisted(() => ({
+  prisma: {
+    $queryRawUnsafe: vi.fn<(...args: unknown[]) => Promise<RateLimitRow[]>>(),
+    rateLimitBucket: {
+      deleteMany: vi.fn<(...args: unknown[]) => Promise<{ count: number }>>(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma }));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const request = new Request("https://astt.app/api/search", {
+  headers: { "x-forwarded-for": "203.0.113.7" },
+});
+
+describe("rateLimitCheckWithPrune", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the bucket in the shared store across module reloads", async () => {
+    const buckets = new Map<string, RateLimitRow>();
+
+    prisma.$queryRawUnsafe.mockImplementation(async (...args: unknown[]) => {
+      const [, key, resetAt, now] = args as [string, string, Date, Date];
+      const existing = buckets.get(key);
+      const next =
+        !existing || existing.resetAt <= now
+          ? { count: 1, resetAt }
+          : { count: existing.count + 1, resetAt: existing.resetAt };
+      buckets.set(key, next);
+      return [next];
+    });
+
+    let rateLimit = await import("@/lib/rate-limit");
+
+    const first = await rateLimit.rateLimitCheckWithPrune(request, {
+      limit: 1,
+      prefix: "durable",
+      key: "user-1",
+    });
+
+    expect(first).toBeNull();
+
+    vi.resetModules();
+    rateLimit = await import("@/lib/rate-limit");
+
+    const limited = await rateLimit.rateLimitCheckWithPrune(request, {
+      limit: 1,
+      prefix: "durable",
+      key: "user-1",
+    });
+
+    expect(limited?.status).toBe(429);
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 429 from the atomically incremented database count", async () => {
+    const resetAt = new Date(Date.now() + 60_000);
+    prisma.$queryRawUnsafe.mockResolvedValueOnce([{ count: 3, resetAt }]);
+
+    const { rateLimitCheckWithPrune } = await import("@/lib/rate-limit");
+
+    const limited = await rateLimitCheckWithPrune(request, {
+      limit: 2,
+      prefix: "atomic",
+      key: "user-2",
+    });
+
+    expect(limited?.status).toBe(429);
+    expect(limited?.headers.get("Retry-After")).toBe("60");
+    expect(limited?.headers.get("X-RateLimit-Limit")).toBe("2");
+    expect(limited?.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(limited?.headers.get("X-RateLimit-Reset")).toBe(
+      String(Math.ceil(resetAt.getTime() / 1000)),
+    );
+
+    const [sql, key] = prisma.$queryRawUnsafe.mock.calls[0]!;
+    expect(key).toBe("atomic:user-2");
+    expect(String(sql)).toContain('ON CONFLICT ("key") DO UPDATE');
+    expect(String(sql)).toContain('RETURNING "count", "resetAt"');
+  });
+});


### PR DESCRIPTION
## Root cause

Route-handler rate limits were stored in a module-level `Map`. That state resets on cold starts and is not shared across Vercel serverless instances, so concurrent or distributed requests could bypass the intended limits.

## Implementation

- Added a Prisma-backed `RateLimitBucket` table and migration.
- Replaced the route-handler limiter with an async database-backed check using one PostgreSQL `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` statement so each request atomically increments or resets its bucket.
- Kept `getClientIp` dependency-free for `src/proxy.ts`; the proxy inline limiter is unchanged.
- Updated route handlers and `withAuth` to await the limiter.
- Added `connection()` to GET route handlers that inspect request headers through the limiter so Next.js 16 Cache Components does not attempt to prerender them.
- Added unit tests for durability across module reloads and 429 behavior from the atomic database count.

## Impact

Rate limits for Node route handlers are now shared through the app database and survive serverless cold starts. If the database-backed limiter is unavailable, route handlers fail closed with a 503 and short `Retry-After` rather than silently falling back to per-instance memory.

## Validation

- `pnpm vitest run tests/unit/rate-limit.test.ts` passed
- `pnpm prisma generate` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test:unit` passed: 17 files, 127 tests
- `pnpm build` passed
- Push hook also ran `prettier --check .`, `eslint`, and `tsc --noEmit` successfully