### PR TITLE
fix: materialize recurring rules on create + Taiwan-day cutoff

### DIFF
--- a/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
@@ -1,9 +1,15 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { updateRecurringCashTransactionSchema } from "@/lib/validators";
 import { serializeRecurringCashTransaction } from "@/lib/types";
-import { firstOccurrenceOnOrAfter } from "@/lib/services/recurring-cash-service";
+import {
+  firstOccurrenceOnOrAfter,
+  materializeDueRecurringTransactions,
+} from "@/lib/services/recurring-cash-service";
+import { taiwanCalendarDay } from "@/lib/app-day";
+import { log } from "@/lib/logger";
 
 /** Parses a YYYY-MM-DD date string to a UTC-midnight Date for a `@db.Date` column. */
 function toUtcDate(dateOnly: string): Date {
@@ -48,7 +54,11 @@ export const PATCH = withAuth(
       const start = toUtcDate(startDate);
       const effectiveFrequency = frequency ?? existing.frequency;
       data.startDate = start;
-      data.nextRunDate = firstOccurrenceOnOrAfter(start, effectiveFrequency, new Date());
+      data.nextRunDate = firstOccurrenceOnOrAfter(
+        start,
+        effectiveFrequency,
+        taiwanCalendarDay(new Date()),
+      );
     }
 
     const [rule] = await prisma.recurringCashTransaction.updateManyAndReturn({
@@ -63,7 +73,29 @@ export const PATCH = withAuth(
       return failure("Recurring transaction changed while updating; please retry", 409);
     }
 
-    return ok(serializeRecurringCashTransaction(rule));
+    // An update can make the rule due right now (reactivation, startDate set
+    // to today) — post immediately rather than waiting for the nightly cron.
+    // Same idempotency/failure story as the POST route.
+    let updated = rule;
+    if (rule.isActive && rule.nextRunDate.getTime() <= taiwanCalendarDay(new Date()).getTime()) {
+      try {
+        const { created: posted } = await materializeDueRecurringTransactions(new Date(), rule.id);
+        if (posted > 0) {
+          revalidateTag(`accounts:${userId}`, { expire: 0 });
+          revalidateTag(`net-worth:${userId}`, { expire: 0 });
+          revalidateTag(`history:${userId}`, { expire: 0 });
+        }
+        updated =
+          (await prisma.recurringCashTransaction.findUnique({ where: { id: rule.id } })) ?? rule;
+      } catch (error) {
+        log.error("recurring.materialize_on_update_failed", {
+          ruleId: rule.id,
+          error: String(error),
+        });
+      }
+    }
+
+    return ok(serializeRecurringCashTransaction(updated));
   },
 );
 

--- a/src/app/api/accounts/[id]/recurring-cash-transactions/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/route.ts
@@ -1,9 +1,15 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { createRecurringCashTransactionSchema } from "@/lib/validators";
-import { listRecurringForAccount } from "@/lib/services/recurring-cash-service";
+import {
+  listRecurringForAccount,
+  materializeDueRecurringTransactions,
+} from "@/lib/services/recurring-cash-service";
 import { serializeRecurringCashTransaction } from "@/lib/types";
+import { taiwanCalendarDay } from "@/lib/app-day";
+import { log } from "@/lib/logger";
 
 /** Parses a YYYY-MM-DD date string to a UTC-midnight Date for a `@db.Date` column. */
 function toUtcDate(dateOnly: string): Date {
@@ -39,8 +45,6 @@ export const POST = withAuth(
 
     const { type, amount, frequency, note, startDate, endDate } = parsed.data;
 
-    // First occurrence is on startDate; the cron posts it (and any catch-up) on
-    // its next run — rules are never materialized synchronously here.
     const rule = await prisma.recurringCashTransaction.create({
       data: {
         accountId: id,
@@ -54,6 +58,29 @@ export const POST = withAuth(
       },
     });
 
-    return ok(serializeRecurringCashTransaction(rule), { status: 201 });
+    // A rule starting today (or backdated) posts immediately instead of
+    // sitting inert until the nightly cron. Idempotent: the
+    // (recurringId, occurrenceDate) unique index makes a cron double-run safe.
+    // Failure falls back to the cron — rule creation never fails for this.
+    let created = rule;
+    if (rule.nextRunDate.getTime() <= taiwanCalendarDay(new Date()).getTime()) {
+      try {
+        const { created: posted } = await materializeDueRecurringTransactions(new Date(), rule.id);
+        if (posted > 0) {
+          revalidateTag(`accounts:${userId}`, { expire: 0 });
+          revalidateTag(`net-worth:${userId}`, { expire: 0 });
+          revalidateTag(`history:${userId}`, { expire: 0 });
+        }
+        created =
+          (await prisma.recurringCashTransaction.findUnique({ where: { id: rule.id } })) ?? rule;
+      } catch (error) {
+        log.error("recurring.materialize_on_create_failed", {
+          ruleId: rule.id,
+          error: String(error),
+        });
+      }
+    }
+
+    return ok(serializeRecurringCashTransaction(created), { status: 201 });
   },
 );

--- a/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
@@ -1,9 +1,13 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { updateRecurringInvestmentSchema } from "@/lib/validators";
 import { serializeRecurringInvestment } from "@/lib/types";
 import { firstOccurrenceOnOrAfter } from "@/lib/services/recurring-cash-service";
+import { materializeDueInvestments } from "@/lib/services/recurring-investment-service";
+import { taiwanCalendarDay } from "@/lib/app-day";
+import { log } from "@/lib/logger";
 
 /** Parses a YYYY-MM-DD date string to a UTC-midnight Date for a `@db.Date` column. */
 function toUtcDate(dateOnly: string): Date {
@@ -46,7 +50,11 @@ export const PATCH = withAuth(
       const start = toUtcDate(startDate);
       const effectiveFrequency = frequency ?? existing.frequency;
       data.startDate = start;
-      data.nextRunDate = firstOccurrenceOnOrAfter(start, effectiveFrequency, new Date());
+      data.nextRunDate = firstOccurrenceOnOrAfter(
+        start,
+        effectiveFrequency,
+        taiwanCalendarDay(new Date()),
+      );
     }
 
     const [rule] = await prisma.recurringInvestment.updateManyAndReturn({
@@ -61,7 +69,29 @@ export const PATCH = withAuth(
       return failure("Recurring investment changed while updating; please retry", 409);
     }
 
-    return ok(serializeRecurringInvestment(rule));
+    // An update can make the rule due right now (reactivation, startDate set
+    // to today) — buy immediately rather than waiting for the nightly cron.
+    // Best-effort like the POST route: no price / failure → cron picks it up.
+    let updated = rule;
+    if (rule.isActive && rule.nextRunDate.getTime() <= taiwanCalendarDay(new Date()).getTime()) {
+      try {
+        const { created: posted } = await materializeDueInvestments(new Date(), rule.id);
+        if (posted > 0) {
+          revalidateTag(`accounts:${userId}`, { expire: 0 });
+          revalidateTag(`net-worth:${userId}`, { expire: 0 });
+          revalidateTag(`history:${userId}`, { expire: 0 });
+          revalidateTag("prices", { expire: 0 });
+        }
+        updated = (await prisma.recurringInvestment.findUnique({ where: { id: rule.id } })) ?? rule;
+      } catch (error) {
+        log.error("recurring.investment_materialize_on_update_failed", {
+          ruleId: rule.id,
+          error: String(error),
+        });
+      }
+    }
+
+    return ok(serializeRecurringInvestment(updated));
   },
 );
 

--- a/src/app/api/accounts/[id]/recurring-investments/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/route.ts
@@ -1,9 +1,15 @@
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/api-handler";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { createRecurringInvestmentSchema } from "@/lib/validators";
-import { listInvestmentsForAccount } from "@/lib/services/recurring-investment-service";
+import {
+  listInvestmentsForAccount,
+  materializeDueInvestments,
+} from "@/lib/services/recurring-investment-service";
 import { serializeRecurringInvestment } from "@/lib/types";
+import { taiwanCalendarDay } from "@/lib/app-day";
+import { log } from "@/lib/logger";
 
 /** Parses a YYYY-MM-DD date string to a UTC-midnight Date for a `@db.Date` column. */
 function toUtcDate(dateOnly: string): Date {
@@ -65,6 +71,28 @@ export const POST = withAuth(
       },
     });
 
-    return ok(serializeRecurringInvestment(rule), { status: 201 });
+    // A rule starting today (or backdated) buys immediately instead of sitting
+    // inert until the nightly cron. Best-effort: no resolvable price → the
+    // service skips and the cron retries; failure falls back to the cron too.
+    let created = rule;
+    if (rule.nextRunDate.getTime() <= taiwanCalendarDay(new Date()).getTime()) {
+      try {
+        const { created: posted } = await materializeDueInvestments(new Date(), rule.id);
+        if (posted > 0) {
+          revalidateTag(`accounts:${userId}`, { expire: 0 });
+          revalidateTag(`net-worth:${userId}`, { expire: 0 });
+          revalidateTag(`history:${userId}`, { expire: 0 });
+          revalidateTag("prices", { expire: 0 });
+        }
+        created = (await prisma.recurringInvestment.findUnique({ where: { id: rule.id } })) ?? rule;
+      } catch (error) {
+        log.error("recurring.investment_materialize_on_create_failed", {
+          ruleId: rule.id,
+          error: String(error),
+        });
+      }
+    }
+
+    return ok(serializeRecurringInvestment(created), { status: 201 });
   },
 );

--- a/src/lib/services/recurring-cash-service.ts
+++ b/src/lib/services/recurring-cash-service.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
 import { log } from "@/lib/logger";
+import { taiwanCalendarDay } from "@/lib/app-day";
 import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import type { RecurringFrequency } from "@/generated/prisma/client";
 
@@ -142,10 +143,13 @@ export function computeDueOccurrences(
  */
 export async function materializeDueRecurringTransactions(
   now: Date = new Date(),
+  ruleId?: string,
 ): Promise<{ created: number; rulesProcessed: number }> {
-  const today = utcDateOnly(now);
+  // Taiwan day, not UTC day: the 21:30 UTC cron IS the next Taipei morning,
+  // and snapshot bucketing (app-day.ts) already lives on that calendar.
+  const today = taiwanCalendarDay(now);
   const dueRules = await prisma.recurringCashTransaction.findMany({
-    where: { isActive: true, nextRunDate: { lte: today } },
+    where: { isActive: true, nextRunDate: { lte: today }, ...(ruleId ? { id: ruleId } : {}) },
   });
 
   let created = 0;

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { log } from "@/lib/logger";
 import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { computeDueOccurrences, utcDateOnly } from "./recurring-cash-service";
+import { taiwanCalendarDay } from "@/lib/app-day";
 import { resolveRate } from "./exchange-rate-service";
 import { fetchStockPrices, fetchCryptoPrices } from "./price-service";
 
@@ -87,10 +88,12 @@ async function resolvePrice(
  */
 export async function materializeDueInvestments(
   now: Date = new Date(),
+  ruleId?: string,
 ): Promise<{ created: number; rulesProcessed: number }> {
-  const today = utcDateOnly(now);
+  // Taiwan day, not UTC day — same cutoff as the cash sweep (see app-day.ts).
+  const today = taiwanCalendarDay(now);
   const dueRules = await prisma.recurringInvestment.findMany({
-    where: { isActive: true, nextRunDate: { lte: today } },
+    where: { isActive: true, nextRunDate: { lte: today }, ...(ruleId ? { id: ruleId } : {}) },
     include: { account: { select: { currency: true } } },
   });
   if (dueRules.length === 0) return { created: 0, rulesProcessed: 0 };

--- a/tests/unit/recurring-cash-service.test.ts
+++ b/tests/unit/recurring-cash-service.test.ts
@@ -300,3 +300,47 @@ describe("materializeDueRecurringTransactions", () => {
     expect(h.ruleUpdates[0].data.isActive).toBe(false);
   });
 });
+
+describe("materializeDueRecurringTransactions — cutoff & filtering", () => {
+  beforeEach(() => {
+    h.dueRules = [];
+    h.createManyCalls = [];
+    h.accountUpdates = [];
+    h.ruleUpdates = [];
+    h.createManyCount = null;
+  });
+
+  it("uses the Taiwan calendar day as the due cutoff", async () => {
+    // 21:30 UTC Jul 19 = 05:30 Taipei Jul 20 — the real cron moment. A rule
+    // whose nextRunDate is Jul 20 (UTC midnight) must be due NOW; the old
+    // utcDateOnly(now) cutoff said "Jul 19" and skipped it for a full day.
+    h.dueRules = [
+      {
+        id: "rule-tw",
+        accountId: "acc1",
+        type: "DEPOSIT",
+        amount: 100,
+        note: null,
+        frequency: "MONTHLY",
+        startDate: d("2026-07-20"),
+        endDate: null,
+        nextRunDate: d("2026-07-20"),
+      },
+    ];
+
+    const result = await materializeDueRecurringTransactions(new Date("2026-07-19T21:30:00.000Z"));
+
+    expect(result).toEqual({ created: 1, rulesProcessed: 1 });
+    expect(iso(h.createManyCalls[0].data[0].occurrenceDate as Date)).toBe("2026-07-20");
+  });
+
+  it("materializes only the given ruleId when provided", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    await materializeDueRecurringTransactions(d("2026-06-14"), "rule-1");
+
+    const where = vi.mocked(prisma.recurringCashTransaction.findMany).mock.lastCall?.[0]
+      ?.where as Record<string, unknown>;
+    expect(where.id).toBe("rule-1");
+    expect(where.isActive).toBe(true);
+  });
+});

--- a/tests/unit/recurring-investment-service.test.ts
+++ b/tests/unit/recurring-investment-service.test.ts
@@ -244,3 +244,26 @@ describe("materializeDueInvestments", () => {
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(1000);
   });
 });
