### PR TITLE
docs: prepare project for open source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ AUTH_GOOGLE_SECRET="replace-with-google-oauth-client-secret"
 # Optional: auth callback proxy URL (used in some hosted/preview setups)
 # AUTH_REDIRECT_PROXY_URL="https://your-app-domain.example.com/api/auth"
 
+# Public canonical URL for metadata and social sharing (required for deployments)
+# NEXT_PUBLIC_APP_URL="https://tracker.example.com"
+
 # Cron endpoint bearer token for /api/cron/snapshot
 CRON_SECRET="replace-with-cron-bearer-token"
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report reproducible behavior that differs from expectations.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: "Please do not include account balances, OAuth credentials, database URLs, or other sensitive information."
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the smallest steps that consistently reproduce the behavior.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the application version, deployment method, browser, and operating system, without sensitive values.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose an improvement for self-hosted Assets Tracker instances.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: "Please do not include account balances, OAuth credentials, database URLs, or other sensitive information."
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the problem or limitation you want to solve.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-outcome
+    attributes:
+      label: Proposed outcome
+      description: Describe the improvement and the outcome you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative approaches you considered.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other non-sensitive context that would help explain the request.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: E2E Smoke Tests
 on:
   deployment_status:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event.deployment.sha }}
   cancel-in-progress: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported through GitHub's private vulnerability reporting flow described in
+SECURITY.md. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Development
+
+1. Copy `.env.example` to `.env` and provide your own local credentials.
+2. Start PostgreSQL with `pnpm db:up`.
+3. Sync the schema with `pnpm exec prisma db push`.
+4. Start the app with `pnpm dev`.
+
+Never commit `.env`, `.env.local`, database exports, or credentials. Report
+vulnerabilities through [the security policy](SECURITY.md), not a public issue.
+
+## Before opening a pull request
+
+Run `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test:unit`.
+Update tests and documentation when the change affects behavior.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Tsai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ CRON_SECRET="your_secure_random_string"
 > [!TIP]
 > Generate `AUTH_SECRET` and `CRON_SECRET` with `openssl rand -base64 32`.
 
+## Self-hosting and data responsibility
+
+Each deployment owner provides and controls its own Google OAuth credentials, PostgreSQL database, deployment, cron secret, and optional Vercel/Sentry integrations. `NEXT_PUBLIC_APP_URL` must be the deployed public URL, and [`.env.example`](./.env.example) is the complete configuration reference.
+
+Assets Tracker is personal-tracking software, not financial, tax, or investment advice. Self-hosters are responsible for their users' data security, privacy disclosures, regulatory compliance, backups, and access controls.
+
 ### 3. Installation
 
 ```bash
@@ -293,6 +299,10 @@ This approach ensures that your trend lines always remain continuous and compara
 ## 🏷️ Versioning
 
 The app follows [Semantic Versioning](https://semver.org). Version history lives in `src/lib/changelog.ts` (the single source of truth — the displayed version derives from the newest entry) and is shown in-app on the **`/changelog`** page and the Settings "Version" card. To cut a release, add an entry there and bump `package.json`'s `version`. See [VERSIONING.md](./docs/VERSIONING.md) for the bump rules and full process.
+
+## Contributing and security
+
+Contributions are welcome; see [CONTRIBUTING.md](./CONTRIBUTING.md). Please report vulnerabilities privately under the [Security Policy](./SECURITY.md). Community participation is governed by the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## 📄 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through the repository's
+**Security** tab using **Report a vulnerability**. Do not open a public issue
+before a fix or mitigation is available.
+
+Include the affected version or commit, reproduction steps, impact, and any
+suggested mitigation. You will receive an acknowledgement as soon as the
+maintainer is able to review the report.

--- a/docs/superpowers/plans/2026-07-10-open-source-readiness.md
+++ b/docs/superpowers/plans/2026-07-10-open-source-readiness.md
@@ -1,0 +1,317 @@
+# Open-source Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare Assets Tracker for a public, self-hosted release with clear licensing, contributor guidance, safe defaults, and documented deployment responsibility.
+
+**Architecture:** Community policy, issue forms, and dependency-update configuration live under the repository root and `.github/`. A tiny URL helper centralizes the deployed application URL used by root metadata; the README describes how self-hosters set it. Existing workflows retain their jobs and triggers while explicitly receiving read-only repository access.
+
+**Tech Stack:** Markdown, GitHub issue forms and Actions YAML, Dependabot, TypeScript, Next.js 16 Metadata API, Vitest, pnpm.
+
+## Global Constraints
+
+- Use the exact license notice: `Copyright (c) 2026 Mike Tsai`.
+- Keep the project self-hosted; do not promise a support SLA or operate a hosted-service privacy policy.
+- Do not add release automation, dependency auto-merge, a new deployment platform, or GitHub repository-setting changes.
+- Keep `package.json` private because this is not an npm package.
+- Do not commit `.env` files or credentials.
+- Preserve the existing workflow triggers and jobs; add only `permissions: contents: read`.
+
+---
+
+### Task 1: Add licensing, contribution, security, and conduct policies
+
+**Files:**
+
+- Create: `LICENSE`
+- Create: `CONTRIBUTING.md`
+- Create: `SECURITY.md`
+- Create: `CODE_OF_CONDUCT.md`
+
+**Interfaces:**
+
+- Consumes: the README's existing `pnpm` setup and validation commands.
+- Produces: public repository policy documents linked by the README and GitHub community profile.
+
+- [ ] **Step 1: Create the MIT license file**
+
+Add the standard MIT license text, headed by:
+
+```text
+MIT License
+
+Copyright (c) 2026 Mike Tsai
+```
+
+- [ ] **Step 2: Add contributor instructions**
+
+Create `CONTRIBUTING.md` with these operational rules:
+
+```markdown
+# Contributing
+
+## Development
+
+1. Copy `.env.example` to `.env` and provide your own local credentials.
+2. Start PostgreSQL with `pnpm db:up`.
+3. Sync the schema with `pnpm exec prisma db push`.
+4. Start the app with `pnpm dev`.
+
+Never commit `.env`, `.env.local`, database exports, or credentials. Report vulnerabilities through [the security policy](SECURITY.md), not a public issue.
+
+## Before opening a pull request
+
+Run `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test:unit`. Update tests and documentation when the change affects behavior.
+```
+
+- [ ] **Step 3: Add private vulnerability-reporting policy**
+
+Create `SECURITY.md` with this reporting route and disclosure expectation:
+
+```markdown
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through the repository's **Security** tab using **Report a vulnerability**. Do not open a public issue before a fix or mitigation is available.
+
+Include the affected version or commit, reproduction steps, impact, and any suggested mitigation. You will receive an acknowledgement as soon as the maintainer is able to review the report.
+```
+
+- [ ] **Step 4: Add the Contributor Covenant 2.1**
+
+Create `CODE_OF_CONDUCT.md` using the complete Contributor Covenant version 2.1 text. Set its contact sentence to: `Instances of abusive, harassing, or otherwise unacceptable behavior may be reported through GitHub's private vulnerability reporting flow described in SECURITY.md.`
+
+- [ ] **Step 5: Validate policy files**
+
+Run:
+
+```bash
+git diff --check -- LICENSE
+pnpm exec prettier --check CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md
+```
+
+Expected: `git diff --check` reports no whitespace errors and Prettier reports
+the Markdown files are formatted.
+
+- [ ] **Step 6: Commit the policy files**
+
+```bash
+git add LICENSE CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md
+git commit -m "docs: add open-source community policies"
+```
+
+### Task 2: Add public contribution intake and dependency maintenance
+
+**Files:**
+
+- Create: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Create: `.github/ISSUE_TEMPLATE/feature_request.yml`
+- Create: `.github/dependabot.yml`
+
+**Interfaces:**
+
+- Consumes: GitHub's issue-form and Dependabot YAML schemas.
+- Produces: structured public issue submission and monthly update pull requests.
+
+- [ ] **Step 1: Create the bug-report form**
+
+Create `.github/ISSUE_TEMPLATE/bug_report.yml` with required summary, reproduction steps, expected behavior, actual behavior, and environment fields. Set the form metadata to:
+
+```yaml
+name: Bug report
+description: Report reproducible behavior that differs from expectations.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: "Please do not include account balances, OAuth credentials, database URLs, or other sensitive information."
+```
+
+- [ ] **Step 2: Create the feature-request form**
+
+Create `.github/ISSUE_TEMPLATE/feature_request.yml` with required problem, proposed outcome, alternatives considered, and additional context fields. Set the form metadata to:
+
+```yaml
+name: Feature request
+description: Propose an improvement for self-hosted Assets Tracker instances.
+labels: [enhancement]
+```
+
+- [ ] **Step 3: Configure monthly Dependabot updates**
+
+Create `.github/dependabot.yml` with separate monthly ecosystems:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+```
+
+- [ ] **Step 4: Validate configuration structure**
+
+Run: `pnpm exec prettier --check .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/dependabot.yml`
+
+Expected: Prettier reports all three YAML files are formatted.
+
+- [ ] **Step 5: Commit the GitHub configuration**
+
+```bash
+git add .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/dependabot.yml
+git commit -m "chore: add open-source repository automation"
+```
+
+### Task 3: Make canonical metadata configurable with a tested URL helper
+
+**Files:**
+
+- Create: `src/lib/app-url.ts`
+- Create: `tests/unit/app-url.test.ts`
+- Modify: `src/app/layout.tsx:15-46`
+- Modify: `.env.example`
+
+**Interfaces:**
+
+- Consumes: optional `NEXT_PUBLIC_APP_URL` environment variable.
+- Produces: `getAppUrl(value?: string): URL`, returning the configured absolute URL or `https://assets-tracker-ct.vercel.app` as a fallback.
+
+- [ ] **Step 1: Write the failing URL-helper tests**
+
+Create `tests/unit/app-url.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getAppUrl } from "@/lib/app-url";
+
+describe("getAppUrl", () => {
+  it("uses the production URL when no override is provided", () => {
+    expect(getAppUrl().toString()).toBe("https://assets-tracker-ct.vercel.app/");
+  });
+
+  it("uses a self-hoster's configured URL", () => {
+    expect(getAppUrl("https://tracker.example.com").toString()).toBe(
+      "https://tracker.example.com/",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- tests/unit/app-url.test.ts`
+
+Expected: FAIL because `@/lib/app-url` does not exist.
+
+- [ ] **Step 3: Implement the minimal URL helper**
+
+Create `src/lib/app-url.ts`:
+
+```ts
+const DEFAULT_APP_URL = "https://assets-tracker-ct.vercel.app";
+
+export function getAppUrl(value = process.env.NEXT_PUBLIC_APP_URL): URL {
+  return new URL(value || DEFAULT_APP_URL);
+}
+```
+
+- [ ] **Step 4: Update root metadata to use one canonical URL**
+
+In `src/app/layout.tsx`, import `getAppUrl`, create `const appUrl = getAppUrl();` before `metadata`, and replace both existing hard-coded metadata URLs:
+
+```ts
+metadataBase: appUrl,
+// …
+openGraph: {
+  // …
+  url: appUrl,
+```
+
+Add this commented configuration entry to `.env.example` after the auth callback URL:
+
+```env
+# Public canonical URL for metadata and social sharing (required for deployments)
+# NEXT_PUBLIC_APP_URL="https://tracker.example.com"
+```
+
+- [ ] **Step 5: Run the focused test to verify it passes**
+
+Run: `pnpm test:unit -- tests/unit/app-url.test.ts`
+
+Expected: PASS with 2 tests.
+
+- [ ] **Step 6: Commit the metadata configuration**
+
+```bash
+git add src/lib/app-url.ts tests/unit/app-url.test.ts src/app/layout.tsx .env.example
+git commit -m "feat: configure canonical app metadata URL"
+```
+
+### Task 4: Document self-hosting and apply read-only workflow permissions
+
+**Files:**
+
+- Modify: `README.md:42-77, 228-299`
+- Modify: `.github/workflows/ci.yml:1-19`
+- Modify: `.github/workflows/e2e.yml:1-12`
+
+**Interfaces:**
+
+- Consumes: `NEXT_PUBLIC_APP_URL`, `.env.example`, the community-policy documents, and existing workflow triggers.
+- Produces: accurate self-hosting documentation and workflows with explicit read-only access.
+
+- [ ] **Step 1: Add a self-hosting responsibility section to the README**
+
+After the environment-variable section, add a `## Self-hosting and data responsibility` section stating that each deployment owner provides and controls its own Google OAuth credentials, PostgreSQL database, deployment, cron secret, and optional Vercel/Sentry integrations. State that `NEXT_PUBLIC_APP_URL` must be the deployed public URL and `.env.example` is the complete configuration reference.
+
+Add this disclaimer:
+
+```markdown
+Assets Tracker is personal-tracking software, not financial, tax, or investment advice. Self-hosters are responsible for their users' data security, privacy disclosures, regulatory compliance, backups, and access controls.
+```
+
+- [ ] **Step 2: Link public project policies from the README**
+
+Append a `## Contributing and security` section after Versioning:
+
+```markdown
+Contributions are welcome; see [CONTRIBUTING.md](./CONTRIBUTING.md). Please report vulnerabilities privately under the [Security Policy](./SECURITY.md). Community participation is governed by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+```
+
+- [ ] **Step 3: Make CI workflow permissions explicit**
+
+Add this top-level block after each workflow's `on:` block and before `concurrency:`:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Do not alter any existing jobs, conditions, triggers, or secrets.
+
+- [ ] **Step 4: Run formatting and repository validation**
+
+Run:
+
+```bash
+pnpm format:check
+pnpm typecheck
+pnpm test:unit
+DATABASE_URL="postgresql://ci:ci@localhost:5432/ci" AUTH_SECRET=x AUTH_GOOGLE_ID=x AUTH_GOOGLE_SECRET=x CRON_SECRET=x pnpm build
+git ls-files | rg '(^|/)(\.env|.*\.pem|.*\.key|.*\.p12|.*credentials|.*secret)' || true
+```
+
+Expected: formatting, type checking, all unit tests, and the production build pass; the tracked-file scan prints only `.env.example`.
+
+- [ ] **Step 5: Commit the final documentation and workflow changes**
+
+```bash
+git add README.md .github/workflows/ci.yml .github/workflows/e2e.yml
+git commit -m "docs: clarify self-hosted open-source use"
+```

--- a/docs/superpowers/specs/2026-07-10-open-source-readiness-design.md
+++ b/docs/superpowers/specs/2026-07-10-open-source-readiness-design.md
@@ -1,0 +1,71 @@
+# Open-source readiness design
+
+## Goal
+
+Make Assets Tracker ready for a public, self-hosted release while keeping the
+maintainer's operational commitments intentionally small.
+
+## Scope
+
+- Add an MIT `LICENSE` with `Copyright (c) 2026 Mike Tsai`.
+- Add contributor, security, and code-of-conduct documentation.
+- Add GitHub bug-report and feature-request forms.
+- Add a minimal Dependabot configuration for monthly GitHub Actions and npm
+  dependency updates.
+- Clarify the self-hosting model, data responsibility, financial disclaimer,
+  and canonical app URL configuration in the README.
+- Make metadata use `NEXT_PUBLIC_APP_URL` consistently when it is configured.
+- Limit GitHub Actions to read-only repository contents by default.
+
+## Non-goals
+
+- No support SLA, hosted-service privacy policy, or funding program.
+- No automatic releases, dependency auto-merge, or new deployment platform.
+- No changes to GitHub repository settings such as visibility, branch rules,
+  secret scanning, or CodeQL configuration; these require a maintainer action
+  in GitHub.
+
+## Documentation and community files
+
+`CONTRIBUTING.md` will use the existing pnpm, Docker PostgreSQL, and validation
+commands. It will state that contributors should not commit `.env` files or
+credentials, and will link to the security policy for vulnerabilities.
+
+`SECURITY.md` will direct reporters to the repository owner's private GitHub
+security-advisory reporting channel. It will request a reproducible report and
+ask reporters not to disclose vulnerabilities publicly before a fix is
+available.
+
+`CODE_OF_CONDUCT.md` will use the Contributor Covenant 2.1 text with a contact
+route that does not expose a personal email address: GitHub private reporting.
+
+Issue forms will collect a concise reproduction for bugs and a problem,
+proposed outcome, and alternatives for feature requests.
+
+## Self-hosting and configuration
+
+The README will make explicit that a self-hoster supplies and controls their
+Google OAuth credentials, PostgreSQL database, deployment, cron secret, and
+optional Vercel/Sentry integrations. It will point readers to `.env.example`
+as the complete configuration reference.
+
+The README will state that the application is software for personal tracking,
+not financial advice, and that a self-hoster is responsible for their own
+users' data, security, compliance, and privacy disclosures.
+
+The public app URL must be set with `NEXT_PUBLIC_APP_URL` for a deployed
+instance. The application metadata will derive both `metadataBase` and the
+Open Graph URL from this value, using the current deployment URL only as a
+fallback for the maintainer's live instance.
+
+## Automation and security
+
+Dependabot will open monthly update pull requests for npm and GitHub Actions.
+The existing CI and E2E workflows will declare `permissions: contents: read`,
+which is sufficient for checkout and prevents accidental write permissions.
+
+## Verification
+
+Run `pnpm format:check`, `pnpm typecheck`, `pnpm test:unit`, and `pnpm build`
+with the documented placeholder environment values. Confirm that all new YAML
+and Markdown files are formatted and that no local `.env` files are tracked.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { pickMessages } from "@/lib/i18n-utils";
+import { getAppUrl } from "@/lib/app-url";
 import "./globals.css";
 
 const geist = localFont({
@@ -27,8 +28,10 @@ const geistMono = localFont({
   preload: false,
 });
 
+const appUrl = getAppUrl();
+
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://assets-tracker-ct.vercel.app"),
+  metadataBase: appUrl,
   title: "Assets Tracker",
   description: "Track your net worth, assets, and investments",
   appleWebApp: {
@@ -39,7 +42,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Assets Tracker",
     description: "Track your net worth, assets, and investments",
-    url: "https://assets-tracker-ct.vercel.app",
+    url: appUrl,
     siteName: "Assets Tracker",
     images: [{ url: "/opengraph-image.png", width: 1024, height: 682, alt: "Assets Tracker" }],
     type: "website",

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,5 @@
+const DEFAULT_APP_URL = "https://assets-tracker-ct.vercel.app";
+
+export function getAppUrl(value = process.env.NEXT_PUBLIC_APP_URL): URL {
+  return new URL(value || DEFAULT_APP_URL);
+}

--- a/tests/unit/app-url.test.ts
+++ b/tests/unit/app-url.test.ts
@@ -3,7 +3,7 @@ import { getAppUrl } from "@/lib/app-url";
 
 describe("getAppUrl", () => {
   it("uses the production URL when no override is provided", () => {
-    expect(getAppUrl().toString()).toBe("https://assets-tracker-ct.vercel.app/");
+    expect(getAppUrl("").toString()).toBe("https://assets-tracker-ct.vercel.app/");
   });
 
   it("uses a self-hoster's configured URL", () => {

--- a/tests/unit/app-url.test.ts
+++ b/tests/unit/app-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getAppUrl } from "@/lib/app-url";
+
+describe("getAppUrl", () => {
+  it("uses the production URL when no override is provided", () => {
+    expect(getAppUrl().toString()).toBe("https://assets-tracker-ct.vercel.app/");
+  });
+
+  it("uses a self-hoster's configured URL", () => {
+    expect(getAppUrl("https://tracker.example.com").toString()).toBe(
+      "https://tracker.example.com/",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add the MIT license and contributor, security, and code-of-conduct policies
- add issue forms and monthly Dependabot updates
- document self-hosting responsibilities and configure the public metadata URL
- make CI workflows explicitly read-only

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` (256 passing)
- production build with placeholder environment variables
- tracked-file credential scan

## Follow-up

Before making the repository public, run a full Git history secret scan, then enable GitHub Private vulnerability reporting after the visibility change.