### PR TITLE
fix: disclose that backdated transactions don't rewrite history

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1022,6 +1022,7 @@
     "closeHint": "Set to 0 to close the position."
   },
   "accountDetail": {
+    "backdateNote": "Shows in ledgers and analysis; past net-worth history isn't recalculated.",
     "breadcrumb": "Accounts",
     "deleteAccount": "Delete Account",
     "deleting": "Deleting...",
@@ -1277,6 +1278,7 @@
     "reorderSaveFailed": "Failed to save watchlist order"
   },
   "transactionHistory": {
+    "backdateNote": "Shows in ledgers and analysis; past net-worth history isn't recalculated.",
     "title": "Transaction History",
     "loading": "Loading...",
     "empty": "No transactions yet.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1022,6 +1022,7 @@
     "closeHint": "設為 0 即可平倉。"
   },
   "accountDetail": {
+    "backdateNote": "會顯示於帳目與分析；過去的淨值歷史不會重新計算。",
     "breadcrumb": "帳戶",
     "deleteAccount": "刪除帳戶",
     "deleting": "刪除中...",
@@ -1277,6 +1278,7 @@
     "reorderSaveFailed": "儲存追蹤清單排序失敗"
   },
   "transactionHistory": {
+    "backdateNote": "會顯示於帳目與分析；過去的淨值歷史不會重新計算。",
     "title": "交易紀錄",
     "loading": "載入中...",
     "empty": "尚無交易紀錄。",

--- a/src/components/accounts/account-stat-cards.tsx
+++ b/src/components/accounts/account-stat-cards.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
+import { isBackdated } from "@/lib/transaction-dates";
 import { Plus } from "lucide-react";
 import { toast } from "sonner";
 
@@ -209,6 +210,9 @@ export function AccountStatCards({
           className="min-h-11 md:min-h-8"
           required
         />
+        {isBackdated(cashDate) && (
+          <p className="text-xs text-muted-foreground">{t("accountDetail.backdateNote")}</p>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="one-off-cash-note">{t("recurringCash.labelNote")}</Label>

--- a/src/components/accounts/transaction-history.tsx
+++ b/src/components/accounts/transaction-history.tsx
@@ -8,7 +8,11 @@ import { Badge } from "@/components/ui/badge";
 import { formatQuantity } from "@/lib/currencies";
 import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import type { SerializedTransaction } from "@/lib/types";
-import { compareTransactionsDesc, formatTransactionDateKey } from "@/lib/transaction-dates";
+import {
+  compareTransactionsDesc,
+  formatTransactionDateKey,
+  isBackdated,
+} from "@/lib/transaction-dates";
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -467,6 +471,9 @@ export function TransactionHistory({
             onChange={(e) => setEditOccurredOn(e.target.value)}
             className="min-h-11 md:min-h-8"
           />
+          {isBackdated(editOccurredOn) && (
+            <p className="text-xs text-muted-foreground">{t("backdateNote")}</p>
+          )}
         </div>
       )}
       <div className="space-y-2">

--- a/src/lib/transaction-dates.ts
+++ b/src/lib/transaction-dates.ts
@@ -52,3 +52,16 @@ export function formatTransactionDateKey(tx: TransactionDateFields, locale?: str
   }
   return new Date(tx.createdAt).toLocaleDateString(locale, options);
 }
+
+/**
+ * True when a form's YYYY-MM-DD date value is before the user's local today.
+ * Drives the "past net-worth history isn't recalculated" disclosure caption —
+ * client-local today is deliberate; exactness doesn't matter for a caption.
+ */
+export function isBackdated(dateOnly: string, now: Date = new Date()): boolean {
+  if (!dateOnly) return false;
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate(),
+  ).padStart(2, "0")}`;
+  return dateOnly < today;
+}

--- a/tests/unit/transaction-dates.test.ts
+++ b/tests/unit/transaction-dates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   compareTransactionsDesc,
+  isBackdated,
   effectiveTransactionTime,
   formatTransactionDateKey,
 } from "@/lib/transaction-dates";
@@ -73,5 +74,20 @@ describe("formatTransactionDateKey", () => {
       day: "numeric",
     });
     expect(formatTransactionDateKey(tx, "en-US")).toBe(expected);
+  });
+});
+
+describe("isBackdated", () => {
+  const now = new Date(2026, 6, 20, 12, 0); // 2026-07-20 local noon
+
+  it("true for a date before local today", () => {
+    expect(isBackdated("2026-07-19", now)).toBe(true);
+    expect(isBackdated("2025-12-31", now)).toBe(true);
+  });
+
+  it("false for today, future, and empty input", () => {
+    expect(isBackdated("2026-07-20", now)).toBe(false);
+    expect(isBackdated("2026-07-21", now)).toBe(false);
+    expect(isBackdated("", now)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem
`occurrenceDate` affects analysis bucketing and ledgers, but `NetWorthSnapshot` rows are immutable — a deposit backdated to last month leaves the net-worth history chart untouched, with no explanation anywhere.

## Fix
A muted caption under the occurrence-date field in the cash-transaction dialog and the transaction edit form, shown only when the picked date is before (client-local) today. Condition extracted as a pure `isBackdated` helper in `transaction-dates.ts`.

## Tests
Unit cases: past date → true; today/future/empty → false.

https://claude.ai/code/session_017Rk1H1fdEkwMF8CwR2wsdu