### PR TITLE
fix(accounts): stabilize backdated ledger history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/app/api/accounts/[id]/transactions/route.ts
+++ b/src/app/api/accounts/[id]/transactions/route.ts
@@ -10,26 +10,36 @@ interface UnifiedRow {
   quantity: unknown; // Decimal from DB
   note: string | null;
   createdAt: Date;
+  effectiveAt: Date;
   occurrenceDate: Date | null;
   holdingId: string | null;
 }
 
 const cursorSchema = z.object({
+  effectiveAt: z.string().datetime(),
   createdAt: z.string().datetime(),
   id: z.string().min(1),
 });
 
-function encodeCursor(row: { createdAt: Date; id: string }): string {
+function encodeCursor(row: { effectiveAt: Date; createdAt: Date; id: string }): string {
   return Buffer.from(
-    JSON.stringify({ createdAt: row.createdAt.toISOString(), id: row.id }),
+    JSON.stringify({
+      effectiveAt: row.effectiveAt.toISOString(),
+      createdAt: row.createdAt.toISOString(),
+      id: row.id,
+    }),
   ).toString("base64url");
 }
 
-function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
+function decodeCursor(cursor: string): { effectiveAt: Date; createdAt: Date; id: string } | null {
   try {
     const raw = JSON.parse(Buffer.from(cursor, "base64url").toString());
     const parsed = cursorSchema.parse(raw);
-    return { createdAt: new Date(parsed.createdAt), id: parsed.id };
+    return {
+      effectiveAt: new Date(parsed.effectiveAt),
+      createdAt: new Date(parsed.createdAt),
+      id: parsed.id,
+    };
   } catch {
     return null;
   }
@@ -56,22 +66,24 @@ export const GET = withAuth(
       // Cursor-based keyset pagination — O(1) regardless of position
       const decoded = decodeCursor(cursorParam);
       if (!decoded) return failure("Invalid cursor", 400);
-      const { createdAt: cursorDate, id: cursorId } = decoded;
+      const { effectiveAt: cursorEffectiveDate, createdAt: cursorDate, id: cursorId } = decoded;
 
       rows = await prisma.$queryRaw<UnifiedRow[]>`
-      SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", NULL AS "occurrenceDate", "holdingId"
-      FROM "HoldingTransaction"
-      WHERE "holdingId" IN (SELECT id FROM "Holding" WHERE "accountId" = ${id})
-        AND ("createdAt", id) < (${cursorDate}::timestamptz, ${cursorId}::text)
+      SELECT *
+      FROM (
+        SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", "createdAt" AS "effectiveAt", NULL AS "occurrenceDate", "holdingId"
+        FROM "HoldingTransaction"
+        WHERE "holdingId" IN (SELECT id FROM "Holding" WHERE "accountId" = ${id})
 
-      UNION ALL
+        UNION ALL
 
-      SELECT id, true AS "isCash", type::text, amount AS quantity, note, "createdAt", "occurrenceDate", NULL AS "holdingId"
-      FROM "CashTransaction"
-      WHERE "accountId" = ${id}
-        AND ("createdAt", id) < (${cursorDate}::timestamptz, ${cursorId}::text)
+        SELECT id, true AS "isCash", type::text, amount AS quantity, note, "createdAt", COALESCE("occurrenceDate"::timestamptz, "createdAt") AS "effectiveAt", "occurrenceDate", NULL AS "holdingId"
+        FROM "CashTransaction"
+        WHERE "accountId" = ${id}
+      ) ledger
+      WHERE ("effectiveAt", "createdAt", id) < (${cursorEffectiveDate}::timestamptz, ${cursorDate}::timestamptz, ${cursorId}::text)
 
-      ORDER BY "createdAt" DESC, id DESC
+      ORDER BY "effectiveAt" DESC, "createdAt" DESC, id DESC
       LIMIT ${limit + 1}
     `;
     } else {
@@ -80,17 +92,17 @@ export const GET = withAuth(
       const offset = (page - 1) * limit;
 
       rows = await prisma.$queryRaw<UnifiedRow[]>`
-      SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", NULL AS "occurrenceDate", "holdingId"
+      SELECT id, false AS "isCash", type::text, quantity, note, "createdAt", "createdAt" AS "effectiveAt", NULL AS "occurrenceDate", "holdingId"
       FROM "HoldingTransaction"
       WHERE "holdingId" IN (SELECT id FROM "Holding" WHERE "accountId" = ${id})
 
       UNION ALL
 
-      SELECT id, true AS "isCash", type::text, amount AS quantity, note, "createdAt", "occurrenceDate", NULL AS "holdingId"
+      SELECT id, true AS "isCash", type::text, amount AS quantity, note, "createdAt", COALESCE("occurrenceDate"::timestamptz, "createdAt") AS "effectiveAt", "occurrenceDate", NULL AS "holdingId"
       FROM "CashTransaction"
       WHERE "accountId" = ${id}
 
-      ORDER BY "createdAt" DESC, id DESC
+      ORDER BY "effectiveAt" DESC, "createdAt" DESC, id DESC
       LIMIT ${limit + 1}
       OFFSET ${offset}
     `;

--- a/src/components/accounts/inline-balance-editor.tsx
+++ b/src/components/accounts/inline-balance-editor.tsx
@@ -43,6 +43,14 @@ export function InlineBalanceEditor({
   const [saving, setSaving] = useState(false);
   const { privacyMode } = usePrivacyMode();
 
+  function resetEditor() {
+    setEditing(false);
+    setBalance("");
+    setNote("");
+    setError("");
+    setOccurredOn(localToday());
+  }
+
   function handleBalanceChange(e: React.ChangeEvent<HTMLInputElement>) {
     const next = maskAmountInput(e.target.value);
     if (next === null) return;
@@ -68,9 +76,7 @@ export function InlineBalanceEditor({
   async function handleSave() {
     const val = balance.replace(/,/g, "");
     if (val.trim() === "") {
-      setEditing(false);
-      setNote("");
-      setError("");
+      resetEditor();
       return;
     }
 
@@ -83,10 +89,7 @@ export function InlineBalanceEditor({
     setSaving(true);
     try {
       await onSave(parsed, note || undefined, occurredOn || undefined);
-      setEditing(false);
-      setBalance("");
-      setNote("");
-      setError("");
+      resetEditor();
     } catch {
       // onSave surfaces its own error toast; keep the editor open with the entered value.
     } finally {
@@ -125,15 +128,7 @@ export function InlineBalanceEditor({
           <Button size="sm" className="flex-1" onClick={handleSave} disabled={saving}>
             {saving ? "..." : "Save"}
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="flex-1"
-            onClick={() => {
-              setEditing(false);
-              setNote("");
-            }}
-          >
+          <Button size="sm" variant="outline" className="flex-1" onClick={resetEditor}>
             Cancel
           </Button>
         </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,30 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.1",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Account transaction history now pages in the same effective-date order it displays, so backdated cash rows stay in the correct chronological position while loading more history.",
+          "zh-TW":
+            "帳戶交易紀錄現在會依顯示用的有效日期分頁，載入更多紀錄時補登現金交易仍會維持正確的時間順序。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Canceling or closing the inline balance editor now clears the draft amount, note, validation message, and occurrence date so stale edits do not reappear the next time it opens.",
+          "zh-TW":
+            "取消或關閉內嵌餘額編輯器時，現在會清除草稿金額、備註、驗證訊息與發生日期，下次開啟不會再看到舊輸入。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.0",
     date: "2026-07-03",
     summary: {


### PR DESCRIPTION
### Motivation
- Backdated cash rows used `occurrenceDate` for display but pagination and keyset ordering still relied on `createdAt`, causing out-of-order items when loading more history. 
- The inline balance editor retained draft state (amount, note, validation, occurrence date) after cancel/blank save/close which could surface stale inputs later.
- Bump app version and document the two fixes in the changelog for a patch release.

### Description
- Update account transaction pagination to use an `effectiveAt` ordering (coalescing `occurrenceDate` → `createdAt`) and include it in the encoded cursor so keyset pagination orders by `effectiveAt`, then `createdAt`, then `id` (changes in `src/app/api/accounts/[id]/transactions/route.ts`).
- Add a `resetEditor()` helper to clear draft amount, note, validation and `occurredOn` on cancel, blank save, or successful save in the inline balance editor (changes in `src/components/accounts/inline-balance-editor.tsx`).
- Bump `package.json` version to `0.10.1` and add a `0.10.1` entry to `src/lib/changelog.ts` describing both fixes.

### Testing
- Ran formatting and lint/typecheck with `pnpm format:check`, `pnpm lint`, and `pnpm typecheck`, all succeeded. 
- Ran unit tests with `pnpm test:unit` (Vitest): `Test Files 17 passed (17)` and `Tests 145 passed (145)`. 
- Prettier auto-formatting was applied where needed and all checks passed after formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476a8dda4c8321af2b5bba6c4943e5)