### PR TITLE
fix(prices): normalize GBp/ZAc pence quotes to major currency at ingest (v0.10.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,21 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.4",
+    date: "2026-07-03",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "London- and Johannesburg-listed holdings quoted in pence/cents (e.g. `.L` and `.JO` symbols) are now converted to pounds/rand, fixing a roughly 100x overstatement of their value.",
+          "zh-TW":
+            "以便士／分計價的倫敦及約翰尼斯堡上市持股（例如 `.L` 與 `.JO` 代號）現在會換算為英鎊／南非蘭特，修正先前約 100 倍的價值高估問題。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.3",
     date: "2026-07-03",
     changes: [

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -93,6 +93,38 @@ const COINGECKO_IDS: Record<string, string> = {
   APT: "aptos",
 };
 
+// Some exchanges are quoted by Yahoo in a currency's *minor* unit rather than
+// its major ISO unit: London (`.L`) trades in pence tagged "GBp" and
+// Johannesburg (`.JO`) in cents tagged "ZAc" — each 1/100 of the major unit.
+// Stored verbatim, a £0.70 share (7000 "GBp") is later valued as if it were
+// £70 (100x overstatement) because no FX provider carries a "GBp"/"ZAc" rate.
+// Normalize such quotes to the major unit + ISO code at the single ingest
+// chokepoint so every downstream consumer (net worth, analysis, watchlist)
+// sees a consistent major-unit price.
+//
+// Case sensitivity matters: "GBp" (minor) and "GBP" (major) differ only by
+// case, so a naive lowercase compare would collapse them. We therefore match
+// the pence/cent tokens exactly (case-sensitive), and only the unambiguous
+// X-suffixed variants (GBX/ZAX — no major currency uses them) case-insensitively.
+const MINOR_UNIT_TO_MAJOR: Record<string, string> = {
+  GBp: "GBP",
+  ZAc: "ZAR",
+};
+
+export function normalizeMinorCurrencyQuote(
+  price: number,
+  currency: string,
+): { price: number; currency: string } {
+  let major = MINOR_UNIT_TO_MAJOR[currency];
+  if (!major) {
+    const upper = currency.toUpperCase();
+    if (upper === "GBX") major = "GBP";
+    else if (upper === "ZAX") major = "ZAR";
+  }
+  if (!major) return { price, currency };
+  return { price: price / 100, currency: major };
+}
+
 async function fetchYahooQuotes(
   symbols: string[],
 ): Promise<Map<string, { price: number; currency: string }>> {
@@ -112,10 +144,10 @@ async function fetchYahooQuotes(
     );
     for (const q of Array.isArray(quotes) ? quotes : [quotes]) {
       if (q?.regularMarketPrice && q.symbol) {
-        results.set(q.symbol, {
-          price: q.regularMarketPrice,
-          currency: q.currency || "USD",
-        });
+        results.set(
+          q.symbol,
+          normalizeMinorCurrencyQuote(q.regularMarketPrice, q.currency || "USD"),
+        );
       }
     }
   };

--- a/src/lib/services/stock-watch-service.ts
+++ b/src/lib/services/stock-watch-service.ts
@@ -1,7 +1,10 @@
 import "server-only";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { refreshPricesForStockSymbols } from "@/lib/services/price-service";
+import {
+  normalizeMinorCurrencyQuote,
+  refreshPricesForStockSymbols,
+} from "@/lib/services/price-service";
 import { getYahooClient } from "@/lib/services/yahoo-client";
 import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log } from "@/lib/logger";
@@ -129,12 +132,20 @@ export async function fetchEquityQuote(symbol: string): Promise<{
     return null;
   }
 
+  // Normalize minor-unit quotes (LSE pence "GBp", JSE cents "ZAc") to the major
+  // ISO unit so both the PriceCache write in warmStockPrice and the watch item's
+  // stored currency stay consistent with the holdings pipeline.
+  const { price, currency } = normalizeMinorCurrencyQuote(
+    quote.regularMarketPrice,
+    quote.currency || "USD",
+  );
+
   return {
     symbol: quote.symbol || normalized,
     name: quote.longName || quote.shortName || normalized,
     exchange: quote.fullExchangeName || quote.exchange || "",
-    currency: quote.currency || "USD",
-    price: quote.regularMarketPrice,
+    currency,
+    price,
   };
 }
 

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -21,8 +21,76 @@ vi.mock("next/cache", () => ({
 
 const { prisma } = await import("@/lib/prisma");
 const { getYahooClient } = await import("@/lib/services/yahoo-client");
-const { refreshPricesForStockSymbols } = await import("@/lib/services/price-service");
+const { refreshPricesForStockSymbols, normalizeMinorCurrencyQuote } =
+  await import("@/lib/services/price-service");
 const { PRICE_REFRESH_TTL_MS } = await import("@/lib/refresh-policy");
+
+describe("normalizeMinorCurrencyQuote — minor-unit (pence/cents) normalization", () => {
+  it("converts a London GBp (pence) quote to major GBP", () => {
+    // Yahoo quotes .L symbols in pence tagged "GBp": 7000p = £70.00
+    expect(normalizeMinorCurrencyQuote(7000, "GBp")).toEqual({ price: 70, currency: "GBP" });
+  });
+
+  it("converts a GBX quote identically to GBp", () => {
+    expect(normalizeMinorCurrencyQuote(7000, "GBX")).toEqual({ price: 70, currency: "GBP" });
+    // Lowercase X variant is unambiguous too
+    expect(normalizeMinorCurrencyQuote(7000, "GBx")).toEqual({ price: 70, currency: "GBP" });
+  });
+
+  it("converts a Johannesburg ZAc (cents) quote to major ZAR", () => {
+    // 1500c = R15.00
+    expect(normalizeMinorCurrencyQuote(1500, "ZAc")).toEqual({ price: 15, currency: "ZAR" });
+    expect(normalizeMinorCurrencyQuote(1500, "ZAX")).toEqual({ price: 15, currency: "ZAR" });
+  });
+
+  it("passes a major GBP quote through untouched (guards the GBp/GBP collision)", () => {
+    // "GBP" (all-caps, major) must NOT be divided by 100
+    expect(normalizeMinorCurrencyQuote(70, "GBP")).toEqual({ price: 70, currency: "GBP" });
+  });
+
+  it("passes a USD quote through unchanged", () => {
+    expect(normalizeMinorCurrencyQuote(123.45, "USD")).toEqual({
+      price: 123.45,
+      currency: "USD",
+    });
+  });
+});
+
+describe("fetchYahooQuotes — persists normalized minor-unit quotes to PriceCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores a London GBp quote of 7000 as 70 GBP in the upsert params", async () => {
+    // AAPL-style existence/fresh gate: LSE.L exists and is stale so it is fetched
+    const staleDate = new Date(Date.now() - PRICE_REFRESH_TTL_MS - 5_000);
+    vi.mocked(prisma.priceCache.findMany)
+      .mockResolvedValueOnce([{ symbol: "VOD.L", updatedAt: staleDate }] as never)
+      // currentRows lookup before the upsert
+      .mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce([{ symbol: "VOD.L" }]);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi
+        .fn()
+        .mockResolvedValue([{ symbol: "VOD.L", regularMarketPrice: 7000, currency: "GBp" }]),
+    } as never);
+    vi.mocked(prisma.$executeRawUnsafe).mockResolvedValue(1 as never);
+
+    const result = await refreshPricesForStockSymbols(["VOD.L"]);
+    expect(result.updated).toBe(1);
+
+    const upsertCall = vi
+      .mocked(prisma.$executeRawUnsafe)
+      .mock.calls.find(([sql]) => typeof sql === "string" && /INSERT INTO "PriceCache"/i.test(sql));
+    expect(upsertCall).toBeDefined();
+    // Params are [symbol, price(string), currency, ...] per row
+    const params = upsertCall!.slice(1);
+    expect(params).toContain("70"); // 7000 / 100, stringified
+    expect(params).toContain("GBP"); // GBp normalized to major ISO code
+    expect(params).not.toContain("GBp");
+    expect(params).not.toContain("7000");
+  });
+});
 
 describe("refreshPricesForStockSymbols — claim deduplication", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Problem

Yahoo Finance quotes London Stock Exchange (`.L`) symbols in **pence** with currency code `"GBp"` (and Johannesburg `.JO` in **cents** as `"ZAc"`) — each 1/100 of the major ISO unit. `fetchYahooQuotes` stored these verbatim in `PriceCache`, so a £0.70 share (`7000 "GBp"`) was later valued as if it were **£70**:

- `search/route.ts` infers the holding currency as `"GBP"`.
- `net-worth-service.ts` multiplies the pence figure by the GBP→base rate → a **~100x overstatement** (a £0.70 share shows as ~$95).
- No FX provider carries a `"GBp"`/`"ZAc"` rate, so `resolveRate` returns undefined and even the fallback path is wrong.

Only bites users holding `.L` / `.JO` symbols. Fixes #508.

## Affected consumers (now correct)

Normalizing at ingest means every downstream reader of `PriceCache` is fixed for free: net worth, analysis, dashboard, and the stock watchlist.

## Fix

A pure helper `normalizeMinorCurrencyQuote(price, currency)` divides the price by 100 and maps the code to its major ISO unit (`GBp`/`GBX` → `GBP`, `ZAc`/`ZAX` → `ZAR`); everything else — including major-unit `GBP`/`ZAR` — passes through untouched.

The **GBp-vs-GBP collision** is handled by matching the pence/cent tokens **case-sensitively** and only the unambiguous `X`-suffixed variants case-insensitively, so a naive lowercase compare never collapses `GBp` into `GBP`.

Applied at the two ingest chokepoints where a raw Yahoo `(price, currency)` pair is persisted to `PriceCache`:
- `fetchYahooQuotes` (price-service) — covers all holdings and the stock-watchlist refresh, which shares this path.
- `fetchEquityQuote` (stock-watch-service) — covers `warmStockPrice`'s direct `PriceCache` write and the watch item's stored `currency`.

Out of scope by design: user-entered `recordPrice`, `search/route.ts` currency inference, and `resolveRate` are all unchanged (`GBP` is correct once the price is in pounds).

## Tests

`tests/unit/price-service.test.ts`:
- Helper: `GBp` 7000 → 70 `GBP`; `GBX`/`GBx` identical; `ZAc`/`ZAX` 1500 → 15 `ZAR`; major `GBP` 70 passes through (guards the collision); `USD` unchanged.
- Integration through `refreshPricesForStockSymbols`: a `GBp` 7000 quote is persisted to the `PriceCache` upsert as `70` / `GBP` (asserts the params contain `70`/`GBP` and **not** `7000`/`GBp`). Fails before the fix (stored `7000`/`GBp`), passes after.

`pnpm format:check`, `lint`, `typecheck`, and `test:unit` (155 tests) all pass.

## Release

PATCH → `0.10.4` (correctness fix), bilingual `fixed` changelog entry + `package.json` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS