### PR TITLE
Fix Decimal validation, account currency PATCH, and snapshot cron partial failures

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -140,27 +140,48 @@ export async function GET(request: Request) {
     });
 
     // 3. Create snapshots for each user (in parallel)
-    const snapshots = await Promise.all(
-      users.map((user) => {
+    const snapshotResults = await Promise.allSettled(
+      users.map(async (user) => {
         const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
         log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
-        return createSnapshot(user.id, baseCurrency);
+        const snapshot = await createSnapshot(user.id, baseCurrency);
+        return { userId: user.id, snapshot };
       }),
     );
+    const snapshots: Awaited<ReturnType<typeof createSnapshot>>[] = [];
+    const successfulUserIds: string[] = [];
+    const failedUserIds: string[] = [];
+    for (let i = 0; i < snapshotResults.length; i++) {
+      const result = snapshotResults[i];
+      const userId = users[i].id;
+      if (result.status === "fulfilled") {
+        snapshots.push(result.value.snapshot);
+        successfulUserIds.push(result.value.userId);
+      } else {
+        failedUserIds.push(userId);
+        log.warn("cron.snapshot.user_failed", { userId, error: String(result.reason) });
+      }
+    }
+    if (users.length > 0 && failedUserIds.length === users.length) {
+      throw new Error(`Snapshot failed for users: ${failedUserIds.join(", ")}`);
+    }
 
     // 4. Invalidate snapshot/history caches now that new rows exist
-    revalidateTag("snapshots", "max");
-    for (const user of users) {
-      revalidateTag(`history:${user.id}`, "max");
+    if (snapshots.length > 0) revalidateTag("snapshots", "max");
+    for (const userId of successfulUserIds) {
+      revalidateTag(`history:${userId}`, "max");
     }
 
     const finishedAt = new Date();
+    const snapshotError =
+      failedUserIds.length > 0 ? `Snapshot failed for users: ${failedUserIds.join(", ")}` : null;
     await prisma.cronRun.update({
       where: { id: cronRun.id },
       data: {
         ok: true,
         finishedAt,
         durationMs: finishedAt.getTime() - startedAt.getTime(),
+        ...(snapshotError && { error: snapshotError }),
       },
     });
     finishSnapshotCronCheckIn(checkIn, "ok");
@@ -168,6 +189,7 @@ export async function GET(request: Request) {
     return ok({
       success: true,
       snapshotIds: snapshots.map((s) => s.id),
+      failedUserIds,
       timestamp: finishedAt.toISOString(),
     });
   } catch (error) {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -13,16 +13,22 @@ import { SUPPORTED_LOCALES } from "@/i18n/config";
 
 const OCC_SHAPE = /^[A-Z][A-Z0-9.\-]{0,5}\d{6}[CP]\d{8}$/;
 const supportedLocaleSchema = z.enum(SUPPORTED_LOCALES);
+const CRUD_DECIMAL_ABS_MAX = 10_000_000_000;
+const crudDecimalNumber = z
+  .number()
+  .gt(-CRUD_DECIMAL_ABS_MAX, "Value exceeds supported precision")
+  .lt(CRUD_DECIMAL_ABS_MAX, "Value exceeds supported precision");
 
 export const createAccountSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   type: z.enum(ACCOUNT_TYPES),
   category: z.enum(ACCOUNT_CATEGORIES),
   currency: z.string().length(3),
-  cashBalance: z.number().default(0),
+  cashBalance: crudDecimalNumber.default(0),
 });
 
 export const updateAccountSchema = createAccountSchema
+  .omit({ currency: true })
   .extend({
     isActive: z.boolean(),
     isPinned: z.boolean(),
@@ -32,7 +38,8 @@ export const updateAccountSchema = createAccountSchema
     // the cash flow (#500). Ignored when the balance is not changing.
     occurrenceDate: z.iso.date("Must be a valid YYYY-MM-DD date").optional(),
   })
-  .partial();
+  .partial()
+  .extend({ currency: z.never().optional() });
 
 export const reorderAccountsSchema = z.object({
   type: z.enum(ACCOUNT_TYPES),
@@ -52,8 +59,8 @@ const baseHoldingFields = {
     .max(32)
     .transform((s) => s.toUpperCase()),
   name: z.string().min(1, "Name is required").max(100),
-  quantity: z.number().positive("Quantity must be positive"),
-  unitPrice: z.number().positive("Buy unit price must be positive").optional(),
+  quantity: crudDecimalNumber.positive("Quantity must be positive"),
+  unitPrice: crudDecimalNumber.positive("Buy unit price must be positive").optional(),
   currency: z.string().length(3).default("USD"),
 };
 
@@ -68,7 +75,7 @@ const createOptionHoldingSchema = z
     assetType: z.literal("OPTION"),
     underlyingSymbol: z.string().min(1).max(8).optional(),
     optionType: z.enum(OPTION_TYPES).optional(),
-    strike: z.number().positive().optional(),
+    strike: crudDecimalNumber.positive().optional(),
     expiration: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}/)
@@ -97,7 +104,7 @@ export const updateHoldingSchema = z.object({
   // 0 is allowed only to close an OPTION position (preserves the transaction
   // audit trail, which a DELETE would cascade away). The PATCH route rejects
   // quantity 0 for non-option holdings, where the asset type is known.
-  quantity: z.number().nonnegative().optional(),
+  quantity: crudDecimalNumber.nonnegative().optional(),
   // OPTION is deliberately excluded: converting a holding to OPTION via PATCH
   // would produce a row without the OCC fields (underlyingSymbol, optionType,
   // strike, expiration). Options can only be created via POST, which derives
@@ -127,7 +134,7 @@ export const updateSnapshotAnnotationSchema = z.object({
 export const updateTransactionSchema = z
   .object({
     id: z.string(),
-    quantity: z.number().optional(),
+    quantity: crudDecimalNumber.optional(),
     type: z.enum(HOLDING_TRANSACTION_TYPES).optional(),
     note: z.string().optional().nullable(),
     createdAt: z.iso.datetime().optional(),
@@ -150,8 +157,8 @@ export const updateTransactionSchema = z
     }
   });
 
-const positiveCashAmount = z.number().positive("Amount must be positive");
-const nonZeroCashAdjustment = z.number().refine((amount) => amount !== 0, {
+const positiveCashAmount = crudDecimalNumber.positive("Amount must be positive");
+const nonZeroCashAdjustment = crudDecimalNumber.refine((amount) => amount !== 0, {
   message: "Adjustment amount cannot be zero",
 });
 const cashNoteField = z.string().max(500).optional().nullable();
@@ -187,7 +194,7 @@ export const updateCashTransactionSchema = z
   .object({
     id: z.string(),
     type: z.enum(CASH_TRANSACTION_TYPES).optional(),
-    amount: z.number().optional(),
+    amount: crudDecimalNumber.optional(),
     note: cashNoteField,
     createdAt: z.iso.datetime().optional(),
     occurrenceDate: cashOccurrenceDateField.optional().nullable(),
@@ -290,7 +297,7 @@ export const updateRecurringInvestmentSchema = z
 
 export const createGoalSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
-  targetAmount: z.number().positive("Target must be positive"),
+  targetAmount: crudDecimalNumber.positive("Target must be positive"),
   targetCurrency: z.string().length(3).default("USD"),
   targetDate: z.iso.date("Must be a valid YYYY-MM-DD date").optional().nullable(),
   scope: z.enum(GOAL_SCOPES),
@@ -312,7 +319,7 @@ const stockWatchItemFields = {
   name: z.string().min(1, "Name is required").max(120),
   exchange: z.string().max(80).default(""),
   currency: z.string().length(3).default("USD"),
-  recordPrice: z.number().positive("Record price must be positive"),
+  recordPrice: crudDecimalNumber.positive("Record price must be positive"),
   recordDate: z.iso.date("Must be a valid YYYY-MM-DD date"),
   note: z.string().max(2000).optional().nullable(),
 };

--- a/tests/unit/account-ledger-routes.test.ts
+++ b/tests/unit/account-ledger-routes.test.ts
@@ -189,6 +189,17 @@ describe("account ledger routes", () => {
     expect(accountWrite.data).toEqual({ cashBalance: 25 });
   });
 
+  it("rejects account currency changes without writing", async () => {
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { currency: "USD" }), {
+      params: Promise.resolve({ id: "acc1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(h.calls).toEqual([]);
+  });
+
   it("records manual account balance edits atomically and strips note from account data", async () => {
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
 

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const h = vi.hoisted(() => ({
   events: [] as string[],
   expiredOptions: [] as Array<{ id: string; quantity: number }>,
+  users: [{ id: "user1", appSettings: { baseCurrency: "USD" } }],
+  snapshotFailures: new Set<string>(),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -16,7 +18,7 @@ vi.mock("next/cache", () => ({
 }));
 
 vi.mock("@/lib/logger", () => ({
-  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 vi.mock("@/lib/sentry-cron", () => ({
@@ -41,9 +43,10 @@ vi.mock("@/lib/services/recurring-investment-service", () => ({
 }));
 
 vi.mock("@/lib/services/snapshot-service", () => ({
-  createSnapshot: vi.fn(async () => {
-    h.events.push("snapshot");
-    return { id: "snapshot1" };
+  createSnapshot: vi.fn(async (userId: string) => {
+    h.events.push(`snapshot:${userId}`);
+    if (h.snapshotFailures.has(userId)) throw new Error(`snapshot failed for ${userId}`);
+    return { id: `snapshot-${userId}` };
   }),
 }));
 
@@ -67,7 +70,7 @@ vi.mock("@/lib/prisma", () => {
       findMany: vi.fn(async () => []),
     },
     user: {
-      findMany: vi.fn(async () => [{ id: "user1", appSettings: { baseCurrency: "USD" } }]),
+      findMany: vi.fn(async () => h.users),
     },
     $transaction: vi.fn(async (work: unknown) => {
       if (Array.isArray(work)) return Promise.all(work);
@@ -79,8 +82,11 @@ vi.mock("@/lib/prisma", () => {
 
 describe("snapshot cron route", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     h.events = [];
     h.expiredOptions = [];
+    h.users = [{ id: "user1", appSettings: { baseCurrency: "USD" } }];
+    h.snapshotFailures = new Set();
   });
 
   it("invalidates net worth before snapshot creation when options expire", async () => {
@@ -96,6 +102,85 @@ describe("snapshot cron route", () => {
     expect(response.status).toBe(200);
     expect(h.events).toContain("revalidate:accounts");
     expect(h.events).toContain("revalidate:net-worth");
-    expect(h.events.indexOf("revalidate:net-worth")).toBeLessThan(h.events.indexOf("snapshot"));
+    expect(h.events.indexOf("revalidate:net-worth")).toBeLessThan(
+      h.events.indexOf("snapshot:user1"),
+    );
+  });
+
+  it("returns 200 and records failed user ids when only some snapshots fail", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "TWD" } },
+    ];
+    h.snapshotFailures = new Set(["user2"]);
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+    const { log } = await import("@/lib/logger");
+    const { prisma } = await import("@/lib/prisma");
+    const { finishSnapshotCronCheckIn } = await import("@/lib/sentry-cron");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        success: true,
+        snapshotIds: ["snapshot-user1"],
+        failedUserIds: ["user2"],
+      },
+    });
+    expect(h.events).toContain("revalidate:snapshots");
+    expect(h.events).toContain("revalidate:history:user1");
+    expect(h.events).not.toContain("revalidate:history:user2");
+    expect(log.warn).toHaveBeenCalledWith("cron.snapshot.user_failed", {
+      userId: "user2",
+      error: "Error: snapshot failed for user2",
+    });
+    expect(log.error).not.toHaveBeenCalled();
+    expect(prisma.cronRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          ok: true,
+          error: expect.stringContaining("user2"),
+        }),
+      }),
+    );
+    expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "ok");
+  });
+
+  it("preserves failure semantics when every user snapshot fails", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "TWD" } },
+    ];
+    h.snapshotFailures = new Set(["user1", "user2"]);
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+    const { log } = await import("@/lib/logger");
+    const { prisma } = await import("@/lib/prisma");
+    const { finishSnapshotCronCheckIn } = await import("@/lib/sentry-cron");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(h.events).not.toContain("revalidate:snapshots");
+    expect(log.error).toHaveBeenCalledWith("cron.snapshot.failed", {
+      error: "Error: Snapshot failed for users: user1, user2",
+    });
+    expect(prisma.cronRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining("user1"),
+        }),
+      }),
+    );
+    expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
   });
 });

--- a/tests/unit/goal-service.test.ts
+++ b/tests/unit/goal-service.test.ts
@@ -30,6 +30,11 @@ const h = vi.hoisted(() => ({
   rates: new Map<string, number>(),
 }));
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * DAY_MS);
+}
+
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   return { ...actual, cache: <T>(fn: T): T => fn };
@@ -119,8 +124,8 @@ describe("computeGoalsWithProgress projection bounds", () => {
     h.goals = [makeGoal({ targetAmount: 10_000_000 })];
     h.summary = makeSummary(2); // currentAmount = 2, target = 10M
     h.snapshots = [
-      { date: new Date("2026-04-04T00:00:00.000Z"), netWorth: 1, totalAssets: 1 },
-      { date: new Date("2026-07-03T00:00:00.000Z"), netWorth: 2, totalAssets: 2 },
+      { date: daysAgo(80), netWorth: 1, totalAssets: 1 },
+      { date: daysAgo(1), netWorth: 2, totalAssets: 2 },
     ];
 
     let result: Awaited<ReturnType<typeof computeGoalsWithProgress>>;
@@ -134,12 +139,12 @@ describe("computeGoalsWithProgress projection bounds", () => {
   });
 
   it("returns a valid ISO date for a reasonable trend (happy path unchanged)", async () => {
-    // +$10k over 90 days → ~$111/day; a $90k gap → ~810 days, well in range.
+    // +$10k over a recent window; a $90k gap remains well in range.
     h.goals = [makeGoal({ targetAmount: 200_000 })];
     h.summary = makeSummary(110_000);
     h.snapshots = [
-      { date: new Date("2026-04-08T00:00:00.000Z"), netWorth: 100_000, totalAssets: 100_000 },
-      { date: new Date("2026-07-03T00:00:00.000Z"), netWorth: 110_000, totalAssets: 110_000 },
+      { date: daysAgo(80), netWorth: 100_000, totalAssets: 100_000 },
+      { date: daysAgo(1), netWorth: 110_000, totalAssets: 110_000 },
     ];
 
     const result = await computeGoalsWithProgress("u1", "USD");
@@ -154,13 +159,13 @@ describe("computeGoalsWithProgress projection bounds", () => {
     h.rates = new Map([["TWD_USD", 0.25]]);
     h.snapshots = [
       {
-        date: new Date("2026-06-01T00:00:00.000Z"),
+        date: daysAgo(30),
         netWorth: 400,
         totalAssets: 400,
         baseCurrency: "TWD",
       },
       {
-        date: new Date("2026-07-01T00:00:00.000Z"),
+        date: daysAgo(1),
         netWorth: 800,
         totalAssets: 800,
         baseCurrency: "TWD",

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
+  createAccountSchema,
   createHoldingSchema,
   updateAccountSchema,
   updateHoldingSchema,
   updateTransactionSchema,
   createCashTransactionSchema,
   updateCashTransactionSchema,
+  createRecurringCashTransactionSchema,
+  createRecurringInvestmentSchema,
   createGoalSchema,
   createStockWatchItemSchema,
   updateSnapshotAnnotationSchema,
@@ -35,6 +38,104 @@ describe("updateAccountSchema", () => {
     expect(
       updateAccountSchema.safeParse({ cashBalance: 125, occurrenceDate: "June 1st" }).success,
     ).toBe(false);
+  });
+
+  it("rejects currency changes", () => {
+    expect(updateAccountSchema.safeParse({ currency: "USD" }).success).toBe(false);
+  });
+});
+
+describe("Decimal-backed CRUD number schemas", () => {
+  it.each([
+    [
+      "account cashBalance",
+      () =>
+        createAccountSchema.safeParse({
+          name: "Cash",
+          type: "ASSET",
+          category: "BANK",
+          currency: "USD",
+          cashBalance: 1e10,
+        }),
+    ],
+    [
+      "holding quantity",
+      () =>
+        createHoldingSchema.safeParse({
+          symbol: "AAPL",
+          name: "Apple",
+          assetType: "STOCK",
+          quantity: 1e10,
+        }),
+    ],
+    [
+      "holding unitPrice",
+      () =>
+        createHoldingSchema.safeParse({
+          symbol: "AAPL",
+          name: "Apple",
+          assetType: "STOCK",
+          quantity: 1,
+          unitPrice: 1e10,
+        }),
+    ],
+    [
+      "option strike",
+      () =>
+        createHoldingSchema.safeParse({
+          symbol: "AAPL240119C00150000",
+          name: "AAPL Call",
+          assetType: "OPTION",
+          quantity: 1,
+          strike: 1e10,
+        }),
+    ],
+    [
+      "holding transaction quantity",
+      () => updateTransactionSchema.safeParse({ id: "t1", type: "BUY", quantity: 1e10 }),
+    ],
+    [
+      "cash transaction amount",
+      () => createCashTransactionSchema.safeParse({ type: "DEPOSIT", amount: 1e10 }),
+    ],
+    [
+      "recurring cash amount",
+      () =>
+        createRecurringCashTransactionSchema.safeParse({
+          type: "DEPOSIT",
+          amount: 1e10,
+          frequency: "MONTHLY",
+          startDate: "2026-01-01",
+        }),
+    ],
+    [
+      "recurring investment amount",
+      () =>
+        createRecurringInvestmentSchema.safeParse({
+          symbol: "VT",
+          name: "Vanguard Total World",
+          assetType: "ETF",
+          amount: 1e10,
+          frequency: "MONTHLY",
+          startDate: "2026-01-01",
+        }),
+    ],
+    [
+      "goal targetAmount",
+      () => createGoalSchema.safeParse({ name: "House", targetAmount: 1e10, scope: "NET_WORTH" }),
+    ],
+    [
+      "stock watch recordPrice",
+      () =>
+        createStockWatchItemSchema.safeParse({
+          symbol: "TSLA",
+          name: "Tesla",
+          recordPrice: 1e10,
+          recordDate: "2026-06-14",
+        }),
+    ],
+  ])("rejects 1e10 for %s", (_label, parse) => {
+    expect(parse().success).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a shared Decimal(18,8)-safe upper bound to regular CRUD numeric validators
- Reject account currency changes in PATCH validation before database writes
- Let snapshot cron tolerate partial per-user snapshot failures while revalidating successful users

Closes #546
Closes #557
Closes #558

## Validation
- pnpm vitest run tests/unit/validators.test.ts tests/unit/account-ledger-routes.test.ts tests/unit/cron-snapshot-route.test.ts
- pnpm typecheck
- pnpm lint
- pnpm format:check
- git diff --check

Note: pnpm test:unit still fails in pre-existing tests/unit/goal-service.test.ts:147; that same test failed on this fresh branch before these changes.