### PR TITLE
fix: prevent invalid recurring rule date ranges

### DIFF
--- a/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
+++ b/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Reject partial recurring-rule edits that would make `endDate` earlier than the effective `startDate`.
 
-**Architecture:** The two existing route handlers remain the validation boundary. Each reads the rule's persisted date range, merges it with the validated PATCH payload, and rejects an invalid merged range before the Prisma update. A focused route-test file supplies mocked Prisma delegates and proves no write occurs for either invalid one-field edit direction.
+**Architecture:** The two existing route handlers remain the validation boundary. Each reads the rule's persisted date range, merges it with the validated PATCH payload, and rejects an invalid merged range before a guarded Prisma update. The update matches the read date range so a conflicting date edit returns 409 rather than writing stale data. A focused route-test file proves both invalid partial-edit directions and stale-write handling.
 
 **Tech Stack:** Next.js 16 Route Handlers, TypeScript, Prisma, Zod, Vitest.
 
@@ -81,7 +81,7 @@ Replace the `select: { id: true }` selection with:
 select: { id: true, startDate: true, endDate: true },
 ```
 
-- [ ] **Step 2: Add the merged-range guard after payload validation**
+- [ ] **Step 2: Add the merged-range guard and conditional write after payload validation**
 
 After destructuring `startDate` and `endDate`, calculate the effective values and return before constructing `data`:
 
@@ -94,7 +94,26 @@ if (effectiveEndDate && effectiveEndDate < effectiveStartDate) {
 }
 ```
 
-Apply the same logic to the cash and investment handlers.
+Replace the final `update` with `updateMany` that also matches the persisted range, then return 409 if no row was affected:
+
+```ts
+const result = await prisma.recurringCashTransaction.updateMany({
+  where: {
+    id: recurringId,
+    startDate: existing.startDate,
+    endDate: existing.endDate,
+  },
+  data,
+});
+if (result.count !== 1) {
+  return failure("Recurring transaction changed while updating; please retry", 409);
+}
+const rule = await prisma.recurringCashTransaction.findUniqueOrThrow({
+  where: { id: recurringId },
+});
+```
+
+Use the analogous `recurringInvestment` delegate and message in the investment handler. Add one stale-write test per route by returning `count: 0` from the mocked `updateMany` and expecting HTTP 409.
 
 - [ ] **Step 3: Run the focused test to verify it passes**
 

