### PR TITLE
fix: surface unresolved exchange rates as an app-wide banner

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -754,6 +754,9 @@
     "noData": "No data yet",
     "refreshing": "Refreshing..."
   },
+  "fxWarning": {
+    "unresolvedRates": "Exchange rate unavailable for {pairs}. Affected values are shown unconverted."
+  },
   "trendChart": {
     "title": "Net Worth Trend",
     "noData": "No data to display yet. Add accounts and your net worth will be tracked automatically each day.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -754,6 +754,9 @@
     "noData": "尚無資料",
     "refreshing": "更新中..."
   },
+  "fxWarning": {
+    "unresolvedRates": "無法取得 {pairs} 匯率，受影響的金額以未換算數值顯示。"
+  },
   "trendChart": {
     "title": "淨資產趨勢",
     "noData": "尚無資料。新增帳戶後，系統每天會自動記錄你的淨資產。",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -10,6 +10,7 @@ import { DensityProvider } from "@/components/layout/density-context";
 import { PullToRefreshProvider } from "@/components/layout/pull-to-refresh-context";
 import { LargeTitleProvider } from "@/components/layout/large-title-context";
 import { LazyCommandPalette } from "@/components/layout/lazy-command-palette";
+import { FxWarningBanner } from "@/components/layout/fx-warning-banner";
 import { getSession } from "@/lib/auth-session";
 import { APP_VERSION } from "@/lib/changelog";
 
@@ -59,6 +60,9 @@ export default async function MainLayout({
               <MobileMainShell>
                 <MobileHeader />
                 <div className="mx-auto w-full max-w-7xl 2xl:max-w-[88rem] p-4 md:p-6">
+                  <Suspense fallback={null}>
+                    <FxWarningBanner />
+                  </Suspense>
                   {children}
                 </div>
               </MobileMainShell>

--- a/src/components/layout/fx-warning-banner.tsx
+++ b/src/components/layout/fx-warning-banner.tsx
@@ -1,0 +1,28 @@
+import { AlertTriangle } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { getSession } from "@/lib/auth-session";
+import { getOrCreateSettings } from "@/lib/services/settings-service";
+import { getUnresolvedRatePairs } from "@/lib/services/exchange-rate-service";
+
+/**
+ * App-wide banner shown while any exchange rate the user's data needs is
+ * unavailable — those values render unconverted (1:1) everywhere, so the
+ * warning belongs to the layout, not a single page.
+ */
+export async function FxWarningBanner() {
+  const session = await getSession();
+  if (!session?.user?.id) return null;
+  const settings = await getOrCreateSettings(session.user.id);
+  const pairs = await getUnresolvedRatePairs(session.user.id, settings.baseCurrency);
+  if (pairs.length === 0) return null;
+  const t = await getTranslations("fxWarning");
+  return (
+    <div
+      role="status"
+      className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+      <span>{t("unresolvedRates", { pairs: pairs.join(", ") })}</span>
+    </div>
+  );
+}

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -346,3 +346,63 @@ export async function refreshExchangeRates(
     fetchFailed: false,
   };
 }
+
+/**
+ * Every "FROM→BASE" pair the user's data references that resolveRate cannot
+ * resolve (no direct, inverse, or USD-cross rate). Non-empty means some
+ * displayed values are silently unconverted (the render-time ?? 1 fallback),
+ * so the layout shows a warning banner while this is non-empty.
+ */
+export async function getUnresolvedRatePairs(
+  userId: string,
+  baseCurrency: string,
+): Promise<string[]> {
+  "use cache";
+  cacheTag("exchange-rates");
+  cacheTag(`accounts:${userId}`);
+  cacheTag("goals");
+  cacheTag("snapshots");
+  cacheLife("minutes");
+
+  const [accounts, goals, snapshotCurrencies, allRatesMap] = await Promise.all([
+    prisma.account.findMany({
+      where: { userId, isActive: true },
+      select: { currency: true, holdings: { select: { currency: true, symbol: true } } },
+    }),
+    prisma.goal.findMany({ where: { userId }, select: { targetCurrency: true } }),
+    prisma.netWorthSnapshot.findMany({
+      where: { userId },
+      select: { baseCurrency: true },
+      distinct: ["baseCurrency"],
+    }),
+    getAllExchangeRates(),
+  ]);
+
+  const currencies = new Set<string>();
+  for (const account of accounts) {
+    currencies.add(account.currency);
+    for (const holding of account.holdings) currencies.add(holding.currency);
+  }
+  // Cached prices can be denominated differently from the holding's stored
+  // currency (see net-worth-service's marketValue conversion comment).
+  const symbols = accounts.flatMap((a) => a.holdings.map((h) => h.symbol));
+  if (symbols.length > 0) {
+    const prices = await prisma.priceCache.findMany({
+      where: { symbol: { in: symbols } },
+      select: { currency: true },
+      distinct: ["currency"],
+    });
+    for (const price of prices) currencies.add(price.currency);
+  }
+  for (const goal of goals) currencies.add(goal.targetCurrency);
+  for (const snapshot of snapshotCurrencies) currencies.add(snapshot.baseCurrency);
+
+  const unresolved: string[] = [];
+  for (const currency of currencies) {
+    if (currency === baseCurrency) continue;
+    if (resolveRate(allRatesMap, currency, baseCurrency) === undefined) {
+      unresolved.push(`${currency}→${baseCurrency}`);
+    }
+  }
+  return unresolved.sort();
+}

--- a/tests/unit/exchange-rate-service.test.ts
+++ b/tests/unit/exchange-rate-service.test.ts
@@ -4,14 +4,31 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // `@/lib/prisma` (loads env + a real DB client) and `@/lib/logger`
 // (loads Sentry). resolveRate is pure, so we stub those import-time
 // dependencies and exercise the function against an in-memory rate map.
-vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+const db = vi.hoisted(() => ({
+  accounts: [] as { currency: string; holdings: { currency: string; symbol: string }[] }[],
+  goals: [] as { targetCurrency: string }[],
+  snapshotCurrencies: [] as { baseCurrency: string }[],
+  priceCurrencies: [] as { currency: string }[],
+  exchangeRates: [] as { fromCurrency: string; toCurrency: string; rate: number }[],
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    account: { findMany: vi.fn(async () => db.accounts) },
+    goal: { findMany: vi.fn(async () => db.goals) },
+    netWorthSnapshot: { findMany: vi.fn(async () => db.snapshotCurrencies) },
+    priceCache: { findMany: vi.fn(async () => db.priceCurrencies) },
+    exchangeRate: { findMany: vi.fn(async () => db.exchangeRates) },
+  },
+}));
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
 const logSpies = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 vi.mock("@/lib/logger", () => ({
   log: logSpies,
   withTiming: <T>(_name: string, fn: () => T) => fn(),
 }));
 
-const { resolveRate, fetchExchangeRates } = await import("@/lib/services/exchange-rate-service");
+const { resolveRate, fetchExchangeRates, getUnresolvedRatePairs } =
+  await import("@/lib/services/exchange-rate-service");
 
 describe("resolveRate", () => {
   it("returns 1 for an identity conversion", () => {
@@ -61,6 +78,50 @@ describe("resolveRate", () => {
       ["USD_EUR", 0.9],
     ]);
     expect(resolveRate(map, "EUR", "TWD")).toBeCloseTo(30 / 0.9);
+  });
+});
+
+describe("getUnresolvedRatePairs", () => {
+  beforeEach(() => {
+    db.accounts = [];
+    db.goals = [];
+    db.snapshotCurrencies = [];
+    db.priceCurrencies = [];
+    db.exchangeRates = [];
+  });
+
+  it("reports currencies that cannot resolve to base", async () => {
+    // TWD resolves via the inverse of USD_TWD; JPY (a price-cache
+    // denomination) has no direct, inverse, or USD-cross path.
+    db.accounts = [{ currency: "TWD", holdings: [{ currency: "USD", symbol: "N225" }] }];
+    db.priceCurrencies = [{ currency: "JPY" }];
+    db.exchangeRates = [{ fromCurrency: "USD", toCurrency: "TWD", rate: 30 }];
+
+    await expect(getUnresolvedRatePairs("user-1", "USD")).resolves.toEqual(["JPY→USD"]);
+  });
+
+  it("returns empty when all currencies resolve (incl. inverse and USD cross)", async () => {
+    db.accounts = [{ currency: "TWD", holdings: [{ currency: "EUR", symbol: "VWCE" }] }];
+    db.priceCurrencies = [{ currency: "EUR" }];
+    db.exchangeRates = [
+      { fromCurrency: "USD", toCurrency: "TWD", rate: 30 },
+      { fromCurrency: "USD", toCurrency: "EUR", rate: 0.9 },
+    ];
+
+    await expect(getUnresolvedRatePairs("user-1", "TWD")).resolves.toEqual([]);
+  });
+
+  it("ignores the base currency itself", async () => {
+    db.accounts = [{ currency: "USD", holdings: [] }];
+
+    await expect(getUnresolvedRatePairs("user-1", "USD")).resolves.toEqual([]);
+  });
+
+  it("covers goal and snapshot currencies, sorted", async () => {
+    db.goals = [{ targetCurrency: "GBP" }];
+    db.snapshotCurrencies = [{ baseCurrency: "AUD" }];
+
+    await expect(getUnresolvedRatePairs("user-1", "USD")).resolves.toEqual(["AUD→USD", "GBP→USD"]);
   });
 });
 


### PR DESCRIPTION
## Problem
`resolveRate(...) ?? 1` in history/goal/projection/cost-basis services (and net-worth's logged fallback) silently rendered unconverted values — a TWD account with a missing rate displays at ~30× its USD value with zero signal.

## Fix
Central `getUnresolvedRatePairs(userId, base)` collects every currency the user's data references (accounts, holdings, price-cache denominations, goals, snapshots) and reports pairs `resolveRate` can't resolve. An async RSC banner in the `(main)` layout shows them; the `exchange-rates` cache tag clears it when rates recover. The 1:1 fallback itself stays — showing something beats hiding money, it's just no longer silent.

## Tests
Unit cases for unresolved detection, inverse/USD-cross resolution, base-currency exclusion, and goal/snapshot currency coverage.

https://claude.ai/code/session_017Rk1H1fdEkwMF8CwR2wsdu