### PR TITLE
fix(analysis): correct first-month cash-flow split and category-trend empty months (v0.10.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -193,12 +193,11 @@ export function AnalysisView({
     return buckets.map((b) => {
       const existing = byKey.get(b.monthKey);
       if (existing) return existing;
-      // Pad empty months with 0s for all categories to match the other charts' X-axis length
-      const empty: CategoryDataPoint & Record<string, number | string> = { monthKey: b.monthKey };
-      for (const acc of rawHistory.accounts) {
-        empty[acc.category] = 0;
-      }
-      return empty as CategoryDataPoint;
+      // Padded month with no snapshot: keep it on the axis (to match the other
+      // charts' X length) but emit only the monthKey — no category values. The
+      // chart reads an absent category as null so the stacked area breaks at the
+      // gap instead of plunging to zero (#511).
+      return { monthKey: b.monthKey } as CategoryDataPoint;
     });
   }, [filteredRawSnapshots, rawHistory.accounts, buckets]);
 

--- a/src/components/analysis/category-trend-chart.tsx
+++ b/src/components/analysis/category-trend-chart.tsx
@@ -45,7 +45,7 @@ interface Props {
 
 interface TooltipPayload {
   dataKey: string;
-  value: number;
+  value: number | null;
   color: string;
   name: string;
 }
@@ -66,8 +66,12 @@ function CategoryTooltip({
   totalLabel: string;
 }) {
   if (!active || !payload?.length) return null;
-  const sorted = [...payload].sort((a, b) => b.value - a.value);
-  const total = payload.reduce((s, p) => s + p.value, 0);
+  // Padded (no-snapshot) months carry null values; drop them so a hovered gap
+  // doesn't render NaN totals (#511).
+  const present = payload.filter((p): p is TooltipPayload & { value: number } => p.value != null);
+  if (present.length === 0) return null;
+  const sorted = [...present].sort((a, b) => b.value - a.value);
+  const total = present.reduce((s, p) => s + p.value, 0);
   return (
     <ChartTooltipContainer title={label} className="max-w-[200px]">
       {sorted.map((p) => (
@@ -124,7 +128,12 @@ export const CategoryTrendChart = memo(function CategoryTrendChart({
     const chartData = data.map((d) => ({
       monthKey: d.monthKey,
       label: formatMonthLabel(d.monthKey as string, locale),
-      ...Object.fromEntries(visibleCategories.map((cat) => [cat, Number(d[cat] ?? 0)])),
+      // Padded months carry no category values; emit null (not 0) so the
+      // stacked area breaks at the gap instead of plunging to zero (#511).
+      // A real category value of 0 is still a present number and stays 0.
+      ...Object.fromEntries(
+        visibleCategories.map((cat) => [cat, d[cat] == null ? null : Number(d[cat])]),
+      ),
     }));
     return { categories, visibleCategories, chartData };
   }, [data, locale]);
@@ -239,6 +248,7 @@ export const CategoryTrendChart = memo(function CategoryTrendChart({
                     stroke={CATEGORY_COLORS[idx % CATEGORY_COLORS.length]}
                     strokeWidth={1.5}
                     fill={`url(#cat-${idx})`}
+                    connectNulls={false}
                     activeDot={{ r: 4 }}
                     isAnimationActive={isAnimationActive}
                     onAnimationEnd={onAnimationEnd}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,30 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.1",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Analysis cash flow no longer misreads an account's opening deposit as a market loss: a deposit made in the same month as your first snapshot is no longer double-counted, so the first month's market performance and the Cumulative Growth chart stay accurate across the whole range.",
+          "zh-TW":
+            "分析頁的現金流不再把帳戶的初始存款誤判為市場虧損：與第一筆快照同月的存款不會再被重複計算，第一個月的市場績效與累積成長圖表在整個區間都能保持正確。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "The Analysis category trend area chart no longer plunges to zero at a trailing month with no snapshot; the stacked area now breaks at empty months instead.",
+          "zh-TW":
+            "分析頁的類別趨勢區域圖不會再在沒有快照的最後一個月驟降到零；堆疊區域現在會在空白月份中斷而非歸零。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.0",
     date: "2026-07-03",
     summary: {

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -430,16 +430,21 @@ export async function getAccountMonthlyCashFlow(
 
   const accountCurrencyMap = new Map(accounts.map((a) => [a.id, a.currency]));
 
-  // PE29 — floor the transaction scan to the first day (UTC) of the month
-  // containing the user's earliest snapshot. Months before the first snapshot
-  // are unreachable by the analysis UI: the axis buckets and attribution math
-  // are snapshot-derived (including the "All" range), so this floor changes no
-  // rendered output — it only avoids scanning/converting unreachable rows.
-  // The floor compares against the effective date (occurrenceDate ?? createdAt)
-  // so it matches the month-key bucketing below.
-  const floor = firstSnapshot
-    ? new Date(Date.UTC(firstSnapshot.date.getUTCFullYear(), firstSnapshot.date.getUTCMonth(), 1))
-    : null;
+  // #509 — floor the transaction scan to the user's earliest snapshot instant,
+  // exclusive. The first analysis bucket uses its own first snapshot as the
+  // start baseline (see aggregateMonthlyChange), so any cash already present in
+  // that snapshot — e.g. a same-month opening deposit — is baked into the
+  // baseline. Counting such a pre-snapshot flow as a contribution double-counts
+  // it: the first bucket then reports contributions ≈ the deposit and a phantom
+  // marketPerformance ≈ −deposit that buildCumulativeGrowth carries across the
+  // whole range. Flooring at the first snapshot's date with a strict `gt`
+  // aligns the contribution window with that baseline, so only flows that
+  // occurred AFTER the starting snapshot are attributed to the first bucket.
+  // (Months before the first snapshot are unreachable by the analysis UI, so
+  // this also preserves PE29's scan-narrowing intent.) The floor compares
+  // against the effective date (occurrenceDate ?? createdAt) to match the
+  // month-key bucketing below.
+  const floor = firstSnapshot ? firstSnapshot.date : null;
 
   const transactions = await prisma.cashTransaction.findMany({
     where: {
@@ -448,8 +453,8 @@ export async function getAccountMonthlyCashFlow(
       ...(floor
         ? {
             OR: [
-              { occurrenceDate: { gte: floor } },
-              { occurrenceDate: null, createdAt: { gte: floor } },
+              { occurrenceDate: { gt: floor } },
+              { occurrenceDate: null, createdAt: { gt: floor } },
             ],
           }
         : {}),

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -56,7 +56,34 @@ vi.mock("@/lib/prisma", () => ({
         return h.latestSnapshot;
       }),
     },
-    cashTransaction: { findMany: vi.fn(async () => h.cashTransactions) },
+    cashTransaction: {
+      findMany: vi.fn(async (args?: { where?: { OR?: Array<Record<string, unknown>> } }) => {
+        const or = args?.where?.OR;
+        if (!or) return h.cashTransactions;
+        // Faithfully apply the first-snapshot floor OR clause so tests that
+        // depend on which rows survive the DB filter (e.g. #509) exercise the
+        // real query semantics instead of ignoring `where`.
+        const cmp = (op: string, a: Date, b: Date) =>
+          op === "gt" ? a.getTime() > b.getTime() : a.getTime() >= b.getTime();
+        return h.cashTransactions.filter((tx) =>
+          or.some((branch) => {
+            const occ = branch.occurrenceDate as Record<string, Date> | null | undefined;
+            if (occ && typeof occ === "object") {
+              if (tx.occurrenceDate == null) return false;
+              const [op, floor] = Object.entries(occ)[0];
+              return cmp(op, tx.occurrenceDate, floor);
+            }
+            if (occ === null) {
+              if (tx.occurrenceDate != null) return false;
+              const created = branch.createdAt as Record<string, Date>;
+              const [op, floor] = Object.entries(created)[0];
+              return cmp(op, tx.createdAt, floor);
+            }
+            return false;
+          }),
+        );
+      }),
+    },
     priceCache: { findMany: vi.fn(async () => h.prices) },
   },
 }));
@@ -67,10 +94,13 @@ vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
 
 const {
   getAccountMonthlyCashFlow,
+  getMonthlyCashFlow,
   getCurrentYearNormalizedHistory,
   getFullNormalizedHistory,
   getSnapshotReconciliationWarning,
 } = await import("@/lib/services/history-service");
+const { aggregateMonthlyChange, fillMonthRange, buildCashFlowBuckets, buildCumulativeGrowth } =
+  await import("@/lib/services/analysis-service");
 const { prisma } = await import("@/lib/prisma");
 
 function row(
@@ -293,7 +323,7 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     expect(result).toEqual([{ accountId: "acc", monthKey: "2026-06", contributions: 60 }]);
   });
 
-  it("applies the first-snapshot floor to the effective date (occurrenceDate ?? createdAt)", async () => {
+  it("floors the effective date to the first snapshot instant, exclusive (#509)", async () => {
     h.accounts = [account()];
     h.latestSnapshot = row({ id: "first", date: new Date("2026-03-05T00:00:00.000Z") });
 
@@ -302,14 +332,65 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     const args = vi.mocked(prisma.cashTransaction.findMany).mock.lastCall?.[0] as {
       where: Record<string, unknown>;
     };
-    const floor = new Date(Date.UTC(2026, 2, 1));
+    // The floor is the first snapshot's date with a strict `gt`: flows on/before
+    // the first snapshot are already baked into the first bucket's baseline, so
+    // counting them as contributions double-counts the opening deposit (#509).
+    const floor = new Date("2026-03-05T00:00:00.000Z");
     expect(args.where.OR).toEqual([
-      { occurrenceDate: { gte: floor } },
-      { occurrenceDate: null, createdAt: { gte: floor } },
+      { occurrenceDate: { gt: floor } },
+      { occurrenceDate: null, createdAt: { gt: floor } },
     ]);
     // The accountId/type conditions stay ANDed alongside the floor OR.
     expect(args.where.accountId).toEqual({ in: ["acc"] });
     expect(args.where.type).toEqual({ in: ["DEPOSIT", "WITHDRAWAL"] });
+  });
+
+  it("keeps an opening deposit out of the first bucket's contributions (#509)", async () => {
+    // Account opened with a $100k deposit on Mar 10; the first snapshot on
+    // Mar 15 already reflects it (netWorth $100k). The market then earns $1k by
+    // April. The opening deposit must NOT be attributed to March as a
+    // contribution — otherwise marketPerformance shows a phantom −$100k loss
+    // that buildCumulativeGrowth carries across the whole range.
+    h.accounts = [account()];
+    h.latestSnapshot = row({ id: "first", date: new Date("2026-03-15T00:00:00.000Z") });
+    h.cashTransactions = [
+      cashTx({
+        amount: 100_000,
+        type: "DEPOSIT",
+        occurrenceDate: new Date("2026-03-10T00:00:00.000Z"),
+        createdAt: new Date("2026-03-10T00:00:00.000Z"),
+      }),
+    ];
+
+    const contributions = await getMonthlyCashFlow("u1", "USD");
+    // No contribution should survive: the only flow predates the first snapshot.
+    expect(contributions).toEqual([]);
+
+    const nSnap = (date: string, netWorth: number) => ({
+      id: date,
+      date,
+      createdAt: `${date}T00:00:00.000Z`,
+      netWorth,
+      totalAssets: netWorth,
+      totalLiabilities: 0,
+      baseCurrency: "USD",
+      label: null,
+      note: null,
+    });
+    const snapshots = [nSnap("2026-03-15", 100_000), nSnap("2026-04-15", 101_000)];
+    const buckets = fillMonthRange(
+      aggregateMonthlyChange(snapshots),
+      new Date(Date.UTC(2026, 2, 1)),
+      new Date(Date.UTC(2026, 3, 1)),
+    );
+    const cashFlow = buildCashFlowBuckets(buckets, contributions, "en-US");
+    const cumulative = buildCumulativeGrowth(cashFlow);
+
+    // First bucket: no fake market loss.
+    expect(cashFlow[0].contributions).toBe(0);
+    expect(cashFlow[0].marketPerformance).toBeCloseTo(0);
+    // Cumulative market reflects the real +$1k gain, not −$99k.
+    expect(cumulative.at(-1)!.cumulativeMarket).toBeCloseTo(1_000);
   });
 
   it("omits the floor filter entirely when the user has no snapshots", async () => {


### PR DESCRIPTION
Two user-facing Analysis bug fixes found in the site audit of master @ v0.10.0. Both are PATCH-level → released as **v0.10.1**.

## #509 — First-month cash flow permanently mis-split for opening deposits

**Problem.** The first analysis bucket uses its own first snapshot as the start baseline (`aggregateMonthlyChange`: the earliest bucket has no prior month, so `startNetWorth = group.first.netWorth`). Anything already in that snapshot — e.g. a same-month opening deposit — is therefore part of the baseline. But `getAccountMonthlyCashFlow` floored the transaction scan to the **first of the month**, so that same deposit was *also* counted as a contribution. Net effect for an account opened with $100k (snapshots $100k → $101k): the first month showed `contributions = +$100k`, `marketPerformance ≈ −$100k`, and `buildCumulativeGrowth` carried that phantom market loss across the entire range forever.

**Fix.** Root-cause option (a): align the contribution window start with the first bucket's baseline. `getAccountMonthlyCashFlow`'s floor is now the **first snapshot's date with a strict `gt`** (was first-of-month `gte`), so only flows that occurred *after* the starting snapshot are attributed to the first bucket.

Why (a) over (b): it restores the invariant `marketPerformance = deltaNetWorth − (net cash within [startSnapshot, endSnapshot])` at the single source that both the aggregate cash-flow view and per-account attribution read, so both are fixed consistently with one change. It does **not** double-shift later months — their start baseline is the prior month's last snapshot, which precedes every flow in the month, so all their flows already fall after it. The occurrenceDate bucketing from #499 and PE29's scan-narrowing intent are both preserved (months before the first snapshot remain unreachable by the UI).

**Test.** `tests/unit/history-service.test.ts` gains a scenario test (opening $100k deposit dated the same month as, and before, the first snapshot; market then earns $1k) asserting the first bucket's `marketPerformance ≈ 0` and cumulative market ends at the real `+$1k`, not `−$99k`. The shared `cashTransaction.findMany` mock now faithfully applies the floor `OR` clause so the test exercises real query semantics. The existing floor test is updated to lock the new `gt firstSnapshot.date` window. Both genuinely **failed before** the service change and **pass after**.

## #511 — Category Trend area chart plunges to zero at trailing padded month

**Problem.** `CategoryDataPoint` carries no emptiness signal, and `analysis-view` zero-filled padded (no-snapshot) months, so `category-trend-chart` mapped them with `Number(d[cat] ?? 0)` and the stacked `<Area>` collapsed to 0 at e.g. a trailing Jul 2026. The assets-vs-liabilities chart got a null-break fix in #481; this one kept `?? 0`.

**Fix.** Mirror the assets-vs-liabilities approach. Padded months now carry **only their `monthKey`** (no category values); the chart emits `null` for any absent category and sets `connectNulls={false}` on each `<Area>`, so the area breaks at gaps instead of plunging. A real category value of 0 is still a present number and stays 0. The tooltip drops null series so a hovered gap can't render NaN totals. No stacking/color changes; `aggregateCategoryHistory`'s return shape and `CategoryDataPoint` are unchanged.

**Test.** Covered by existing `aggregateCategoryHistory` unit tests (return shape unchanged); the padding/null behavior lives in the client chart + view.

## Verification

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (146 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS