### PR TITLE
Make local preview login passwordless

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ POSTGRES_PORT="5432"
 # Vercel environment: development | preview | production
 # VERCEL_ENV="development"
 
-# Required only when VERCEL_ENV=preview.
+# Required on hosted Vercel previews unless PREVIEW_AUTH_DISABLED is enabled.
+# Local preview login is passwordless, including when VERCEL_ENV="preview".
 # PREVIEW_AUTH_PASSWORD="replace-with-preview-login-password"
 # PREVIEW_AUTH_DISABLED="true"
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ next-env.d.ts
 /AGENTS.md
 /CLAUDE.md
 /.worktreeinclude
+/.worktrees/
 /docs/superpowers/
 
 # Local agent artifacts

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,6 +13,8 @@ pnpm dev
 
 The application runs at `http://localhost:3000`. `pnpm db:up` starts only PostgreSQL; the application runs directly on the host for faster hot reload.
 
+Local development includes a one-click **Preview Login** for the dedicated test user. It does not require `PREVIEW_AUTH_PASSWORD`; hosted Vercel previews remain password-protected by default.
+
 ## Validation
 
 Run the same fast checks used for pull requests:

--- a/docs/superpowers/specs/2026-07-13-passwordless-local-preview-login-design.md
+++ b/docs/superpowers/specs/2026-07-13-passwordless-local-preview-login-design.md
@@ -1,0 +1,30 @@
+# Passwordless Local Preview Login
+
+## Goal
+
+Make local testing faster by allowing the preview user to sign in with one button and no password, while preserving password protection on hosted Vercel preview deployments.
+
+## Behavior
+
+- Local development, including an unset `VERCEL_ENV` or `VERCEL_ENV=development`, shows the preview login button without a password field and accepts the credentials sign-in without a password.
+- A Vercel preview deployment, `VERCEL_ENV=preview`, continues to show the password field and validates `PREVIEW_AUTH_PASSWORD`.
+- `PREVIEW_AUTH_DISABLED` remains an explicit override that makes a hosted preview passwordless when intentionally enabled.
+- Production continues to omit the credentials provider and uses Google sign-in only.
+
+## Implementation
+
+Define one shared environment-derived boolean for whether preview authentication requires a password. Both the login page and the NextAuth credentials provider will use it, preventing the UI and server-side authorization rules from drifting.
+
+The login form will submit a password only when one is required. No new configuration or UI component is needed.
+
+## Security Boundary
+
+Passwordless authentication is automatic only outside Vercel preview and production environments. Hosted previews remain protected by default. Production behavior is unchanged.
+
+## Verification
+
+- A unit test proves local development does not require a preview password.
+- A unit test proves Vercel preview requires a password by default.
+- A unit test proves `PREVIEW_AUTH_DISABLED` explicitly bypasses the hosted-preview password.
+- Existing unit tests, lint, and type checking remain green.
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import { auth, signIn } from "@/auth";
 import { Button } from "@/components/ui/button";
 import { TrendingUp, Lock, ShieldCheck, EyeOff } from "lucide-react";
 import { SESSION_COOKIE_NAMES } from "@/lib/auth-cookies";
-import { isPreviewOrLocal, previewAuthDisabled } from "@/lib/env";
+import { isPreviewOrLocal, previewAuthRequiresPassword } from "@/lib/env";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import Link from "next/link";
@@ -125,7 +125,7 @@ async function LoginContent() {
               }}
             >
               <div className="flex flex-col gap-3">