+
+describe("materializeDueInvestments — cutoff & filtering", () => {
+  it("materializes only the given ruleId when provided", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    await materializeDueInvestments(d("2026-06-14"), "rule-7");
+
+    const where = vi.mocked(prisma.recurringInvestment.findMany).mock.lastCall?.[0]
+      ?.where as Record<string, unknown>;
+    expect(where.id).toBe("rule-7");
+    expect(where.isActive).toBe(true);
+  });
+
+  it("uses the Taiwan calendar day as the due cutoff", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    await materializeDueInvestments(new Date("2026-07-19T21:30:00.000Z"));
+
+    const where = vi.mocked(prisma.recurringInvestment.findMany).mock.lastCall?.[0]?.where as {
+      nextRunDate: { lte: Date };
+    };
+    // 21:30 UTC Jul 19 is already Jul 20 in Taipei.
+    expect(where.nextRunDate.lte.toISOString()).toBe("2026-07-20T00:00:00.000Z");
+  });
+});

--- a/tests/unit/recurring-rule-routes.test.ts
+++ b/tests/unit/recurring-rule-routes.test.ts
@@ -9,7 +9,35 @@ const h = vi.hoisted(() => ({
   investmentUpdateManyAndReturnCalls: [] as Array<Record<string, unknown>>,
   investmentUpdateManyAndReturnCount: 1,
   investmentFindUniqueOrThrowCalls: [] as Array<Record<string, unknown>>,
+  materializeCash: vi.fn(async (_now?: Date, _ruleId?: string) => ({
+    created: 1,
+    rulesProcessed: 1,
+  })),
+  materializeInvestment: vi.fn(async (_now?: Date, _ruleId?: string) => ({
+    created: 1,
+    rulesProcessed: 1,
+  })),
+  revalidatedTags: [] as string[],
 }));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn((tag: string) => {
+    h.revalidatedTags.push(tag);
+  }),
+  cacheTag: () => {},
+  cacheLife: () => {},
+  unstable_cache: <T>(fn: T) => fn,
+}));
+
+vi.mock("@/lib/services/recurring-cash-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/recurring-cash-service")>();
+  return { ...actual, materializeDueRecurringTransactions: h.materializeCash };
+});
+
+vi.mock("@/lib/services/recurring-investment-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/recurring-investment-service")>();
+  return { ...actual, materializeDueInvestments: h.materializeInvestment };
+});
 
 vi.mock("@/lib/api-handler", () => ({
   withAuth:
@@ -20,8 +48,14 @@ vi.mock("@/lib/api-handler", () => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
+    account: { findUnique: vi.fn(async () => ({ id: "acc1" })) },
     recurringCashTransaction: {
       findFirst: vi.fn(async () => h.cashRule),
+      findUnique: vi.fn(async () => h.cashRule),
+      create: vi.fn(
+        async (args: { data: Record<string, unknown> }) =>
+          ({ ...h.cashRule, ...args.data, id: "cash-new" }) as Record<string, unknown>,
+      ),
       updateManyAndReturn: vi.fn(async (args: Record<string, unknown>) => {
         h.cashUpdateManyAndReturnCalls.push(args);
         return h.cashUpdateManyAndReturnCount === 0
@@ -35,6 +69,11 @@ vi.mock("@/lib/prisma", () => ({
     },
     recurringInvestment: {
       findFirst: vi.fn(async () => h.investmentRule),
+      findUnique: vi.fn(async () => h.investmentRule),
+      create: vi.fn(
+        async (args: { data: Record<string, unknown> }) =>
+          ({ ...h.investmentRule, ...args.data, id: "investment-new" }) as Record<string, unknown>,
+      ),
       updateManyAndReturn: vi.fn(async (args: Record<string, unknown>) => {
         h.investmentUpdateManyAndReturnCalls.push(args);
         return h.investmentUpdateManyAndReturnCount === 0
@@ -244,5 +283,104 @@ describe("recurring rule PATCH routes", () => {
     expect(response.status).toBe(200);
     expect(h.investmentUpdateManyAndReturnCalls).toHaveLength(1);
     expect(h.investmentFindUniqueOrThrowCalls).toHaveLength(0);
+  });
+});
+
+describe("recurring rule POST/PATCH materialization", () => {
+  beforeEach(() => {
+    h.cashRule = recurringCashRule();
+    h.investmentRule = recurringInvestmentRule();
+    h.materializeCash.mockClear();
+    h.materializeCash.mockResolvedValue({ created: 1, rulesProcessed: 1 });
+    h.materializeInvestment.mockClear();
+    h.materializeInvestment.mockResolvedValue({ created: 1, rulesProcessed: 1 });
+    h.revalidatedTags = [];
+  });
+
+  const postRequest = (body: Record<string, unknown>) =>
+    new Request("http://unit.test", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+  const postParams = { params: Promise.resolve({ id: "acc1" }) };
+
+  it("POST materializes a due cash rule immediately", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/recurring-cash-transactions/route");
+
+    const response = await POST(
+      postRequest({ type: "DEPOSIT", amount: 100, frequency: "MONTHLY", startDate: "2026-07-01" }),
+      postParams,
+    );
+
+    expect(response.status).toBe(201);
+    expect(h.materializeCash).toHaveBeenCalledTimes(1);
+    expect(h.materializeCash.mock.calls[0][1]).toBe("cash-new");
+    expect(h.revalidatedTags).toEqual(
+      expect.arrayContaining(["accounts:user1", "net-worth:user1", "history:user1"]),
+    );
+  });
+
+  it("POST does not materialize a future-dated cash rule", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/recurring-cash-transactions/route");
+
+    const response = await POST(
+      postRequest({ type: "DEPOSIT", amount: 100, frequency: "MONTHLY", startDate: "2100-01-01" }),
+      postParams,
+    );
+
+    expect(response.status).toBe(201);
+    expect(h.materializeCash).not.toHaveBeenCalled();
+  });
+
+  it("POST still succeeds when materialization throws", async () => {
+    h.materializeCash.mockRejectedValueOnce(new Error("boom"));
+    const { POST } = await import("@/app/api/accounts/[id]/recurring-cash-transactions/route");
+
+    const response = await POST(
+      postRequest({ type: "DEPOSIT", amount: 100, frequency: "MONTHLY", startDate: "2026-07-01" }),
+      postParams,
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it("POST materializes a due investment rule and revalidates prices", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/recurring-investments/route");
+
+    const response = await POST(
+      postRequest({
+        symbol: "VTI",
+        name: "Vanguard Total Stock Market ETF",
+        assetType: "ETF",
+        holdingCurrency: "USD",
+        amount: 100,
+        frequency: "MONTHLY",
+        startDate: "2026-07-01",
+      }),
+      postParams,
+    );
+
+    expect(response.status).toBe(201);
+    expect(h.materializeInvestment).toHaveBeenCalledTimes(1);
+    expect(h.materializeInvestment.mock.calls[0][1]).toBe("investment-new");
+    expect(h.revalidatedTags).toEqual(expect.arrayContaining(["prices"]));
+  });
+
+  it("PATCH materializes a cash rule that became due (reactivation)", async () => {
+    h.cashRule = recurringCashRule({
+      isActive: false,
+      startDate: date("2026-07-01"),
+      nextRunDate: date("2026-07-01"),
+      endDate: null,
+    });
+    const { PATCH } =
+      await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
+
+    const response = await PATCH(jsonRequest({ isActive: true }), params("cash-rule-1"));
+
+    expect(response.status).toBe(200);
+    expect(h.materializeCash).toHaveBeenCalledTimes(1);
+    expect(h.materializeCash.mock.calls[0][1]).toBe("cash-rule-1");
   });
 });


### PR DESCRIPTION
## Problems
1. Creating a recurring rule starting today did nothing until the nightly cron — up to ~24h of "Next: today" with no transaction and no explanation.
2. Both materialize sweeps computed today = `utcDateOnly(now)`: at the real cron moment (21:30 UTC = 05:30 Taipei) that is the PREVIOUS Taipei day, so every recurring posting ran one day behind snapshot bucketing — violating the contract documented in `app-day.ts`.

## Fix
- `materializeDueRecurringTransactions` / `materializeDueInvestments` accept an optional `ruleId` filter; POST/PATCH routes call them synchronously for the written rule when due (try/caught — failure falls back to the cron; the `(recurringId, occurrenceDate)` unique index keeps this idempotent).
- Both sweeps and the PATCH re-anchor cutoff use `taiwanCalendarDay(now)`. Occurrence dates stay UTC-midnight — no data changes.
- Investment materialization stays best-effort: no resolvable price → skip, cron retries.

## Tests
Taiwan-cutoff at the exact cron timestamp, `ruleId` filtering (both services), route-level immediate-posting, future-dated skip, failure-tolerance, and PATCH reactivation cases. Full unit suite green (331).

https://claude.ai/code/session_017Rk1H1fdEkwMF8CwR2wsdu