### PR TITLE
ci: publish container images to GHCR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 APP_PORT="3000"
 # Host port exposed for local database tools.
 POSTGRES_PORT="5432"
+# Optional GHCR tag for the app and migration images. Defaults to latest.
+# ASSETS_TRACKER_VERSION="1.0.0"
 
 # Optional stable OAuth callback proxy for hosted previews.
 # AUTH_REDIRECT_PROXY_URL="https://stable-preview-host.example.com"

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,79 @@
+name: Publish Container Images
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - "v*"
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "public/readme-*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: containers-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.name }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: app
+            target: runner
+            image: ghcr.io/${{ github.repository }}
+          - name: migrations
+            target: migrate
+            image: ghcr.io/${{ github.repository }}-migrate
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # 💰 Assets Tracker
 
-[![CI](https://github.com/mike840609/asset_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/asset_tracker/actions/workflows/ci.yml)
-[![E2E](https://github.com/mike840609/asset_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/asset_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
-[![Release](https://img.shields.io/github/v/release/mike840609/asset_tracker)](https://github.com/mike840609/asset_tracker/releases/latest)
+[![CI](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml)
+[![E2E](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
+[![Release](https://img.shields.io/github/v/release/mike840609/assets_tracker)](https://github.com/mike840609/assets_tracker/releases/latest)
+[![GHCR](https://img.shields.io/badge/GHCR-container-blue?logo=docker)](https://github.com/mike840609/assets_tracker/pkgs/container/assets_tracker)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mike840609/asset_tracker)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mike840609/assets_tracker)
 
 [English](./README.md) | [繁體中文](./README.zh-TW.md)
 
@@ -103,7 +104,14 @@ To explore the app with sample data, sign in with the one-click **Preview Login*
 
 ### Docker Compose
 
-Set `NEXT_PUBLIC_APP_URL`, `POSTGRES_PASSWORD`, and the production secrets in `.env`, then build the complete application and PostgreSQL stack:
+Set `NEXT_PUBLIC_APP_URL`, `POSTGRES_PASSWORD`, and the production secrets in `.env`, then pull the prebuilt application and migration images from GHCR and start the complete stack:
+
+```bash
+docker compose --profile full pull
+docker compose --profile full up --no-build -d
+```
+
+To build both images from source instead:
 
 ```bash
 docker compose --profile full up --build -d
@@ -121,7 +129,8 @@ Docker deployments:
 
 ```bash
 git pull
-docker compose --profile full up --build -d
+docker compose --profile full pull
+docker compose --profile full up --no-build -d
 ```
 
 Source deployments:
@@ -133,7 +142,7 @@ pnpm exec prisma migrate deploy
 pnpm build
 ```
 
-Always back up the database before an upgrade and review the [release notes](https://github.com/mike840609/asset_tracker/releases).
+Always back up the database before an upgrade and review the [release notes](https://github.com/mike840609/assets_tracker/releases).
 
 ## Documentation
 
@@ -158,7 +167,7 @@ Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) before open
 
 ## Support and Security
 
-Use [GitHub Issues](https://github.com/mike840609/asset_tracker/issues) for reproducible bugs and feature requests. Report vulnerabilities privately through the [Security Policy](./SECURITY.md), not a public issue.
+Use [GitHub Issues](https://github.com/mike840609/assets_tracker/issues) for reproducible bugs and feature requests. Report vulnerabilities privately through the [Security Policy](./SECURITY.md), not a public issue.
 
 ## Data Responsibility
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,11 +1,12 @@
 # 💰 資產追蹤器
 
-[![CI](https://github.com/mike840609/asset_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/asset_tracker/actions/workflows/ci.yml)
-[![E2E](https://github.com/mike840609/asset_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/asset_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
-[![Release](https://img.shields.io/github/v/release/mike840609/asset_tracker)](https://github.com/mike840609/asset_tracker/releases/latest)
+[![CI](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml)
+[![E2E](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
+[![Release](https://img.shields.io/github/v/release/mike840609/assets_tracker)](https://github.com/mike840609/assets_tracker/releases/latest)
+[![GHCR](https://img.shields.io/badge/GHCR-container-blue?logo=docker)](https://github.com/mike840609/assets_tracker/pkgs/container/assets_tracker)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mike840609/asset_tracker)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mike840609/assets_tracker)
 
 [English](./README.md) | [繁體中文](./README.zh-TW.md)
 
@@ -103,7 +104,14 @@ pnpm dev
 
 ### Docker Compose
 
-在 `.env` 設定 `NEXT_PUBLIC_APP_URL`、`POSTGRES_PASSWORD` 與正式環境 secrets，然後建立完整的應用程式與 PostgreSQL stack：
+在 `.env` 設定 `NEXT_PUBLIC_APP_URL`、`POSTGRES_PASSWORD` 與正式環境 secrets，接著從 GHCR 拉取預先建置的應用程式與 migration images，再啟動完整 stack：
+
+```bash
+docker compose --profile full pull
+docker compose --profile full up --no-build -d
+```
+
+若要從原始碼建置兩個 images，請改用：
 
 ```bash
 docker compose --profile full up --build -d
@@ -121,7 +129,8 @@ Docker 部署：
 
 ```bash
 git pull
-docker compose --profile full up --build -d
+docker compose --profile full pull
+docker compose --profile full up --no-build -d
 ```
 
 原始碼部署：
@@ -133,7 +142,7 @@ pnpm exec prisma migrate deploy
 pnpm build
 ```
 
-升級前請先備份資料庫，並查看 [Release Notes](https://github.com/mike840609/asset_tracker/releases)。
+升級前請先備份資料庫，並查看 [Release Notes](https://github.com/mike840609/assets_tracker/releases)。
 
 ## 文件
 
@@ -158,7 +167,7 @@ pnpm test:unit
 
 ## 支援與安全性
 
-可透過 [GitHub Issues](https://github.com/mike840609/asset_tracker/issues) 回報可重現的錯誤或提出功能需求。安全漏洞請依照[安全政策](./SECURITY.md)私下回報，請勿建立公開 Issue。
+可透過 [GitHub Issues](https://github.com/mike840609/assets_tracker/issues) 回報可重現的錯誤或提出功能需求。安全漏洞請依照[安全政策](./SECURITY.md)私下回報，請勿建立公開 Issue。
 
 ## 資料責任
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   migrate:
     profiles: ["full"]
+    image: ghcr.io/mike840609/assets_tracker-migrate:${ASSETS_TRACKER_VERSION:-latest}
     build:
       context: .
       target: migrate
@@ -31,6 +32,7 @@ services:
 
   app:
     profiles: ["full"]
+    image: ghcr.io/mike840609/assets_tracker:${ASSETS_TRACKER_VERSION:-latest}
     build:
       context: .
       target: runner

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,13 +35,16 @@ The default Compose profile starts PostgreSQL only for local development:
 pnpm db:up
 ```
 
-The `full` profile builds and starts migrations plus the standalone Next.js application:
+The `full` profile pulls and starts the published migration and application images:
 
 ```bash
 cp .env.example .env
 # Set AUTH_SECRET, AUTH_SELF_HOST_PASSWORD, CRON_SECRET, and NEXT_PUBLIC_APP_URL
-docker compose --profile full up --build -d
+docker compose --profile full pull
+docker compose --profile full up --no-build -d
 ```
+
+Set `ASSETS_TRACKER_VERSION` in `.env` to pin both images to a release tag. Leave it unset to follow `latest`. To build both images from source, use `docker compose --profile full up --build -d`.
 
 Services start in this order:
 


### PR DESCRIPTION
## What

- publish multi-architecture app and migration images to GHCR on `master`, version tags, and manual runs
- let Docker Compose pull the published images while preserving source builds
- update README badges and links for the renamed `assets_tracker` repository
- document image pulling, upgrades, and version pinning in English and Traditional Chinese

## Verification

- pre-commit formatting completed
- pre-push `prettier --check .`, ESLint, and `tsc --noEmit` passed
- YAML parsed locally

The local environment does not include Docker, so the actual multi-architecture image build is left to GitHub Actions.