### PR TITLE
fix(analysis): bucket cash flows by occurrence date, not entry date (v0.9.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,21 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.9.1",
+    date: "2026-07-02",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Cash Flow, Cumulative Growth, and Attribution now bucket transactions by their actual occurrence date, so backdated deposits and withdrawals land in the right month.",
+          "zh-TW":
+            "現金流、累積成長與績效歸因現在依實際發生日期歸類交易，補登的存提款會落在正確的月份。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.9.0",
     date: "2026-07-02",
     summary: {

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -435,6 +435,8 @@ export async function getAccountMonthlyCashFlow(
   // are unreachable by the analysis UI: the axis buckets and attribution math
   // are snapshot-derived (including the "All" range), so this floor changes no
   // rendered output — it only avoids scanning/converting unreachable rows.
+  // The floor compares against the effective date (occurrenceDate ?? createdAt)
+  // so it matches the month-key bucketing below.
   const floor = firstSnapshot
     ? new Date(Date.UTC(firstSnapshot.date.getUTCFullYear(), firstSnapshot.date.getUTCMonth(), 1))
     : null;
@@ -443,16 +445,25 @@ export async function getAccountMonthlyCashFlow(
     where: {
       accountId: { in: accounts.map((a) => a.id) },
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
-      ...(floor ? { createdAt: { gte: floor } } : {}),
+      ...(floor
+        ? {
+            OR: [
+              { occurrenceDate: { gte: floor } },
+              { occurrenceDate: null, createdAt: { gte: floor } },
+            ],
+          }
+        : {}),
     },
-    select: { amount: true, type: true, createdAt: true, accountId: true },
+    select: { amount: true, type: true, createdAt: true, occurrenceDate: true, accountId: true },
     orderBy: { createdAt: "asc" },
   });
 
   const byKey = new Map<string, number>();
 
   for (const tx of transactions) {
-    const monthKey = tx.createdAt.toISOString().slice(0, 7);
+    // Bucket by when the cash flow actually happened (occurrenceDate), falling
+    // back to createdAt for legacy rows that never recorded one (#498).
+    const monthKey = (tx.occurrenceDate ?? tx.createdAt).toISOString().slice(0, 7);
     const key = `${tx.accountId}::${monthKey}`;
     const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -78,7 +78,12 @@ export async function getProjectionData(
     where: {
       accountId: { in: accountIds },
       type: { in: ["DEPOSIT", "WITHDRAWAL"] },
-      createdAt: { gte: twelveMonthsAgo },
+      // Window by the effective date (occurrenceDate ?? createdAt) so backdated
+      // or catch-up-materialized flows count in the month they occurred (#498).
+      OR: [
+        { occurrenceDate: { gte: twelveMonthsAgo } },
+        { occurrenceDate: null, createdAt: { gte: twelveMonthsAgo } },
+      ],
     },
     select: { amount: true, type: true, accountId: true },
   });

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -13,6 +13,13 @@ interface SnapshotRowFixture {
   label: string | null;
   note: string | null;
 }
+interface CashTransactionFixture {
+  amount: number;
+  type: "DEPOSIT" | "WITHDRAWAL";
+  createdAt: Date;
+  occurrenceDate: Date | null;
+  accountId: string;
+}
 const h = vi.hoisted(() => ({
   rows: [] as SnapshotRowFixture[],
   currentYearRows: [] as SnapshotRowFixture[],
@@ -20,6 +27,7 @@ const h = vi.hoisted(() => ({
   previousDateRow: null as { date: Date } | null,
   latestSnapshot: null as SnapshotRowFixture | null,
   accounts: [] as unknown[],
+  cashTransactions: [] as CashTransactionFixture[],
   prices: [] as { symbol: string; price: number; currency: string }[],
   rates: new Map<string, number>(),
 }));
@@ -48,6 +56,7 @@ vi.mock("@/lib/prisma", () => ({
         return h.latestSnapshot;
       }),
     },
+    cashTransaction: { findMany: vi.fn(async () => h.cashTransactions) },
     priceCache: { findMany: vi.fn(async () => h.prices) },
   },
 }));
@@ -57,10 +66,12 @@ vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
 });
 
 const {
+  getAccountMonthlyCashFlow,
   getCurrentYearNormalizedHistory,
   getFullNormalizedHistory,
   getSnapshotReconciliationWarning,
 } = await import("@/lib/services/history-service");
