### PR TITLE
feat: add end-of-range activity tail so seeded demos show same-day activity

### DIFF
--- a/demo-data.json
+++ b/demo-data.json
@@ -1,6 +1,6 @@
 {
   "version": "1.3",
-  "exportedAt": "2026-07-18T08:09:17.901Z",
+  "exportedAt": "2026-07-19T03:10:33.148Z",
   "settings": {
     "baseCurrency": "USD",
     "locale": "en-US"
@@ -12,12 +12,12 @@
       "type": "ASSET",
       "category": "BANK",
       "currency": "TWD",
-      "cashBalance": 500000,
+      "cashBalance": 580000,
       "isActive": true,
       "isPinned": false,
       "sortOrder": 0,
       "createdAt": "2025-11-03T02:00:00.000Z",
-      "updatedAt": "2026-03-02T02:00:00.000Z",
+      "updatedAt": "2026-07-17T02:00:00.000Z",
       "cashTransactions": [
         {
           "type": "DEPOSIT",
@@ -31,6 +31,13 @@
           "amount": 150000,
           "note": "Year-end bonus",
           "createdAt": "2026-03-02T02:00:00.000Z",
+          "occurrenceDate": null
+        },
+        {
+          "type": "DEPOSIT",
+          "amount": 80000,
+          "note": "Salary deposit",
+          "createdAt": "2026-07-17T02:00:00.000Z",
           "occurrenceDate": null
         }
       ],
@@ -52,12 +59,12 @@
       "type": "ASSET",
       "category": "BROKERAGE",
       "currency": "TWD",
-      "cashBalance": 46405,
+      "cashBalance": 35965,
       "isActive": true,
       "isPinned": true,
       "sortOrder": 1,
       "createdAt": "2025-09-01T02:00:00.000Z",
-      "updatedAt": "2026-05-12T02:00:00.000Z",
+      "updatedAt": "2026-07-14T02:00:00.000Z",
       "holdings": [
         {
           "symbol": "2330.TW",
@@ -89,11 +96,11 @@
         {
           "symbol": "0050.TW",
           "name": "Yuanta Taiwan Top 50 ETF",
-          "quantity": 1200,
+          "quantity": 1300,
           "currency": "TWD",
           "assetType": "ETF",
           "createdAt": "2025-10-20T02:00:00.000Z",
-          "updatedAt": "2026-05-12T02:00:00.000Z",
+          "updatedAt": "2026-07-14T02:00:00.000Z",
           "transactions": [
             {
               "type": "BUY",
@@ -109,6 +116,14 @@
               "unitPrice": 96.85,
               "note": "Added to position",
               "createdAt": "2026-05-12T02:00:00.000Z",
+              "occurrenceDate": null
+            },
+            {
+              "type": "BUY",
+              "quantity": 100,
+              "unitPrice": 104.4,
+              "note": "Added to position",
+              "createdAt": "2026-07-14T02:00:00.000Z",
               "occurrenceDate": null
             }
           ]
@@ -158,12 +173,12 @@
       "type": "ASSET",
       "category": "BROKERAGE",
       "currency": "USD",
-      "cashBalance": 1598.1,
+      "cashBalance": 2398.1,
       "isActive": true,
       "isPinned": false,
       "sortOrder": 2,
       "createdAt": "2025-08-15T14:30:00.000Z",
-      "updatedAt": "2026-03-20T14:30:00.000Z",
+      "updatedAt": "2026-07-07T14:30:00.000Z",
       "holdings": [
         {
           "symbol": "NVDA",
@@ -240,6 +255,13 @@
           "amount": 1500,
           "note": "Wire transfer",
           "createdAt": "2026-01-12T14:30:00.000Z",
+          "occurrenceDate": null
+        },
+        {
+          "type": "DEPOSIT",
+          "amount": 800,
+          "note": "Wire transfer",
+          "createdAt": "2026-07-07T14:30:00.000Z",
           "occurrenceDate": null
         }
       ]
@@ -5255,9 +5277,9 @@
     },
     {
       "date": "2026-07-07T00:00:00.000Z",
-      "totalAssets": 62641.27,
+      "totalAssets": 63441.27,
       "totalLiabilities": 1088.99,
-      "netWorth": 61552.29,
+      "netWorth": 62352.29,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5269,7 +5291,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10550.35,
+          "value": 11350.35,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5284,9 +5306,9 @@
     },
     {
       "date": "2026-07-08T00:00:00.000Z",
-      "totalAssets": 62989.31,
+      "totalAssets": 63789.31,
       "totalLiabilities": 1090,
-      "netWorth": 61899.3,
+      "netWorth": 62699.3,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5298,7 +5320,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10641.7,
+          "value": 11441.7,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5313,9 +5335,9 @@
     },
     {
       "date": "2026-07-09T00:00:00.000Z",
-      "totalAssets": 62883.2,
+      "totalAssets": 63683.2,
       "totalLiabilities": 1090.34,
-      "netWorth": 61792.86,
+      "netWorth": 62592.86,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5327,7 +5349,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10733.1,
+          "value": 11533.1,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5342,9 +5364,9 @@
     },
     {
       "date": "2026-07-10T00:00:00.000Z",
-      "totalAssets": 63088.65,
+      "totalAssets": 63888.65,
       "totalLiabilities": 1090.34,
-      "netWorth": 61998.31,
+      "netWorth": 62798.31,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5356,7 +5378,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10949.7,
+          "value": 11749.7,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5371,9 +5393,9 @@
     },
     {
       "date": "2026-07-11T00:00:00.000Z",
-      "totalAssets": 63088.65,
+      "totalAssets": 63888.65,
       "totalLiabilities": 1090.34,
-      "netWorth": 61998.31,
+      "netWorth": 62798.31,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5385,7 +5407,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10949.7,
+          "value": 11749.7,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5400,9 +5422,9 @@
     },
     {
       "date": "2026-07-12T00:00:00.000Z",
-      "totalAssets": 63088.65,
+      "totalAssets": 63888.65,
       "totalLiabilities": 1090.34,
-      "netWorth": 61998.31,
+      "netWorth": 62798.31,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5414,7 +5436,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10949.7,
+          "value": 11749.7,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5429,9 +5451,9 @@
     },
     {
       "date": "2026-07-13T00:00:00.000Z",
-      "totalAssets": 62901.53,
+      "totalAssets": 63701.53,
       "totalLiabilities": 1088.31,
-      "netWorth": 61813.22,
+      "netWorth": 62613.22,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5443,7 +5465,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10633.95,
+          "value": 11433.95,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5458,9 +5480,9 @@
     },
     {
       "date": "2026-07-14T00:00:00.000Z",
-      "totalAssets": 62911.45,
+      "totalAssets": 63711.45,
       "totalLiabilities": 1089.32,
-      "netWorth": 61822.13,
+      "netWorth": 62622.13,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5472,7 +5494,7 @@
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10854.9,
+          "value": 11654.9,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5487,9 +5509,9 @@
     },
     {
       "date": "2026-07-15T00:00:00.000Z",
-      "totalAssets": 63410.09,
+      "totalAssets": 64215.99,
       "totalLiabilities": 1086.62,
-      "netWorth": 62323.47,
+      "netWorth": 63129.37,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5497,11 +5519,11 @@
           "currency": "TWD"
         },
         "acc-yuanta": {
-          "value": 661965,
+          "value": 662155,
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10855.2,
+          "value": 11655.2,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5516,9 +5538,9 @@
     },
     {
       "date": "2026-07-16T00:00:00.000Z",
-      "totalAssets": 63536.88,
+      "totalAssets": 64343.08,
       "totalLiabilities": 1084.93,
-      "netWorth": 62451.95,
+      "netWorth": 63258.15,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
@@ -5526,11 +5548,11 @@
           "currency": "TWD"
         },
         "acc-yuanta": {
-          "value": 668085,
+          "value": 668285,
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10693.7,
+          "value": 11493.7,
           "currency": "USD"
         },
         "acc-firstrade": {
@@ -5545,21 +5567,21 @@
     },
     {
       "date": "2026-07-17T00:00:00.000Z",
-      "totalAssets": 61832.6,
+      "totalAssets": 65090.9,
       "totalLiabilities": 1081.25,
-      "netWorth": 60751.35,
+      "netWorth": 64009.65,
       "baseCurrency": "USD",
       "breakdown": {
         "acc-bot": {
-          "value": 500000,
+          "value": 580000,
           "currency": "TWD"
         },
         "acc-yuanta": {
-          "value": 624585,
+          "value": 624160,
           "currency": "TWD"
         },
         "acc-schwab": {
-          "value": 10476.75,
+          "value": 11276.75,
           "currency": "USD"
         },
         "acc-firstrade": {


### PR DESCRIPTION
## Summary

Follow-up to #609. The seed shifts all dates so the newest **snapshot** lands on today, but the newest **transactions** were ~2 months back, so recent-activity views (transaction feeds, current-month analysis) looked stale after seeding.

This regenerates `demo-data.json` with an activity tail at the end of the snapshot range, which the seed's date shift pins to the present:

- **Final day (= today after shift):** Bank of Taiwan salary deposit (NT$80,000)
- **3 days back:** Yuanta buy of 0050.TW ×100 at that day's real close
- **10 days back:** Charles Schwab wire transfer ($800)

Ledgers still reconcile (deposits − buys + sells = cash balance; holding quantities include the new lot). Latest snapshot is now ~$65.1k assets / ~$64.0k net worth (USD). Today's snapshot includes the same-day deposit, consistent with an end-of-day valuation.

## Test plan

- [x] `npx vitest run tests/unit/demo-data.test.ts` — 5 tests pass (schema, ledger, quantity, monotonicity, reference checks)
- [x] `pnpm seed:demo` then queried the DB: newest CashTransaction lands on today's Taiwan calendar day (10:00 Taipei), newest BUY three days back