-                {!previewAuthDisabled && (
+                {previewAuthRequiresPassword && (
                   <input
                     name="password"
                     type="password"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import Credentials from "next-auth/providers/credentials";
 import authConfig from "./auth.config";
 import { customPrismaAdapter } from "@/lib/auth-adapter";
 import { prisma } from "@/lib/prisma";
-import { isPreviewOrLocal, previewAuthDisabled, PREVIEW_AUTH_PASSWORD } from "@/lib/env";
+import { isPreviewOrLocal, previewAuthRequiresPassword, PREVIEW_AUTH_PASSWORD } from "@/lib/env";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
@@ -18,7 +18,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               password: { label: "Password", type: "password" },
             },
             authorize: async (credentials) => {
-              if (!previewAuthDisabled) {
+              if (previewAuthRequiresPassword) {
                 const expected = PREVIEW_AUTH_PASSWORD;
                 if (!expected || credentials?.password !== expected) return null;
               }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,10 +1,6 @@
 import "server-only";
 import { z } from "zod";
-
-/** Parse a boolean-ish env flag: "1" | "true" | "yes" | "on" (case-insensitive) → true. */
-function isTruthyFlag(value: string | undefined): boolean {
-  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
-}
+import { requiresPreviewAuthPassword } from "@/lib/preview-auth-policy";
 
 const envSchema = z
   .object({
@@ -23,6 +19,7 @@ const envSchema = z
     AUTH_REDIRECT_PROXY_URL: z.string().url("must be a valid URL").optional(),
     PREVIEW_AUTH_PASSWORD: z.string().trim().min(1, "must not be empty").optional(),
     PREVIEW_AUTH_DISABLED: z.string().trim().optional(),
+    VERCEL: z.literal("1").optional(),
     VERCEL_ENV: z.enum(["production", "preview", "development"]).optional(),
     // E19 — Sentry error reporting. All optional: when no DSN is set the
     // integration is a complete no-op (local dev / CI / build need no Sentry
@@ -36,14 +33,17 @@ const envSchema = z
   })
   .superRefine((value, ctx) => {
     if (
-      value.VERCEL_ENV === "preview" &&
-      !isTruthyFlag(value.PREVIEW_AUTH_DISABLED) &&
+      requiresPreviewAuthPassword({
+        vercel: value.VERCEL,
+        vercelEnv: value.VERCEL_ENV,
+        authDisabled: value.PREVIEW_AUTH_DISABLED,
+      }) &&
       !value.PREVIEW_AUTH_PASSWORD
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["PREVIEW_AUTH_PASSWORD"],
-        message: 'is required when VERCEL_ENV is "preview"',
+        message: 'is required on a hosted Vercel preview when VERCEL_ENV is "preview"',
       });
     }
   });
@@ -57,6 +57,7 @@ const parsedEnv = envSchema.safeParse({
   AUTH_REDIRECT_PROXY_URL: process.env.AUTH_REDIRECT_PROXY_URL,
   PREVIEW_AUTH_PASSWORD: process.env.PREVIEW_AUTH_PASSWORD,
   PREVIEW_AUTH_DISABLED: process.env.PREVIEW_AUTH_DISABLED,
+  VERCEL: process.env.VERCEL,
   VERCEL_ENV: process.env.VERCEL_ENV,
   SENTRY_DSN: process.env.SENTRY_DSN,
   NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -88,6 +89,7 @@ export const {
   AUTH_REDIRECT_PROXY_URL,
   PREVIEW_AUTH_PASSWORD,
   PREVIEW_AUTH_DISABLED,
+  VERCEL,
   VERCEL_ENV,
   SENTRY_DSN,
   NEXT_PUBLIC_SENTRY_DSN,
@@ -103,5 +105,8 @@ export const {
 export const isPreviewOrLocal =
   VERCEL_ENV === "preview" || VERCEL_ENV === "development" || !VERCEL_ENV;
 
-/** When set, preview login skips the password check (passwordless preview). */
-export const previewAuthDisabled = isTruthyFlag(PREVIEW_AUTH_DISABLED);
+export const previewAuthRequiresPassword = requiresPreviewAuthPassword({
+  vercel: VERCEL,
+  vercelEnv: VERCEL_ENV,
+  authDisabled: PREVIEW_AUTH_DISABLED,
+});

--- a/src/lib/preview-auth-policy.ts
+++ b/src/lib/preview-auth-policy.ts
@@ -1,0 +1,17 @@
+export type PreviewAuthEnvironment = {
+  vercel: string | undefined;
+  vercelEnv: "production" | "preview" | "development" | undefined;
+  authDisabled: string | undefined;
+};
+
+export function isTruthyFlag(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
+export function requiresPreviewAuthPassword({
+  vercel,
+  vercelEnv,
+  authDisabled,
+}: PreviewAuthEnvironment): boolean {
+  return vercel === "1" && vercelEnv === "preview" && !isTruthyFlag(authDisabled);
+}

--- a/tests/unit/preview-auth-policy.test.ts
+++ b/tests/unit/preview-auth-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { requiresPreviewAuthPassword } from "@/lib/preview-auth-policy";
+
+describe("requiresPreviewAuthPassword", () => {
+  it("does not require a password for a local preview simulation", () => {
+    expect(
+      requiresPreviewAuthPassword({
+        vercel: undefined,
+        vercelEnv: "preview",
+        authDisabled: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires a password on a hosted Vercel preview", () => {
+    expect(
+      requiresPreviewAuthPassword({
+        vercel: "1",
+        vercelEnv: "preview",
+        authDisabled: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("honors the explicit passwordless override on a hosted preview", () => {
+    expect(
+      requiresPreviewAuthPassword({
+        vercel: "1",
+        vercelEnv: "preview",
+        authDisabled: "true",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- make local preview login a one-click flow without a password field
- keep hosted Vercel previews password-protected by default
- centralize the password requirement across environment validation, the login UI, and server-side authorization
- document the local and hosted preview behavior

## Why

Local testing previously depended on preview-password configuration and typing. The new policy uses Vercel's host marker to distinguish a hosted preview from a local process, including local environments that simulate `VERCEL_ENV=preview`.

## Validation

- `pnpm test:unit` (276 tests)
- `pnpm lint`
- `pnpm typecheck`
- `VERCEL_ENV=preview PREVIEW_AUTH_PASSWORD=e2e-smoke-test pnpm build`
- Playwright smoke suite on an isolated local port (6 tests across Chromium and Mobile Chrome)

## Review note

The final independent review found no critical or important issues. A minor follow-up suggestion was to add deeper hosted-preview integration coverage.