+const { prisma } = await import("@/lib/prisma");
 
 function row(
   over: Partial<SnapshotRowFixture> & Pick<SnapshotRowFixture, "id" | "date">,
@@ -106,6 +117,7 @@ beforeEach(() => {
   h.previousDateRow = null;
   h.latestSnapshot = null;
   h.accounts = [];
+  h.cashTransactions = [];
   h.prices = [];
   h.rates = new Map<string, number>();
 });
@@ -235,6 +247,80 @@ describe("getCurrentYearNormalizedHistory", () => {
     const result = await getCurrentYearNormalizedHistory("u1", "USD");
 
     expect(result.map((s) => s.date)).toEqual(["2026-01-01"]);
+  });
+});
+
+describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)", () => {
+  function cashTx(over: Partial<CashTransactionFixture> = {}): CashTransactionFixture {
+    return {
+      amount: 100,
+      type: "DEPOSIT",
+      createdAt: new Date("2026-07-01T10:00:00.000Z"),
+      occurrenceDate: null,
+      accountId: "acc",
+      ...over,
+    };
+  }
+
+  it("buckets a backdated transaction into its occurrenceDate month, not its createdAt month", async () => {
+    h.accounts = [account()];
+    h.cashTransactions = [
+      cashTx({
+        occurrenceDate: new Date("2026-05-15T00:00:00.000Z"), // happened in May…
+        createdAt: new Date("2026-07-01T10:00:00.000Z"), // …entered in July
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([{ accountId: "acc", monthKey: "2026-05", contributions: 100 }]);
+  });
+
+  it("falls back to createdAt when occurrenceDate is null", async () => {
+    h.accounts = [account()];
+    h.cashTransactions = [
+      cashTx({ occurrenceDate: null, createdAt: new Date("2026-06-10T08:00:00.000Z") }),
+      cashTx({
+        type: "WITHDRAWAL",
+        amount: 40,
+        occurrenceDate: null,
+        createdAt: new Date("2026-06-20T08:00:00.000Z"),
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([{ accountId: "acc", monthKey: "2026-06", contributions: 60 }]);
+  });
+
+  it("applies the first-snapshot floor to the effective date (occurrenceDate ?? createdAt)", async () => {
+    h.accounts = [account()];
+    h.latestSnapshot = row({ id: "first", date: new Date("2026-03-05T00:00:00.000Z") });
+
+    await getAccountMonthlyCashFlow("u1", "USD");
+
+    const args = vi.mocked(prisma.cashTransaction.findMany).mock.lastCall?.[0] as {
+      where: Record<string, unknown>;
+    };
+    const floor = new Date(Date.UTC(2026, 2, 1));
+    expect(args.where.OR).toEqual([
+      { occurrenceDate: { gte: floor } },
+      { occurrenceDate: null, createdAt: { gte: floor } },
+    ]);
+    // The accountId/type conditions stay ANDed alongside the floor OR.
+    expect(args.where.accountId).toEqual({ in: ["acc"] });
+    expect(args.where.type).toEqual({ in: ["DEPOSIT", "WITHDRAWAL"] });
+  });
+
+  it("omits the floor filter entirely when the user has no snapshots", async () => {
+    h.accounts = [account()];
+
+    await getAccountMonthlyCashFlow("u1", "USD");
+
+    const args = vi.mocked(prisma.cashTransaction.findMany).mock.lastCall?.[0] as {
+      where: Record<string, unknown>;
+    };
+    expect(args.where.OR).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

`getAccountMonthlyCashFlow` (src/lib/services/history-service.ts) bucketed cash transactions into months by **`createdAt`**, ignoring `CashTransaction.occurrenceDate` — the field that records when the flow actually happened. Since `getMonthlyCashFlow` is a thin reduction over it, the mis-bucketing propagated to every analysis consumer: Cash Flow Decomposition, Cumulative Growth (v0.9.0), and F11 Performance Attribution. A deposit backdated to May but entered in July landed in July's bucket — inflating July's contributions (and forcing a fake negative "market" residual) while May showed the deposit as phantom market gains.

## Fix

- **Month-key derivation** now uses the effective date: `(tx.occurrenceDate ?? tx.createdAt).toISOString().slice(0, 7)` — `occurrenceDate` is nullable, so legacy/manual rows fall back to `createdAt` unchanged.
- **PE29 first-snapshot floor** now filters on the same effective date via `OR: [{ occurrenceDate: { gte: floor } }, { occurrenceDate: null, createdAt: { gte: floor } }]` (ANDed with the existing `accountId`/`type` conditions), so the filter and the bucketing can never disagree. Comment updated accordingly.

## Consumer sweep (per the issue's "check other consumers")

- **`projection-service.ts`** — the trailing-12-month savings scan windowed on `createdAt: { gte: twelveMonthsAgo }`; same class of bug (catch-up-materialized or backdated flows counted by entry date). Fixed with the same effective-date OR filter.
- **Account detail / ledger transaction lists** — display-only ordering by `createdAt`; intentionally left alone.
- **`settings/data` export/import** — not a date-bucketing consumer, but noted: import recreates cash transactions without `occurrenceDate`, so a round-trip drops it (pre-existing, out of scope here).
- **Cache invalidation** — no new wiring needed: `getAccountMonthlyCashFlow` is tagged `accounts:${userId}` / `history:${userId}`, and all cash-transaction mutation routes already `revalidateTag` both.

## Tests

Extended `tests/unit/history-service.test.ts` with a `getAccountMonthlyCashFlow` block (mocked prisma, real `resolveRate`):
- a transaction with `occurrenceDate` in May but `createdAt` in July lands in the **2026-05** bucket;
- null `occurrenceDate` falls back to `createdAt` (with a DEPOSIT/WITHDRAWAL netting check);
- the snapshot floor produces the effective-date OR filter with `accountId`/`type` still ANDed;
- no snapshots ⇒ no floor filter.

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (130 passed) all green.

## Release

v0.9.1 prepended to `src/lib/changelog.ts` (bilingual `fixed` entry); `package.json` bumped to match.

Fixes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS