### PR TITLE
fix(settings): preserve cash-transaction occurrence dates in data export/import (v0.9.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -371,6 +371,9 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                     quantity: t.quantity,
                     note: t.note,
                     createdAt: t.createdAt,
+                    // Preserve null as null — analysis bucketing falls back to
+                    // createdAt only when occurrenceDate is null.
+                    occurrenceDate: t.occurrenceDate ?? null,
                   })),
                 });
               }
@@ -387,6 +390,9 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                 amount: t.amount,
                 note: t.note,
                 createdAt: t.createdAt,
+                // Preserve null as null — analysis bucketing falls back to
+                // createdAt only when occurrenceDate is null.
+                occurrenceDate: t.occurrenceDate ?? null,
               })),
             });
           }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,21 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.9.2",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Data export/import now preserves each transaction's occurrence date, so recurring and backdated entries keep their correct month in analysis after restoring a backup.",
+          "zh-TW":
+            "資料匯出／匯入現在會保留每筆交易的發生日期，還原備份後定期與補登的交易在分析中仍會落在正確的月份。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.9.1",
     date: "2026-07-02",
     changes: [

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -331,6 +331,11 @@ const MAX_IMPORT_GOALS = 500;
 // else turns a write-time Prisma 500 into a 400 with a field path.
 const importTimestamp = z.iso.datetime().optional();
 
+// Recurring-materialized transactions carry the UTC calendar day they belong
+// to; manual rows export it as null. Preserve null as null — never default it,
+// since analysis bucketing falls back to createdAt only when it is null.
+const importOccurrenceDate = z.iso.datetime().optional().nullable();
+
 export const dataImportSchema = z.object({
   version: z.string(),
   settings: z
@@ -376,6 +381,7 @@ export const dataImportSchema = z.object({
                     quantity: decimalSchema,
                     note: z.string().optional().nullable(),
                     createdAt: importTimestamp,
+                    occurrenceDate: importOccurrenceDate,
                   }),
                 )
                 .max(MAX_IMPORT_TRANSACTIONS_PER_HOLDING)
@@ -391,6 +397,7 @@ export const dataImportSchema = z.object({
               amount: decimalSchema,
               note: z.string().optional().nullable(),
               createdAt: importTimestamp,
+              occurrenceDate: importOccurrenceDate,
             }),
           )
           .max(MAX_IMPORT_CASH_TRANSACTIONS_PER_ACCOUNT)

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -218,4 +218,69 @@ describe("dataImportSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("preserves transaction occurrenceDate through parsing, keeping null as null", () => {
+    const result = dataImportSchema.safeParse({
+      version: "1.2",
+      accounts: [
+        {
+          name: "Checking",
+          type: "ASSET",
+          category: "BANK",
+          currency: "USD",
+          cashBalance: "100",
+          holdings: [
+            {
+              symbol: "VT",
+              name: "Vanguard Total World",
+              quantity: "1",
+              currency: "USD",
+              assetType: "ETF",
+              transactions: [
+                { type: "BUY", quantity: "1", occurrenceDate: "2026-06-01T00:00:00.000Z" },
+                { type: "SELL", quantity: "1", occurrenceDate: null },
+              ],
+            },
+          ],
+          cashTransactions: [
+            { type: "DEPOSIT", amount: "50", occurrenceDate: "2026-06-15T00:00:00.000Z" },
+            { type: "WITHDRAWAL", amount: "10", occurrenceDate: null },
+            { type: "DEPOSIT", amount: "5" },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const account = result.data.accounts[0];
+    expect(account.holdings?.[0].transactions?.map((t) => t.occurrenceDate)).toEqual([
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ]);
+    expect(account.cashTransactions?.map((t) => t.occurrenceDate)).toEqual([
+      "2026-06-15T00:00:00.000Z",
+      null,
+      undefined,
+    ]);
+  });
+
+  it("rejects a non-datetime occurrenceDate", () => {
+    const result = dataImportSchema.safeParse({
+      version: "1.2",
+      accounts: [
+        {
+          name: "Checking",
+          type: "ASSET",
+          category: "BANK",
+          currency: "USD",
+          cashBalance: "0",
+          cashTransactions: [{ type: "DEPOSIT", amount: "1", occurrenceDate: "not-a-date" }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

The Settings data export already carries `occurrenceDate` (the export GET serializes full Prisma models), but the import POST silently dropped it twice:

1. `dataImportSchema` (Zod strips unknown keys) didn't declare the field, and
2. the import `createMany` mappings only copied `type` / `amount` / `note` / `createdAt`.

So an export → import round-trip reset `occurrenceDate` to `null`, and since PR #499 the field drives monthly bucketing for Cash Flow, Cumulative Growth, Attribution, and the projections savings scan — previously correctly-bucketed backdated/recurring transactions would shift to their new `createdAt` month after a restore.

## Fix

- `src/lib/validators.ts`: accept `occurrenceDate` as a nullable ISO datetime (`importOccurrenceDate`) on both `cashTransactions` and holding `transactions` entries.
- `src/app/api/settings/data/route.ts`: restore `occurrenceDate` in both `createMany` maps, preserving `null` as `null` (no defaulting — analysis falls back to `createdAt` only when it is null).
- No export-side change needed; the payload shape is unchanged (version string stays `"1.2"`).

## Round-trip audit (per the issue)

Checked every exported model's scalar fields against the import path:

- **Fixed:** `HoldingTransaction.occurrenceDate` had the identical gap (same recurring-materialization pattern) and is now restored too.
- **Deliberately left:** `recurringId` on both transaction models is not restored — the recurring *rules* (`RecurringCashTransaction`, `RecurringInvestment`) are not part of the export payload at all, so the FK has nothing to point at. Materialized transactions still import with their amounts and occurrence dates intact; they just import as unlinked rows (safe w.r.t. the `@@unique([recurringId, occurrenceDate])` constraint since NULLs are distinct). Exporting recurring rules themselves (and `StockWatchItem`) would be a feature addition, not a round-trip fix — worth a follow-up issue if desired.
- **Clean:** `Setting`, `Account`, `Holding` (incl. option fields), `Goal`, and snapshot fields all round-trip.

## Tests

- New unit tests in `tests/unit/validators.test.ts`: `dataImportSchema` preserves `occurrenceDate` through parsing for both transaction kinds (datetime value, explicit `null`, and absent), and rejects non-datetime values.
- `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` — all green (132 tests).

## Release

- 0.9.2 prepended to `src/lib/changelog.ts` (bilingual `fixed` entry, dated 2026-07-03); `package.json` bumped to match.

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS