### PR TITLE
fix: update vulnerable ws dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5295,8 +5295,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.12:
+    resolution: {integrity: sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10412,7 +10412,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 7.5.12
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10539,7 +10539,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10: {}
+  ws@7.5.12: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

- update the transitive `ws` dependency used by `webpack-bundle-analyzer` from 7.5.10 to 7.5.12
- remove the only high-severity finding reported by `pnpm audit`
- keep the direct runtime `ws` dependency unchanged at 8.21.0

## Root cause

`@next/bundle-analyzer@16.2.10` pins `webpack-bundle-analyzer@4.10.1`, whose `ws ^7.3.1` dependency had resolved to vulnerable `ws@7.5.10` in the lockfile. The compatible 7.5.12 patch contains the memory-exhaustion DoS fix.

## Impact

This changes only the development-time bundle analyzer dependency. Production runtime behavior is unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level high` — 0 high findings
- `pnpm test:unit` — 42 files, 302 tests passed
- `pnpm check` — format, lint, typecheck, and production build passed
- pre-push format, lint, and typecheck hooks passed