--- a/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
+++ b/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
@@ -1,0 +1,120 @@
+# Recurring Rule PATCH Date-Range Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject partial recurring-rule edits that would make `endDate` earlier than the effective `startDate`.
+
+**Architecture:** The two existing route handlers remain the validation boundary. Each reads the rule's persisted date range, merges it with the validated PATCH payload, and rejects an invalid merged range before the Prisma update. A focused route-test file supplies mocked Prisma delegates and proves no write occurs for either invalid one-field edit direction.
+
+**Tech Stack:** Next.js 16 Route Handlers, TypeScript, Prisma, Zod, Vitest.
+
+## Global Constraints
+
+- Do not add a database migration or change cron scheduling semantics.
+- Preserve the existing `nextRunDate` reset when a valid `startDate` changes.
+- Return `End date must be on or after the start date` with HTTP 400.
+- Follow test-driven development: run the focused test red before changing production handlers.
+
+---
+
+### Task 1: Add failing route regressions
+
+**Files:**
+
+- Create: `tests/unit/recurring-rule-routes.test.ts`
+- Test: `tests/unit/recurring-rule-routes.test.ts`
+
+**Interfaces:**
+
+- Consumes: exported `PATCH` handlers from both recurring route files.
+- Produces: regression coverage that asserts a 400 response and no Prisma update for an invalid merged date range.
+
+- [ ] **Step 1: Write the failing tests**
+
+Mock `withAuth` to call the handler as `user1`, then mock these Prisma methods:
+
+```ts
+recurringCashTransaction: {
+  findFirst: vi.fn(async () => cashRule),
+  update: vi.fn(async () => cashRule),
+},
+recurringInvestment: {
+  findFirst: vi.fn(async () => investmentRule),
+  update: vi.fn(async () => investmentRule),
+},
+```
+
+Use complete rule fixtures with `startDate`, `endDate`, `nextRunDate`, `createdAt`, and `updatedAt` as `Date` objects. For each route, add one test for:
+
+```ts
+await PATCH(jsonRequest({ endDate: "2026-07-31" }), params());
+expect(response.status).toBe(400);
+expect(prismaDelegate.update).not.toHaveBeenCalled();
+```
+
+with an existing `startDate` of `2026-08-01`, and one test for a later submitted `startDate` against an existing `endDate`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `pnpm vitest run tests/unit/recurring-rule-routes.test.ts`
+
+Expected: the invalid one-field PATCH tests fail because the current handlers return 200 and call `update`.
+
+### Task 2: Validate the effective date range in both PATCH handlers
+
+**Files:**
+
+- Modify: `src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts:20-47`
+- Modify: `src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts:19-44`
+- Test: `tests/unit/recurring-rule-routes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `parsed.data.startDate`, `parsed.data.endDate`, and the persisted rule's `startDate`/`endDate`.
+- Produces: a 400 `failure("End date must be on or after the start date", 400)` response before any rule update when the merged range is invalid.
+
+- [ ] **Step 1: Expand each ownership lookup**
+
+Replace the `select: { id: true }` selection with:
+
+```ts
+select: { id: true, startDate: true, endDate: true },
+```
+
+- [ ] **Step 2: Add the merged-range guard after payload validation**
+
+After destructuring `startDate` and `endDate`, calculate the effective values and return before constructing `data`:
+
+```ts
+const effectiveStartDate = startDate ? toUtcDate(startDate) : existing.startDate;
+const effectiveEndDate =
+  endDate === undefined ? existing.endDate : endDate ? toUtcDate(endDate) : null;
+if (effectiveEndDate && effectiveEndDate < effectiveStartDate) {
+  return failure("End date must be on or after the start date", 400);
+}
+```
+
+Apply the same logic to the cash and investment handlers.
+
+- [ ] **Step 3: Run the focused test to verify it passes**
+
+Run: `pnpm vitest run tests/unit/recurring-rule-routes.test.ts`
+
+Expected: all four invalid partial-edit regressions pass and the mocked `update` methods remain uncalled.
+
+- [ ] **Step 4: Run the project validation suite**
+
+Run: `pnpm test:unit && pnpm lint && pnpm typecheck`
+
+Expected: all unit tests, ESLint, and TypeScript checks pass.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md \
+  docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md \
+  tests/unit/recurring-rule-routes.test.ts \
+  src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts \
+  src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+git commit -m "fix: validate merged recurring rule date ranges"
+```

--- a/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
+++ b/docs/superpowers/plans/2026-07-10-recurring-rule-patch-validation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Reject partial recurring-rule edits that would make `endDate` earlier than the effective `startDate`.
 
-**Architecture:** The two existing route handlers remain the validation boundary. Each reads the rule's persisted date range, merges it with the validated PATCH payload, and rejects an invalid merged range before a guarded Prisma update. The update matches the read date range so a conflicting date edit returns 409 rather than writing stale data. A focused route-test file proves both invalid partial-edit directions and stale-write handling.
+**Architecture:** The two existing route handlers remain the validation boundary. Each reads the rule's persisted date range, merges it with the validated PATCH payload, and rejects an invalid merged range before a guarded Prisma update. The `updateManyAndReturn` write matches the read date range so a conflicting date edit returns 409 rather than writing stale data, while the returned row avoids a post-write read race. A focused route-test file proves both invalid partial-edit directions, stale-write handling, and direct returned-row responses.
 
 **Tech Stack:** Next.js 16 Route Handlers, TypeScript, Prisma, Zod, Vitest.
 
@@ -94,10 +94,10 @@ if (effectiveEndDate && effectiveEndDate < effectiveStartDate) {
 }
 ```
 
-Replace the final `update` with `updateMany` that also matches the persisted range, then return 409 if no row was affected:
+Replace the final `update` with `updateManyAndReturn` that also matches the persisted range, then return 409 if no row was affected:
 
 ```ts
-const result = await prisma.recurringCashTransaction.updateMany({
+const [rule] = await prisma.recurringCashTransaction.updateManyAndReturn({
   where: {
     id: recurringId,
     startDate: existing.startDate,
@@ -105,15 +105,12 @@ const result = await prisma.recurringCashTransaction.updateMany({
   },
   data,
 });
-if (result.count !== 1) {
+if (!rule) {
   return failure("Recurring transaction changed while updating; please retry", 409);
 }
-const rule = await prisma.recurringCashTransaction.findUniqueOrThrow({
-  where: { id: recurringId },
-});
 ```
 
-Use the analogous `recurringInvestment` delegate and message in the investment handler. Add one stale-write test per route by returning `count: 0` from the mocked `updateMany` and expecting HTTP 409.
+Use the analogous `recurringInvestment` delegate and message in the investment handler. Add one stale-write test per route by returning an empty array from the mocked `updateManyAndReturn` and expecting HTTP 409, plus one successful-write test per route that proves no follow-up lookup occurs.
 
 - [ ] **Step 3: Run the focused test to verify it passes**
 

--- a/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
+++ b/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
@@ -1,0 +1,33 @@
+# Recurring Rule PATCH Date-Range Validation
+
+## Goal
+
+Prevent a partial edit of a recurring cash or investment rule from persisting an end date that precedes its effective start date.
+
+## Scope
+
+Apply the same behavior to both PATCH endpoints:
+
+- `/api/accounts/[id]/recurring-cash-transactions/[recurringId]`
+- `/api/accounts/[id]/recurring-investments/[recurringId]`
+
+No database migration, cron behavior change, or change to valid scheduling semantics is needed.
+
+## Design
+
+Each handler will select `startDate` and `endDate` alongside the existing ownership lookup. After the existing Zod payload validation succeeds, it will merge the submitted date fields with the persisted fields. If the effective end date exists and is earlier than the effective start date, the handler returns the existing 400 failure response before creating the Prisma update.
+
+The existing schema-level refinement remains responsible for payloads that contain both dates. The route-level check covers the missing case where a one-field PATCH interacts with the other persisted field. A `null` end date remains valid and clears an existing schedule limit.
+
+## Error Handling
+
+The response message is `End date must be on or after the start date`, matching the existing Zod validation message. Invalid requests make no write; valid requests preserve the current behavior, including resetting `nextRunDate` when `startDate` changes.
+
+## Tests
+
+Route-level Vitest tests will mock authenticated user context and the two Prisma rule delegates. For both rule types, they will verify that:
+
+1. a PATCH which moves `endDate` before the existing `startDate` returns 400 and never calls `update`;
+2. a PATCH which moves `startDate` after the existing `endDate` returns 400 and never calls `update`.
+
+The focused test will be run red before production edits, then green afterward, followed by the full unit suite, lint, and type-check.

--- a/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
+++ b/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
@@ -17,6 +17,8 @@ No database migration, cron behavior change, or change to valid scheduling seman
 
 Each handler will select `startDate` and `endDate` alongside the existing ownership lookup. After the existing Zod payload validation succeeds, it will merge the submitted date fields with the persisted fields. If the effective end date exists and is earlier than the effective start date, the handler returns the existing 400 failure response before creating the Prisma update.
 
+The write uses `updateMany` guarded by the same persisted start/end values that were read. If a concurrent edit has changed either date, the guarded write affects zero rows and the handler returns 409 rather than committing against a stale schedule. This keeps two individually valid partial edits from combining into an invalid range.
+
 The existing schema-level refinement remains responsible for payloads that contain both dates. The route-level check covers the missing case where a one-field PATCH interacts with the other persisted field. A `null` end date remains valid and clears an existing schedule limit.
 
 ## Error Handling
@@ -27,7 +29,8 @@ The response message is `End date must be on or after the start date`, matching 
 
 Route-level Vitest tests will mock authenticated user context and the two Prisma rule delegates. For both rule types, they will verify that:
 
-1. a PATCH which moves `endDate` before the existing `startDate` returns 400 and never calls `update`;
-2. a PATCH which moves `startDate` after the existing `endDate` returns 400 and never calls `update`.
+1. a PATCH which moves `endDate` before the existing `startDate` returns 400 and never calls `updateMany`;
+2. a PATCH which moves `startDate` after the existing `endDate` returns 400 and never calls `updateMany`;
+3. a stale guarded write returns 409 for either rule type.
 
 The focused test will be run red before production edits, then green afterward, followed by the full unit suite, lint, and type-check.

--- a/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
+++ b/docs/superpowers/specs/2026-07-10-recurring-rule-patch-validation-design.md
@@ -17,7 +17,7 @@ No database migration, cron behavior change, or change to valid scheduling seman
 
 Each handler will select `startDate` and `endDate` alongside the existing ownership lookup. After the existing Zod payload validation succeeds, it will merge the submitted date fields with the persisted fields. If the effective end date exists and is earlier than the effective start date, the handler returns the existing 400 failure response before creating the Prisma update.
 
-The write uses `updateMany` guarded by the same persisted start/end values that were read. If a concurrent edit has changed either date, the guarded write affects zero rows and the handler returns 409 rather than committing against a stale schedule. This keeps two individually valid partial edits from combining into an invalid range.
+The write uses `updateManyAndReturn` guarded by the same persisted start/end values that were read. If a concurrent edit has changed either date, the guarded write returns no rows and the handler returns 409 rather than committing against a stale schedule. The returned row is serialized directly, avoiding a post-write read that could race with a delete or later edit. This keeps two individually valid partial edits from combining into an invalid range.
 
 The existing schema-level refinement remains responsible for payloads that contain both dates. The route-level check covers the missing case where a one-field PATCH interacts with the other persisted field. A `null` end date remains valid and clears an existing schedule limit.
 

--- a/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
@@ -47,7 +47,7 @@ export const PATCH = withAuth(
       data.nextRunDate = toUtcDate(startDate);
     }
 
-    const result = await prisma.recurringCashTransaction.updateMany({
+    const [rule] = await prisma.recurringCashTransaction.updateManyAndReturn({
       where: {
         id: recurringId,
         startDate: existing.startDate,
@@ -55,13 +55,9 @@ export const PATCH = withAuth(
       },
       data,
     });
-    if (result.count !== 1) {
+    if (!rule) {
       return failure("Recurring transaction changed while updating; please retry", 409);
     }
-
-    const rule = await prisma.recurringCashTransaction.findUniqueOrThrow({
-      where: { id: recurringId },
-    });
 
     return ok(serializeRecurringCashTransaction(rule));
   },

--- a/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
@@ -47,9 +47,20 @@ export const PATCH = withAuth(
       data.nextRunDate = toUtcDate(startDate);
     }
 
-    const rule = await prisma.recurringCashTransaction.update({
-      where: { id: recurringId },
+    const result = await prisma.recurringCashTransaction.updateMany({
+      where: {
+        id: recurringId,
+        startDate: existing.startDate,
+        endDate: existing.endDate,
+      },
       data,
+    });
+    if (result.count !== 1) {
+      return failure("Recurring transaction changed while updating; please retry", 409);
+    }
+
+    const rule = await prisma.recurringCashTransaction.findUniqueOrThrow({
+      where: { id: recurringId },
     });
 
     return ok(serializeRecurringCashTransaction(rule));

--- a/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
@@ -19,11 +19,17 @@ export const PATCH = withAuth(
     // Scope ownership into the lookup so a foreign rule can't be edited.
     const existing = await prisma.recurringCashTransaction.findFirst({
       where: { id: recurringId, accountId: id, account: { userId } },
-      select: { id: true },
+      select: { id: true, startDate: true, endDate: true },
     });
     if (!existing) return failure("Recurring transaction not found", 404);
 
     const { type, amount, frequency, note, startDate, endDate, isActive } = parsed.data;
+    const effectiveStartDate = startDate ? toUtcDate(startDate) : existing.startDate;
+    const effectiveEndDate =
+      endDate === undefined ? existing.endDate : endDate ? toUtcDate(endDate) : null;
+    if (effectiveEndDate && effectiveEndDate < effectiveStartDate) {
+      return failure("End date must be on or after the start date", 400);
+    }
 
     const data: Record<string, unknown> = {};
     if (type !== undefined) data.type = type;

--- a/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
@@ -44,9 +44,20 @@ export const PATCH = withAuth(
       data.nextRunDate = toUtcDate(startDate);
     }
 
-    const rule = await prisma.recurringInvestment.update({
-      where: { id: recurringId },
+    const result = await prisma.recurringInvestment.updateMany({
+      where: {
+        id: recurringId,
+        startDate: existing.startDate,
+        endDate: existing.endDate,
+      },
       data,
+    });
+    if (result.count !== 1) {
+      return failure("Recurring investment changed while updating; please retry", 409);
+    }
+
+    const rule = await prisma.recurringInvestment.findUniqueOrThrow({
+      where: { id: recurringId },
     });
 
     return ok(serializeRecurringInvestment(rule));

--- a/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
@@ -44,7 +44,7 @@ export const PATCH = withAuth(
       data.nextRunDate = toUtcDate(startDate);
     }
 
-    const result = await prisma.recurringInvestment.updateMany({
+    const [rule] = await prisma.recurringInvestment.updateManyAndReturn({
       where: {
         id: recurringId,
         startDate: existing.startDate,
@@ -52,13 +52,9 @@ export const PATCH = withAuth(
       },
       data,
     });
-    if (result.count !== 1) {
+    if (!rule) {
       return failure("Recurring investment changed while updating; please retry", 409);
     }
-
-    const rule = await prisma.recurringInvestment.findUniqueOrThrow({
-      where: { id: recurringId },
-    });
 
     return ok(serializeRecurringInvestment(rule));
   },

--- a/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
@@ -18,11 +18,17 @@ export const PATCH = withAuth(
 
     const existing = await prisma.recurringInvestment.findFirst({
       where: { id: recurringId, accountId: id, account: { userId } },
-      select: { id: true },
+      select: { id: true, startDate: true, endDate: true },
     });
     if (!existing) return failure("Recurring investment not found", 404);
 
     const { amount, frequency, note, startDate, endDate, isActive } = parsed.data;
+    const effectiveStartDate = startDate ? toUtcDate(startDate) : existing.startDate;
+    const effectiveEndDate =
+      endDate === undefined ? existing.endDate : endDate ? toUtcDate(endDate) : null;
+    if (effectiveEndDate && effectiveEndDate < effectiveStartDate) {
+      return failure("End date must be on or after the start date", 400);
+    }
 
     const data: Record<string, unknown> = {};
     if (amount !== undefined) data.amount = amount;

--- a/tests/unit/recurring-rule-routes.test.ts
+++ b/tests/unit/recurring-rule-routes.test.ts
@@ -4,7 +4,11 @@ const h = vi.hoisted(() => ({
   cashRule: null as Record<string, unknown> | null,
   investmentRule: null as Record<string, unknown> | null,
   cashUpdateCalls: [] as Array<Record<string, unknown>>,
+  cashUpdateManyCalls: [] as Array<Record<string, unknown>>,
+  cashUpdateManyCount: 1,
   investmentUpdateCalls: [] as Array<Record<string, unknown>>,
+  investmentUpdateManyCalls: [] as Array<Record<string, unknown>>,
+  investmentUpdateManyCount: 1,
 }));
 
 vi.mock("@/lib/api-handler", () => ({
@@ -22,6 +26,11 @@ vi.mock("@/lib/prisma", () => ({
         h.cashUpdateCalls.push(args);
         return { ...h.cashRule, ...(args.data as Record<string, unknown>) };
       }),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.cashUpdateManyCalls.push(args);
+        return { count: h.cashUpdateManyCount };
+      }),
+      findUniqueOrThrow: vi.fn(async () => h.cashRule),
     },
     recurringInvestment: {
       findFirst: vi.fn(async () => h.investmentRule),
@@ -29,6 +38,11 @@ vi.mock("@/lib/prisma", () => ({
         h.investmentUpdateCalls.push(args);
         return { ...h.investmentRule, ...(args.data as Record<string, unknown>) };
       }),
+      updateMany: vi.fn(async (args: Record<string, unknown>) => {
+        h.investmentUpdateManyCalls.push(args);
+        return { count: h.investmentUpdateManyCount };
+      }),
+      findUniqueOrThrow: vi.fn(async () => h.investmentRule),
     },
   },
 }));
@@ -90,7 +104,11 @@ describe("recurring rule PATCH routes", () => {
     h.cashRule = recurringCashRule();
     h.investmentRule = recurringInvestmentRule();
     h.cashUpdateCalls = [];
+    h.cashUpdateManyCalls = [];
+    h.cashUpdateManyCount = 1;
     h.investmentUpdateCalls = [];
+    h.investmentUpdateManyCalls = [];
+    h.investmentUpdateManyCount = 1;
   });
 
   it("rejects a cash-rule end date before its persisted start date", async () => {
@@ -111,6 +129,16 @@ describe("recurring rule PATCH routes", () => {
 
     expect(response.status).toBe(400);
     expect(h.cashUpdateCalls).toHaveLength(0);
+  });
+
+  it("rejects a cash-rule edit when its date range changed concurrently", async () => {
+    h.cashUpdateManyCount = 0;
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ note: "updated" }), params("cash-rule-1"));
+
+    expect(response.status).toBe(409);
   });
 
   it("rejects an investment-rule end date before its persisted start date", async () => {
@@ -137,5 +165,15 @@ describe("recurring rule PATCH routes", () => {
 
     expect(response.status).toBe(400);
     expect(h.investmentUpdateCalls).toHaveLength(0);
+  });
+
+  it("rejects an investment-rule edit when its date range changed concurrently", async () => {
+    h.investmentUpdateManyCount = 0;
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ note: "updated" }), params("investment-rule-1"));
+
+    expect(response.status).toBe(409);
   });
 });

--- a/tests/unit/recurring-rule-routes.test.ts
+++ b/tests/unit/recurring-rule-routes.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  cashRule: null as Record<string, unknown> | null,
+  investmentRule: null as Record<string, unknown> | null,
+  cashUpdateCalls: [] as Array<Record<string, unknown>>,
+  investmentUpdateCalls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@/lib/api-handler", () => ({
+  withAuth:
+    (handler: (req: Request, ctx: unknown, userId: string) => Promise<Response>) =>
+    (req: Request, ctx: unknown) =>
+      handler(req, ctx, "user1"),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    recurringCashTransaction: {
+      findFirst: vi.fn(async () => h.cashRule),
+      update: vi.fn(async (args: Record<string, unknown>) => {
+        h.cashUpdateCalls.push(args);
+        return { ...h.cashRule, ...(args.data as Record<string, unknown>) };
+      }),
+    },
+    recurringInvestment: {
+      findFirst: vi.fn(async () => h.investmentRule),
+      update: vi.fn(async (args: Record<string, unknown>) => {
+        h.investmentUpdateCalls.push(args);
+        return { ...h.investmentRule, ...(args.data as Record<string, unknown>) };
+      }),
+    },
+  },
+}));
+
+const date = (value: string) => new Date(`${value}T00:00:00.000Z`);
+
+const params = (recurringId: string) => ({
+  params: Promise.resolve({ id: "acc1", recurringId }),
+});
+
+const jsonRequest = (body: Record<string, unknown>) =>
+  new Request("http://unit.test", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+
+function recurringCashRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cash-rule-1",
+    accountId: "acc1",
+    type: "DEPOSIT",
+    amount: 100,
+    frequency: "MONTHLY",
+    note: null,
+    startDate: date("2026-08-01"),
+    endDate: date("2026-08-31"),
+    nextRunDate: date("2026-08-01"),
+    isActive: true,
+    createdAt: date("2026-07-01"),
+    updatedAt: date("2026-07-01"),
+    ...overrides,
+  };
+}
+
+function recurringInvestmentRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "investment-rule-1",
+    accountId: "acc1",
+    symbol: "VTI",
+    name: "Vanguard Total Stock Market ETF",
+    assetType: "ETF",
+    holdingCurrency: "USD",
+    amount: 100,
+    frequency: "MONTHLY",
+    note: null,
+    startDate: date("2026-08-01"),
+    endDate: date("2026-08-31"),
+    nextRunDate: date("2026-08-01"),
+    isActive: true,
+    createdAt: date("2026-07-01"),
+    updatedAt: date("2026-07-01"),
+    ...overrides,
+  };
+}
+
+describe("recurring rule PATCH routes", () => {
+  beforeEach(() => {
+    h.cashRule = recurringCashRule();
+    h.investmentRule = recurringInvestmentRule();
+    h.cashUpdateCalls = [];
+    h.investmentUpdateCalls = [];
+  });
+
+  it("rejects a cash-rule end date before its persisted start date", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ endDate: "2026-07-31" }), params("cash-rule-1"));
+
+    expect(response.status).toBe(400);
+    expect(h.cashUpdateCalls).toHaveLength(0);
+  });
+
+  it("rejects a cash-rule start date after its persisted end date", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ startDate: "2026-09-01" }), params("cash-rule-1"));
+
+    expect(response.status).toBe(400);
+    expect(h.cashUpdateCalls).toHaveLength(0);
+  });
+
+  it("rejects an investment-rule end date before its persisted start date", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
+
+    const response = await PATCH(
+      jsonRequest({ endDate: "2026-07-31" }),
+      params("investment-rule-1"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(h.investmentUpdateCalls).toHaveLength(0);
+  });
+
+  it("rejects an investment-rule start date after its persisted end date", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
+
+    const response = await PATCH(
+      jsonRequest({ startDate: "2026-09-01" }),
+      params("investment-rule-1"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(h.investmentUpdateCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/recurring-rule-routes.test.ts
+++ b/tests/unit/recurring-rule-routes.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({
   cashRule: null as Record<string, unknown> | null,
   investmentRule: null as Record<string, unknown> | null,
-  cashUpdateCalls: [] as Array<Record<string, unknown>>,
-  cashUpdateManyCalls: [] as Array<Record<string, unknown>>,
-  cashUpdateManyCount: 1,
-  investmentUpdateCalls: [] as Array<Record<string, unknown>>,
-  investmentUpdateManyCalls: [] as Array<Record<string, unknown>>,
-  investmentUpdateManyCount: 1,
+  cashUpdateManyAndReturnCalls: [] as Array<Record<string, unknown>>,
+  cashUpdateManyAndReturnCount: 1,
+  cashFindUniqueOrThrowCalls: [] as Array<Record<string, unknown>>,
+  investmentUpdateManyAndReturnCalls: [] as Array<Record<string, unknown>>,
+  investmentUpdateManyAndReturnCount: 1,
+  investmentFindUniqueOrThrowCalls: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("@/lib/api-handler", () => ({
@@ -22,27 +22,29 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     recurringCashTransaction: {
       findFirst: vi.fn(async () => h.cashRule),
-      update: vi.fn(async (args: Record<string, unknown>) => {
-        h.cashUpdateCalls.push(args);
-        return { ...h.cashRule, ...(args.data as Record<string, unknown>) };
+      updateManyAndReturn: vi.fn(async (args: Record<string, unknown>) => {
+        h.cashUpdateManyAndReturnCalls.push(args);
+        return h.cashUpdateManyAndReturnCount === 0
+          ? []
+          : [{ ...h.cashRule, ...(args.data as Record<string, unknown>) }];
       }),
-      updateMany: vi.fn(async (args: Record<string, unknown>) => {
-        h.cashUpdateManyCalls.push(args);
-        return { count: h.cashUpdateManyCount };
+      findUniqueOrThrow: vi.fn(async (args: Record<string, unknown>) => {
+        h.cashFindUniqueOrThrowCalls.push(args);
+        return h.cashRule;
       }),
-      findUniqueOrThrow: vi.fn(async () => h.cashRule),
     },
     recurringInvestment: {
       findFirst: vi.fn(async () => h.investmentRule),
-      update: vi.fn(async (args: Record<string, unknown>) => {
-        h.investmentUpdateCalls.push(args);
-        return { ...h.investmentRule, ...(args.data as Record<string, unknown>) };
+      updateManyAndReturn: vi.fn(async (args: Record<string, unknown>) => {
+        h.investmentUpdateManyAndReturnCalls.push(args);
+        return h.investmentUpdateManyAndReturnCount === 0
+          ? []
+          : [{ ...h.investmentRule, ...(args.data as Record<string, unknown>) }];
       }),
-      updateMany: vi.fn(async (args: Record<string, unknown>) => {
-        h.investmentUpdateManyCalls.push(args);
-        return { count: h.investmentUpdateManyCount };
+      findUniqueOrThrow: vi.fn(async (args: Record<string, unknown>) => {
+        h.investmentFindUniqueOrThrowCalls.push(args);
+        return h.investmentRule;
       }),
-      findUniqueOrThrow: vi.fn(async () => h.investmentRule),
     },
   },
 }));
@@ -103,12 +105,12 @@ describe("recurring rule PATCH routes", () => {
   beforeEach(() => {
     h.cashRule = recurringCashRule();
     h.investmentRule = recurringInvestmentRule();
-    h.cashUpdateCalls = [];
-    h.cashUpdateManyCalls = [];
-    h.cashUpdateManyCount = 1;
-    h.investmentUpdateCalls = [];
-    h.investmentUpdateManyCalls = [];
-    h.investmentUpdateManyCount = 1;
+    h.cashUpdateManyAndReturnCalls = [];
+    h.cashUpdateManyAndReturnCount = 1;
+    h.cashFindUniqueOrThrowCalls = [];
+    h.investmentUpdateManyAndReturnCalls = [];
+    h.investmentUpdateManyAndReturnCount = 1;
+    h.investmentFindUniqueOrThrowCalls = [];
   });
 
   it("rejects a cash-rule end date before its persisted start date", async () => {
@@ -118,7 +120,7 @@ describe("recurring rule PATCH routes", () => {
     const response = await PATCH(jsonRequest({ endDate: "2026-07-31" }), params("cash-rule-1"));
 
     expect(response.status).toBe(400);
-    expect(h.cashUpdateCalls).toHaveLength(0);
+    expect(h.cashUpdateManyAndReturnCalls).toHaveLength(0);
   });
 
   it("rejects a cash-rule start date after its persisted end date", async () => {
@@ -128,11 +130,11 @@ describe("recurring rule PATCH routes", () => {
     const response = await PATCH(jsonRequest({ startDate: "2026-09-01" }), params("cash-rule-1"));
 
     expect(response.status).toBe(400);
-    expect(h.cashUpdateCalls).toHaveLength(0);
+    expect(h.cashUpdateManyAndReturnCalls).toHaveLength(0);
   });
 
   it("rejects a cash-rule edit when its date range changed concurrently", async () => {
-    h.cashUpdateManyCount = 0;
+    h.cashUpdateManyAndReturnCount = 0;
     const { PATCH } =
       await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
 
@@ -151,7 +153,7 @@ describe("recurring rule PATCH routes", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(h.investmentUpdateCalls).toHaveLength(0);
+    expect(h.investmentUpdateManyAndReturnCalls).toHaveLength(0);
   });
 
   it("rejects an investment-rule start date after its persisted end date", async () => {
@@ -164,16 +166,38 @@ describe("recurring rule PATCH routes", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(h.investmentUpdateCalls).toHaveLength(0);
+    expect(h.investmentUpdateManyAndReturnCalls).toHaveLength(0);
   });
 
   it("rejects an investment-rule edit when its date range changed concurrently", async () => {
-    h.investmentUpdateManyCount = 0;
+    h.investmentUpdateManyAndReturnCount = 0;
     const { PATCH } =
       await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
 
     const response = await PATCH(jsonRequest({ note: "updated" }), params("investment-rule-1"));
 
     expect(response.status).toBe(409);
+  });
+
+  it("returns the cash rule from its guarded write without a follow-up read", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ note: "updated" }), params("cash-rule-1"));
+
+    expect(response.status).toBe(200);
+    expect(h.cashUpdateManyAndReturnCalls).toHaveLength(1);
+    expect(h.cashFindUniqueOrThrowCalls).toHaveLength(0);
+  });
+
+  it("returns the investment rule from its guarded write without a follow-up read", async () => {
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ note: "updated" }), params("investment-rule-1"));
+
+    expect(response.status).toBe(200);
+    expect(h.investmentUpdateManyAndReturnCalls).toHaveLength(1);
+    expect(h.investmentFindUniqueOrThrowCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #571 by validating the merged persisted and submitted dates for recurring cash and investment rule PATCHes.

- Rejects one-field edits that would make `endDate < startDate` with HTTP 400 before any write.
- Uses a date-range-guarded `updateManyAndReturn` write, returning HTTP 409 when a concurrent edit makes the request stale.
- Returns the atomic write result, avoiding a post-write read race.
- Adds regression coverage for invalid partial updates, stale writes, and atomic response behavior.

## Validation

- `pnpm test:unit` — 29 files, 252 tests passed
- `pnpm check` — format, lint, type-check, and production build passed