### PR TITLE
fix(goals): cap unbounded goal ETA projections to avoid RangeError crash (v0.10.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,21 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.3",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            'The Goals page no longer errors out when a goal\'s trend is nearly flat against a large remaining gap: the projected "at current pace" date could run millions of years into the future and crash the page, so such out-of-range estimates are now simply omitted.',
+          "zh-TW":
+            "當某個目標的趨勢近乎持平、但距離目標金額仍差距很大時，目標頁面不會再發生錯誤：先前「依目前速度」的預估日期可能推算到數百萬年後而導致頁面崩潰，現在這類超出合理範圍的預估會直接略過不顯示。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.2",
     date: "2026-07-03",
     changes: [

--- a/src/lib/services/goal-service.ts
+++ b/src/lib/services/goal-service.ts
@@ -44,6 +44,28 @@ function getCurrentAmount(goal: SerializedGoal, summary: NetWorthSummary): numbe
 
 type SnapshotRow = { date: string; netWorth: number; totalAssets: number };
 
+// Cap ETA projections at ~100 years. A near-flat trend against a large
+// remaining gap can make `daysToGoal` astronomically large — well beyond the
+// JS Date range (±100,000,000 days from epoch) — so `Date.setDate()` would
+// yield an Invalid Date and the subsequent `.toISOString()` throws a
+// RangeError, 500ing /goals. Anything past this horizon is meaningless as a
+// forecast anyway, so we return the existing "no projection" sentinel (null).
+const MAX_PROJECTION_DAYS = 100 * 365;
+
+/**
+ * Project a date `daysFromToday` days into the future, returning `null` when
+ * the horizon is not a sane, finite, in-range number of days. Shared by both
+ * the linear and CAGR branches so the overflow guard can't drift between them.
+ */
+function projectDate(today: Date, daysFromToday: number): string | null {
+  if (!Number.isFinite(daysFromToday) || daysFromToday < 0 || daysFromToday > MAX_PROJECTION_DAYS) {
+    return null;
+  }
+  const projected = new Date(today);
+  projected.setDate(projected.getDate() + Math.ceil(daysFromToday));
+  return projected.toISOString();
+}
+
 /**
  * Cached 90-day snapshot window backing the goal projections. Was the only
  * uncached read on the dashboard's goals section; the cron / data import
@@ -108,9 +130,7 @@ function computeProjection(
   const dailyChange = (lastValue - firstValue) / daysDiff;
   if (dailyChange > 0) {
     const daysToGoal = (targetAmountInBase - currentAmount) / dailyChange;
-    const projected = new Date(today);
-    projected.setDate(projected.getDate() + Math.ceil(daysToGoal));
-    linearDate = projected.toISOString();
+    linearDate = projectDate(today, daysToGoal);
   }
 
   if (firstValue > 0 && lastValue > firstValue) {
@@ -118,9 +138,7 @@ function computeProjection(
     if (annualRate > 0 && currentAmount > 0) {
       const daysToGoal =
         (365 * Math.log(targetAmountInBase / currentAmount)) / Math.log(1 + annualRate);
-      const projected = new Date(today);
-      projected.setDate(projected.getDate() + Math.ceil(daysToGoal));
-      cagrDate = projected.toISOString();
+      cagrDate = projectDate(today, daysToGoal);
     }
   }
 

--- a/tests/unit/goal-service.test.ts
+++ b/tests/unit/goal-service.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NetWorthSummary } from "@/lib/types";
+
+// Shared fixtures, hoisted so the vi.mock factories (themselves hoisted above
+// imports) can close over them.
+interface GoalFixture {
+  id: string;
+  userId: string;
+  name: string;
+  targetAmount: number;
+  targetCurrency: string;
+  targetDate: Date | null;
+  scope: "NET_WORTH" | "ASSETS_ONLY" | "CATEGORY" | "ACCOUNT";
+  scopeRefId: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+interface SnapshotFixture {
+  date: Date;
+  netWorth: number;
+  totalAssets: number;
+}
+const h = vi.hoisted(() => ({
+  goals: [] as GoalFixture[],
+  snapshots: [] as SnapshotFixture[],
+  summary: null as NetWorthSummary | null,
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, cache: <T>(fn: T): T => fn };
+});
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    goal: { findMany: vi.fn(async () => h.goals) },
+    netWorthSnapshot: {
+      findMany: vi.fn(async () =>
+        h.snapshots.map((s) => ({
+          date: s.date,
+          netWorth: s.netWorth,
+          totalAssets: s.totalAssets,
+        })),
+      ),
+    },
+  },
+}));
+vi.mock("@/lib/services/net-worth-service", () => ({
+  getCachedNetWorthSummary: vi.fn(async () => h.summary),
+}));
+// Keep resolveRate real (identity path returns 1 for same-currency); only stub
+// the bulk loader so no DB/network is hit.
+vi.mock("@/lib/services/exchange-rate-service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getAllExchangeRates: vi.fn(async () => new Map<string, number>()) };
+});
+
+import { computeGoalsWithProgress } from "@/lib/services/goal-service";
+
+function makeGoal(overrides: Partial<GoalFixture> = {}): GoalFixture {
+  return {
+    id: "g1",
+    userId: "u1",
+    name: "Test goal",
+    targetAmount: 10_000_000,
+    targetCurrency: "USD",
+    targetDate: null,
+    scope: "NET_WORTH",
+    scopeRefId: null,
+    sortOrder: 0,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeSummary(netWorth: number): NetWorthSummary {
+  return {
+    totalAssets: netWorth,
+    totalLiabilities: 0,
+    netWorth,
+    baseCurrency: "USD",
+    currencyExposure: [],
+    accounts: [],
+  };
+}
+
+describe("computeGoalsWithProgress projection bounds", () => {
+  beforeEach(() => {
+    h.goals = [];
+    h.snapshots = [];
+    h.summary = null;
+  });
+
+  it("returns null linear projection (does not throw RangeError) for a near-flat trend against a huge gap", async () => {
+    // +$1 over a 90-day window → dailyChange ≈ 0.011/day; a ~$10M remaining gap
+    // makes daysToGoal ≈ 9e8 days, beyond the JS Date range. Pre-fix this
+    // 500'd via `.toISOString()` on an Invalid Date.
+    h.goals = [makeGoal({ targetAmount: 10_000_000 })];
+    h.summary = makeSummary(2); // currentAmount = 2, target = 10M
+    h.snapshots = [
+      { date: new Date("2026-04-04T00:00:00.000Z"), netWorth: 1, totalAssets: 1 },
+      { date: new Date("2026-07-03T00:00:00.000Z"), netWorth: 2, totalAssets: 2 },
+    ];
+
+    let result: Awaited<ReturnType<typeof computeGoalsWithProgress>>;
+    await expect(
+      (async () => {
+        result = await computeGoalsWithProgress("u1", "USD");
+      })(),
+    ).resolves.not.toThrow();
+
+    expect(result![0].projectedDateLinear).toBeNull();
+  });
+
+  it("returns a valid ISO date for a reasonable trend (happy path unchanged)", async () => {
+    // +$10k over 90 days → ~$111/day; a $90k gap → ~810 days, well in range.
+    h.goals = [makeGoal({ targetAmount: 200_000 })];
+    h.summary = makeSummary(110_000);
+    h.snapshots = [
+      { date: new Date("2026-04-04T00:00:00.000Z"), netWorth: 100_000, totalAssets: 100_000 },
+      { date: new Date("2026-07-03T00:00:00.000Z"), netWorth: 110_000, totalAssets: 110_000 },
+    ];
+
+    const result = await computeGoalsWithProgress("u1", "USD");
+    const linear = result[0].projectedDateLinear;
+    expect(linear).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(Number.isNaN(Date.parse(linear!))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
`/goals` can 500 with `RangeError: Invalid time value`. Goal ETA projections were unbounded: both the linear and CAGR branches computed a date via `new Date(today); setDate(+ Math.ceil(daysToGoal)); toISOString()`. When the recent trend is near-flat (tiny `dailyChange` / `annualRate` just above 0) against a large remaining gap, `daysToGoal` becomes astronomically large — beyond the JS Date range (±100,000,000 days from epoch). `setDate` then produces an Invalid Date and `.toISOString()` throws. The error propagated out of `computeGoalsWithProgress` and 500'd the whole `/goals` page (and the dashboard goals card). Fixes #510.

## Repro
A goal whose 90-day snapshot window moves only +$1 (`dailyChange ≈ 0.011/day`) against a ~$10M remaining gap → `daysToGoal ≈ 9e8` days → `toISOString()` throws. Captured as a unit test.

## Fix
Extracted a shared `projectDate(today, daysFromToday): string | null` helper reused by both the linear and CAGR branches (so the guard can't drift between them). It returns `null` — the existing "no projection" sentinel both branches already initialize to — when `daysFromToday` is non-finite, negative, or exceeds `MAX_PROJECTION_DAYS` (100 years / 36500 days).

**Chosen bound rationale:** 100 years sits comfortably inside the Date range, and any ETA past a century is meaningless as a forecast anyway. Reasonable projections are unchanged byte-for-byte; only the overflow/absurd case flips from crash → `null`.

**Graceful degradation:** `null` is already what the UI expects. `goal-card.tsx` renders the "At current pace" / CAGR lines only when the formatted label is truthy (`!isCompleted && linearLabel && …`), so an out-of-range estimate is simply omitted rather than shown.

## Test
Added `tests/unit/goal-service.test.ts` (mirrors sibling service specs: mocks `@/lib/prisma`, `getCachedNetWorthSummary`, and `getAllExchangeRates`, keeps `resolveRate` real):
- Near-flat-trend scenario now resolves with `projectedDateLinear === null` and does not throw (confirmed it threw `RangeError` at `goal-service.ts:113` against the pre-fix source).
- A normal trend still returns a valid ISO date (happy path unchanged).

`pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` all pass (149 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS