### PR TITLE
Fix DST day counting

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,12 +11,15 @@ export function localToday() {
   return local.toISOString().slice(0, 10);
 }
 
-function dateToLocalTime(value: string) {
+function dateToUtcMidnight(value: string) {
   const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, month - 1, day).getTime();
+  return Date.UTC(year, month - 1, day);
 }
 
 export function daysBetweenDates(startDate: string, endDate: string) {
   const DAY_MS = 24 * 60 * 60 * 1000;
-  return Math.max(0, Math.floor((dateToLocalTime(endDate) - dateToLocalTime(startDate)) / DAY_MS));
+  return Math.max(
+    0,
+    Math.floor((dateToUtcMidnight(endDate) - dateToUtcMidnight(startDate)) / DAY_MS),
+  );
 }

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,23 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { daysBetweenDates } from "@/lib/utils";
+
+describe("daysBetweenDates", () => {
+  const originalTz = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = "America/New_York";
+  });
+
+  afterAll(() => {
+    process.env.TZ = originalTz;
+  });
+
+  it("counts calendar days across a DST spring-forward boundary", () => {
+    expect(daysBetweenDates("2026-03-08", "2026-03-09")).toBe(1);
+  });
+
+  it("keeps same-day and reversed-date behavior at zero", () => {
+    expect(daysBetweenDates("2026-03-08", "2026-03-08")).toBe(0);
+    expect(daysBetweenDates("2026-03-09", "2026-03-08")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Calculate stock day ranges from UTC calendar dates to avoid DST-short-day undercounts
- Add a focused regression test for the America/New_York spring-forward boundary

## Validation
- pnpm test:unit
- pnpm test:e2e
- pnpm format:check
- pnpm lint
- pnpm typecheck
- git diff --check origin/master...HEAD

Closes #548