### PR TITLE
[codex] Fix analytics edge cases

### DIFF
--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -81,7 +81,7 @@ export function aggregateMonthlyChange(snapshots: NormalizedSnapshot[]): Monthly
     const startNetWorth = prevKey ? groups.get(prevKey)!.last.netWorth : group.first.netWorth;
     const endNetWorth = group.last.netWorth;
     const deltaNetWorth = endNetWorth - startNetWorth;
-    const deltaPct = startNetWorth === 0 ? null : (deltaNetWorth / startNetWorth) * 100;
+    const deltaPct = startNetWorth === 0 ? null : (deltaNetWorth / Math.abs(startNetWorth)) * 100;
 
     buckets.push({
       monthKey: key,
@@ -188,7 +188,7 @@ export function computeKpis(
     currentYearSnapshots[0]?.netWorth ??
     0;
   const ytdDelta = latest.netWorth - baseline;
-  const ytdPct = baseline === 0 ? null : (ytdDelta / baseline) * 100;
+  const ytdPct = baseline === 0 ? null : (ytdDelta / Math.abs(baseline)) * 100;
 
   return { best, worst, avgMonthlyDelta, ytdDelta, ytdPct };
 }
@@ -271,7 +271,7 @@ export function buildCashFlowBuckets(
   const contribMap = new Map(contributions.map((c) => [c.monthKey, c.contributions]));
 
   return buckets.map((b) => {
-    const contrib = contribMap.get(b.monthKey) ?? 0;
+    const contrib = b.isEmpty ? 0 : (contribMap.get(b.monthKey) ?? 0);
     return {
       monthKey: b.monthKey,
       label: formatMonthLabel(b.monthKey, locale),

--- a/src/lib/services/goal-service.ts
+++ b/src/lib/services/goal-service.ts
@@ -4,6 +4,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getCachedNetWorthSummary } from "./net-worth-service";
 import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
+import { getNormalizedHistory } from "./history-service";
 import { serializeGoal } from "@/lib/types";
 import type { GoalWithProgress, NetWorthSummary, SerializedGoal } from "@/lib/types";
 
@@ -66,37 +67,14 @@ function projectDate(today: Date, daysFromToday: number): string | null {
   return projected.toISOString();
 }
 
-/**
- * Cached 90-day snapshot window backing the goal projections. Was the only
- * uncached read on the dashboard's goals section; the cron / data import
- * revalidate `snapshots` + `history:${userId}` after every snapshot write.
- * The 90-day floor is captured at cache-fill time — same accepted drift as
- * getNormalizedHistory. Serialized shape (`"use cache"` can't carry
- * Prisma Decimal/Date).
- */
-async function fetchRecentSnapshotsInner(
-  userId: string,
-  baseCurrency: string,
-): Promise<SnapshotRow[]> {
-  "use cache";
-  cacheTag("snapshots");
-  cacheTag(`history:${userId}`);
-  cacheLife("hours");
-  const ninetyDaysAgo = new Date();
-  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
-  const rows = await prisma.netWorthSnapshot.findMany({
-    where: { userId, baseCurrency, date: { gte: ninetyDaysAgo } },
-    orderBy: { date: "asc" },
-    select: { date: true, netWorth: true, totalAssets: true },
-  });
+async function fetchRecentSnapshots(userId: string, baseCurrency: string): Promise<SnapshotRow[]> {
+  const rows = await getNormalizedHistory(userId, baseCurrency);
   return rows.map((s) => ({
-    date: s.date.toISOString(),
-    netWorth: Number(s.netWorth),
-    totalAssets: Number(s.totalAssets),
+    date: s.date,
+    netWorth: s.netWorth,
+    totalAssets: s.totalAssets,
   }));
 }
-
-const fetchRecentSnapshots = cache(fetchRecentSnapshotsInner);
 
 function computeProjection(
   goal: SerializedGoal,

--- a/tests/unit/analysis-service.test.ts
+++ b/tests/unit/analysis-service.test.ts
@@ -72,6 +72,11 @@ describe("aggregateMonthlyChange", () => {
     const buckets = aggregateMonthlyChange([snap("2026-01-05", 0), snap("2026-01-20", 100)]);
     expect(buckets[0].deltaPct).toBeNull();
   });
+
+  it("uses the baseline magnitude for deltaPct when net worth recovers from negative", () => {
+    const buckets = aggregateMonthlyChange([snap("2026-01-05", -100), snap("2026-01-20", -50)]);
+    expect(buckets[0].deltaPct).toBeCloseTo(50);
+  });
 });
 
 describe("fillMonthRange", () => {
@@ -141,6 +146,13 @@ describe("computeKpis", () => {
     expect(kpis.ytdDelta).toBe(100);
     expect(kpis.ytdPct).toBeCloseTo(10);
   });
+
+  it("uses the baseline magnitude for YTD percent when net worth recovers from negative", () => {
+    const snapshots = [snap("2025-12-31", -1000), snap("2026-02-28", -500)];
+    const kpis = computeKpis(aggregateMonthlyChange(snapshots), snapshots);
+    expect(kpis.ytdDelta).toBe(500);
+    expect(kpis.ytdPct).toBeCloseTo(50);
+  });
 });
 
 describe("formatMonthLabel", () => {
@@ -196,6 +208,28 @@ describe("buildCashFlowBuckets", () => {
     ];
     const result = buildCashFlowBuckets(buckets, [], "en-US");
     expect(result[0]).toMatchObject({ contributions: 0, marketPerformance: -10 });
+  });
+
+  it("does not merge cash contributions into empty padded months", () => {
+    const buckets = [
+      {
+        monthKey: "2026-03",
+        endDate: "2026-03",
+        startNetWorth: 0,
+        endNetWorth: 0,
+        totalAssets: 0,
+        totalLiabilities: 0,
+        deltaNetWorth: 0,
+        deltaPct: null,
+        isEmpty: true,
+      },
+    ];
+    const result = buildCashFlowBuckets(
+      buckets,
+      [{ monthKey: "2026-03", contributions: 500 }],
+      "en-US",
+    );
+    expect(result[0]).toMatchObject({ contributions: 0, marketPerformance: 0 });
   });
 });
 

--- a/tests/unit/goal-service.test.ts
+++ b/tests/unit/goal-service.test.ts
@@ -20,11 +20,14 @@ interface SnapshotFixture {
   date: Date;
   netWorth: number;
   totalAssets: number;
+  baseCurrency?: string;
+  createdAt?: Date;
 }
 const h = vi.hoisted(() => ({
   goals: [] as GoalFixture[],
   snapshots: [] as SnapshotFixture[],
   summary: null as NetWorthSummary | null,
+  rates: new Map<string, number>(),
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -39,12 +42,24 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     goal: { findMany: vi.fn(async () => h.goals) },
     netWorthSnapshot: {
-      findMany: vi.fn(async () =>
-        h.snapshots.map((s) => ({
-          date: s.date,
-          netWorth: s.netWorth,
-          totalAssets: s.totalAssets,
-        })),
+      findMany: vi.fn(async (args?: { where?: { baseCurrency?: string; date?: { gte?: Date } } }) =>
+        h.snapshots
+          .filter(
+            (s) =>
+              !args?.where?.baseCurrency || (s.baseCurrency ?? "USD") === args.where.baseCurrency,
+          )
+          .filter((s) => !args?.where?.date?.gte || s.date >= args.where.date.gte)
+          .map((s) => ({
+            id: s.date.toISOString(),
+            date: s.date,
+            createdAt: s.createdAt ?? s.date,
+            netWorth: s.netWorth,
+            totalAssets: s.totalAssets,
+            totalLiabilities: 0,
+            baseCurrency: s.baseCurrency ?? "USD",
+            label: null,
+            note: null,
+          })),
       ),
     },
   },
@@ -56,7 +71,7 @@ vi.mock("@/lib/services/net-worth-service", () => ({
 // the bulk loader so no DB/network is hit.
 vi.mock("@/lib/services/exchange-rate-service", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/services/exchange-rate-service")>();
-  return { ...actual, getAllExchangeRates: vi.fn(async () => new Map<string, number>()) };
+  return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
 });
 
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
@@ -94,6 +109,7 @@ describe("computeGoalsWithProgress projection bounds", () => {
     h.goals = [];
     h.snapshots = [];
     h.summary = null;
+    h.rates = new Map<string, number>();
   });
 
   it("returns null linear projection (does not throw RangeError) for a near-flat trend against a huge gap", async () => {
@@ -122,7 +138,7 @@ describe("computeGoalsWithProgress projection bounds", () => {
     h.goals = [makeGoal({ targetAmount: 200_000 })];
     h.summary = makeSummary(110_000);
     h.snapshots = [
-      { date: new Date("2026-04-04T00:00:00.000Z"), netWorth: 100_000, totalAssets: 100_000 },
+      { date: new Date("2026-04-08T00:00:00.000Z"), netWorth: 100_000, totalAssets: 100_000 },
       { date: new Date("2026-07-03T00:00:00.000Z"), netWorth: 110_000, totalAssets: 110_000 },
     ];
 
@@ -130,5 +146,29 @@ describe("computeGoalsWithProgress projection bounds", () => {
     const linear = result[0].projectedDateLinear;
     expect(linear).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(Number.isNaN(Date.parse(linear!))).toBe(false);
+  });
+
+  it("projects from snapshots captured before a base-currency switch", async () => {
+    h.goals = [makeGoal({ targetAmount: 400 })];
+    h.summary = makeSummary(300);
+    h.rates = new Map([["TWD_USD", 0.25]]);
+    h.snapshots = [
+      {
+        date: new Date("2026-06-01T00:00:00.000Z"),
+        netWorth: 400,
+        totalAssets: 400,
+        baseCurrency: "TWD",
+      },
+      {
+        date: new Date("2026-07-01T00:00:00.000Z"),
+        netWorth: 800,
+        totalAssets: 800,
+        baseCurrency: "TWD",
+      },
+    ];
+
+    const result = await computeGoalsWithProgress("u1", "USD");
+
+    expect(result[0].projectedDateLinear).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 });


### PR DESCRIPTION
## Summary

- Normalize goal projection snapshots through the existing history reader so base-currency switches do not drop the recent projection window.
- Treat cash contributions as zero for padded empty analysis months so cash-flow and cumulative growth stay flat until a real snapshot exists.
- Compute `deltaPct` and `ytdPct` against the magnitude of a negative baseline instead of the signed baseline.
- Add regression coverage for the three edge cases.

## Why

The analytics views had three small edge-case leaks: goal projections ignored pre-switch snapshots, cash activity in an empty padded month appeared as market loss, and recovery from negative net worth displayed inverted percentages.

Closes #521
Closes #515
Closes #520

## Verification

- `pnpm vitest run tests/unit/analysis-service.test.ts tests/unit/goal-service.test.ts`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`