### PR TITLE
fix: don't let one user's snapshot failure block revalidation for others (#558)

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -10,6 +10,7 @@ import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
 import { log } from "@/lib/logger";
 import { finishSnapshotCronCheckIn, startSnapshotCronCheckIn } from "@/lib/sentry-cron";
+import { classifyCronRunStatus, type CronUserOutcome } from "@/lib/cron-run-status";
 
 function hasValidCronSecret(authHeader: string | null): boolean {
   const expected = Buffer.from(`Bearer ${CRON_SECRET}`);
@@ -139,35 +140,78 @@ export async function GET(request: Request) {
       include: { appSettings: true },
     });
 
-    // 3. Create snapshots for each user (in parallel)
-    const snapshots = await Promise.all(
-      users.map((user) => {
+    // 3. Create snapshots for each user (in parallel). Use allSettled — one
+    // user's snapshot failure must not stop the others from committing, and
+    // must not skip revalidation for the users who succeeded (#558).
+    const settled = await Promise.allSettled(
+      users.map(async (user) => {
         const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
         log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
         return createSnapshot(user.id, baseCurrency);
       }),
     );
 
-    // 4. Invalidate snapshot/history caches now that new rows exist
-    revalidateTag("snapshots", "max");
-    for (const user of users) {
-      revalidateTag(`history:${user.id}`, "max");
+    const outcomes: CronUserOutcome[] = settled.map((result, i) => ({
+      userId: users[i].id,
+      status: result.status,
+      reason: result.status === "rejected" ? result.reason : undefined,
+    }));
+    const classification = classifyCronRunStatus(outcomes);
+
+    for (const outcome of outcomes) {
+      if (outcome.status === "rejected") {
+        log.error("cron.snapshot.user_failed", {
+          userId: outcome.userId,
+          error: String(outcome.reason),
+        });
+      }
+    }
+    if (classification.status !== "ok") {
+      log.error("cron.snapshot.partial_or_total_failure", {
+        status: classification.status,
+        succeeded: classification.succeededUserIds.length,
+        failed: classification.failedUserIds.length,
+        failedUserIds: classification.failedUserIds,
+      });
+    }
+
+    const snapshots = settled
+      .filter(
+        (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof createSnapshot>>> =>
+          result.status === "fulfilled",
+      )
+      .map((result) => result.value);
+
+    // 4. Invalidate snapshot/history caches for every user whose snapshot
+    // actually committed, regardless of whether other users failed.
+    if (classification.succeededUserIds.length > 0) {
+      revalidateTag("snapshots", "max");
+      for (const userId of classification.succeededUserIds) {
+        revalidateTag(`history:${userId}`, "max");
+      }
     }
 
     const finishedAt = new Date();
     await prisma.cronRun.update({
       where: { id: cronRun.id },
       data: {
-        ok: true,
+        ok: classification.ok,
         finishedAt,
         durationMs: finishedAt.getTime() - startedAt.getTime(),
+        error: classification.errorSummary,
       },
     });
-    finishSnapshotCronCheckIn(checkIn, "ok");
+    finishSnapshotCronCheckIn(checkIn, classification.ok ? "ok" : "error");
+
+    if (classification.status === "failed") {
+      return failure("All user snapshots failed", 500);
+    }
 
     return ok({
       success: true,
+      degraded: classification.status === "degraded",
       snapshotIds: snapshots.map((s) => s.id),
+      failedUserIds: classification.failedUserIds,
       timestamp: finishedAt.toISOString(),
     });
   } catch (error) {

--- a/src/lib/cron-run-status.ts
+++ b/src/lib/cron-run-status.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure classification helper for per-user cron work (currently: snapshot
+ * creation in `/api/cron/snapshot`). Kept separate from the route so it's
+ * unit-testable without mocking Prisma/Next.js — see issue #558: one user's
+ * snapshot failure used to reject the whole `Promise.all` batch, which
+ * skipped cache revalidation for every user (including ones whose snapshot
+ * had already committed) and reported total failure even when most users
+ * succeeded.
+ */
+
+export type CronUserOutcome = {
+  userId: string;
+  status: "fulfilled" | "rejected";
+  reason?: unknown;
+};
+
+export type CronRunStatus = "ok" | "degraded" | "failed";
+
+export type CronRunClassification = {
+  /** Whether the `CronRun.ok` audit column should be set to true. */
+  ok: boolean;
+  /** "ok" = everyone succeeded, "degraded" = a subset failed, "failed" = everyone failed. */
+  status: CronRunStatus;
+  succeededUserIds: string[];
+  failedUserIds: string[];
+  /** Human-readable summary for the `CronRun.error` column, or null if nothing failed. */
+  errorSummary: string | null;
+};
+
+/**
+ * Classifies the outcome of a per-user batch (e.g. `Promise.allSettled` over
+ * per-user snapshot creation) into an overall run status.
+ *
+ * - No failures → "ok"
+ * - Some, but not all, failed → "degraded" (still `ok: true` — the run made
+ *   progress and revalidation should proceed for the users who succeeded)
+ * - Everyone failed (or the batch was empty) → "failed"
+ */
+export function classifyCronRunStatus(outcomes: CronUserOutcome[]): CronRunClassification {
+  const succeededUserIds = outcomes.filter((o) => o.status === "fulfilled").map((o) => o.userId);
+  const failed = outcomes.filter((o) => o.status === "rejected");
+  const failedUserIds = failed.map((o) => o.userId);
+
+  if (outcomes.length === 0 || failed.length === 0) {
+    return { ok: true, status: "ok", succeededUserIds, failedUserIds, errorSummary: null };
+  }
+
+  const errorSummary = failed
+    .map((o) => `${o.userId}: ${o.reason instanceof Error ? o.reason.message : String(o.reason)}`)
+    .join("; ");
+
+  if (failed.length === outcomes.length) {
+    return { ok: false, status: "failed", succeededUserIds, failedUserIds, errorSummary };
+  }
+
+  return { ok: true, status: "degraded", succeededUserIds, failedUserIds, errorSummary };
+}

--- a/tests/unit/cron-run-status.test.ts
+++ b/tests/unit/cron-run-status.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { classifyCronRunStatus, type CronUserOutcome } from "@/lib/cron-run-status";
+
+describe("classifyCronRunStatus", () => {
+  it("classifies an all-success batch as ok", () => {
+    const outcomes: CronUserOutcome[] = [
+      { userId: "u1", status: "fulfilled" },
+      { userId: "u2", status: "fulfilled" },
+    ];
+
+    const result = classifyCronRunStatus(outcomes);
+
+    expect(result).toEqual({
+      ok: true,
+      status: "ok",
+      succeededUserIds: ["u1", "u2"],
+      failedUserIds: [],
+      errorSummary: null,
+    });
+  });
+
+  it("classifies a partial failure as degraded but ok — the whole point of #558", () => {
+    const outcomes: CronUserOutcome[] = [
+      { userId: "u1", status: "fulfilled" },
+      { userId: "u2", status: "rejected", reason: new Error("boom") },
+      { userId: "u3", status: "fulfilled" },
+    ];
+
+    const result = classifyCronRunStatus(outcomes);
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("degraded");
+    expect(result.succeededUserIds).toEqual(["u1", "u3"]);
+    expect(result.failedUserIds).toEqual(["u2"]);
+    expect(result.errorSummary).toContain("u2");
+    expect(result.errorSummary).toContain("boom");
+  });
+
+  it("classifies a total failure as failed and not ok", () => {
+    const outcomes: CronUserOutcome[] = [
+      { userId: "u1", status: "rejected", reason: new Error("db down") },
+      { userId: "u2", status: "rejected", reason: "some string reason" },
+    ];
+
+    const result = classifyCronRunStatus(outcomes);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("failed");
+    expect(result.succeededUserIds).toEqual([]);
+    expect(result.failedUserIds).toEqual(["u1", "u2"]);
+    expect(result.errorSummary).toContain("db down");
+    expect(result.errorSummary).toContain("some string reason");
+  });
+
+  it("classifies an empty batch as ok", () => {
+    const result = classifyCronRunStatus([]);
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("ok");
+    expect(result.errorSummary).toBeNull();
+  });
+});

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -3,6 +3,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const h = vi.hoisted(() => ({
   events: [] as string[],
   expiredOptions: [] as Array<{ id: string; quantity: number }>,
+  users: [{ id: "user1", appSettings: { baseCurrency: "USD" } }] as Array<{
+    id: string;
+    appSettings: { baseCurrency: string } | null;
+  }>,
+  /** userIds whose createSnapshot call should reject. */
+  failingUserIds: [] as string[],
+  cronRunUpdates: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -41,9 +48,12 @@ vi.mock("@/lib/services/recurring-investment-service", () => ({
 }));
 
 vi.mock("@/lib/services/snapshot-service", () => ({
-  createSnapshot: vi.fn(async () => {
-    h.events.push("snapshot");
-    return { id: "snapshot1" };
+  createSnapshot: vi.fn(async (userId: string) => {
+    if (h.failingUserIds.includes(userId)) {
+      throw new Error(`snapshot failed for ${userId}`);
+    }
+    h.events.push(`snapshot:${userId}`);
+    return { id: `snapshot-${userId}` };
   }),
 }));
 
@@ -51,7 +61,10 @@ vi.mock("@/lib/prisma", () => {
   const prisma = {
     cronRun: {
       create: vi.fn(async () => ({ id: "cron1" })),
-      update: vi.fn(async () => ({})),
+      update: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        h.cronRunUpdates.push(args.data);
+        return {};
+      }),
     },
     holding: {
       findMany: vi.fn(async () => h.expiredOptions),
@@ -67,7 +80,7 @@ vi.mock("@/lib/prisma", () => {
       findMany: vi.fn(async () => []),
     },
     user: {
-      findMany: vi.fn(async () => [{ id: "user1", appSettings: { baseCurrency: "USD" } }]),
+      findMany: vi.fn(async () => h.users),
     },
     $transaction: vi.fn(async (work: unknown) => {
       if (Array.isArray(work)) return Promise.all(work);
@@ -81,6 +94,9 @@ describe("snapshot cron route", () => {
   beforeEach(() => {
     h.events = [];
     h.expiredOptions = [];
+    h.users = [{ id: "user1", appSettings: { baseCurrency: "USD" } }];
+    h.failingUserIds = [];
+    h.cronRunUpdates = [];
   });
 
   it("invalidates net worth before snapshot creation when options expire", async () => {
@@ -96,6 +112,76 @@ describe("snapshot cron route", () => {
     expect(response.status).toBe(200);
     expect(h.events).toContain("revalidate:accounts");
     expect(h.events).toContain("revalidate:net-worth");
-    expect(h.events.indexOf("revalidate:net-worth")).toBeLessThan(h.events.indexOf("snapshot"));
+    expect(h.events.indexOf("revalidate:net-worth")).toBeLessThan(
+      h.events.indexOf("snapshot:user1"),
+    );
+  });
+
+  it("still revalidates and reports success for users whose snapshot succeeded when another user's fails (#558)", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "USD" } },
+      { id: "user3", appSettings: { baseCurrency: "TWD" } },
+    ];
+    h.failingUserIds = ["user2"];
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+    const body = (await response.json()) as {
+      data: { success: boolean; degraded: boolean; snapshotIds: string[]; failedUserIds: string[] };
+    };
+
+    // Overall request still succeeds — a single user's failure isn't a total outage.
+    expect(response.status).toBe(200);
+    expect(body.data.success).toBe(true);
+    expect(body.data.degraded).toBe(true);
+    expect(body.data.failedUserIds).toEqual(["user2"]);
+
+    // The users who succeeded still got their snapshot committed...
+    expect(h.events).toContain("snapshot:user1");
+    expect(h.events).toContain("snapshot:user3");
+    expect(body.data.snapshotIds).toEqual(
+      expect.arrayContaining(["snapshot-user1", "snapshot-user3"]),
+    );
+
+    // ...and, crucially, revalidation still ran for every user whose snapshot
+    // committed — this is exactly what used to get skipped when Promise.all
+    // rejected on the first failing user.
+    expect(h.events).toContain("revalidate:snapshots");
+    expect(h.events).toContain("revalidate:history:user1");
+    expect(h.events).toContain("revalidate:history:user3");
+    // The failed user's history tag should not be revalidated — nothing new
+    // was written for them.
+    expect(h.events).not.toContain("revalidate:history:user2");
+
+    // The CronRun audit row records a degraded-but-ok run, not a hard failure.
+    const lastUpdate = h.cronRunUpdates[h.cronRunUpdates.length - 1];
+    expect(lastUpdate.ok).toBe(true);
+    expect(String(lastUpdate.error)).toContain("user2");
+  });
+
+  it("marks the CronRun as a hard failure only when every user's snapshot fails", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "USD" } },
+    ];
+    h.failingUserIds = ["user1", "user2"];
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(h.events).not.toContain("revalidate:snapshots");
+
+    const lastUpdate = h.cronRunUpdates[h.cronRunUpdates.length - 1];
+    expect(lastUpdate.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- The daily snapshot cron (`GET /api/cron/snapshot`) created all users' `NetWorthSnapshot` rows with `Promise.all`, so one user's failure rejected the entire batch. In-flight upserts for *other* users still committed to the DB, but control jumped straight to the outer `catch`, which meant `revalidateTag("snapshots")` and the per-user `history:${id}` tag never ran for **any** user — leaving users whose snapshot succeeded looking at stale history until their next mutation or the next day's cron.
- It also masked partial success: the `CronRun` audit row and Sentry check-in reported total failure even when only one user out of many actually failed, with no per-user attribution in the logs.
- Fixed by switching the per-user snapshot loop to `Promise.allSettled` and adding a small pure helper, `classifyCronRunStatus` (`src/lib/cron-run-status.ts`), that classifies the settled results into `ok` / `degraded` / `failed`:
  - `ok` — everyone succeeded.
  - `degraded` — a subset failed; `CronRun.ok` stays `true` (progress was made) but `CronRun.error` records which user(s) failed and why. Revalidation (`snapshots` tag + per-user `history:${id}` tags) now runs for every user whose snapshot actually committed, regardless of the others.
  - `failed` — every user failed; `CronRun.ok = false`, Sentry check-in reports `error`, and the route returns `500`. This is the only case where the batch itself is treated as a hard cron failure — a non-per-user step throwing (price/rate refresh, recurring materialization, etc.) still hits the existing outer `catch` unchanged.
- Each per-user failure is logged individually via `log.error("cron.snapshot.user_failed", { userId, error })` for attribution.
- The recurring cash/investment "catch-up loop" (F6) and the price/rate refresh step are untouched — this PR only touches the per-user snapshot-creation loop and its downstream revalidation/audit logic.

## Test plan

- [x] `pnpm test:unit` — added `tests/unit/cron-run-status.test.ts` (pure classifier: all-success/degraded/all-failed/empty) and extended `tests/unit/cron-snapshot-route.test.ts` with two new cases: (1) one user fails among three — asserts the other two still get their snapshot + revalidation tags, the response is 200 with `degraded: true`, and `CronRun.ok` stays `true` with an error summary naming the failed user; (2) every user fails — asserts a 500 response and `CronRun.ok = false`.
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm build` — skipped locally (no `DATABASE_URL` in this sandbox); no schema changes were made so this shouldn't be affected.

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQk8cJwVFpVmdVCAd45XXB