### PR TITLE
[codex] Fix spoofable IP rate-limit identity

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -37,8 +37,11 @@ const store = new Map<string, WindowEntry>();
 export function getClientIp(request: Request): string {
   const xff = request.headers.get("x-forwarded-for");
   if (xff) {
-    const first = xff.split(",")[0]?.trim();
-    if (first) return first;
+    const ip = xff
+      .split(",")
+      .map((part) => part.trim())
+      .findLast(Boolean);
+    if (ip) return ip;
   }
 
   const cfIp = request.headers.get("cf-connecting-ip")?.trim();

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getClientIp, rateLimitCheckWithPrune } from "@/lib/rate-limit";
+
+function request(headers: HeadersInit): Request {
+  return new Request("https://example.test", { headers });
+}
+
+describe("getClientIp", () => {
+  it("uses the rightmost non-empty x-forwarded-for hop", () => {
+    expect(
+      getClientIp(
+        request({
+          "x-forwarded-for": "198.51.100.9, 203.0.113.7",
+        }),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("keeps single x-forwarded-for values working", () => {
+    expect(getClientIp(request({ "x-forwarded-for": "198.51.100.9" }))).toBe("198.51.100.9");
+  });
+
+  it("skips empty x-forwarded-for tokens before falling back", () => {
+    expect(getClientIp(request({ "x-forwarded-for": " , 203.0.113.7 , " }))).toBe("203.0.113.7");
+    expect(
+      getClientIp(
+        request({
+          "x-forwarded-for": " , ",
+          "cf-connecting-ip": "198.51.100.11",
+          "x-real-ip": "198.51.100.12",
+        }),
+      ),
+    ).toBe("198.51.100.11");
+    expect(getClientIp(request({ "x-forwarded-for": " , " }))).toBe("unknown");
+  });
+});
+
+describe("rateLimitCheckWithPrune", () => {
+  it("keys limits by the platform-appended x-forwarded-for hop", () => {
+    const options = { limit: 1, prefix: "xff-rightmost-test" };
+
+    expect(
+      rateLimitCheckWithPrune(request({ "x-forwarded-for": "198.51.100.1, 203.0.113.7" }), options),
+    ).toBeNull();
+
+    expect(
+      rateLimitCheckWithPrune(request({ "x-forwarded-for": "198.51.100.2, 203.0.113.7" }), options)
+        ?.status,
+    ).toBe(429);
+  });
+});


### PR DESCRIPTION
## Summary

- Change `getClientIp` to use the rightmost non-empty `X-Forwarded-For` hop instead of the leftmost caller-controlled hop.
- Preserve the existing fallback order for `cf-connecting-ip`, `x-real-ip`, and `unknown`.
- Add focused regression tests for multi-hop XFF, empty XFF tokens, and rate-limit keying.

## Why

IP-keyed limiters trusted the leftmost `X-Forwarded-For` value, so callers could rotate a fabricated first hop and avoid sharing a rate-limit bucket. The proxy auth limiter imports the same helper, so the shared fix covers both route-handler and `/api/auth` proxy usage.

Closes #516

## Verification

- `pnpm vitest run tests/unit/rate-limit.test.ts`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

## Not included

This does not include PR #495's durable database-backed limiter work; it only fixes the spoofable client identity root cause.