### PR TITLE
fix(cache): tag net-worth read with prices and analysis payload with exchange-rates (v0.10.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,30 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.2",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Dashboard net worth now updates immediately after a price refresh: the cached net-worth read is tagged with prices, so refreshing a watchlist stock you also hold no longer leaves the dashboard showing the old valuation.",
+          "zh-TW":
+            "刷新價格後，儀表板的淨值現在會立即更新：淨值的快取讀取已加上價格標籤，因此刷新你同時持有的追蹤股票後，儀表板不會再顯示舊的估值。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "The Analysis page no longer disagrees with the dashboard after an exchange-rate refresh: its bundled reads are now tagged with exchange-rates, so an FX refresh invalidates them instead of serving stale figures for up to five minutes.",
+          "zh-TW":
+            "匯率刷新後，分析頁不會再與儀表板數字不一致：其彙整的讀取已加上匯率標籤，因此匯率刷新會立即使其失效，而不會在最多五分鐘內顯示過期的數字。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.1",
     date: "2026-07-03",
     changes: [

--- a/src/lib/services/analysis-payload-service.ts
+++ b/src/lib/services/analysis-payload-service.ts
@@ -37,7 +37,9 @@ export async function getCachedAnalysisPayload(
     ["analysis-payload", userId, baseCurrency],
     {
       revalidate: 300,
-      tags: ["net-worth", "snapshots", `history:${userId}`, `accounts:${userId}`],
+      // All four bundled reads convert at current FX (getAllExchangeRates +
+      // resolveRate), so an FX refresh must be able to invalidate this composite.
+      tags: ["net-worth", "snapshots", "exchange-rates", `history:${userId}`, `accounts:${userId}`],
     },
   )();
 }

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -220,6 +220,9 @@ async function getCachedNetWorthSummaryInner(
   cacheTag("net-worth");
   cacheTag(`net-worth:${userId}`);
   cacheTag("exchange-rates");
+  // computeNetWorthSummary reads PriceCache, so a price-only refresh
+  // (watchlist stock, holdings write, cron) must be able to invalidate it.
+  cacheTag("prices");
   cacheLife("hours");
   return computeNetWorthSummary(userId, baseCurrency);
 }

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -158,6 +158,24 @@ describe("getCachedNetWorthSummary (two-pass valuation)", () => {
     expect(h.tags).toContain("exchange-rates");
   });
 
+  it("tags the cached read with prices so a stock-only price refresh invalidates it", async () => {
+    h.tags = [];
+    h.rates = new Map([["USD_TWD", 30]]);
+    h.prices = [{ symbol: "AAPL", price: 200, currency: "USD" }];
+    h.accounts = [
+      account({
+        id: "A",
+        type: "ASSET",
+        currency: "USD",
+        holdings: [holding({ id: "h1", symbol: "AAPL", quantity: 1, currency: "USD" })],
+      }),
+    ];
+
+    await getCachedNetWorthSummary("u1", "USD");
+
+    expect(h.tags).toContain("prices");
+  });
+
   it("falls back to rate 1 and warns for an unresolvable currency", async () => {
     h.warnings = [];
     h.rates = new Map([["USD_TWD", 30]]); // no EUR path


### PR DESCRIPTION
Two missing cache-tag bugs that let reads serve stale/inconsistent numbers: a mutation revalidated a tag that the read never declared, so the read stayed cached.

Both additions are **read-side dependencies** — they only let more (relevant) mutations bust the cache; they cannot produce incorrect data, at worst a slightly earlier recompute. `prices` / `exchange-rates` are revalidated only on genuine price/FX changes (throttled manual refresh via `/api/refresh`, daily cron, and account/holding writes that actually change the data), not on every unrelated mutation, so the caches are not effectively disabled.

## Fixes #512 — Dashboard net worth stale after a stock-only price refresh

**Problem:** `getCachedNetWorthSummaryInner` (`net-worth-service.ts`) reads `prisma.priceCache` (in `computeNetWorthSummary`) but was tagged only `net-worth` / `net-worth:${userId}` / `exchange-rates`. A price-only refresh calls `revalidateTag("prices")` and never touched this read, so a symbol you both hold and watch kept its old valuation for up to the `"hours"` cacheLife.

**Fix:** Add `cacheTag("prices")` (mirrors `getCachedTrackedStocks` in `stock-watch-service.ts`, which tags `prices` for the same reason).

**Mutation routes that now correctly bust this cache:** `stock-watch-service.ts` (watchlist refresh), `api/accounts/[id]/holdings` (holdings write), `api/refresh`, `api/cron/snapshot`, `price-service.ts` — all call `revalidateTag("prices")`.

## Fixes #513 — /analysis disagrees with dashboard after an FX refresh

**Problem:** `getCachedAnalysisPayload` (`analysis-payload-service.ts`) is an `unstable_cache` whose four bundled reads (`getFullNormalizedHistory`, `getMonthlyCashFlow`, `getRawHistoryWithBreakdown`, `getAccountMonthlyCashFlow`) all convert at current FX via `getAllExchangeRates` + `resolveRate`, but its `tags` omitted `exchange-rates`. `revalidateTag("exchange-rates")` missed the composite, so it served stale figures until the 300s `revalidate` TTL.

**Fix:** Add `"exchange-rates"` to the `tags` array.

**Mutation routes that now correctly bust this cache:** `api/settings` + `api/settings/data` (base-currency / settings save), `api/refresh`, `api/accounts`, `api/accounts/[id]/holdings`, `api/cron/snapshot` — all call `revalidateTag("exchange-rates")`.

## Tests

The repo already has a tag-coverage pattern in `tests/unit/net-worth-service.test.ts` (a `next/cache` mock captures `cacheTag` calls into `h.tags`, with an existing assertion for `exchange-rates`). Added a parallel test asserting the read is now tagged `prices`. #513 is verified by reading — `unstable_cache` tag arrays aren't exercised by the mocked suite, and the change is a one-line tag addition covered by the mutation routes listed above.

`pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` — all pass (147 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS