### PR TITLE
fix: improve dashboard portfolio layout

### DIFF
--- a/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
+++ b/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
@@ -1,0 +1,441 @@
+# Dashboard Portfolio Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the height-coupled dashboard portfolio row with a content-sized 8/4 overview row and a separate full-width horizontal Concentration summary.
+
+**Architecture:** Keep `DashboardContent` as the server-side streaming orchestrator and preserve each existing Suspense boundary. Change only the dashboard grid topology, the dashboard-only `fillHeight` call site, matching skeletons, and the responsive internal layout of `ConcentrationCard`; all calculations and client interactions stay in their current components.
+
+**Tech Stack:** Next.js 16.2 App Router, React 19 Server and Client Components, TypeScript 5, Tailwind CSS 4, Recharts 3, Vitest 4, Playwright 1.52.
+
+## Global Constraints
+
+- Read relevant guidance in `node_modules/next/dist/docs/` before modifying Next.js code; the applicable Server and Client Component guide has already been identified at `node_modules/next/dist/docs/01-app/01-getting-started/05-server-and-client-components.md`.
+- Preserve the current mobile-first source order: Asset Allocation, Currency Exposure, Portfolio Composition, Concentration.
+- Preserve the existing 12-column desktop proportions: Portfolio Composition spans 8 columns and the allocation/currency rail spans 4 columns.
+- Do not change financial calculations, translations, navigation, privacy behavior, chart colors, account colors, typography, or global spacing tokens.
+- Keep `DashboardContent` as a Server Component and `PortfolioHeatmap` and `ConcentrationCard` as focused Client Components.
+- Preserve independent Suspense boundaries and existing empty-state behavior.
+- Maintain 44px mobile touch targets, visible focus states, compact density, localization, dark/light themes, and reduced-motion behavior.
+- Use existing 4pt spacing values through Tailwind utilities: 12px (`gap-3`), 16px (`gap-4`), and 24px (`gap-6`).
+
+---
+
+## File Map
+
+- Modify `src/components/dashboard/dashboard-content.tsx`: remove dashboard `fillHeight`, restructure Tier 3 into two rows, and consume the shared concentration skeleton.
+- Modify `src/components/dashboard/dashboard-skeleton.tsx`: export the concentration skeleton and mirror the final two-row topology.
+- Modify `src/components/dashboard/concentration-card.tsx`: make the full-width card horizontal at `lg` while retaining the current stacked mobile layout.
+- Create `tests/unit/dashboard-portfolio-layout.test.ts`: guard the dashboard-only height fix, the two-row topology, skeleton parity, and horizontal concentration layout using the repository's existing source-inspection test pattern.
+
+---
+
+### Task 1: Decouple Portfolio Composition from the right rail
+
+**Files:**
+
+- Create: `tests/unit/dashboard-portfolio-layout.test.ts`
+- Modify: `src/components/dashboard/dashboard-content.tsx:27,376-390,448-472`
+- Modify: `src/components/dashboard/dashboard-skeleton.tsx:116-139,167-179`
+
+**Interfaces:**
+
+- Consumes: `PortfolioHeatmap({ summary, fillHeight? })`, existing dashboard section components, `Card`, `CardContent`, `CardHeader`, and `Skeleton`.
+- Produces: exported `ConcentrationCardSkeleton`, `data-testid="portfolio-overview-row"`, and `data-testid="portfolio-concentration-row"` for structural and visual verification.
+
+- [ ] **Step 1: Write the failing dashboard topology tests**
+
+Create `tests/unit/dashboard-portfolio-layout.test.ts` with:
+
+```ts
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
+const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
+
+describe("dashboard portfolio layout", () => {
+  it("keeps the dashboard treemap at its content-driven height", () => {
+    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} />");
+    expect(dashboardSource).not.toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+  });
+
+  it("separates concentration from the 8/4 portfolio overview row", () => {
+    const overviewStart = dashboardSource.indexOf('data-testid="portfolio-overview-row"');
+    const concentrationStart = dashboardSource.indexOf('data-testid="portfolio-concentration-row"');
+
+    expect(overviewStart).toBeGreaterThan(-1);
+    expect(concentrationStart).toBeGreaterThan(overviewStart);
+
+    const overviewSource = dashboardSource.slice(overviewStart, concentrationStart);
+    expect(overviewSource).toContain("lg:col-span-8");
+    expect(overviewSource).toContain("lg:col-span-4");
+    expect(overviewSource).not.toContain("<ConcentrationSection");
+  });
+
+  it("keeps the loading skeleton topology aligned with the dashboard", () => {
+    expect(skeletonSource).toContain('data-testid="portfolio-overview-skeleton"');
+    expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
+    expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
+  });
+});
+```
+
+- [ ] **Step 2: Run the topology tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts
+```
+
+Expected: FAIL because the dashboard still passes `fillHeight`, the two data test IDs do not exist, and `ConcentrationCardSkeleton` is not exported.
+
+- [ ] **Step 3: Add and export the full-width concentration skeleton**
+
+In `src/components/dashboard/dashboard-skeleton.tsx`, add this function immediately after `PortfolioHeatmapSkeleton`:
+
+```tsx
+export function ConcentrationCardSkeleton() {
+  return (
+    <Card data-testid="portfolio-concentration-skeleton">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-64 max-w-full" />
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+        <div className="flex items-end justify-between gap-3 lg:flex-col lg:items-start lg:justify-start">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-6 w-28 rounded-full" />
+        </div>
+        <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+          {[...Array(5)].map((_, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex justify-between gap-3">
+                <Skeleton className="h-3 w-32 max-w-[70%]" />
+                <Skeleton className="h-3 w-10" />
+              </div>
+              <Skeleton className="h-1.5 w-full rounded-full" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Mirror the new topology in `DashboardSkeleton`**
+
+Replace the existing Tier 3 skeleton block in `src/components/dashboard/dashboard-skeleton.tsx` with:
+
+```text
+{/* Tier 3 — content-sized portfolio overview, then full-width concentration. */}
+<div className="space-y-3 sm:space-y-6">
+  <div
+    data-testid="portfolio-overview-skeleton"
+    className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+  >
+    <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+      <ChartCardSkeleton />
+      <ChartCardSkeleton />
+    </div>
+    <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+      <PortfolioHeatmapSkeleton />
+    </div>
+  </div>
+  <ConcentrationCardSkeleton />
+</div>
+```
+
+- [ ] **Step 5: Stop enabling height fill on the dashboard heatmap**
+
+In `PortfolioHeatmapSection` inside `src/components/dashboard/dashboard-content.tsx`, replace:
+
+```tsx
+return <PortfolioHeatmap summary={summary} fillHeight />;
+```
+
+with:
+
+```tsx
+return <PortfolioHeatmap summary={summary} />;
+```
+
+Do not remove the optional `fillHeight` API from `PortfolioHeatmap`; the Accounts page still uses it for its own layout.
+
+- [ ] **Step 6: Import the shared concentration skeleton**
+
+Replace the current dashboard-skeleton import in `src/components/dashboard/dashboard-content.tsx` with:
+
+```tsx
+import {
+  ConcentrationCardSkeleton,
+  WatchlistCardSkeleton,
+} from "@/components/dashboard/dashboard-skeleton";
+```
+
+- [ ] **Step 7: Replace the Tier 3 dashboard block**
+
+Replace the existing Tier 3 block in `src/components/dashboard/dashboard-content.tsx` with:
+
+```text
+{/* Tier 3 — "what it's made of": a content-sized 8/4 overview row followed
+    by a full-width concentration summary. Source order stays allocation →
+    currency → portfolio → concentration for mobile and assistive technology. */}
+<div className="space-y-3 sm:space-y-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
+  <div
+    data-testid="portfolio-overview-row"
+    className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+  >
+    <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+      <Suspense fallback={<ChartCardSkeleton />}>
+        <AllocationSection userId={userId} baseCurrency={baseCurrency} />
+      </Suspense>
+      <Suspense fallback={<ChartCardSkeleton />}>
+        <CurrencySection userId={userId} baseCurrency={baseCurrency} />
+      </Suspense>
+    </div>
+    <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+      <Suspense fallback={<PortfolioHeatmapSkeleton />}>
+        <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+      </Suspense>
+    </div>
+  </div>
+  <div data-testid="portfolio-concentration-row">
+    <Suspense fallback={<ConcentrationCardSkeleton />}>
+      <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
+    </Suspense>
+  </div>
+</div>
+```
+
+- [ ] **Step 8: Run the focused tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 9: Run format and lint for Task 1 files**
+
+Run:
+
+```bash
+pnpm prettier --check src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx tests/unit/dashboard-portfolio-layout.test.ts
+pnpm eslint src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx tests/unit/dashboard-portfolio-layout.test.ts
+```
+
+Expected: both commands exit 0. If Prettier reports differences, run `pnpm prettier --write` on the same three files, then repeat both checks.
+
+- [ ] **Step 10: Commit the topology change**
+
+```bash
+git add src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx tests/unit/dashboard-portfolio-layout.test.ts
+git commit -m "fix: decouple dashboard portfolio layout"
+```
+
+Expected: one commit containing the new two-row topology, skeleton parity, and the regression test.
+
+---
+
+### Task 2: Make Concentration a horizontal desktop summary
+
+**Files:**
+
+- Modify: `src/components/dashboard/concentration-card.tsx:19-57`
+- Test: `tests/unit/dashboard-portfolio-layout.test.ts`
+
+**Interfaces:**
+
+- Consumes: unchanged `NetWorthSummary`, `computeConcentration(summary)`, `usePrivacyMode()`, and existing `concentration` translation keys.
+- Produces: the same `ConcentrationCard({ summary }: { summary: NetWorthSummary })` public component with a stacked mobile layout and a two-region desktop grid.
+
+- [ ] **Step 1: Add the failing horizontal Concentration test**
+
+In `tests/unit/dashboard-portfolio-layout.test.ts`, add this source constant below the existing `skeletonSource` constant:
+
+```ts
+const concentrationSource = readFileSync("src/components/dashboard/concentration-card.tsx", "utf8");
+```
+
+Then add this test before the closing `});` of the existing `describe` block:
+
+```ts
+it("lays concentration out horizontally on desktop", () => {
+  expect(concentrationSource).toContain("lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)]");
+  expect(concentrationSource).toContain("sm:grid-cols-2 xl:grid-cols-3");
+});
+```
+
+- [ ] **Step 2: Confirm the new test fails for the intended reason**
+
+Run:
+
+```bash
+pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts -t "lays concentration out horizontally on desktop"
+```
+
+Expected: FAIL because `concentration-card.tsx` does not contain the `lg` summary/positions grid or the responsive positions grid.
+
+- [ ] **Step 3: Replace the Concentration card return block**
+
+Keep the current imports, memoized calculation, empty return, and `level` calculation. Replace only the `return` block in `src/components/dashboard/concentration-card.tsx` with:
+
+```tsx
+return (
+  <Card className="flex flex-col">
+    <CardHeader className="pb-2">
+      <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
+      <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
+    </CardHeader>
+    <CardContent className="grid flex-1 gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+      <div className="flex items-baseline justify-between gap-3 lg:flex-col lg:items-start lg:justify-start lg:gap-3">
+        <div>
+          <div className="text-2xl font-semibold tabular-nums text-foreground">
+            {privacyMode ? "***" : `${topHoldingPct.toFixed(1)}%`}
+          </div>
+          <div className="text-[11px] text-muted-foreground">{t("largestPosition")}</div>
+        </div>
+        <span className="rounded-full bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+          {t(`level_${level}` as "level_low" | "level_moderate" | "level_high")}
+        </span>
+      </div>
+      <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+        {top.map((position) => (
+          <li key={position.label} className="min-w-0">
+            <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
+              <span className="min-w-0 truncate text-foreground">{position.label}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {privacyMode ? "***" : `${position.pct.toFixed(1)}%`}
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${Math.min(100, position.pct)}%` }}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </CardContent>
+  </Card>
+);
+```
+
+- [ ] **Step 4: Run the complete layout regression test**
+
+Run:
+
+```bash
+pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts
+```
+
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Run static verification**
+
+Run:
+
+```bash
+pnpm prettier --check src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
+pnpm eslint src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
+pnpm typecheck
+```
+
+Expected: all three commands exit 0. If Prettier reports differences, run `pnpm prettier --write src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts`, then repeat the checks.
+
+- [ ] **Step 6: Commit the responsive Concentration layout**
+
+```bash
+git add src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
+git commit -m "refactor: widen dashboard concentration summary"
+```
+
+Expected: one focused commit containing only the responsive Concentration presentation change.
+
+---
+
+### Task 3: Verify the complete dashboard flow and visual result
+
+**Files:**
+
+- Verify: `src/components/dashboard/dashboard-content.tsx`
+- Verify: `src/components/dashboard/dashboard-skeleton.tsx`
+- Verify: `src/components/dashboard/concentration-card.tsx`
+- Verify: `src/components/analysis/portfolio-heatmap.tsx`
+
+**Interfaces:**
+
+- Consumes: the complete two-row dashboard implementation from Tasks 1 and 2.
+- Produces: verified behavior at desktop and mobile widths with no further interface changes.
+
+- [ ] **Step 1: Run the focused and existing unit suites**
+
+Run:
+
+```bash
+pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts tests/unit/analysis-service.test.ts
+```
+
+Expected: all tests PASS, including the existing concentration calculation coverage.
+
+- [ ] **Step 2: Run the project static checks**
+
+Run:
+
+```bash
+pnpm format:check
+pnpm lint
+pnpm typecheck
+```
+
+Expected: all commands exit 0 with no new errors.
+
+- [ ] **Step 3: Run the desktop dashboard smoke test**
+
+Run:
+
+```bash
+pnpm playwright test tests/e2e/smoke.spec.ts --project=chromium
+```
+
+Expected: the authenticated dashboard test passes and the dashboard continues to render Net Worth and Net Worth Trend. If the local environment cannot provide the configured preview credentials or database, record that environment limitation and continue with local browser verification against the running app.
+
+- [ ] **Step 4: Verify the live dashboard visually**
+
+At a desktop viewport around 1440×900, confirm:
+
+- `portfolio-overview-row` renders Portfolio Composition on the left and only Asset Allocation plus Currency Exposure on the right.
+- The Portfolio Composition card ends after its 280px chart and legend content; it does not stretch to the former three-card rail height.
+- `portfolio-concentration-row` starts below both first-row columns and spans the available dashboard width.
+- Concentration shows its headline/status region on the left and a two- or three-column position grid on the right.
+- All Accounts follows the Concentration row without overlap or excessive gap.
+
+At a mobile viewport around 412×915, confirm:
+
+- The source and visual order is Asset Allocation, Currency Exposure, Portfolio Composition, Concentration.
+- Portfolio account buttons remain at least 44px tall and treemap selection/back behavior still works.
+- Concentration returns to a single-column card with its metric/status row above the positions grid.
+- No horizontal document overflow appears.
+
+Repeat one desktop check in compact density and one in dark mode. Confirm the chart height drops to 220px in compact density and all text, bars, borders, and focus states remain legible.
+
+- [ ] **Step 5: Review the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff HEAD~2 --check
+git diff HEAD~2 -- src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
+```
+
+Expected: no whitespace errors, no unrelated files, no dashboard `fillHeight` call, and no financial or translation changes.

--- a/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
+++ b/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the height-coupled dashboard portfolio row with a content-sized 8/4 overview row and a separate full-width horizontal Concentration summary.
 
-**Architecture:** Keep `DashboardContent` as the server-side streaming orchestrator and preserve each existing Suspense boundary. Change only the dashboard grid topology, the dashboard-only `fillHeight` call site, matching skeletons, and the responsive internal layout of `ConcentrationCard`; all calculations and client interactions stay in their current components.
+**Architecture:** Keep `DashboardContent` as the server-side streaming orchestrator and preserve each existing Suspense boundary. Change the dashboard grid topology, keep dashboard `fillHeight` scoped to the Portfolio Composition card's internal chart/list row, update matching skeletons, and adjust the responsive internal layout of `ConcentrationCard`; all calculations and client interactions stay in their current components.
 
 **Tech Stack:** Next.js 16.2 App Router, React 19 Server and Client Components, TypeScript 5, Tailwind CSS 4, Recharts 3, Vitest 4, Playwright 1.52.
 
@@ -23,7 +23,7 @@
 
 ## File Map
 
-- Modify `src/components/dashboard/dashboard-content.tsx`: remove dashboard `fillHeight`, restructure Tier 3 into two rows, and consume the shared concentration skeleton.
+- Modify `src/components/dashboard/dashboard-content.tsx`: retain dashboard `fillHeight` for internal card filling, remove the parent stretch coupling, restructure Tier 3 into two rows, and consume the shared concentration skeleton.
 - Modify `src/components/dashboard/dashboard-skeleton.tsx`: export the concentration skeleton and mirror the final two-row topology.
 - Modify `src/components/dashboard/concentration-card.tsx`: make the full-width card horizontal at `lg` while retaining the current stacked mobile layout.
 - Create `tests/unit/dashboard-portfolio-layout.test.ts`: guard the dashboard-only height fix, the two-row topology, skeleton parity, and horizontal concentration layout using the repository's existing source-inspection test pattern.
@@ -55,9 +55,10 @@ const dashboardSource = readFileSync("src/components/dashboard/dashboard-content
 const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
 
 describe("dashboard portfolio layout", () => {
-  it("keeps the dashboard treemap at its content-driven height", () => {
-    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} />");
-    expect(dashboardSource).not.toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+  it("fills the composition card internally without stretching the overview column", () => {
+    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+    expect(dashboardSource).not.toContain("[&>*]:min-h-0");
+    expect(dashboardSource).not.toContain("[&>*]:flex-1");
   });
 
   it("separates concentration from the 8/4 portfolio overview row", () => {
@@ -89,7 +90,7 @@ Run:
 pnpm vitest run tests/unit/dashboard-portfolio-layout.test.ts
 ```
 
-Expected: FAIL because the dashboard still passes `fillHeight`, the two data test IDs do not exist, and `ConcentrationCardSkeleton` is not exported.
+Expected: FAIL because the two data test IDs do not exist and `ConcentrationCardSkeleton` is not exported.
 
 - [ ] **Step 3: Add and export the full-width concentration skeleton**
 
@@ -151,21 +152,15 @@ Replace the existing Tier 3 skeleton block in `src/components/dashboard/dashboar
 </div>
 ```
 
-- [ ] **Step 5: Stop enabling height fill on the dashboard heatmap**
+- [ ] **Step 5: Keep height fill scoped to the dashboard heatmap's internal row**
 
-In `PortfolioHeatmapSection` inside `src/components/dashboard/dashboard-content.tsx`, replace:
+In `PortfolioHeatmapSection` inside `src/components/dashboard/dashboard-content.tsx`, keep:
 
 ```tsx
 return <PortfolioHeatmap summary={summary} fillHeight />;
 ```
 
-with:
-
-```tsx
-return <PortfolioHeatmap summary={summary} />;
-```
-
-Do not remove the optional `fillHeight` API from `PortfolioHeatmap`; the Accounts page still uses it for its own layout.
+Do not restore the removed parent flex/stretch utilities. `fillHeight` may fill the card's internal treemap/list row, but the Portfolio Composition card must continue sizing independently from the external allocation/currency rail.
 
 - [ ] **Step 6: Import the shared concentration skeleton**
 
@@ -414,7 +409,7 @@ Expected: the authenticated dashboard test passes and the dashboard continues to
 At a desktop viewport around 1440×900, confirm:
 
 - `portfolio-overview-row` renders Portfolio Composition on the left and only Asset Allocation plus Currency Exposure on the right.
-- The Portfolio Composition card ends after its responsive chart and legend content; it does not stretch to the former three-card rail height. Treat the 1440px viewport width separately from the measured inner chart-column width: the phone branch takes precedence, then chart columns below 420px use `max(190, round(width * 0.62))`, columns below 760px use `max(240, round(width * 0.55))`, and only columns at least 760px use the density fallback (280px comfortable or 220px compact).
+- The Portfolio Composition card ends after its own responsive chart and legend content; it does not stretch to the former three-card rail height. On desktop, the responsive calculation supplies the treemap's minimum height and `fillHeight` grows it only to match the card's internal detail/account-list column. On mobile, the existing phone width rules remain authoritative.
 - `portfolio-concentration-row` starts below both first-row columns and spans the available dashboard width.
 - Concentration shows its headline/status region on the left and a two- or three-column position grid on the right.
 - All Accounts follows the Concentration row without overlap or excessive gap.
@@ -438,4 +433,4 @@ git diff HEAD~2 --check
 git diff HEAD~2 -- src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
 ```
 
-Expected: no whitespace errors, no unrelated files, no dashboard `fillHeight` call, and no financial or translation changes.
+Expected: no whitespace errors, no unrelated files, no parent flex/stretch coupling, dashboard `fillHeight` present only at the Portfolio Composition call site, and no financial or translation changes.

--- a/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
+++ b/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
@@ -414,7 +414,7 @@ Expected: the authenticated dashboard test passes and the dashboard continues to
 At a desktop viewport around 1440×900, confirm:
 
 - `portfolio-overview-row` renders Portfolio Composition on the left and only Asset Allocation plus Currency Exposure on the right.
-- The Portfolio Composition card ends after its 280px chart and legend content; it does not stretch to the former three-card rail height.
+- The Portfolio Composition card ends after its responsive chart and legend content; it does not stretch to the former three-card rail height. Treat the 1440px viewport width separately from the measured inner chart-column width: the phone branch takes precedence, then chart columns below 420px use `max(190, round(width * 0.62))`, columns below 760px use `max(240, round(width * 0.55))`, and only columns at least 760px use the density fallback (280px comfortable or 220px compact).
 - `portfolio-concentration-row` starts below both first-row columns and spans the available dashboard width.
 - Concentration shows its headline/status region on the left and a two- or three-column position grid on the right.
 - All Accounts follows the Concentration row without overlap or excessive gap.
@@ -426,7 +426,7 @@ At a mobile viewport around 412×915, confirm:
 - Concentration returns to a single-column card with its metric/status row above the positions grid.
 - No horizontal document overflow appears.
 
-Repeat one desktop check in compact density and one in dark mode. Confirm the chart height drops to 220px in compact density and all text, bars, borders, and focus states remain legible.
+Repeat one desktop check in compact density and one in dark mode. Confirm the chart height follows the same measured chart-column branches in compact density; expect 220px only when the inner chart column is at least 760px. Confirm all text, bars, borders, and focus states remain legible.
 
 - [ ] **Step 5: Review the final diff**
 

--- a/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
+++ b/docs/superpowers/plans/2026-07-10-dashboard-portfolio-layout.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the height-coupled dashboard portfolio row with a content-sized 8/4 overview row and a separate full-width horizontal Concentration summary.
+**Goal:** Replace the former three-card height coupling with an aligned 8/4 overview row and a separate full-width horizontal Concentration summary. On desktop, Portfolio Composition ends on the same baseline as Currency Exposure without blank treemap space.
 
-**Architecture:** Keep `DashboardContent` as the server-side streaming orchestrator and preserve each existing Suspense boundary. Change the dashboard grid topology, keep dashboard `fillHeight` scoped to the Portfolio Composition card's internal chart/list row, update matching skeletons, and adjust the responsive internal layout of `ConcentrationCard`; all calculations and client interactions stay in their current components.
+**Architecture:** Keep `DashboardContent` as the server-side streaming orchestrator and preserve each existing Suspense boundary. Change the dashboard grid topology, contain the Portfolio Composition grid item's intrinsic size so the two-card rail resolves the desktop row height, keep dashboard `fillHeight` scoped to the card's shrinkable internal chart/list row, update matching skeletons, and adjust the responsive internal layout of `ConcentrationCard`; all calculations and client interactions stay in their current components.
 
 **Tech Stack:** Next.js 16.2 App Router, React 19 Server and Client Components, TypeScript 5, Tailwind CSS 4, Recharts 3, Vitest 4, Playwright 1.52.
 
@@ -23,14 +23,15 @@
 
 ## File Map
 
-- Modify `src/components/dashboard/dashboard-content.tsx`: retain dashboard `fillHeight` for internal card filling, remove the parent stretch coupling, restructure Tier 3 into two rows, and consume the shared concentration skeleton.
-- Modify `src/components/dashboard/dashboard-skeleton.tsx`: export the concentration skeleton and mirror the final two-row topology.
+- Modify `src/components/dashboard/dashboard-content.tsx`: retain dashboard `fillHeight` for internal card filling, use desktop size containment to align Portfolio Composition with Currency Exposure, restructure Tier 3 into two rows, and consume the shared concentration skeleton.
+- Modify `src/components/analysis/portfolio-heatmap.tsx`: make the desktop chart and account-list columns shrinkable so they share the externally resolved card height without blank space or overflow.
+- Modify `src/components/dashboard/dashboard-skeleton.tsx`: export the concentration skeleton and mirror the final aligned two-row topology.
 - Modify `src/components/dashboard/concentration-card.tsx`: make the full-width card horizontal at `lg` while retaining the current stacked mobile layout.
 - Create `tests/unit/dashboard-portfolio-layout.test.ts`: guard the dashboard-only height fix, the two-row topology, skeleton parity, and horizontal concentration layout using the repository's existing source-inspection test pattern.
 
 ---
 
-### Task 1: Decouple Portfolio Composition from the right rail
+### Task 1: Align Portfolio Composition with the two-card right rail
 
 **Files:**
 
@@ -55,10 +56,11 @@ const dashboardSource = readFileSync("src/components/dashboard/dashboard-content
 const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
 
 describe("dashboard portfolio layout", () => {
-  it("fills the composition card internally without stretching the overview column", () => {
+  it("fills the composition card within the right rail's resolved desktop row", () => {
     expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} fillHeight />");
-    expect(dashboardSource).not.toContain("[&>*]:min-h-0");
-    expect(dashboardSource).not.toContain("[&>*]:flex-1");
+    expect(dashboardSource).toContain("lg:contain-size");
+    expect(dashboardSource).toContain("lg:[&>*]:min-h-0");
+    expect(dashboardSource).toContain("lg:[&>*]:flex-1");
   });
 
   it("separates concentration from the 8/4 portfolio overview row", () => {
@@ -134,7 +136,7 @@ export function ConcentrationCardSkeleton() {
 Replace the existing Tier 3 skeleton block in `src/components/dashboard/dashboard-skeleton.tsx` with:
 
 ```text
-{/* Tier 3 — content-sized portfolio overview, then full-width concentration. */}
+{/* Tier 3 — aligned portfolio overview, then full-width concentration. */}
 <div className="space-y-3 sm:space-y-6">
   <div
     data-testid="portfolio-overview-skeleton"
@@ -144,7 +146,7 @@ Replace the existing Tier 3 skeleton block in `src/components/dashboard/dashboar
       <ChartCardSkeleton />
       <ChartCardSkeleton />
     </div>
-    <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+    <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
       <PortfolioHeatmapSkeleton />
     </div>
   </div>
@@ -160,7 +162,7 @@ In `PortfolioHeatmapSection` inside `src/components/dashboard/dashboard-content.
 return <PortfolioHeatmap summary={summary} fillHeight />;
 ```
 
-Do not restore the removed parent flex/stretch utilities. `fillHeight` may fill the card's internal treemap/list row, but the Portfolio Composition card must continue sizing independently from the external allocation/currency rail.
+Use size containment only on the desktop Portfolio Composition grid item. `fillHeight` fills the card and its shrinkable internal treemap/list row, while the Asset Allocation/Currency Exposure rail determines the external row height. The internal account list may scroll rather than increasing that row.
 
 - [ ] **Step 6: Import the shared concentration skeleton**
 
@@ -178,7 +180,7 @@ import {
 Replace the existing Tier 3 block in `src/components/dashboard/dashboard-content.tsx` with:
 
 ```text
-{/* Tier 3 — "what it's made of": a content-sized 8/4 overview row followed
+{/* Tier 3 — "what it's made of": an aligned 8/4 overview row followed
     by a full-width concentration summary. Source order stays allocation →
     currency → portfolio → concentration for mobile and assistive technology. */}
 <div className="space-y-3 sm:space-y-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
@@ -194,7 +196,7 @@ Replace the existing Tier 3 block in `src/components/dashboard/dashboard-content
         <CurrencySection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
     </div>
-    <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+    <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
       <Suspense fallback={<PortfolioHeatmapSkeleton />}>
         <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
       </Suspense>
@@ -409,7 +411,7 @@ Expected: the authenticated dashboard test passes and the dashboard continues to
 At a desktop viewport around 1440×900, confirm:
 
 - `portfolio-overview-row` renders Portfolio Composition on the left and only Asset Allocation plus Currency Exposure on the right.
-- The Portfolio Composition card ends after its own responsive chart and legend content; it does not stretch to the former three-card rail height. On desktop, the responsive calculation supplies the treemap's minimum height and `fillHeight` grows it only to match the card's internal detail/account-list column. On mobile, the existing phone width rules remain authoritative.
+- The Portfolio Composition card and Currency Exposure share the same bottom edge on desktop. The right rail resolves the row height, the contained left item fills that row, and its shrinkable treemap/detail columns use the available height with no bottom gap or content overflow. On mobile, the existing phone width rules remain authoritative.
 - `portfolio-concentration-row` starts below both first-row columns and spans the available dashboard width.
 - Concentration shows its headline/status region on the left and a two- or three-column position grid on the right.
 - All Accounts follows the Concentration row without overlap or excessive gap.
@@ -433,4 +435,4 @@ git diff HEAD~2 --check
 git diff HEAD~2 -- src/components/dashboard/dashboard-content.tsx src/components/dashboard/dashboard-skeleton.tsx src/components/dashboard/concentration-card.tsx tests/unit/dashboard-portfolio-layout.test.ts
 ```
 
-Expected: no whitespace errors, no unrelated files, no parent flex/stretch coupling, dashboard `fillHeight` present only at the Portfolio Composition call site, and no financial or translation changes.
+Expected: no whitespace errors, no unrelated files, desktop containment/fill utilities mirrored in the skeleton, dashboard `fillHeight` present only at the Portfolio Composition call site, and no financial or translation changes.

--- a/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
+++ b/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
@@ -27,9 +27,9 @@ This preserves the dashboard's existing sequence of “what changed,” “what 
 
 ## Portfolio Composition
 
-- Remove dashboard `fillHeight` behavior and its parent flex-stretch rules.
+- Keep dashboard `fillHeight` so the treemap fills the Portfolio Composition card's own chart/list row, while removing the parent flex-stretch rules that previously tied the card to the external allocation/currency rail.
 - Keep the existing treemap, account selection, holding drill-in, privacy behavior, accessible chart summary, and reduced-motion behavior.
-- Use the component's existing content-driven responsive chart height: 280px in comfortable desktop density and 220px in compact density at wide desktop widths, with the current width-based smaller-container rules preserved.
+- Use the component's existing responsive chart height as the minimum, then let the treemap grow to the height of its internal detail/account-list column on desktop. Mobile keeps the existing width-based height rules.
 - Keep the detail card and account list beside the treemap on desktop.
 - Let the card end after its content instead of visually aligning its bottom edge with the neighboring rail.
 - Keep the total-assets label and unpriced-holdings warning in the header.

--- a/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
+++ b/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
@@ -1,0 +1,95 @@
+# Dashboard Portfolio Layout Design
+
+## Goal
+
+Remove the excessive empty space in the dashboard's Portfolio Composition card while preserving its role as the primary account-allocation drill-in. Improve the surrounding portfolio modules so the desktop section reads as one coherent composition zone without changing financial calculations or navigation.
+
+## Current Problem
+
+The desktop dashboard places Portfolio Composition in an eight-column card beside a four-column rail containing Asset Allocation, Currency Exposure, and Concentration. The left card is forced to fill the height of the entire right rail. `PortfolioHeatmap` then measures that stretched container and expands the treemap to the same height, producing a large low-information area below the useful visualization and legend.
+
+The layout also makes Concentration feel like a third unrelated rail card even though it is a direct interpretation of portfolio composition.
+
+## Chosen Structure
+
+Use a two-row portfolio composition zone on desktop:
+
+1. First row:
+   - Portfolio Composition spans eight of twelve columns.
+   - Asset Allocation and Currency Exposure form a four-column vertical rail.
+   - Each side sizes itself from its content. The Portfolio Composition card is not stretched to the rail height.
+2. Second row:
+   - Concentration spans all twelve columns.
+   - Its content becomes a compact horizontal summary rather than a tall narrow card.
+3. All Accounts remains the next full-width section.
+
+This preserves the dashboard's existing sequence of “what changed,” “what it is made of,” and “drill into accounts.”
+
+## Portfolio Composition
+
+- Remove dashboard `fillHeight` behavior and its parent flex-stretch rules.
+- Keep the existing treemap, account selection, holding drill-in, privacy behavior, accessible chart summary, and reduced-motion behavior.
+- Use the component's existing content-driven responsive chart height: 280px in comfortable desktop density and 220px in compact density at wide desktop widths, with the current width-based smaller-container rules preserved.
+- Keep the detail card and account list beside the treemap on desktop.
+- Let the card end after its content instead of visually aligning its bottom edge with the neighboring rail.
+- Keep the total-assets label and unpriced-holdings warning in the header.
+
+## Concentration Summary
+
+At large desktop widths, reorganize the existing concentration content into two horizontal regions:
+
+- Summary region: largest-position percentage, “Largest position” label, and concentration status.
+- Positions region: the existing top-position list with names, percentages, and bars, using the remaining width.
+
+The card keeps the same data and semantic color tokens. It does not introduce another chart, new threshold logic, or a new destination.
+
+At narrower widths, including mobile, the concentration content falls back to the existing vertical reading order. Long holding names remain truncated or wrapped according to the existing component's behavior, and percentages retain tabular alignment.
+
+## Responsive Behavior
+
+- Below the large dashboard breakpoint, modules remain single-column.
+- Preserve the current mobile-first source order for Allocation, Currency Exposure, Portfolio Composition, and Concentration so streaming and screen-reader order remain predictable.
+- Desktop placement uses grid column and row positioning only.
+- Touch targets, focus rings, privacy mode, compact density, localization, and reduced motion remain supported.
+- Skeletons mirror the new topology: the first portfolio row contains the treemap and two-card rail; the concentration skeleton is a separate full-width row.
+
+## Component and Data Boundaries
+
+- `DashboardContent` remains the server-side orchestrator with independent Suspense boundaries.
+- `PortfolioHeatmapSection` continues to load the cached net-worth summary and passes it to the existing client-side `PortfolioHeatmap`.
+- `ConcentrationSection` continues to derive concentration from the cached summary.
+- No additional client boundary, database query, API route, or shared state is introduced.
+- The production dashboard skeleton and local section fallbacks are updated to match the final visual structure.
+
+## Empty and Error States
+
+- Existing no-account onboarding remains unchanged.
+- Portfolio Composition continues to render nothing when no positive asset account exists.
+- Concentration continues to render nothing when total assets are zero or negative.
+- Existing Suspense fallbacks remain isolated so one delayed module does not block the rest of the dashboard.
+- The unpriced-holdings warning remains local to Portfolio Composition.
+
+## Verification
+
+1. Static checks:
+   - Format check for changed files.
+   - ESLint for changed TypeScript files.
+   - TypeScript typecheck.
+2. Behavioral checks:
+   - Selecting an account still drills the treemap into its holdings.
+   - Back navigation returns to account allocation.
+   - Privacy mode obscures values and chart detail as before.
+   - Compact density reduces the treemap height without collapsing labels or controls.
+3. Visual checks at representative widths:
+   - Wide desktop: 8/4 first row plus full-width horizontal Concentration.
+   - Standard desktop: no stretched Portfolio Composition card and no large internal blank area.
+   - Tablet/mobile: single-column order, readable labels, and 44px touch targets.
+   - Dark and light themes: existing borders, surfaces, and chart colors remain legible.
+
+## Out of Scope
+
+- Changing portfolio or concentration calculations.
+- Moving Portfolio Composition to the Analysis page.
+- Adding dashboard customization or drag-and-drop modules.
+- Combining the portfolio modules into one nested mega-card.
+- Changing chart colors, account colors, typography, or global spacing tokens.

--- a/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
+++ b/docs/superpowers/specs/2026-07-10-dashboard-portfolio-layout-design.md
@@ -17,7 +17,7 @@ Use a two-row portfolio composition zone on desktop:
 1. First row:
    - Portfolio Composition spans eight of twelve columns.
    - Asset Allocation and Currency Exposure form a four-column vertical rail.
-   - Each side sizes itself from its content. The Portfolio Composition card is not stretched to the rail height.
+   - On desktop, Portfolio Composition ends on the same baseline as Currency Exposure. Size containment on the left grid item lets the two-card rail resolve the row height without allowing the treemap's intrinsic height to inflate it.
 2. Second row:
    - Concentration spans all twelve columns.
    - Its content becomes a compact horizontal summary rather than a tall narrow card.
@@ -27,11 +27,11 @@ This preserves the dashboard's existing sequence of “what changed,” “what 
 
 ## Portfolio Composition
 
-- Keep dashboard `fillHeight` so the treemap fills the Portfolio Composition card's own chart/list row, while removing the parent flex-stretch rules that previously tied the card to the external allocation/currency rail.
+- Keep dashboard `fillHeight` so the treemap fills the Portfolio Composition card's internal chart/list row, while the external card fills only the desktop overview row resolved by the allocation/currency rail.
 - Keep the existing treemap, account selection, holding drill-in, privacy behavior, accessible chart summary, and reduced-motion behavior.
-- Use the component's existing responsive chart height as the minimum, then let the treemap grow to the height of its internal detail/account-list column on desktop. Mobile keeps the existing width-based height rules.
+- On desktop, let the treemap and detail/account-list columns share the available card height. The account list may scroll within that height instead of forcing the row taller. Mobile keeps the existing width-based height rules and document flow.
 - Keep the detail card and account list beside the treemap on desktop.
-- Let the card end after its content instead of visually aligning its bottom edge with the neighboring rail.
+- Align the card's bottom edge with Currency Exposure without introducing blank space below the treemap or internal overflow.
 - Keep the total-assets label and unpriced-holdings warning in the header.
 
 ## Concentration Summary
@@ -82,7 +82,7 @@ At narrower widths, including mobile, the concentration content falls back to th
    - Compact density reduces the treemap height without collapsing labels or controls.
 3. Visual checks at representative widths:
    - Wide desktop: 8/4 first row plus full-width horizontal Concentration.
-   - Standard desktop: no stretched Portfolio Composition card and no large internal blank area.
+   - Standard desktop: Portfolio Composition and Currency Exposure share a bottom edge; treemap bottom gap and internal overflow are both zero.
    - Tablet/mobile: single-column order, readable labels, and 44px touch targets.
    - Dark and light themes: existing borders, surfaces, and chart colors remain legible.
 

--- a/src/components/analysis/portfolio-heatmap.tsx
+++ b/src/components/analysis/portfolio-heatmap.tsx
@@ -444,15 +444,25 @@ export function PortfolioHeatmap({
           </div>
         </div>
       </CardHeader>
-      <CardContent className={isCompact ? "space-y-3 pt-1" : "space-y-4 pt-1"}>
+      <CardContent
+        className={cn(
+          isCompact ? "space-y-3 pt-1" : "space-y-4 pt-1",
+          fillHeight && "lg:flex lg:min-h-0 lg:flex-1 lg:flex-col",
+        )}
+      >
         {accounts.length === 0 ? (
           <div className="flex min-h-[220px] items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/20 px-6 text-center text-sm text-muted-foreground">
             {t("heatmapEmpty")}
           </div>
         ) : (
           <>
-            <div className="grid gap-3 sm:gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
-              <div className={cn("min-w-0", fillHeight && "lg:flex lg:flex-col")}>
+            <div
+              className={cn(
+                "grid gap-3 sm:gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]",
+                fillHeight && "lg:min-h-0 lg:flex-1",
+              )}
+            >
+              <div className={cn("min-w-0", fillHeight && "lg:flex lg:min-h-0 lg:flex-col")}>
                 <div className="mb-2 flex min-h-8 items-center gap-2 overflow-hidden">
                   {selectedAccount && (
                     <>
@@ -519,11 +529,18 @@ export function PortfolioHeatmap({
                 </div>
               </div>
 
-              <div className="min-w-0 space-y-3">
+              <div
+                className={cn("min-w-0 space-y-3", fillHeight && "lg:flex lg:min-h-0 lg:flex-col")}
+              >
                 {renderDetailCard("hidden sm:block")}
 
                 {selectedAccount?.children && selectedAccount.children.length > 0 ? (
-                  <div className="max-h-[15rem] space-y-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/10 p-1 sm:max-h-[18rem] lg:max-h-[23rem]">
+                  <div
+                    className={cn(
+                      "max-h-[15rem] space-y-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/10 p-1 sm:max-h-[18rem] lg:max-h-[23rem]",
+                      fillHeight && "lg:min-h-0 lg:flex-1",
+                    )}
+                  >
                     {selectedAccount.children.map((child) => (
                       <button
                         key={child.id}
@@ -572,7 +589,10 @@ export function PortfolioHeatmap({
                 ) : (
                   <div className="relative sm:contents">
                     <div
-                      className="-mx-1 flex snap-x gap-2 overflow-x-auto px-1 pb-1 pr-2 overscroll-x-contain scrollbar-none sm:mx-0 sm:grid sm:max-h-[18rem] sm:grid-cols-2 sm:gap-1.5 sm:overflow-x-visible sm:overflow-y-auto sm:px-0 lg:block lg:max-h-[23rem] lg:space-y-1.5"
+                      className={cn(
+                        "-mx-1 flex snap-x gap-2 overflow-x-auto px-1 pb-1 pr-2 overscroll-x-contain scrollbar-none sm:mx-0 sm:grid sm:max-h-[18rem] sm:grid-cols-2 sm:gap-1.5 sm:overflow-x-visible sm:overflow-y-auto sm:px-0 lg:block lg:max-h-[23rem] lg:space-y-1.5",
+                        fillHeight && "lg:min-h-0 lg:flex-1",
+                      )}
                       style={
                         isPhone
                           ? ({

--- a/src/components/dashboard/concentration-card.tsx
+++ b/src/components/dashboard/concentration-card.tsx
@@ -22,8 +22,8 @@ export function ConcentrationCard({ summary }: { summary: NetWorthSummary }) {
         <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
         <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
       </CardHeader>
-      <CardContent className="flex flex-1 flex-col">
-        <div className="mb-3 flex items-baseline justify-between gap-2">
+      <CardContent className="grid flex-1 gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+        <div className="flex items-baseline justify-between gap-3 lg:flex-col lg:items-start lg:justify-start lg:gap-3">
           <div>
             <div className="text-2xl font-semibold tabular-nums text-foreground">
               {privacyMode ? "***" : `${topHoldingPct.toFixed(1)}%`}
@@ -34,19 +34,19 @@ export function ConcentrationCard({ summary }: { summary: NetWorthSummary }) {
             {t(`level_${level}` as "level_low" | "level_moderate" | "level_high")}
           </span>
         </div>
-        <ul className="space-y-2">
-          {top.map((p) => (
-            <li key={p.label}>
+        <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+          {top.map((position) => (
+            <li key={position.label} className="min-w-0">
               <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
-                <span className="min-w-0 truncate text-foreground">{p.label}</span>
+                <span className="min-w-0 truncate text-foreground">{position.label}</span>
                 <span className="shrink-0 tabular-nums text-muted-foreground">
-                  {privacyMode ? "***" : `${p.pct.toFixed(1)}%`}
+                  {privacyMode ? "***" : `${position.pct.toFixed(1)}%`}
                 </span>
               </div>
               <div className="h-1.5 overflow-hidden rounded-full bg-muted">
                 <div
                   className="h-full rounded-full bg-primary"
-                  style={{ width: `${Math.min(100, p.pct)}%` }}
+                  style={{ width: `${Math.min(100, position.pct)}%` }}
                 />
               </div>
             </li>

--- a/src/components/dashboard/concentration-card.tsx
+++ b/src/components/dashboard/concentration-card.tsx
@@ -17,42 +17,44 @@ export function ConcentrationCard({ summary }: { summary: NetWorthSummary }) {
   const level = hhi >= 0.25 ? "high" : hhi >= 0.15 ? "moderate" : "low";
 
   return (
-    <Card className="flex flex-col">
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
-        <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
-      </CardHeader>
-      <CardContent className="grid flex-1 gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
-        <div className="flex items-baseline justify-between gap-3 lg:flex-col lg:items-start lg:justify-start lg:gap-3">
-          <div>
-            <div className="text-2xl font-semibold tabular-nums text-foreground">
-              {privacyMode ? "***" : `${topHoldingPct.toFixed(1)}%`}
+    <div data-testid="portfolio-concentration-row">
+      <Card className="flex flex-col">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-medium text-foreground">{t("title")}</CardTitle>
+          <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
+        </CardHeader>
+        <CardContent className="grid flex-1 gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+          <div className="flex items-baseline justify-between gap-3 lg:flex-col lg:items-start lg:justify-start lg:gap-3">
+            <div>
+              <div className="text-2xl font-semibold tabular-nums text-foreground">
+                {privacyMode ? "***" : `${topHoldingPct.toFixed(1)}%`}
+              </div>
+              <div className="text-[11px] text-muted-foreground">{t("largestPosition")}</div>
             </div>
-            <div className="text-[11px] text-muted-foreground">{t("largestPosition")}</div>
+            <span className="rounded-full bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+              {t(`level_${level}` as "level_low" | "level_moderate" | "level_high")}
+            </span>
           </div>
-          <span className="rounded-full bg-muted px-2 py-1 text-[11px] text-muted-foreground">
-            {t(`level_${level}` as "level_low" | "level_moderate" | "level_high")}
-          </span>
-        </div>
-        <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
-          {top.map((position) => (
-            <li key={position.label} className="min-w-0">
-              <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
-                <span className="min-w-0 truncate text-foreground">{position.label}</span>
-                <span className="shrink-0 tabular-nums text-muted-foreground">
-                  {privacyMode ? "***" : `${position.pct.toFixed(1)}%`}
-                </span>
-              </div>
-              <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-primary"
-                  style={{ width: `${Math.min(100, position.pct)}%` }}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
+          <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+            {top.map((position) => (
+              <li key={position.label} className="min-w-0">
+                <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
+                  <span className="min-w-0 truncate text-foreground">{position.label}</span>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {privacyMode ? "***" : `${position.pct.toFixed(1)}%`}
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{ width: `${Math.min(100, position.pct)}%` }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -23,7 +23,10 @@ import { GoalsMilestoneCard } from "@/components/dashboard/goals-milestone-card"
 import { ProjectionEntryCard } from "@/components/dashboard/projection-entry-card";
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import { WatchlistCard } from "@/components/dashboard/watchlist-card";
-import { WatchlistCardSkeleton } from "@/components/dashboard/dashboard-skeleton";
+import {
+  ConcentrationCardSkeleton,
+  WatchlistCardSkeleton,
+} from "@/components/dashboard/dashboard-skeleton";
 import { ConcentrationCard } from "./concentration-card";
 import Link from "next/link";
 import { ArrowRight, History } from "lucide-react";
@@ -386,7 +389,7 @@ async function PortfolioHeatmapSection({
   );
   if (!hasAssets) return null;
 
-  return <PortfolioHeatmap summary={summary} fillHeight />;
+  return <PortfolioHeatmap summary={summary} />;
 }
 
 /* ---------- Orchestrator ---------- */
@@ -445,28 +448,31 @@ export async function DashboardContent({ userId }: { userId: string }) {
         </div>
       </div>
 
-      {/* Tier 3 — "what it's made of": the portfolio treemap (wide) sits beside a
-          stacked allocation + currency-exposure column so the short currency card
-          no longer leaves a gap. Source order is allocation → currency → portfolio
-          (the phone reading order); on desktop the donut stack is placed in the
-          right column and the treemap fills the left, same row. */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
-        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
-          <Suspense fallback={<ChartCardSkeleton />}>
-            <AllocationSection userId={userId} baseCurrency={baseCurrency} />
-          </Suspense>
-          <Suspense fallback={<ChartCardSkeleton />}>
-            <CurrencySection userId={userId} baseCurrency={baseCurrency} />
-          </Suspense>
-          <Suspense fallback={<ChartCardSkeleton />}>
-            <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
-          </Suspense>
+      {/* Tier 3 — "what it's made of": a content-sized 8/4 overview row followed
+          by a full-width concentration summary. Source order stays allocation →
+          currency → portfolio → concentration for mobile and assistive technology. */}
+      <div className="space-y-3 sm:space-y-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
+        <div
+          data-testid="portfolio-overview-row"
+          className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+        >
+          <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+            <Suspense fallback={<ChartCardSkeleton />}>
+              <AllocationSection userId={userId} baseCurrency={baseCurrency} />
+            </Suspense>
+            <Suspense fallback={<ChartCardSkeleton />}>
+              <CurrencySection userId={userId} baseCurrency={baseCurrency} />
+            </Suspense>
+          </div>
+          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+            <Suspense fallback={<PortfolioHeatmapSkeleton />}>
+              <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+            </Suspense>
+          </div>
         </div>
-        {/* Force the treemap card to fill the row so its bottom aligns with the
-            stacked allocation + currency column to its right. */}
-        <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 [&>*]:min-h-0 [&>*]:flex-1">
-          <Suspense fallback={<PortfolioHeatmapSkeleton />}>
-            <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+        <div data-testid="portfolio-concentration-row">
+          <Suspense fallback={<ConcentrationCardSkeleton />}>
+            <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
           </Suspense>
         </div>
       </div>

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -269,11 +269,7 @@ async function ConcentrationSection({
 }) {
   const summary = await getCachedNetWorthSummary(userId, baseCurrency);
   if (summary.totalAssets <= 0) return null;
-  return (
-    <div data-testid="portfolio-concentration-row">
-      <ConcentrationCard summary={summary} />
-    </div>
-  );
+  return <ConcentrationCard summary={summary} />;
 }
 
 /**

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -269,7 +269,11 @@ async function ConcentrationSection({
 }) {
   const summary = await getCachedNetWorthSummary(userId, baseCurrency);
   if (summary.totalAssets <= 0) return null;
-  return <ConcentrationCard summary={summary} />;
+  return (
+    <div data-testid="portfolio-concentration-row">
+      <ConcentrationCard summary={summary} />
+    </div>
+  );
 }
 
 /**
@@ -470,11 +474,15 @@ export async function DashboardContent({ userId }: { userId: string }) {
             </Suspense>
           </div>
         </div>
-        <div data-testid="portfolio-concentration-row">
-          <Suspense fallback={<ConcentrationCardSkeleton />}>
-            <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
-          </Suspense>
-        </div>
+        <Suspense
+          fallback={
+            <div>
+              <ConcentrationCardSkeleton />
+            </div>
+          }
+        >
+          <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
+        </Suspense>
       </div>
 
       {/* Tier 4 — drill-in detail: full-width accounts summary */}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -389,7 +389,7 @@ async function PortfolioHeatmapSection({
   );
   if (!hasAssets) return null;
 
-  return <PortfolioHeatmap summary={summary} />;
+  return <PortfolioHeatmap summary={summary} fillHeight />;
 }
 
 /* ---------- Orchestrator ---------- */

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -464,7 +464,7 @@ export async function DashboardContent({ userId }: { userId: string }) {
               <CurrencySection userId={userId} baseCurrency={baseCurrency} />
             </Suspense>
           </div>
-          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
             <Suspense fallback={<PortfolioHeatmapSkeleton />}>
               <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
             </Suspense>

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -138,6 +138,37 @@ function PortfolioHeatmapSkeleton() {
   );
 }
 
+export function ConcentrationCardSkeleton() {
+  return (
+    <Card data-testid="portfolio-concentration-skeleton">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-64 max-w-full" />
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+        <div className="flex items-end justify-between gap-3 lg:flex-col lg:items-start lg:justify-start">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-6 w-28 rounded-full" />
+        </div>
+        <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+          {[...Array(5)].map((_, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex justify-between gap-3">
+                <Skeleton className="h-3 w-32 max-w-[70%]" />
+                <Skeleton className="h-3 w-10" />
+              </div>
+              <Skeleton className="h-1.5 w-full rounded-full" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function DashboardSkeleton() {
   return (
     <div className="space-y-4 md:space-y-8">
@@ -164,18 +195,21 @@ export function DashboardSkeleton() {
         </div>
       </div>
 
-      {/* Tier 3 — portfolio treemap (8) beside the stacked allocation + currency
-          donut rail (4). Source order puts the donuts first so the phone reading
-          order (allocation → currency → treemap) is preserved; on desktop the
-          col-start values place the treemap left and the donuts right. */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 sm:gap-6">
-        <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
-          <ChartCardSkeleton />
-          <ChartCardSkeleton />
+      {/* Tier 3 — content-sized portfolio overview, then full-width concentration. */}
+      <div className="space-y-3 sm:space-y-6">
+        <div
+          data-testid="portfolio-overview-skeleton"
+          className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+        >
+          <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+            <ChartCardSkeleton />
+            <ChartCardSkeleton />
+          </div>
+          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+            <PortfolioHeatmapSkeleton />
+          </div>
         </div>
-        <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 [&>*]:min-h-0 [&>*]:flex-1">
-          <PortfolioHeatmapSkeleton />
-        </div>
+        <ConcentrationCardSkeleton />
       </div>
 
       {/* Tier 4 — accounts summary (matches AccountsSummarySkeleton) */}

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -195,7 +195,7 @@ export function DashboardSkeleton() {
         </div>
       </div>
 
-      {/* Tier 3 — content-sized portfolio overview, then full-width concentration. */}
+      {/* Tier 3 — aligned portfolio overview, then full-width concentration. */}
       <div className="space-y-3 sm:space-y-6">
         <div
           data-testid="portfolio-overview-skeleton"
@@ -205,7 +205,7 @@ export function DashboardSkeleton() {
             <ChartCardSkeleton />
             <ChartCardSkeleton />
           </div>
-          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
             <PortfolioHeatmapSkeleton />
           </div>
         </div>

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -4,12 +4,19 @@ import { describe, expect, it } from "vitest";
 const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
 const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
 const concentrationSource = readFileSync("src/components/dashboard/concentration-card.tsx", "utf8");
+const heatmapSource = readFileSync("src/components/analysis/portfolio-heatmap.tsx", "utf8");
 
 describe("dashboard portfolio layout", () => {
-  it("fills the composition card internally without stretching the overview column", () => {
+  it("aligns the composition card with the desktop overview row and fills it internally", () => {
     expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} fillHeight />");
-    expect(dashboardSource).not.toContain("[&>*]:min-h-0");
-    expect(dashboardSource).not.toContain("[&>*]:flex-1");
+    expect(dashboardSource).toContain("lg:[&>*]:flex-1");
+    expect(dashboardSource).toContain("lg:[&>*]:min-h-0");
+    expect(dashboardSource).toContain("lg:min-h-0");
+    expect(dashboardSource).toContain("lg:contain-size");
+    expect(heatmapSource).not.toContain('fillHeight && "lg:h-full"');
+    expect(heatmapSource).toContain('fillHeight && "lg:flex lg:min-h-0 lg:flex-1 lg:flex-col"');
+    expect(heatmapSource).toContain('fillHeight && "lg:min-h-0 lg:flex-1"');
+    expect(heatmapSource.match(/fillHeight && "lg:flex lg:min-h-0 lg:flex-col"/g)).toHaveLength(2);
   });
 
   it("separates concentration from the 8/4 portfolio overview row", () => {
@@ -64,9 +71,11 @@ describe("dashboard portfolio layout", () => {
     const overviewSource = skeletonSource.slice(overviewStart, concentrationStart);
     expect(overviewSource).toContain("lg:col-span-8");
     expect(overviewSource).toContain("lg:col-span-4");
+    expect(overviewSource).toContain("lg:contain-size");
+    expect(overviewSource).toContain("lg:[&>*]:flex-1");
     expect(overviewSource).not.toContain("<ConcentrationCardSkeleton />");
     expect(skeletonSource)
-      .toContain(`          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+      .toContain(`          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
             <PortfolioHeatmapSkeleton />
           </div>
         </div>

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
+const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
+
+describe("dashboard portfolio layout", () => {
+  it("keeps the dashboard treemap at its content-driven height", () => {
+    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} />");
+    expect(dashboardSource).not.toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+  });
+
+  it("separates concentration from the 8/4 portfolio overview row", () => {
+    const overviewStart = dashboardSource.indexOf('data-testid="portfolio-overview-row"');
+    const concentrationStart = dashboardSource.indexOf('data-testid="portfolio-concentration-row"');
+
+    expect(overviewStart).toBeGreaterThan(-1);
+    expect(concentrationStart).toBeGreaterThan(overviewStart);
+
+    const overviewSource = dashboardSource.slice(overviewStart, concentrationStart);
+    expect(overviewSource).toContain("lg:col-span-8");
+    expect(overviewSource).toContain("lg:col-span-4");
+    expect(overviewSource).not.toContain("<ConcentrationSection");
+  });
+
+  it("keeps the loading skeleton topology aligned with the dashboard", () => {
+    expect(skeletonSource).toContain('data-testid="portfolio-overview-skeleton"');
+    expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
+    expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
+  });
+});

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -13,7 +13,17 @@ describe("dashboard portfolio layout", () => {
 
   it("separates concentration from the 8/4 portfolio overview row", () => {
     const overviewStart = dashboardSource.indexOf('data-testid="portfolio-overview-row"');
-    const concentrationStart = dashboardSource.indexOf('data-testid="portfolio-concentration-row"');
+    const concentrationBoundary = `            </Suspense>
+          </div>
+        </div>
+        <Suspense
+          fallback={
+            <div>
+              <ConcentrationCardSkeleton />
+            </div>
+          }
+        >`;
+    const concentrationStart = dashboardSource.indexOf(concentrationBoundary, overviewStart);
 
     expect(overviewStart).toBeGreaterThan(-1);
     expect(concentrationStart).toBeGreaterThan(overviewStart);
@@ -22,6 +32,12 @@ describe("dashboard portfolio layout", () => {
     expect(overviewSource).toContain("lg:col-span-8");
     expect(overviewSource).toContain("lg:col-span-4");
     expect(overviewSource).not.toContain("<ConcentrationSection");
+    expect(dashboardSource).toContain(`  if (summary.totalAssets <= 0) return null;
+  return (
+    <div data-testid="portfolio-concentration-row">
+      <ConcentrationCard summary={summary} />
+    </div>
+  );`);
   });
 
   it("keeps the loading skeleton topology aligned with the dashboard", () => {
@@ -38,6 +54,12 @@ describe("dashboard portfolio layout", () => {
     expect(overviewSource).toContain("lg:col-span-8");
     expect(overviewSource).toContain("lg:col-span-4");
     expect(overviewSource).not.toContain("<ConcentrationCardSkeleton />");
+    expect(skeletonSource)
+      .toContain(`          <div className="min-w-0 lg:col-span-8 lg:col-start-1 lg:row-start-1">
+            <PortfolioHeatmapSkeleton />
+          </div>
+        </div>
+        <ConcentrationCardSkeleton />`);
     expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
     expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
   });

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -25,7 +25,19 @@ describe("dashboard portfolio layout", () => {
   });
 
   it("keeps the loading skeleton topology aligned with the dashboard", () => {
-    expect(skeletonSource).toContain('data-testid="portfolio-overview-skeleton"');
+    const overviewStart = skeletonSource.indexOf('data-testid="portfolio-overview-skeleton"');
+    const concentrationStart = skeletonSource.indexOf(
+      "<ConcentrationCardSkeleton />",
+      overviewStart,
+    );
+
+    expect(overviewStart).toBeGreaterThan(-1);
+    expect(concentrationStart).toBeGreaterThan(overviewStart);
+
+    const overviewSource = skeletonSource.slice(overviewStart, concentrationStart);
+    expect(overviewSource).toContain("lg:col-span-8");
+    expect(overviewSource).toContain("lg:col-span-4");
+    expect(overviewSource).not.toContain("<ConcentrationCardSkeleton />");
     expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
     expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
   });

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -33,9 +33,19 @@ describe("dashboard portfolio layout", () => {
     expect(overviewSource).toContain("lg:col-span-4");
     expect(overviewSource).not.toContain("<ConcentrationSection");
     expect(dashboardSource).toContain(`  if (summary.totalAssets <= 0) return null;
-  return (
+  return <ConcentrationCard summary={summary} />;`);
+
+    const emptyGuard = concentrationSource.indexOf("if (top.length === 0) return null;");
+    const loadedRow = concentrationSource.indexOf(
+      '<div data-testid="portfolio-concentration-row">',
+    );
+
+    expect(emptyGuard).toBeGreaterThan(-1);
+    expect(loadedRow).toBeGreaterThan(emptyGuard);
+    expect(concentrationSource).toContain(`  return (
     <div data-testid="portfolio-concentration-row">
-      <ConcentrationCard summary={summary} />
+      <Card className="flex flex-col">`);
+    expect(concentrationSource).toContain(`      </Card>
     </div>
   );`);
   });

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -6,9 +6,10 @@ const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton
 const concentrationSource = readFileSync("src/components/dashboard/concentration-card.tsx", "utf8");
 
 describe("dashboard portfolio layout", () => {
-  it("keeps the dashboard treemap at its content-driven height", () => {
-    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} />");
-    expect(dashboardSource).not.toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+  it("fills the composition card internally without stretching the overview column", () => {
+    expect(dashboardSource).toContain("<PortfolioHeatmap summary={summary} fillHeight />");
+    expect(dashboardSource).not.toContain("[&>*]:min-h-0");
+    expect(dashboardSource).not.toContain("[&>*]:flex-1");
   });
 
   it("separates concentration from the 8/4 portfolio overview row", () => {

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
 const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
+const concentrationSource = readFileSync("src/components/dashboard/concentration-card.tsx", "utf8");
 
 describe("dashboard portfolio layout", () => {
   it("keeps the dashboard treemap at its content-driven height", () => {
@@ -27,5 +28,10 @@ describe("dashboard portfolio layout", () => {
     expect(skeletonSource).toContain('data-testid="portfolio-overview-skeleton"');
     expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
     expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
+  });
+
+  it("lays concentration out horizontally on desktop", () => {
+    expect(concentrationSource).toContain("lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)]");
+    expect(concentrationSource).toContain("sm:grid-cols-2 xl:grid-cols-3");
   });
 });


### PR DESCRIPTION
## Summary

- Rework the dashboard portfolio area into a content-sized 8/4 overview row with Portfolio Composition beside Asset Allocation and Currency Exposure.
- Move Concentration into a compact full-width horizontal summary below the overview row.
- Fill the Portfolio Composition treemap to the height of its own detail/account-list column without coupling the card to the external right rail.
- Preserve mobile ordering, privacy behavior, compact density, streaming boundaries, empty states, and loading skeleton parity.
- Add focused regression coverage and document the approved layout.

## Root cause

Portfolio Composition was previously forced to match the combined height of the external allocation, currency, and concentration rail. Removing that coupling fixed the oversized card, but left the treemap at its responsive minimum while the card's internal account list remained taller. The final layout keeps the outer card content-sized and applies `fillHeight` only inside the card, eliminating the internal blank area without restoring the original external height coupling.

## User impact

- Desktop portfolio information is denser and easier to scan.
- The treemap uses all available space inside its card.
- Mobile retains the existing touch-friendly single-column flow.
- Cash-only and no-priced-position portfolios do not leave empty Concentration spacing.

## Validation

- `pnpm test:unit` — 32 files, 258 tests passed.
- `pnpm playwright test tests/e2e/smoke.spec.ts --project=chromium` — 3 tests passed.
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- Browser verification at 1440×900 and 412×915 in dark mode: no error overlay or horizontal overflow.
- Desktop DOM measurement after the final fix: `blankBelowChart = 0px`, `svgGap = 0px`.
