### PR TITLE
fix(analysis,projections): read UTC-constructed dates with UTC getters (v0.10.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -72,8 +72,11 @@ function pickDefaultRange(snapshots: NormalizedSnapshot[]): RangeLabel {
   if (snapshots.length === 0) return "YTD";
   const first = new Date(snapshots[0].date);
   const now = new Date();
+  // `first` is a snapshot date parsed from a UTC "YYYY-MM-DD" string (UTC-midnight),
+  // so read its month with UTC getters to match how snapshots are bucketed
+  // everywhere else; `now` is a genuine local instant (the user's current month).
   const historyMonths =
-    (now.getFullYear() - first.getFullYear()) * 12 + now.getMonth() - first.getMonth() + 1;
+    (now.getFullYear() - first.getUTCFullYear()) * 12 + now.getMonth() - first.getUTCMonth() + 1;
   if (historyMonths <= 6) return "All";
   if (now.getMonth() < 3) return "6M"; // Jan–Mar: YTD would be a thin 1–3 month slice
   return "YTD";
@@ -147,7 +150,14 @@ export function AnalysisView({
 
     if (selected.months === Infinity) {
       const firstDate = snapshots.length > 0 ? new Date(snapshots[0].date) : now;
-      const rangeStart = new Date(Date.UTC(firstDate.getFullYear(), firstDate.getMonth(), 1));
+      // firstDate from a snapshot is UTC-midnight; use UTC getters so the range
+      // starts on its UTC month (matching the snapshot buckets) rather than a
+      // phantom prior month west of UTC. The `now` fallback is a local instant,
+      // but with no snapshots the range is unused.
+      const rangeStart =
+        snapshots.length > 0
+          ? new Date(Date.UTC(firstDate.getUTCFullYear(), firstDate.getUTCMonth(), 1))
+          : new Date(Date.UTC(firstDate.getFullYear(), firstDate.getMonth(), 1));
       return {
         filteredSnapshots: snapshots,
         rangeStart,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,30 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.10.5",
+    date: "2026-07-04",
+    changes: [
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Analysis charts and KPIs no longer drop the current month for users in Americas (west-of-UTC) timezones — the month range was being read with local date getters off UTC-midnight boundaries, shifting the range back a month and hiding the latest data.",
+          "zh-TW":
+            "分析圖表與關鍵指標不再對位於美洲（UTC 以西）時區的使用者遺漏當月資料——先前月份範圍以本地時間讀取 UTC 午夜的邊界日期，導致範圍整體往前推一個月而隱藏最新資料。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "FIRE / retirement projections now group net-worth snapshots by their UTC year, so a January-1 snapshot is no longer misfiled into the previous year on non-UTC servers.",
+          "zh-TW":
+            "FIRE／退休預測現在以 UTC 年份彙整淨值快照，因此在非 UTC 伺服器上，1 月 1 日的快照不會再被誤歸入前一年。",
+        },
+      },
+    ],
+  },
+  {
     version: "0.10.4",
     date: "2026-07-03",
     changes: [

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -114,8 +114,12 @@ export function fillMonthRange(
 ): MonthlyBucket[] {
   const byKey = new Map(buckets.map((b) => [b.monthKey, b]));
   const result: MonthlyBucket[] = [];
-  const cursor = new Date(Date.UTC(rangeStart.getFullYear(), rangeStart.getMonth(), 1));
-  const endKey = `${rangeEnd.getFullYear()}-${String(rangeEnd.getMonth() + 1).padStart(2, "0")}`;
+  // rangeStart/rangeEnd are constructed as UTC-midnight (`new Date(Date.UTC(...))`)
+  // by callers, so read them back with UTC getters. Local getters would roll the
+  // boundary back a month in any timezone west of UTC (#507), dropping the current
+  // month and prepending a phantom empty one.
+  const cursor = new Date(Date.UTC(rangeStart.getUTCFullYear(), rangeStart.getUTCMonth(), 1));
+  const endKey = `${rangeEnd.getUTCFullYear()}-${String(rangeEnd.getUTCMonth() + 1).padStart(2, "0")}`;
   while (true) {
     const year = cursor.getUTCFullYear();
     const month = cursor.getUTCMonth();

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -61,7 +61,10 @@ export async function getProjectionData(
   // Last snapshot per calendar year
   const byYear = new Map<number, number>();
   for (const s of normalized) {
-    byYear.set(s.date.getFullYear(), s.netWorth);
+    // Snapshots are stored at UTC-midnight and deduped by their UTC date, so
+    // bucket by the UTC year. A local getter would land a Jan-1-UTC snapshot in
+    // the prior year on a west-of-UTC server (#514).
+    byYear.set(s.date.getUTCFullYear(), s.netWorth);
   }
   const annualSnapshots = Array.from(byYear.entries())
     .sort(([a], [b]) => a - b)

--- a/tests/unit/analysis-service.test.ts
+++ b/tests/unit/analysis-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   aggregateMonthlyChange,
   fillMonthRange,
@@ -80,6 +80,34 @@ describe("fillMonthRange", () => {
     expect(filled.map((b) => b.monthKey)).toEqual(["2026-01", "2026-02", "2026-03"]);
     expect(filled[1]).toMatchObject({ monthKey: "2026-02", isEmpty: true, deltaNetWorth: 0 });
     expect(filled[0].isEmpty).toBe(false);
+  });
+
+  // Regression for #507: callers construct rangeStart/rangeEnd as UTC-midnight
+  // (`new Date(Date.UTC(...))`), so fillMonthRange must read them back with UTC
+  // getters. Read with local getters, a west-of-UTC timezone rolls the boundary
+  // back a month — the current month (holding the latest snapshots) is dropped
+  // and a phantom empty month is prepended. Force America/New_York (UTC-5) so
+  // this fails deterministically with the old local-getter code and passes with
+  // the fix, regardless of the CI runner's own timezone (UTC).
+  describe("under a west-of-UTC timezone (America/New_York)", () => {
+    const originalTz = process.env.TZ;
+    beforeAll(() => {
+      process.env.TZ = "America/New_York";
+    });
+    afterAll(() => {
+      process.env.TZ = originalTz;
+    });
+
+    it("keeps the first and current month when rangeStart/rangeEnd are UTC-midnight", () => {
+      // Jan-1-UTC is Dec-31 in New York; Jul-1-UTC is Jun-30 in New York.
+      const rangeStart = new Date(Date.UTC(2026, 0, 1));
+      const rangeEnd = new Date(Date.UTC(2026, 6, 1));
+      const filled = fillMonthRange([], rangeStart, rangeEnd);
+      const keys = filled.map((b) => b.monthKey);
+      expect(keys[0]).toBe("2026-01"); // no phantom "2025-12" lead
+      expect(keys[keys.length - 1]).toBe("2026-07"); // current month not dropped
+      expect(keys).not.toContain("2025-12");
+    });
   });
 });
 

--- a/tests/unit/projection-service.test.ts
+++ b/tests/unit/projection-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+// Hoisted fixtures so the vi.mock factories can close over them.
+interface SnapshotFixture {
+  date: Date;
+  netWorth: number;
+  baseCurrency: string;
+}
+const h = vi.hoisted(() => ({
+  snapshots: [] as SnapshotFixture[],
+}));
+
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    netWorthSnapshot: {
+      findMany: vi.fn(async () =>
+        h.snapshots.map((s) => ({
+          date: s.date,
+          netWorth: s.netWorth,
+          baseCurrency: s.baseCurrency,
+        })),
+      ),
+    },
+    account: { findMany: vi.fn(async () => []) },
+    cashTransaction: { findMany: vi.fn(async () => []) },
+  },
+}));
+// Keep resolveRate real (identity path returns 1 for same-currency); only stub
+// the bulk loader so no DB/network is hit.
+vi.mock("@/lib/services/exchange-rate-service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getAllExchangeRates: vi.fn(async () => new Map<string, number>()) };
+});
+
+import { getProjectionData } from "@/lib/services/projection-service";
+
+describe("getProjectionData annual bucketing", () => {
+  // Regression for #514: snapshots are stored at UTC-midnight and deduped by
+  // their UTC date (`toISOString().split("T")[0]`), so the per-year bucket key
+  // must also be UTC. Read with a local getter, a Jan-1-UTC snapshot lands in
+  // the prior year for a west-of-UTC server. Force America/New_York (UTC-5) so
+  // this fails with the old local-getter code and passes with the fix,
+  // regardless of the CI runner's own timezone (UTC).
+  describe("under a west-of-UTC timezone (America/New_York)", () => {
+    const originalTz = process.env.TZ;
+    beforeAll(() => {
+      process.env.TZ = "America/New_York";
+    });
+    afterAll(() => {
+      process.env.TZ = originalTz;
+    });
+
+    it("buckets a 2026-01-01T00:00:00Z snapshot into year 2026", async () => {
+      h.snapshots = [
+        { date: new Date("2025-06-01T00:00:00.000Z"), netWorth: 500, baseCurrency: "USD" },
+        { date: new Date("2026-01-01T00:00:00.000Z"), netWorth: 1000, baseCurrency: "USD" },
+      ];
+      const result = await getProjectionData("u1", "USD");
+      const years = result.annualSnapshots.map((a) => a.year);
+      expect(years).toContain(2026);
+      expect(years).not.toContain(2025.5); // sanity
+      const y2026 = result.annualSnapshots.find((a) => a.year === 2026);
+      expect(y2026?.netWorth).toBe(1000);
+    });
+  });
+});


### PR DESCRIPTION
## Bug class

Range/boundary dates across the app are constructed as UTC-midnight (`new Date(Date.UTC(y, m, 1))`), or come from net-worth snapshots that are stored and deduped by their **UTC** date (`toISOString().slice(0,10)`). Several call sites then read those dates back with **local** getters (`getFullYear()`, `getMonth()`). In any timezone west of UTC, a UTC-midnight instant is the *previous* day/month locally, so the local getters return a boundary shifted back one month (or one year). CI/Vercel run in UTC, so the bug is invisible there — it only hits real users in Americas timezones (and non-UTC self-hosters). Fix: read these UTC-constructed / snapshot dates with the UTC getters (`getUTCFullYear`/`getUTCMonth`) consistently.

## #507 — Analysis charts + KPIs drop the current month

Site: `analysis-service.ts` `fillMonthRange` (cursor init + `endKey`). Callers in `analysis-view.tsx` pass `rangeStart`/`rangeEnd` as `new Date(Date.UTC(...))`, but `fillMonthRange` read them with local getters.

Worked example (America/New_York, UTC-5):

```
now = 2026-07-02 local
  -> rangeEnd = Date.UTC(2026, 6, 1) = 2026-07-01T00:00Z
  -> in NY that instant's LOCAL month is June
  -> old endKey = "2026-06"  -> the loop breaks before emitting July,
     which holds the latest snapshots; a phantom empty "2025-12" is prepended.
After fix (UTC getters): endKey = "2026-07", first key = "2026-01".
```

Best/Worst/Avg KPIs inherit the gap because they read from the same buckets.

## #514 — FIRE projection buckets snapshots by local year

Site: `projection-service.ts` — `byYear.set(s.date.getFullYear(), ...)` on UTC-midnight snapshot dates. A Jan-1-UTC snapshot lands in the prior year for a west-of-UTC server. Changed to `getUTCFullYear()`.

## Broader sweep

Grepped `getFullYear`/`getMonth`/`getDate()` across `src/lib/services` + `src/components/analysis`. Each hit classified as UTC-constructed/snapshot date (→ UTC getter) vs. genuine local "now" (→ local is correct):

**Fixed (true mismatches):**
- `analysis-service.ts` `fillMonthRange` — cursor + endKey (#507).
- `projection-service.ts` — per-year bucket key (#514).
- `analysis-view.tsx` "All"-range start — read `firstDate` (a UTC-midnight snapshot date) via UTC getters, so the range starts on the snapshot's UTC month instead of a phantom prior month west of UTC.
- `analysis-view.tsx` `pickDefaultRange` history span — read `first` (snapshot date) via UTC getters; `now` stays local. (Low-stakes heuristic, but same class.)

**Correct as-is (genuine local "now" / date arithmetic):**
- `analysis-view.tsx` `rangeCutoff` (`new Date()` minus N months) — genuine now-relative cutoff.
- `analysis-view.tsx` YTD/normal `rangeEnd`/`rangeStart` built from `now = new Date()` — local getters correctly capture the user's *current local month*, then wrapped in `Date.UTC(...)`; `fillMonthRange` reads them back with UTC getters, so the round trip is internally consistent.
- `analysis-view.tsx` `now.getMonth() < 3` Jan–Mar check — genuine current local month.
- `analysis-view.tsx` cutoff-based `rangeStart` — `cutoff` is a local date, local getters correct.
- `projection-service.ts` `twelveMonthsAgo` — `new Date()` now-relative query window.
- `goal-service.ts` `projectDate` / 90-day window, `history-service.ts` default-history window — all `new Date()` now-relative `setDate/getDate` arithmetic on the same object; TZ-safe.

## Tests

Added TZ-forced regression tests (`process.env.TZ = "America/New_York"` in `beforeAll`, restored in `afterAll`; runtime TZ change verified to affect `Date` in this Node). They fail with the old local-getter code and pass with the fix **regardless of the CI runner's own timezone** (UTC), because the assertions are on UTC-derived month/year keys:
- `analysis-service.test.ts`: `fillMonthRange([], Date.UTC(2026,0,1), Date.UTC(2026,6,1))` → first key `2026-01`, last `2026-07`, no phantom `2025-12`.
- `projection-service.test.ts` (new): a `2026-01-01T00:00:00Z` snapshot buckets into year `2026`.

Fail-before / pass-after was confirmed locally (both failed on master's getters, both pass after the fix). Full suite: 157 passing.

Verification: `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` all pass.

Fixes #507
Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VdCD1kHqhzwh9Y4dDxkwS