### PR TITLE
fix: compute unrealized gain over costed holdings only

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -463,7 +463,7 @@
     "unrealizedGain": "Unrealized gain/loss",
     "unrealizedGainPct": "Unrealized %",
     "costBasisNoData": "No priced investment holdings yet.",
-    "costBasisPartialNote": "Cost basis only includes holdings with buy unit prices.",
+    "costBasisPartialNote": "Cost basis and unrealized gain cover only holdings with buy unit prices.",
     "returnTrend": "Return Trend",
     "returnTrendSubtitle": "Monthly investment return and cumulative index, brokerage and crypto accounts only.",
     "returnTrendNote": "Monthly returns use the Modified Dietz approximation (deposits at half weight); the line chains them geometrically. Not annualized.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -463,7 +463,7 @@
     "unrealizedGain": "未實現損益",
     "unrealizedGainPct": "未實現 %",
     "costBasisNoData": "目前沒有可定價的投資持倉。",
-    "costBasisPartialNote": "成本基準僅包含有買入單價的持倉。",
+    "costBasisPartialNote": "成本基準與未實現損益僅涵蓋有買入單價的持倉。",
     "returnTrend": "投資報酬走勢",
     "returnTrendSubtitle": "每月投資報酬率與累積報酬指數，僅計入券商與加密貨幣帳戶。",
     "returnTrendNote": "每月報酬採 Modified Dietz 近似法（存入資金以半權重計入），折線為幾何鏈接的累積值，未年化。",

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -480,6 +480,8 @@ export interface CostBasisPosition {
 
 export interface InvestmentCostBasisSummary {
   marketValue: number;
+  /** Market value of only the holdings that have a known cost basis. */
+  costedMarketValue: number;
   costBasis: number;
   unrealizedGain: number | null;
   unrealizedGainPct: number | null;

--- a/src/lib/services/investment-cost-basis-service.ts
+++ b/src/lib/services/investment-cost-basis-service.ts
@@ -58,6 +58,7 @@ export async function getInvestmentCostBasisSummary(
   );
 
   let marketValue = 0;
+  let costedMarketValue = 0;
   let costBasis = 0;
   let pricedHoldingCount = 0;
   let costedHoldingCount = 0;
@@ -103,14 +104,18 @@ export async function getInvestmentCostBasisSummary(
       );
       if (position.hasCostBasis) {
         costBasis += position.costBasis * costRate;
+        costedMarketValue += holdingMarketValue;
         costedHoldingCount += 1;
       }
     }
   }
 
-  const unrealizedGain = costBasis > 0 ? marketValue - costBasis : null;
+  // Gain compares like with like: only holdings with a known cost contribute
+  // market value here, or uncosted imports would read as pure profit.
+  const unrealizedGain = costBasis > 0 ? costedMarketValue - costBasis : null;
   return {
     marketValue,
+    costedMarketValue,
     costBasis,
     unrealizedGain,
     unrealizedGainPct: unrealizedGain == null ? null : unrealizedGain / costBasis,

--- a/tests/unit/investment-cost-basis-service.test.ts
+++ b/tests/unit/investment-cost-basis-service.test.ts
@@ -160,6 +160,67 @@ describe("getInvestmentCostBasisSummary", () => {
     expect(summary.costedHoldingCount).toBe(1);
   });
 
+  it("excludes uncosted holdings' market value from unrealized gain", async () => {
+    h.accounts = [
+      account({
+        holdings: [
+          holding({
+            symbol: "COSTED",
+            quantity: 10,
+            currency: "USD",
+            assetType: "STOCK",
+            transactions: [tx({ id: "b1", type: "BUY", quantity: 10, unitPrice: 800 })],
+          }),
+          holding({
+            symbol: "UNCOSTED",
+            quantity: 10,
+            currency: "USD",
+            assetType: "STOCK",
+            // Quantity-only import: BUY without a unit price → no cost basis.
+            transactions: [tx({ id: "b2", type: "BUY", quantity: 10 })],
+          }),
+        ],
+      }),
+    ];
+    h.prices = [
+      { symbol: "COSTED", price: 1000, currency: "USD" },
+      { symbol: "UNCOSTED", price: 1000, currency: "USD" },
+    ];
+
+    const summary = await getInvestmentCostBasisSummary("u1", "USD");
+
+    expect(summary.marketValue).toBeCloseTo(20000); // total stays total
+    expect(summary.costedMarketValue).toBeCloseTo(10000); // only the costed holding
+    expect(summary.costBasis).toBeCloseTo(8000);
+    expect(summary.unrealizedGain).toBeCloseTo(2000); // NOT 12000
+    expect(summary.unrealizedGainPct).toBeCloseTo(0.25);
+    expect(summary.pricedHoldingCount).toBe(2);
+    expect(summary.costedHoldingCount).toBe(1);
+  });
+
+  it("returns null gain when no holding has cost basis", async () => {
+    h.accounts = [
+      account({
+        holdings: [
+          holding({
+            symbol: "UNCOSTED",
+            quantity: 10,
+            currency: "USD",
+            assetType: "STOCK",
+            transactions: [tx({ id: "b1", type: "BUY", quantity: 10 })],
+          }),
+        ],
+      }),
+    ];
+    h.prices = [{ symbol: "UNCOSTED", price: 1000, currency: "USD" }];
+
+    const summary = await getInvestmentCostBasisSummary("u1", "USD");
+
+    expect(summary.unrealizedGain).toBeNull();
+    expect(summary.unrealizedGainPct).toBeNull();
+    expect(summary.costedMarketValue).toBe(0);
+  });
+
   it("converts market value using the price-cache currency, not the stale holding currency", async () => {
     // Holding says USD, but the provider actually quotes BTC-EUR in EUR.
     h.accounts = [


### PR DESCRIPTION
## Problem
The analysis cost-basis card computed unrealized gain as (market value of ALL priced holdings) − (cost basis of only the holdings with buy prices). A quantity-only imported holding counted its full market value as gain — e.g. a $10k costed holding (+$2k real gain) plus a $10k uncosted holding displayed +$12k / +150%.

## Fix
Track `costedMarketValue`; gain = costedMarketValue − costBasis. Total market value display unchanged; the partial-coverage note now mentions the gain figure too (both locales).

## Tests
Mixed costed/uncosted and all-uncosted unit cases in `investment-cost-basis-service.test.ts`.

https://claude.ai/code/session_017Rk1H1fdEkwMF8CwR2wsdu