### PR TITLE
Fix remaining open issues

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -49,7 +49,15 @@
     "discardTitle": "Discard changes?",
     "discardBody": "What you've entered will be lost.",
     "discardConfirm": "Discard",
-    "keepEditing": "Keep editing"
+    "keepEditing": "Keep editing",
+    "theme": {
+      "label": "Theme",
+      "change": "Change theme",
+      "switchTo": "Switch to {theme} mode",
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    }
   },
   "errors": {
     "title": "Something went wrong",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -49,7 +49,15 @@
     "discardTitle": "捨棄變更？",
     "discardBody": "您輸入的內容將會遺失。",
     "discardConfirm": "捨棄",
-    "keepEditing": "繼續編輯"
+    "keepEditing": "繼續編輯",
+    "theme": {
+      "label": "外觀",
+      "change": "切換外觀",
+      "switchTo": "切換為{theme}模式",
+      "light": "淺色",
+      "dark": "深色",
+      "system": "系統"
+    }
   },
   "errors": {
     "title": "發生錯誤",

--- a/src/app/(main)/projections/page.tsx
+++ b/src/app/(main)/projections/page.tsx
@@ -28,7 +28,7 @@ async function ProjectionsContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <MobileHubRedirect hash="#projections" />
-      <div className="space-y-4 md:space-y-8 animate-in fade-in duration-200">
+      <div className="hidden space-y-4 md:block md:space-y-8 md:animate-in md:fade-in md:duration-200">
         <LargeTitleHeading>{t("title")}</LargeTitleHeading>
 
         <ProjectionView

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -12,7 +12,14 @@ import { NextIntlClientProvider } from "next-intl";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 
-const CLIENT_NAMESPACES = ["settings", "toast", "languages", "dataManagement", "freshness"];
+const CLIENT_NAMESPACES = [
+  "settings",
+  "toast",
+  "languages",
+  "dataManagement",
+  "freshness",
+  "common",
+];
 
 async function SettingsContent() {
   const session = await getSession();

--- a/src/app/(main)/stocks/page.tsx
+++ b/src/app/(main)/stocks/page.tsx
@@ -22,7 +22,7 @@ async function StocksContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(messages, CLIENT_NAMESPACES)}>
       <MobileHubRedirect hash="#watchlist" />
-      <div className="space-y-4 md:space-y-8 animate-in fade-in duration-200">
+      <div className="hidden space-y-4 md:block md:space-y-8 md:animate-in md:fade-in md:duration-200">
         <div>
           <LargeTitleHeading>{t("title")}</LargeTitleHeading>
           <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{t("subtitle")}</p>

--- a/src/app/api/accounts/[id]/holdings/route.ts
+++ b/src/app/api/accounts/[id]/holdings/route.ts
@@ -127,26 +127,26 @@ export const POST = withAuth<IdCtx>(async (request, { params }, userId) => {
     return upserted;
   });
 
-  // Auto-fetch the market price for the holding
-  try {
-    const isCrypto = parsed.data.assetType === "CRYPTO";
-    const priceResults = isCrypto
-      ? await fetchCryptoPrices([holding.symbol])
-      : await fetchStockPrices([holding.symbol]);
+  after(async () => {
+    try {
+      const isCrypto = holding.assetType === "CRYPTO";
+      const priceResults = isCrypto
+        ? await fetchCryptoPrices([holding.symbol])
+        : await fetchStockPrices([holding.symbol]);
 
-    const result = priceResults.get(holding.symbol);
-    if (result) {
-      await prisma.priceCache.upsert({
-        where: { symbol: holding.symbol },
-        update: { price: result.price, currency: result.currency, updatedAt: new Date() },
-        create: { symbol: holding.symbol, price: result.price, currency: result.currency },
-      });
-      revalidateTag("prices", { expire: 0 });
+      const result = priceResults.get(holding.symbol);
+      if (result) {
+        await prisma.priceCache.upsert({
+          where: { symbol: holding.symbol },
+          update: { price: result.price, currency: result.currency, updatedAt: new Date() },
+          create: { symbol: holding.symbol, price: result.price, currency: result.currency },
+        });
+        revalidateTag("prices", { expire: 0 });
+      }
+    } catch (error) {
+      log.error("holdings.price_fetch.failed", { symbol: holding.symbol, error: String(error) });
     }
-  } catch (error) {
-    // Non-blocking: if price fetch fails, holding is still created
-    log.error("holdings.price_fetch.failed", { symbol: holding.symbol, error: String(error) });
-  }
+  });
 
   invalidateUserCaches(userId);
   if (holding.currency) after(() => maybeWarmExchangeRate(holding.currency));

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -19,6 +19,16 @@ export const PATCH = withAuth<IdCtx>(async (request, { params }, userId) => {
   const existing = await prisma.goal.findUnique({ where: { id, userId } });
   if (!existing) return failure("Not found", 404);
 
+  const scope = parsed.data.scope ?? existing.scope;
+  const scopeRefId =
+    parsed.data.scopeRefId !== undefined ? parsed.data.scopeRefId : existing.scopeRefId;
+  if (scope === "ACCOUNT") {
+    const account = scopeRefId
+      ? await prisma.account.findUnique({ where: { id: scopeRefId, userId }, select: { id: true } })
+      : null;
+    if (!account) return failure("Invalid account scope", 400);
+  }
+
   const { targetDate, ...rest } = parsed.data;
   const goal = await prisma.goal.update({
     where: { id, userId },

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,7 +1,7 @@
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { createGoalSchema } from "@/lib/validators";
-import { ok, validationError } from "@/lib/api-responses";
+import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
 function invalidateGoalCaches(userId: string) {
@@ -20,6 +20,16 @@ export const POST = withAuth(async (request, _ctx, userId) => {
   const body = await request.json();
   const parsed = createGoalSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
+
+  if (parsed.data.scope === "ACCOUNT") {
+    const account = parsed.data.scopeRefId
+      ? await prisma.account.findUnique({
+          where: { id: parsed.data.scopeRefId, userId },
+          select: { id: true },
+        })
+      : null;
+    if (!account) return failure("Invalid account scope", 400);
+  }
 
   // Append new goals to the bottom so a manually saved order stays intact.
   const { _max } = await prisma.goal.aggregate({

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { useTheme } from "next-themes";
+import { useTranslations } from "next-intl";
 import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const themes = [
-  { value: "light", icon: Sun, label: "Light" },
-  { value: "dark", icon: Moon, label: "Dark" },
-  { value: "system", icon: Monitor, label: "System" },
+  { value: "light", icon: Sun },
+  { value: "dark", icon: Moon },
+  { value: "system", icon: Monitor },
 ] as const;
 
 type ThemeValue = (typeof themes)[number]["value"];
@@ -29,6 +30,7 @@ export function ThemeToggle({
   variant?: "compact" | "full" | "cycle" | "popover";
 }) {
   const { theme, setTheme } = useTheme();
+  const t = useTranslations("common.theme");
   const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -86,6 +88,7 @@ export function ThemeToggle({
     const CurrentIcon = mounted
       ? (themes.find((t) => t.value === theme)?.icon ?? Monitor)
       : Monitor;
+    const changeTheme = t("change");
 
     return (
       <div ref={containerRef} className="relative">
@@ -94,8 +97,8 @@ export function ThemeToggle({
           onClick={() => setOpen((o) => !o)}
           aria-expanded={open}
           aria-haspopup="listbox"
-          aria-label="Change theme"
-          title="Change theme"
+          aria-label={changeTheme}
+          title={changeTheme}
           className="inline-flex items-center justify-center rounded-md h-11 w-11 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           <CurrentIcon className="h-4 w-4" />
@@ -104,10 +107,11 @@ export function ThemeToggle({
         {open && (
           <div
             role="listbox"
-            aria-label="Theme"
+            aria-label={t("label")}
             className="absolute top-full right-0 mt-1 z-[60] w-36 rounded-xl border border-border bg-popover shadow-lg shadow-black/10 dark:shadow-black/30 overflow-hidden"
           >
-            {themes.map(({ value, icon: Icon, label }) => {
+            {themes.map(({ value, icon: Icon }) => {
+              const label = t(value);
               const isActive = mounted && theme === value;
               return (
                 <button
@@ -140,7 +144,8 @@ export function ThemeToggle({
   if (variant === "full") {
     return (
       <div className="flex w-full items-center gap-1 rounded-lg border p-1 bg-muted/30 sm:w-fit">
-        {themes.map(({ value, icon: Icon, label }) => {
+        {themes.map(({ value, icon: Icon }) => {
+          const label = t(value);
           const isActive = mounted && theme === value;
           return (
             <button
@@ -169,6 +174,7 @@ export function ThemeToggle({
     const currentIndex = CYCLE_ORDER.indexOf((theme as ThemeValue) ?? "system");
     const nextTheme = CYCLE_ORDER[(currentIndex + 1) % CYCLE_ORDER.length];
     const nextEntry = themes.find((t) => t.value === nextTheme)!;
+    const nextLabel = t(nextEntry.value);
     const CurrentIcon = mounted
       ? (themes.find((t) => t.value === theme)?.icon ?? Monitor)
       : Monitor;
@@ -177,8 +183,8 @@ export function ThemeToggle({
       <button
         type="button"
         onClick={(e) => handleSelect(nextTheme, e)}
-        aria-label={`Switch to ${nextEntry.label} mode`}
-        title={`Switch to ${nextEntry.label} mode`}
+        aria-label={t("switchTo", { theme: nextLabel })}
+        title={t("switchTo", { theme: nextLabel })}
         className="inline-flex items-center justify-center rounded-md h-11 w-11 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         <CurrentIcon className="h-4 w-4" />
@@ -200,21 +206,24 @@ export function ThemeToggle({
 
   return (
     <div className="flex items-center gap-0.5 rounded-lg bg-muted/50 p-0.5">
-      {themes.map(({ value, icon: Icon, label }) => (
-        <button
-          key={value}
-          onClick={(e) => handleSelect(value, e)}
-          className={cn(
-            "inline-flex items-center justify-center rounded-md p-1.5 text-sm transition-all duration-200",
-            theme === value
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          title={label}
-        >
-          <Icon className="h-4 w-4" />
-        </button>
-      ))}
+      {themes.map(({ value, icon: Icon }) => {
+        const label = t(value);
+        return (
+          <button
+            key={value}
+            onClick={(e) => handleSelect(value, e)}
+            className={cn(
+              "inline-flex items-center justify-center rounded-md p-1.5 text-sm transition-all duration-200",
+              theme === value
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            title={label}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -424,7 +424,7 @@ export async function getAccountMonthlyCashFlow(
     prisma.netWorthSnapshot.findFirst({
       where: { userId },
       orderBy: { date: "asc" },
-      select: { date: true },
+      select: { date: true, createdAt: true },
     }),
   ]);
 
@@ -437,14 +437,14 @@ export async function getAccountMonthlyCashFlow(
   // baseline. Counting such a pre-snapshot flow as a contribution double-counts
   // it: the first bucket then reports contributions ≈ the deposit and a phantom
   // marketPerformance ≈ −deposit that buildCumulativeGrowth carries across the
-  // whole range. Flooring at the first snapshot's date with a strict `gt`
+  // whole range. Flooring at the first snapshot's createdAt with a strict `gt`
   // aligns the contribution window with that baseline, so only flows that
   // occurred AFTER the starting snapshot are attributed to the first bucket.
   // (Months before the first snapshot are unreachable by the analysis UI, so
   // this also preserves PE29's scan-narrowing intent.) The floor compares
   // against the effective date (occurrenceDate ?? createdAt) to match the
   // month-key bucketing below.
-  const floor = firstSnapshot ? firstSnapshot.date : null;
+  const floor = firstSnapshot ? (firstSnapshot.createdAt ?? firstSnapshot.date) : null;
 
   const transactions = await prisma.cashTransaction.findMany({
     where: {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -347,7 +347,8 @@ export const reorderStocksSchema = z.object({
   orderedIds: z.array(z.string().min(1)),
 });
 
-const decimalSchema = z.union([z.string(), z.number()]);
+const decimalStringSchema = z.string().regex(/^-?\d+(\.\d+)?$/, "Must be a decimal number");
+const decimalSchema = z.union([decimalStringSchema, z.number().finite()]);
 
 const MAX_IMPORT_ACCOUNTS = 200;
 const MAX_IMPORT_HOLDINGS_PER_ACCOUNT = 2_000;
@@ -410,7 +411,7 @@ export const dataImportSchema = z.object({
               underlyingSymbol: z.string().optional().nullable(),
               optionType: z.enum(OPTION_TYPES).optional().nullable(),
               strike: decimalSchema.optional().nullable(),
-              expiration: z.string().optional().nullable(),
+              expiration: z.iso.datetime().optional().nullable(),
               contractMultiplier: z.number().int().optional().nullable(),
               transactions: z
                 .array(
@@ -450,7 +451,7 @@ export const dataImportSchema = z.object({
               type: z.enum(RECURRING_CASH_TYPES),
               amount: decimalSchema,
               frequency: z.enum(RECURRING_FREQUENCIES),
-              note: z.string().optional().nullable(),
+              note: z.string().max(500).optional().nullable(),
               startDate: importTimestamp,
               endDate: importTimestamp,
               nextRunDate: importTimestamp,
@@ -471,7 +472,7 @@ export const dataImportSchema = z.object({
               holdingCurrency: z.string().length(3),
               amount: decimalSchema,
               frequency: z.enum(RECURRING_FREQUENCIES),
-              note: z.string().optional().nullable(),
+              note: z.string().max(500).optional().nullable(),
               startDate: importTimestamp,
               endDate: importTimestamp,
               nextRunDate: importTimestamp,
@@ -488,7 +489,7 @@ export const dataImportSchema = z.object({
   snapshots: z
     .array(
       z.object({
-        date: z.string(),
+        date: z.iso.datetime(),
         totalAssets: decimalSchema,
         totalLiabilities: decimalSchema,
         netWorth: decimalSchema,
@@ -507,7 +508,7 @@ export const dataImportSchema = z.object({
         name: z.string().min(1).max(100),
         targetAmount: decimalSchema,
         targetCurrency: z.string().length(3),
-        targetDate: z.string().optional().nullable(),
+        targetDate: z.iso.datetime().optional().nullable(),
         scope: z.enum(GOAL_SCOPES),
         scopeRefId: z.string().optional().nullable(),
         sortOrder: z.number().int().default(0),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,10 +46,20 @@ interface _RLEntry {
   resetAt: number;
 }
 const _authRLStore = new Map<string, _RLEntry>();
+let _authRLLastPruned = 0;
+
+function _authRLMaybePrune(now: number): void {
+  if (now - _authRLLastPruned < 60_000) return;
+  _authRLLastPruned = now;
+  for (const [ip, entry] of _authRLStore) {
+    if (now >= entry.resetAt) _authRLStore.delete(ip);
+  }
+}
 
 function _authRateLimit(request: Request): Response | null {
   const ip = getClientIp(request);
   const now = Date.now();
+  _authRLMaybePrune(now);
   const windowMs = 60_000;
   const limit = 20;
   const entry = _authRLStore.get(ip);

--- a/tests/unit/goals-route.test.ts
+++ b/tests/unit/goals-route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  account: null as { id: string } | null,
+  goal: {
+    id: "goal1",
+    userId: "user1",
+    name: "Brokerage target",
+    targetAmount: 1000,
+    targetCurrency: "USD",
+    targetDate: null,
+    scope: "ACCOUNT",
+    scopeRefId: "acc1",
+    sortOrder: 0,
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/api-handler", () => ({
+  withAuth:
+    (handler: (req: Request, ctx: unknown, userId: string) => Promise<Response>) =>
+    (req: Request, ctx: unknown) =>
+      handler(req, ctx, "user1"),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    account: {
+      findUnique: vi.fn(async () => h.account),
+    },
+    goal: {
+      aggregate: vi.fn(async () => ({ _max: { sortOrder: null } })),
+      create: vi.fn(async () => h.goal),
+      findUnique: vi.fn(async () => h.goal),
+      update: vi.fn(async () => h.goal),
+    },
+  },
+}));
+
+const jsonRequest = (body: Record<string, unknown>, method = "POST") =>
+  new Request("http://unit.test/api/goals", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+
+describe("goals route account scope validation", () => {
+  beforeEach(() => {
+    h.account = null;
+    vi.clearAllMocks();
+  });
+
+  it("rejects creating an account-scoped goal for an unowned account", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    const { POST } = await import("@/app/api/goals/route");
+
+    const response = await POST(
+      jsonRequest({
+        name: "Brokerage target",
+        targetAmount: 1000,
+        targetCurrency: "USD",
+        scope: "ACCOUNT",
+        scopeRefId: "acc1",
+      }),
+      undefined,
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.goal.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects updating a goal to reference an unowned account", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    const { PATCH } = await import("@/app/api/goals/[id]/route");
+
+    const response = await PATCH(jsonRequest({ scope: "ACCOUNT", scopeRefId: "acc1" }, "PATCH"), {
+      params: Promise.resolve({ id: "goal1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(prisma.goal.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -325,17 +325,21 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
 
   it("floors the effective date to the first snapshot instant, exclusive (#509)", async () => {
     h.accounts = [account()];
-    h.latestSnapshot = row({ id: "first", date: new Date("2026-03-05T00:00:00.000Z") });
+    h.latestSnapshot = row({
+      id: "first",
+      date: new Date("2026-03-05T00:00:00.000Z"),
+      createdAt: new Date("2026-03-05T21:30:00.000Z"),
+    });
 
     await getAccountMonthlyCashFlow("u1", "USD");
 
     const args = vi.mocked(prisma.cashTransaction.findMany).mock.lastCall?.[0] as {
       where: Record<string, unknown>;
     };
-    // The floor is the first snapshot's date with a strict `gt`: flows on/before
+    // The floor is the first snapshot's createdAt with a strict `gt`: flows on/before
     // the first snapshot are already baked into the first bucket's baseline, so
     // counting them as contributions double-counts the opening deposit (#509).
-    const floor = new Date("2026-03-05T00:00:00.000Z");
+    const floor = new Date("2026-03-05T21:30:00.000Z");
     expect(args.where.OR).toEqual([
       { occurrenceDate: { gt: floor } },
       { occurrenceDate: null, createdAt: { gt: floor } },
@@ -343,6 +347,31 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     // The accountId/type conditions stay ANDed alongside the floor OR.
     expect(args.where.accountId).toEqual({ in: ["acc"] });
     expect(args.where.type).toEqual({ in: ["DEPOSIT", "WITHDRAWAL"] });
+  });
+
+  it("excludes flows between snapshot date midnight and the snapshot creation instant (#551)", async () => {
+    h.accounts = [account()];
+    h.latestSnapshot = row({
+      id: "first",
+      date: new Date("2026-03-05T00:00:00.000Z"),
+      createdAt: new Date("2026-03-05T21:30:00.000Z"),
+    });
+    h.cashTransactions = [
+      cashTx({
+        amount: 100,
+        occurrenceDate: null,
+        createdAt: new Date("2026-03-05T12:00:00.000Z"),
+      }),
+      cashTx({
+        amount: 25,
+        occurrenceDate: null,
+        createdAt: new Date("2026-03-05T22:00:00.000Z"),
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([{ accountId: "acc", monthKey: "2026-03", contributions: 25 }]);
   });
 
   it("keeps an opening deposit out of the first bucket's contributions (#509)", async () => {

--- a/tests/unit/holdings-route.test.ts
+++ b/tests/unit/holdings-route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
   account: { id: "acc1" } as Record<string, unknown> | null,
+  afterTasks: [] as Array<() => void | Promise<void>>,
   calls: [] as Array<{ op: string; args?: Record<string, unknown> }>,
   existingHolding: null as Record<string, unknown> | null,
   updateError: null as Error | null,
@@ -15,7 +16,9 @@ vi.mock("next/server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("next/server")>();
   return {
     ...actual,
-    after: vi.fn((fn: () => void) => fn()),
+    after: vi.fn((fn: () => void | Promise<void>) => {
+      h.afterTasks.push(fn);
+    }),
   };
 });
 
@@ -90,9 +93,11 @@ const jsonRequest = (body: Record<string, unknown>) =>
 describe("holdings route", () => {
   beforeEach(() => {
     h.account = { id: "acc1" };
+    h.afterTasks = [];
     h.calls = [];
     h.existingHolding = null;
     h.updateError = null;
+    vi.clearAllMocks();
   });
 
   it("writes optional unitPrice to the initial BUY transaction", async () => {
@@ -150,6 +155,39 @@ describe("holdings route", () => {
       | undefined;
     expect(data).toMatchObject({ holdingId: "holding1", type: "BUY", quantity: 10 });
     expect(data).not.toHaveProperty("unitPrice");
+  });
+
+  it("schedules price cache warming after returning the created holding", async () => {
+    const { fetchStockPrices } = await import("@/lib/services/price-service");
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(fetchStockPrices).mockResolvedValueOnce(
+      new Map([["AAPL", { price: 180.25, currency: "USD" }]]),
+    );
+    const { POST } = await import("@/app/api/accounts/[id]/holdings/route");
+
+    const response = await POST(
+      jsonRequest({
+        symbol: "aapl",
+        name: "Apple",
+        quantity: 10,
+        assetType: "STOCK",
+        currency: "USD",
+      }),
+      params,
+    );
+
+    expect(response.status).toBe(201);
+    expect(fetchStockPrices).not.toHaveBeenCalled();
+    expect(prisma.priceCache.upsert).not.toHaveBeenCalled();
+
+    await h.afterTasks[0]();
+
+    expect(fetchStockPrices).toHaveBeenCalledWith(["AAPL"]);
+    expect(prisma.priceCache.upsert).toHaveBeenCalledWith({
+      where: { symbol: "AAPL" },
+      update: { price: 180.25, currency: "USD", updatedAt: expect.any(Date) },
+      create: { symbol: "AAPL", price: 180.25, currency: "USD" },
+    });
   });
 
   it("maps a P2002 symbol conflict on PATCH to a 409", async () => {

--- a/tests/unit/mobile-hub-redirect.test.ts
+++ b/tests/unit/mobile-hub-redirect.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("mobile hub redirects", () => {
+  it("hides standalone stocks and projections content on mobile before redirect", () => {
+    const stocksPage = readFileSync("src/app/(main)/stocks/page.tsx", "utf8");
+    const projectionsPage = readFileSync("src/app/(main)/projections/page.tsx", "utf8");
+
+    expect(stocksPage).toContain("hidden");
+    expect(stocksPage).toContain("md:block");
+    expect(projectionsPage).toContain("hidden");
+    expect(projectionsPage).toContain("md:block");
+  });
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -48,3 +48,27 @@ describe("Sentry tunnel proxy bypass", () => {
     expect(response.headers.get("location")).toBe("https://astt.app/login");
   });
 });
+
+describe("auth proxy rate limiter", () => {
+  it("prunes expired IP windows lazily", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T00:00:00.000Z"));
+    const deleteSpy = vi.spyOn(Map.prototype, "delete");
+
+    const first = new NextRequest("https://astt.app/api/auth/session", {
+      headers: { "x-forwarded-for": "198.51.100.1" },
+    });
+    expect(proxy(first, {} as NextFetchEvent)).toBeUndefined();
+
+    vi.setSystemTime(new Date("2026-07-06T00:01:01.000Z"));
+    const second = new NextRequest("https://astt.app/api/auth/session", {
+      headers: { "x-forwarded-for": "198.51.100.2" },
+    });
+    expect(proxy(second, {} as NextFetchEvent)).toBeUndefined();
+
+    expect(deleteSpy).toHaveBeenCalledWith("198.51.100.1");
+
+    deleteSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/tests/unit/theme-toggle-i18n.test.ts
+++ b/tests/unit/theme-toggle-i18n.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const en = JSON.parse(readFileSync("messages/en-US.json", "utf8"));
+const zh = JSON.parse(readFileSync("messages/zh-TW.json", "utf8"));
+
+describe("theme toggle i18n", () => {
+  it("defines localized labels for every theme option", () => {
+    expect(en.common.theme.light).toBe("Light");
+    expect(en.common.theme.dark).toBe("Dark");
+    expect(en.common.theme.system).toBe("System");
+    expect(zh.common.theme.light).toBe("淺色");
+    expect(zh.common.theme.dark).toBe("深色");
+    expect(zh.common.theme.system).toBe("系統");
+  });
+
+  it("does not keep theme option labels hardcoded in the component", () => {
+    const source = readFileSync("src/components/layout/theme-toggle.tsx", "utf8");
+
+    expect(source).not.toContain('label: "Light"');
+    expect(source).not.toContain('label: "Dark"');
+    expect(source).not.toContain('label: "System"');
+  });
+});

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -556,6 +556,57 @@ describe("dataImportSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects non-numeric imported decimals", () => {
+    const result = dataImportSchema.safeParse({
+      version: "1.2",
+      accounts: [
+        {
+          name: "Checking",
+          type: "ASSET",
+          category: "BANK",
+          currency: "USD",
+          cashBalance: "not-a-number",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed imported snapshot and goal dates", () => {
+    expect(
+      dataImportSchema.safeParse({
+        version: "1.2",
+        accounts: [],
+        snapshots: [
+          {
+            date: "not-a-date",
+            totalAssets: "1",
+            totalLiabilities: "0",
+            netWorth: "1",
+            baseCurrency: "USD",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      dataImportSchema.safeParse({
+        version: "1.2",
+        accounts: [],
+        goals: [
+          {
+            name: "House",
+            targetAmount: "100",
+            targetCurrency: "USD",
+            targetDate: "not-a-date",
+            scope: "NET_WORTH",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   // #517 — bounded string lengths on imported rows (prevents multi-MB padding
   // across up to 200 accounts x 2000 holdings x 10,000 transactions).
   it("rejects oversized imported account name", () => {


### PR DESCRIPTION
## Summary

- prune expired edge-auth rate-limit entries and defer holding price fetches after the response
- use the first snapshot creation instant for cash-flow baselines
- eliminate mobile redirect flashes, tighten import validation, and enforce owned account goal scopes
- localize theme controls in English and Traditional Chinese

## Validation

- `pnpm test:unit`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`

Closes #559
Closes #555
Closes #551
Closes #526
Closes #525
Closes #524
Closes #522