### PR TITLE
fix: use PriceCache currency for crypto valuation (#550)

### DIFF
--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -154,7 +154,14 @@ async function computeNetWorthSummary(
     let holdingsInAccountCurrency = 0;
     for (const h of awv.holdings) {
       if (h.marketValue !== null) {
-        const holdingCurrency = h.currency || priceMap[h.symbol]?.currency || "USD";
+        // The market value above was computed from the PriceCache's own price,
+        // so its denomination — not the holding's stored currency — is the
+        // truth for conversion. They usually agree, but for crypto pairs not
+        // denominated in USD (e.g. BTC-EUR) the two can drift: the holding's
+        // currency is inferred at creation time (search route), while the
+        // cached price's currency reflects whatever the provider actually
+        // quoted. Trusting priceMap here keeps price and denomination together.
+        const holdingCurrency = priceMap[h.symbol]?.currency || h.currency || "USD";
         const holdingRateToBase = getRate(holdingCurrency, baseCurrency);
         const valueInBase = h.marketValue * holdingRateToBase;
         h.marketValueInBaseCurrency = valueInBase;

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -184,6 +184,13 @@ function stripCurrencySuffix(symbol: string): string {
   return symbol.replace(/-[A-Z]{3,4}$/, "");
 }
 
+// Extract the quote-currency suffix from a crypto pair (e.g. "BTC-EUR" -> "EUR").
+// Defaults to USD for symbols with no recognizable suffix (e.g. bare "BTC").
+function extractQuoteCurrency(symbol: string): string {
+  const match = symbol.match(/-([A-Z]{3,4})$/);
+  return match ? match[1] : "USD";
+}
+
 export async function fetchCryptoPrices(
   symbols: string[],
 ): Promise<Map<string, { price: number; currency: string }>> {
@@ -198,12 +205,18 @@ export async function fetchCryptoPrices(
     const symbolMap = missing.map((s) => {
       const base = stripCurrencySuffix(s);
       const geckoId = COINGECKO_IDS[base] || base.toLowerCase();
-      return { original: s, base, geckoId };
+      // Respect the pair's own quote currency (e.g. BTC-EUR -> "eur") instead
+      // of always pricing in USD — CoinGecko's `vs_currencies` supports most
+      // major fiat codes, and mismatching this against the pair silently
+      // crosses the FX leg at valuation time.
+      const quoteCurrency = extractQuoteCurrency(s);
+      return { original: s, base, geckoId, quoteCurrency };
     });
 
     const ids = symbolMap.map((s) => s.geckoId).filter(Boolean);
+    const vsCurrencies = [...new Set(symbolMap.map((s) => s.quoteCurrency.toLowerCase()))];
     if (ids.length > 0) {
-      const url = `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=usd`;
+      const url = `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=${vsCurrencies.join(",")}`;
       try {
         const data = await withTiming(
           "price.coingecko.fetch",
@@ -217,16 +230,17 @@ export async function fetchCryptoPrices(
                   next: { revalidate: 60, tags: ["prices:crypto"] },
                 } as RequestInit);
                 if (!res.ok) throw new Error(`CoinGecko returned HTTP ${res.status}`);
-                return res.json() as Promise<Record<string, { usd: number }>>;
+                return res.json() as Promise<Record<string, Record<string, number>>>;
               } finally {
                 clearTimeout(timeoutId);
               }
             }),
           { idCount: ids.length },
         );
-        for (const { original, geckoId } of symbolMap) {
-          if (data[geckoId]?.usd) {
-            results.set(original, { price: data[geckoId].usd, currency: "USD" });
+        for (const { original, geckoId, quoteCurrency } of symbolMap) {
+          const price = data[geckoId]?.[quoteCurrency.toLowerCase()];
+          if (price) {
+            results.set(original, { price, currency: quoteCurrency });
           }
         }
       } catch (error) {

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -211,6 +211,42 @@ describe("getCachedNetWorthSummary (two-pass valuation)", () => {
     expect(summary.accounts[0].holdings[0].marketValue).toBeNull();
   });
 
+  it("values a crypto holding using the PriceCache's own currency, not the holding's mismatched stored currency (#550)", async () => {
+    h.warnings = [];
+    // BTC-EUR: the holding was created with currency USD (e.g. inferCurrency's
+    // no-crypto-mapping default), but the cached price is genuinely EUR-quoted.
+    // EURUSD = 1.1, i.e. 1 EUR = 1.1 USD -> USD_EUR resolves to 1/1.1.
+    h.rates = new Map([["EUR_USD", 1.1]]);
+    h.prices = [{ symbol: "BTC-EUR", price: 50000, currency: "EUR" }];
+    h.accounts = [
+      account({
+        id: "A",
+        type: "ASSET",
+        currency: "USD",
+        cashBalance: 0,
+        holdings: [
+          holding({
+            id: "h1",
+            symbol: "BTC-EUR",
+            quantity: 1,
+            currency: "USD", // mismatched: stored as USD, priced in EUR
+            assetType: "CRYPTO",
+          }),
+        ],
+      }),
+    ];
+
+    const summary = await getCachedNetWorthSummary("u1", "USD");
+
+    // Correct: 50000 EUR * 1.1 (EUR->USD) = 55000 USD.
+    // Buggy (trusting h.currency=USD, no conversion): would be 50000.
+    expect(summary.totalAssets).toBeCloseTo(55000);
+    expect(summary.accounts[0].holdings[0].marketValueInBaseCurrency).toBeCloseTo(55000);
+    expect(summary.currencyExposure).toHaveLength(1);
+    expect(summary.currencyExposure[0].currency).toBe("EUR");
+    expect(summary.currencyExposure[0].value).toBeCloseTo(55000);
+  });
+
   it("applies the option contract multiplier to market value", async () => {
     h.warnings = [];
     h.rates = new Map();


### PR DESCRIPTION
## Summary

Fixes #550 — non-USD crypto pairs (e.g. `BTC-EUR`) could be valued with mismatched price/holding currency, silently mis-valuing the position by the FX factor between the two currencies.

Root cause:
- Net-worth valuation (`net-worth-service.ts`) converted a holding's market value using `h.currency` (the holding's own stored currency), even though the market value was already computed from the `PriceCache` row's price. The `|| priceMap[...].currency` fallback existed but was dead code, since `h.currency` is always non-empty.
- The search route's `inferCurrency` (`src/app/api/search/route.ts`) has no crypto mapping, so a non-USD crypto pair like `BTC-EUR` defaults the new holding's stored currency to `USD` — while Yahoo Finance actually quotes the pair in EUR.
- Separately, when Yahoo misses and the CoinGecko fallback fires (`price-service.ts`), the price was always stored as `USD` regardless of the pair's actual quote-currency suffix.

Either path crosses the EUR/USD legs, mis-valuing the position by the exchange rate factor.

## Changes

- `src/lib/services/net-worth-service.ts`: at valuation time, prefer the `PriceCache` row's own currency over `holding.currency` when converting a holding's market value — price and its denomination should travel together.
- `src/lib/services/price-service.ts`: the CoinGecko fallback now requests `vs_currencies` matching each pair's quote-currency suffix (e.g. `BTC-EUR` → `eur`) instead of hardcoding `usd`, so a Yahoo miss doesn't silently relabel a foreign-currency pair as USD.
- `tests/unit/net-worth-service.test.ts`: added a regression test with a crypto holding whose stored `currency` (USD) and cached price currency (EUR) intentionally disagree, asserting the valuation now correctly uses the EUR-denominated price with the EUR→USD conversion applied.

## Test plan

- [x] `pnpm test:unit` — 217/217 tests pass, including new regression test
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] `pnpm build` — not run (requires `DATABASE_URL`, unavailable in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQk8cJwVFpVmdVCAd45XXB