### PR TITLE
fix(skeletons): align loading skeletons with final layouts

### DIFF
--- a/src/app/(main)/accounts/loading.tsx
+++ b/src/app/(main)/accounts/loading.tsx
@@ -1,65 +1,109 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
+/**
+ * Route skeleton for /accounts. Mirrors the real layout: the page title over the
+ * AccountsList shell (net-worth headline + actions, the portfolio heatmap card,
+ * then the desktop table / mobile grouped lists). Holding both the lg table and
+ * the mobile list keeps the skeleton→content swap from shifting at any width.
+ */
 export default function AccountsLoading() {
   return (
     <div className="space-y-4 md:space-y-8">
       {/* Title — matches LargeTitleHeading (text-4xl md:text-3xl) */}
-      <Skeleton className="h-10 md:h-9 w-32 rounded-lg" />
+      <Skeleton className="h-10 w-32 rounded-lg md:h-9" />
 
-      {/* Toolbar */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-5 w-5" />
-          <Skeleton className="h-4 w-20" />
+      {/* AccountsList shell (space-y-6 md:space-y-8) */}
+      <div className="space-y-6 md:space-y-8">
+        {/* Net-worth headline + actions */}
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between md:border-b md:border-border/60 md:pb-6">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-9 w-48 rounded-lg md:h-10" />
+          </div>
+          <div className="flex items-center gap-2">
+            {/* Add Holding + Manage are desktop-only; Add Account always shows */}
+            <Skeleton className="hidden h-9 w-28 md:block" />
+            <Skeleton className="hidden h-9 w-32 md:block" />
+            <Skeleton className="h-9 w-28" />
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-24" />
-          <Skeleton className="h-9 w-28" />
-        </div>
-      </div>
 
-      {/* Category sections */}
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-16" />
-
-        {[...Array(3)].map((_, i) => (
-          <div key={i} className="rounded-xl border border-border/50 overflow-hidden">
-            <div className="px-5 py-4 bg-muted/30 flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <Skeleton className="h-8 w-8" />
-                <div className="space-y-1.5">
-                  <Skeleton className="h-4 w-24" />
-                  <Skeleton className="h-3 w-32" />
-                </div>
-              </div>
-              <Skeleton className="h-4 w-20" />
+        {/* Portfolio heatmap card (treemap + desktop legend column) */}
+        <Card>
+          <CardHeader className="pb-0">
+            <div className="space-y-1.5">
+              <Skeleton className="h-5 w-44" />
+              <Skeleton className="h-4 w-64 max-w-full" />
             </div>
+          </CardHeader>
+          <CardContent className="pt-1">
+            <div className="grid gap-3 sm:gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
+              <Skeleton className="h-[240px] sm:h-[280px]" />
+              <div className="hidden space-y-2 lg:block">
+                {[...Array(5)].map((_, i) => (
+                  <Skeleton key={i} className="h-11" />
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-            <div className="px-4 py-4 space-y-3 bg-background/50">
-              {[...Array(i === 0 ? 2 : 1)].map((_, j) => (
-                <div key={j} className="rounded-lg border border-border/40 p-4">
-                  <div className="flex justify-between">
-                    <Skeleton className="h-5 w-32" />
-                    <Skeleton className="h-6 w-24" />
-                  </div>
-                  {i !== 0 && (
-                    <div className="mt-3 space-y-2">
-                      {[...Array(2)].map((_, k) => (
-                        <div
-                          key={k}
-                          className="flex justify-between py-1.5 border-t border-border/30 first:border-0"
-                        >
-                          <Skeleton className="h-3.5 w-28" />
-                          <Skeleton className="h-3.5 w-16" />
-                        </div>
-                      ))}
-                    </div>
-                  )}
+        {/* Desktop table */}
+        <div className="hidden overflow-hidden rounded-xl border lg:block">
+          <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
+            {[...Array(7)].map((_, i) => (
+              <Skeleton key={i} className="h-3" style={{ flex: i === 0 ? 2 : 1 }} />
+            ))}
+          </div>
+          {[...Array(5)].map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 border-b border-border/60 px-4 py-3.5 last:border-0"
+            >
+              {[...Array(7)].map((_, j) => (
+                <Skeleton key={j} className="h-4" style={{ flex: j === 0 ? 2 : 1 }} />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* Mobile summary strip + quick actions + grouped lists */}
+        <div className="lg:hidden">
+          <div className="mb-6 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              {[0, 1].map((i) => (
+                <div key={i} className="space-y-2 rounded-xl border border-border/50 p-4">
+                  <Skeleton className="h-3 w-16" />
+                  <Skeleton className="h-6 w-24 max-w-full" />
                 </div>
               ))}
             </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-9 flex-1" />
+              <Skeleton className="h-9 flex-1" />
+            </div>
           </div>
-        ))}
+
+          <div className="space-y-6">
+            {[0, 1].map((section) => (
+              <div key={section}>
+                <Skeleton className="mb-3 h-3 w-16" />
+                <div className="divide-y divide-border/60 overflow-hidden rounded-xl border">
+                  {[...Array(section === 0 ? 3 : 1)].map((_, i) => (
+                    <div key={i} className="flex items-center justify-between gap-3 px-4 py-3.5">
+                      <div className="space-y-1.5">
+                        <Skeleton className="h-4 w-32" />
+                        <Skeleton className="h-3 w-20" />
+                      </div>
+                      <Skeleton className="h-5 w-24" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(main)/goals/loading.tsx
+++ b/src/app/(main)/goals/loading.tsx
@@ -22,8 +22,8 @@ export default function GoalsLoading() {
         </div>
 
         <div className="space-y-6">
-          {/* Subtitle + Add button (size="sm" → h-7) */}
-          <div className="flex items-center justify-between">
+          {/* Subtitle + Add button (size="sm" → h-7); stacks on mobile like GoalsView */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <Skeleton className="h-4 w-48" />
             <Skeleton className="h-7 w-24 rounded-md" />
           </div>

--- a/src/app/(main)/stocks/loading.tsx
+++ b/src/app/(main)/stocks/loading.tsx
@@ -1,40 +1,82 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent } from "@/components/ui/card";
 
+/**
+ * Route skeleton for /stocks. Mirrors the real layout: a title + subtitle block
+ * over the StockTrackerView shell (tracked-count toolbar that stacks on mobile,
+ * then the watchlist rows). Each row card carries both the desktop single-row
+ * grid and the mobile stacked layout so the skeleton→content swap never shifts.
+ */
 export default function StocksLoading() {
   return (
     <div className="space-y-4 md:space-y-8">
-      <div className="space-y-2">
-        <Skeleton className="h-9 w-36" />
-        <Skeleton className="h-4 w-80 max-w-full" />
+      {/* Title block — matches LargeTitleHeading (text-4xl md:text-3xl) + subtitle */}
+      <div>
+        <Skeleton className="h-10 w-36 rounded-lg md:h-9" />
+        <Skeleton className="mt-2 h-4 w-80 max-w-full" />
       </div>
-      <div className="flex justify-between gap-3">
-        <Skeleton className="h-8 w-36" />
-        <div className="flex gap-2">
-          <Skeleton className="h-8 w-28" />
-          <Skeleton className="h-8 w-24" />
+
+      {/* StockTrackerView shell (space-y-4) */}
+      <div className="space-y-4">
+        {/* Toolbar — stacks on mobile, row on desktop (mirrors the view) */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-7 w-7 rounded-md" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-28 flex-1 sm:flex-none" />
+            <Skeleton className="h-9 w-24 flex-1 sm:flex-none" />
+          </div>
         </div>
-      </div>
-      <div className="space-y-3">
-        {[0, 1, 2].map((item) => (
-          <Card key={item} size="sm">
-            <CardContent className="space-y-3">
-              <div className="flex justify-between gap-3">
-                <div className="space-y-2">
-                  <Skeleton className="h-5 w-24" />
-                  <Skeleton className="h-4 w-52" />
+
+        {/* Watchlist rows */}
+        <div className="space-y-3 md:space-y-2">
+          {[0, 1, 2].map((item) => (
+            <Card key={item} size="sm" className="md:py-2">
+              <CardContent className="space-y-3 md:px-3">
+                {/* Desktop single-row grid */}
+                <div className="hidden items-center gap-5 md:grid md:grid-cols-[minmax(180px,1.5fr)_minmax(280px,1.3fr)_minmax(116px,auto)_1.75rem]">
+                  <div className="space-y-1.5">
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-3 w-40 max-w-full" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Skeleton className="h-3 w-32" />
+                    <Skeleton className="h-5 w-44 max-w-full" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                  <div className="flex flex-col items-end gap-1.5 justify-self-end">
+                    <Skeleton className="h-6 w-20 rounded-full" />
+                    <Skeleton className="h-3 w-14" />
+                  </div>
+                  <Skeleton className="h-7 w-7 justify-self-end" />
                 </div>
-                <Skeleton className="h-7 w-7" />
-              </div>
-              <div className="grid gap-2 sm:grid-cols-4">
-                {[0, 1, 2, 3].map((cell) => (
-                  <Skeleton key={cell} className="h-20" />
-                ))}
-              </div>
-              <Skeleton className="h-16" />
-            </CardContent>
-          </Card>
-        ))}
+
+                {/* Mobile stacked layout */}
+                <div className="flex flex-col gap-3.5 md:hidden">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 space-y-1.5">
+                      <Skeleton className="h-5 w-24" />
+                      <Skeleton className="h-4 w-40 max-w-full" />
+                    </div>
+                    <div className="flex shrink-0 flex-col items-end gap-1.5">
+                      <Skeleton className="h-7 w-24 rounded-full" />
+                      <Skeleton className="h-5 w-20" />
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/30 px-3 py-2.5">
+                    <div className="space-y-1.5">
+                      <Skeleton className="h-3.5 w-32" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                    <Skeleton className="h-7 w-7 shrink-0" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/analysis/lazy-analysis-charts.tsx
+++ b/src/components/analysis/lazy-analysis-charts.tsx
@@ -12,7 +12,9 @@ function ChartSkeleton({ height = 200 }: { height?: number }) {
   return (
     <>
       <CardHeader className="pb-2 px-2 sm:px-4">
-        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-5 w-40 max-w-full" />
+        {/* Subtitle line — every analysis chart header has one (e.g. monthlyChangeSubtitle) */}
+        <Skeleton className="mt-1.5 h-3 w-52 max-w-full" />
       </CardHeader>
       <CardContent className="flex flex-1 flex-col px-2 pb-4 sm:px-4">
         <Skeleton className="min-h-0 flex-1" style={{ minHeight: skeletonHeight }} />

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -22,6 +22,7 @@ import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card"
 import { ProjectionEntryCard } from "@/components/dashboard/projection-entry-card";
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import { WatchlistCard } from "@/components/dashboard/watchlist-card";
+import { WatchlistCardSkeleton } from "@/components/dashboard/dashboard-skeleton";
 import Link from "next/link";
 import { ArrowRight, History } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -390,7 +391,7 @@ export async function DashboardContent({ userId }: { userId: string }) {
           <Suspense fallback={null}>
             <GoalsMilestoneSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>
-          <Suspense fallback={<ChartCardSkeleton />}>
+          <Suspense fallback={<WatchlistCardSkeleton />}>
             <WatchlistSection userId={userId} />
           </Suspense>
         </div>

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -80,7 +80,7 @@ function GoalsCardSkeleton() {
 }
 
 /** Watchlist rail card — header + three quote rows (symbol/name + change pill). */
-function WatchlistCardSkeleton() {
+export function WatchlistCardSkeleton() {
   return (
     <Card>
       <CardHeader className="pb-2">

--- a/src/components/projections/lazy-projection-chart.tsx
+++ b/src/components/projections/lazy-projection-chart.tsx
@@ -1,16 +1,12 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { Card, CardContent } from "@/components/ui/card";
 
+// The chart renders directly inside the parent CardContent (no card of its own)
+// at the height ProjectionView passes (420). Match both so the chunk-load swap
+// doesn't add padding or jump the row.
 function ChartSkeleton() {
-  return (
-    <Card className="border-0 bg-transparent shadow-none">
-      <CardContent className="p-4">
-        <div className="h-[320px] bg-muted animate-pulse rounded" />
-      </CardContent>
-    </Card>
-  );
+  return <div className="h-[420px] w-full animate-pulse rounded-lg bg-muted" />;
 }
 
 export const LazyProjectionChart = dynamic(


### PR DESCRIPTION
## Summary

Audited every tab's loading skeleton ("sketch animation") against the layout it reveals — both route-level `loading.tsx` and component-level Suspense / lazy-import fallbacks — at desktop and mobile. Several diverged enough to cause a layout jump or flicker on reveal. This aligns them.

## Route skeletons

- **`stocks/loading`** — title was flat `h-9` (real is `LargeTitleHeading`, `text-4xl md:text-3xl`); toolbar was always horizontal (real stacks on mobile); card body was a `sm:grid-cols-4` of stat tiles that doesn't exist in the real row. Now responsive title, mobile-stacking toolbar, and a card carrying the real desktop single-row grid + mobile stacked layout.
- **`accounts/loading`** — was a stale small toolbar + category cards. Rebuilt to lead with the **net-worth headline** + responsive actions, the **portfolio heatmap card**, then the **`lg` table / mobile grouped lists** — matching `AccountsList` at every width.
- **`goals/loading`** — subtitle/action row now stacks on mobile like `GoalsView`.

## Component fallbacks

- **`analysis/lazy-analysis-charts`** — the lazy `ChartSkeleton` rendered only a title; every real analysis chart header has a subtitle line. Added it so the header doesn't grow ~16px on chunk load.
- **`projections/lazy-projection-chart`** — chart renders at `height={420}` directly in the parent `CardContent`, but the fallback was a `h-[320px]` block in an extra padded card → ~100px jump + phantom padding. Now a flush `h-[420px]` block.
- **dashboard watchlist** — `WatchlistSection`'s Suspense fallback used the generic chart-card block while the route skeleton uses a watchlist-shaped one (header + 3 rows), causing a cold-load flicker. Exported `WatchlistCardSkeleton` and used it for both stages.

## Left as-is (intentional)

- Dashboard allocation/currency `ChartCardSkeleton` stays generic — consistent across route + Suspense, so the only gap is skeleton→real.
- `GoalsMilestoneSection` fallback is `null` because that slot may render a projection card or nothing for goal-less users.

## Verification

`pnpm format:check`, `pnpm lint`, `pnpm typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)