### PR TITLE
fix: disclose history rows converted from another base currency

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -651,6 +651,7 @@
       "description": "The latest snapshot differs from current balances by {amount} ({percent}). Review the ledger before making corrections.",
       "descriptionPrivate": "The latest snapshot differs from current balances by {percent}. Review the ledger before making corrections."
     },
+    "convertedNote": "Part of this history was recorded in a different base currency and is converted at today's rate.",
     "snapshotLabel": {
       "addSnapshotAction": "Add label for {date}",
       "editSnapshotAction": "Edit label for {date}",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -651,6 +651,7 @@
       "description": "最新快照與目前餘額相差 {amount}（{percent}）。請先檢查分類帳再進行修正。",
       "descriptionPrivate": "最新快照與目前餘額相差 {percent}。請先檢查分類帳再進行修正。"
     },
+    "convertedNote": "部分歷史紀錄原以其他基準貨幣記錄，已按目前匯率換算。",
     "snapshotLabel": {
       "addSnapshotAction": "為 {date} 加上標籤",
       "editSnapshotAction": "編輯 {date} 的標籤",

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -8,6 +8,7 @@ import { HistoryView } from "@/components/history/history-view";
 import {
   getFullNormalizedHistory,
   getSnapshotReconciliationWarning,
+  hasForeignCurrencySnapshots,
 } from "@/lib/services/history-service";
 import { countActiveAccounts } from "@/lib/services/account-service";
 
@@ -18,15 +19,15 @@ async function HistoryContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   const settingsP = getOrCreateSettings(userId);
-  const [allMessages, snapshots, settings, accountCount, reconciliationWarning] = await Promise.all(
-    [
+  const [allMessages, snapshots, settings, accountCount, reconciliationWarning, converted] =
+    await Promise.all([
       getMessages(),
       settingsP.then((s) => getFullNormalizedHistory(userId, s.baseCurrency)),
       settingsP,
       countActiveAccounts(userId),
       settingsP.then((s) => getSnapshotReconciliationWarning(userId, s.baseCurrency)),
-    ],
-  );
+      settingsP.then((s) => hasForeignCurrencySnapshots(userId, s.baseCurrency)),
+    ]);
 
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
@@ -38,6 +39,7 @@ async function HistoryContent() {
           className="animate-in fade-in duration-200"
           hasAccounts={accountCount > 0}
           reconciliationWarning={reconciliationWarning}
+          hasConvertedSnapshots={converted}
         />
       </HistoryPullRefresh>
     </NextIntlClientProvider>

--- a/src/components/history/history-view.tsx
+++ b/src/components/history/history-view.tsx
@@ -26,6 +26,8 @@ type Props = {
   className?: string;
   hasAccounts?: boolean;
   reconciliationWarning?: SnapshotReconciliationWarning | null;
+  /** True when some snapshots were recorded in a different base currency. */
+  hasConvertedSnapshots?: boolean;
 };
 
 export function HistoryView({
@@ -36,6 +38,7 @@ export function HistoryView({
   className,
   hasAccounts,
   reconciliationWarning = null,
+  hasConvertedSnapshots = false,
 }: Props) {
   const t = useTranslations("history");
   const format = useFormatter();
@@ -108,6 +111,10 @@ export function HistoryView({
             </p>
           </div>
         </div>
+      )}
+
+      {hasConvertedSnapshots && (
+        <p className="text-xs text-muted-foreground">{t("convertedNote")}</p>
       )}
 
       {/* Hero row: trend + heatmap hold the width; the rail stacks the derived

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -513,3 +513,24 @@ export async function getMonthlyCashFlow(
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([monthKey, contributions]) => ({ monthKey, contributions }));
 }
+
+/**
+ * True when any of the user's snapshots was recorded under a different base
+ * currency than the current one — meaning the history view converts those
+ * rows at TODAY's rate, not the rate of their day. Drives a disclosure note.
+ */
+export async function hasForeignCurrencySnapshots(
+  userId: string,
+  targetBaseCurrency: string,
+): Promise<boolean> {
+  "use cache";
+  cacheTag("snapshots");
+  cacheTag(`history:${userId}`);
+  cacheLife("minutes");
+
+  const row = await prisma.netWorthSnapshot.findFirst({
+    where: { userId, baseCurrency: { not: targetBaseCurrency } },
+    select: { id: true },
+  });
+  return row !== null;
+}

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -26,6 +26,7 @@ const h = vi.hoisted(() => ({
   previousRows: [] as SnapshotRowFixture[],
   previousDateRow: null as { date: Date } | null,
   latestSnapshot: null as SnapshotRowFixture | null,
+  foreignCurrencySnapshot: null as { id: string } | null,
   accounts: [] as unknown[],
   cashTransactions: [] as CashTransactionFixture[],
   prices: [] as { symbol: string; price: number; currency: string }[],
@@ -51,10 +52,13 @@ vi.mock("@/lib/prisma", () => ({
         if (dateWhere && "gte" in dateWhere) return h.currentYearRows;
         return h.rows;
       }),
-      findFirst: vi.fn(async (args?: { where?: { date?: { lt?: Date } } }) => {
-        if (args?.where?.date?.lt) return h.previousDateRow;
-        return h.latestSnapshot;
-      }),
+      findFirst: vi.fn(
+        async (args?: { where?: { date?: { lt?: Date }; baseCurrency?: { not?: string } } }) => {
+          if (args?.where?.baseCurrency?.not) return h.foreignCurrencySnapshot;
+          if (args?.where?.date?.lt) return h.previousDateRow;
+          return h.latestSnapshot;
+        },
+      ),
     },
     cashTransaction: {
       findMany: vi.fn(async (args?: { where?: { OR?: Array<Record<string, unknown>> } }) => {
@@ -98,6 +102,7 @@ const {
   getCurrentYearNormalizedHistory,
   getFullNormalizedHistory,
   getSnapshotReconciliationWarning,
+  hasForeignCurrencySnapshots,
   isBetterDuplicate,
 } = await import("@/lib/services/history-service");
 const { aggregateMonthlyChange, fillMonthRange, buildCashFlowBuckets, buildCumulativeGrowth } =
@@ -147,6 +152,7 @@ beforeEach(() => {
   h.previousRows = [];
   h.previousDateRow = null;
   h.latestSnapshot = null;
+  h.foreignCurrencySnapshot = null;
   h.accounts = [];
   h.cashTransactions = [];
   h.prices = [];
@@ -485,5 +491,22 @@ describe("isBetterDuplicate (exported for import dedupe)", () => {
         { matchesTarget: true, createdAt: new Date("2026-06-01T00:00:00Z") },
       ),
     ).toBe(false);
+  });
+});
+
+describe("hasForeignCurrencySnapshots", () => {
+  it("true when any snapshot was stored in another base currency", async () => {
+    h.foreignCurrencySnapshot = { id: "snap-1" };
+
+    await expect(hasForeignCurrencySnapshots("user-1", "USD")).resolves.toBe(true);
+
+    const args = vi.mocked(prisma.netWorthSnapshot.findFirst).mock.lastCall?.[0] as {
+      where?: Record<string, unknown>;
+    };
+    expect(args.where).toEqual({ userId: "user-1", baseCurrency: { not: "USD" } });
+  });
+
+  it("false when all snapshots match the target", async () => {
+    await expect(hasForeignCurrencySnapshots("user-1", "USD")).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Problem
After switching base currency, `normalizeSnapshots` converts old snapshots at TODAY's rate — the past visibly changes shape with no explanation.

## Fix
Cached `hasForeignCurrencySnapshots(userId, base)` check; `HistoryView` shows a muted one-line note when true (both locales). Converting at historical rates isn't possible — no historical rate data is stored — so disclosure is the ceiling here.

## Tests
Unit cases for both branches including the where-clause shape.

https://claude.ai/code/session_017Rk1H1fdEkwMF8CwR2wsdu