### PR TITLE
Optimize dashboard quick-scan experience

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -244,6 +244,14 @@ Cards frame data modules, not entire page sections.
 
 The net-worth card may carry a soft animated mesh and bottom accent, but both must derive from schema tokens (`--gain`, `--loss`, `--primary`, and chart tokens). The mesh is a data/state wash, not a marketing hero.
 
+### Dashboard Information Priority
+
+The dashboard answers the quick-check questions in this order: current net worth, what changed, and what needs attention. On viewports below 768px, allocation, currency exposure, portfolio composition, concentration, and the complete account list live behind one accessible “Portfolio details” disclosure that starts collapsed. Goals/projections and the watchlist remain visible because they are short, actionable status previews.
+
+At 768px and above, the disclosure control is hidden and the complete portfolio area remains visible in its 8/4 overview layout, followed by concentration and account detail. Loading states must mirror the same responsive hierarchy so hidden mobile details do not produce a long skeleton page before collapsing.
+
+The net-worth hero renders its real value on the server and at first paint. Motion is reserved for a later value change, such as a successful market-data refresh; it must never delay the first trustworthy number.
+
 ### App Icon / Favicon
 
 The app mark is a rounded square with a diagonal gradient and white chart-arrow glyph. Preserve the original shape, radius, white stroke, and shadow treatment. Only recolor the gradient using the active schema's dedicated app-icon gradient tokens. The browser favicon may update through a generated SVG data URL; Apple/PWA icons remain stable because iOS caches them aggressively.

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -199,6 +199,9 @@
     "emptyAction": "Add your first account",
     "emptyHint": "Snapshots are captured daily, so charts fill in as your history grows.",
     "viewFullHistory": "View full history",
+    "portfolioDetails": "Portfolio details",
+    "showPortfolioDetails": "Show portfolio details",
+    "hidePortfolioDetails": "Hide portfolio details",
     "onboarding": {
       "eyebrow": "Private by default",
       "title": "Your dashboard is ready for the first account.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -199,6 +199,9 @@
     "emptyAction": "新增您的第一個帳戶",
     "emptyHint": "系統每日擷取快照，隨著歷史累積，圖表會逐漸顯示。",
     "viewFullHistory": "查看完整歷史記錄",
+    "portfolioDetails": "投資組合詳情",
+    "showPortfolioDetails": "顯示投資組合詳情",
+    "hidePortfolioDetails": "隱藏投資組合詳情",
     "onboarding": {
       "eyebrow": "預設保護隱私",
       "title": "儀表板已準備好加入第一個帳戶。",

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -24,15 +24,17 @@ import { ProjectionEntryCard } from "@/components/dashboard/projection-entry-car
 import { PortfolioHeatmap } from "@/components/analysis/portfolio-heatmap";
 import { WatchlistCard } from "@/components/dashboard/watchlist-card";
 import {
+  AccountsSummarySkeleton,
+  ChartCardSkeleton,
   ConcentrationCardSkeleton,
+  NetWorthSkeleton,
+  PortfolioHeatmapSkeleton,
   WatchlistCardSkeleton,
-} from "@/components/dashboard/dashboard-skeleton";
+} from "@/components/dashboard/dashboard-section-skeletons";
 import { ConcentrationCard } from "./concentration-card";
 import Link from "next/link";
 import { ArrowRight, History } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { DashboardOnboarding } from "./dashboard-onboarding";
 import { getCachedTrackedStocks } from "@/lib/services/stock-watch-service";
 import { countActiveAccounts } from "@/lib/services/account-service";
@@ -81,93 +83,6 @@ async function fetchLastPriceUpdate(): Promise<string | null> {
     select: { updatedAt: true },
   });
   return latest?.updatedAt.toISOString() ?? null;
-}
-
-/* ---------- Section skeleton helpers ---------- */
-
-function NetWorthSkeleton() {
-  return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6">
-      {/* Primary: Net Worth */}
-      <Card className="col-span-2 rounded-2xl">
-        <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-          <div className="flex items-center gap-2.5 mb-1.5">
-            <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-            <Skeleton className="h-3.5 sm:h-4 w-20" />
-          </div>
-          <Skeleton className="h-7 sm:h-8 w-40 max-w-full mt-1" />
-          <Skeleton className="h-6 w-28 rounded-full mt-3" />
-        </CardContent>
-      </Card>
-      {/* Secondary: Assets + Liabilities */}
-      {[0, 1].map((i) => (
-        <Card key={i} className="col-span-1 rounded-2xl">
-          <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-            <div className="flex items-center gap-1.5 sm:gap-2 mb-1">
-              <Skeleton className="h-3.5 w-3.5 sm:h-4 sm:w-4 rounded-sm shrink-0" />
-              <Skeleton className="h-3.5 sm:h-4 w-16" />
-            </div>
-            <Skeleton className="h-5 sm:h-6 w-24 max-w-full mt-1" />
-            <Skeleton className="h-1.5 w-full rounded-full mt-3 sm:mt-4" />
-            <div className="mt-1.5 flex items-center justify-between">
-              <Skeleton className="h-3 w-16" />
-              <Skeleton className="h-3 w-8" />
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function ChartCardSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-32" />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className="h-[250px]" />
-      </CardContent>
-    </Card>
-  );
-}
-
-function AccountsSummarySkeleton() {
-  return (
-    <div className="space-y-3">
-      <div className="h-5 w-40 bg-muted animate-pulse rounded" />
-      <div className="space-y-3">
-        {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-10 bg-muted animate-pulse rounded" />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function PortfolioHeatmapSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-36" />
-        <Skeleton className="h-4 w-64 max-w-full" />
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
-          <Skeleton className="h-[240px] sm:h-[280px]" />
-          <div className="hidden space-y-3 lg:block">
-            <Skeleton className="h-24" />
-            <div className="space-y-2">
-              {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-10" />
-              ))}
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
 }
 
 /* ---------- Streaming section components ---------- */

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -37,6 +37,7 @@ import { DashboardOnboarding } from "./dashboard-onboarding";
 import { getCachedTrackedStocks } from "@/lib/services/stock-watch-service";
 import { countActiveAccounts } from "@/lib/services/account-service";
 import type { GoalWithProgress } from "@/lib/types";
+import { DashboardPortfolioDisclosure } from "./dashboard-portfolio-disclosure";
 
 /**
  * Cached previous-snapshot read — on the LCP critical path (NetWorthSection),
@@ -448,45 +449,43 @@ export async function DashboardContent({ userId }: { userId: string }) {
         </div>
       </div>
 
-      {/* Tier 3 — "what it's made of": a content-sized 8/4 overview row followed
-          by a full-width concentration summary. Source order stays allocation →
-          currency → portfolio → concentration for mobile and assistive technology. */}
-      <div className="space-y-3 sm:space-y-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
-        <div
-          data-testid="portfolio-overview-row"
-          className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
-        >
-          <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
-            <Suspense fallback={<ChartCardSkeleton />}>
-              <AllocationSection userId={userId} baseCurrency={baseCurrency} />
-            </Suspense>
-            <Suspense fallback={<ChartCardSkeleton />}>
-              <CurrencySection userId={userId} baseCurrency={baseCurrency} />
-            </Suspense>
-          </div>
-          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
-            <Suspense fallback={<PortfolioHeatmapSkeleton />}>
-              <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
-            </Suspense>
-          </div>
-        </div>
-        <Suspense
-          fallback={
-            <div>
-              <ConcentrationCardSkeleton />
+      <DashboardPortfolioDisclosure>
+        <div className="space-y-3 sm:space-y-6 animate-in fade-in slide-in-from-bottom-10 motion-slow fill-mode-both delay-100">
+          <div
+            data-testid="portfolio-overview-row"
+            className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+          >
+            <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+              <Suspense fallback={<ChartCardSkeleton />}>
+                <AllocationSection userId={userId} baseCurrency={baseCurrency} />
+              </Suspense>
+              <Suspense fallback={<ChartCardSkeleton />}>
+                <CurrencySection userId={userId} baseCurrency={baseCurrency} />
+              </Suspense>
             </div>
-          }
-        >
-          <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
-      </div>
+            <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
+              <Suspense fallback={<PortfolioHeatmapSkeleton />}>
+                <PortfolioHeatmapSection userId={userId} baseCurrency={baseCurrency} />
+              </Suspense>
+            </div>
+          </div>
+          <Suspense
+            fallback={
+              <div>
+                <ConcentrationCardSkeleton />
+              </div>
+            }
+          >
+            <ConcentrationSection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+        </div>
 
-      {/* Tier 4 — drill-in detail: full-width accounts summary */}
-      <div className="animate-in fade-in slide-in-from-bottom-12 motion-slow fill-mode-both delay-150">
-        <Suspense fallback={<AccountsSummarySkeleton />}>
-          <AccountsSummarySection userId={userId} baseCurrency={baseCurrency} />
-        </Suspense>
-      </div>
+        <div className="animate-in fade-in slide-in-from-bottom-12 motion-slow fill-mode-both delay-150">
+          <Suspense fallback={<AccountsSummarySkeleton />}>
+            <AccountsSummarySection userId={userId} baseCurrency={baseCurrency} />
+          </Suspense>
+        </div>
+      </DashboardPortfolioDisclosure>
     </>
   );
 }

--- a/src/components/dashboard/dashboard-portfolio-disclosure.tsx
+++ b/src/components/dashboard/dashboard-portfolio-disclosure.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+import { ChevronDown, PieChart } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function DashboardPortfolioDisclosure({ children }: { children: ReactNode }) {
+  const t = useTranslations("dashboard");
+  const [expanded, setExpanded] = useState(false);
+  const contentId = useId();
+
+  return (
+    <section className="space-y-4 md:space-y-8">
+      <button
+        type="button"
+        data-testid="dashboard-portfolio-disclosure-toggle"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        aria-label={t(expanded ? "hidePortfolioDetails" : "showPortfolioDetails")}
+        onClick={() => setExpanded((current) => !current)}
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 text-left shadow-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background md:hidden"
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <PieChart className="size-4 shrink-0 text-primary" aria-hidden="true" />
+          <span className="truncate text-sm font-medium text-foreground">
+            {t("portfolioDetails")}
+          </span>
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none",
+            expanded && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+      </button>
+
+      <div
+        id={contentId}
+        data-testid="dashboard-portfolio-details"
+        className={cn("space-y-4 md:block md:space-y-8", expanded ? "block" : "hidden")}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/dashboard-section-skeletons.tsx
+++ b/src/components/dashboard/dashboard-section-skeletons.tsx
@@ -1,0 +1,149 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ChartCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-[250px]" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function NetWorthSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:gap-6 lg:grid-cols-4">
+      <Card className="col-span-2 rounded-2xl">
+        <CardContent className="flex h-full flex-col justify-center p-4 sm:p-6">
+          <div className="mb-1.5 flex items-center gap-2.5">
+            <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+            <Skeleton className="h-3.5 w-20 sm:h-4" />
+          </div>
+          <Skeleton className="mt-1 h-7 w-40 max-w-full sm:h-8" />
+          <Skeleton className="mt-3 h-6 w-28 rounded-full" />
+        </CardContent>
+      </Card>
+      {[0, 1].map((index) => (
+        <Card key={index} className="col-span-1 rounded-2xl">
+          <CardContent className="flex h-full flex-col justify-center p-4 sm:p-6">
+            <div className="mb-1 flex items-center gap-1.5 sm:gap-2">
+              <Skeleton className="h-3.5 w-3.5 shrink-0 rounded-sm sm:h-4 sm:w-4" />
+              <Skeleton className="h-3.5 w-16 sm:h-4" />
+            </div>
+            <Skeleton className="mt-1 h-5 w-24 max-w-full sm:h-6" />
+            <Skeleton className="mt-3 h-1.5 w-full rounded-full sm:mt-4" />
+            <div className="mt-1.5 flex items-center justify-between">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-8" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function WatchlistCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+            <Skeleton className="h-5 w-24" />
+          </div>
+          <Skeleton className="h-4 w-14" />
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {[...Array(3)].map((_, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between gap-3 border-t border-border/50 py-2.5 first:border-t-0 first:pt-0 last:pb-0"
+          >
+            <div className="min-w-0 space-y-1.5">
+              <Skeleton className="h-3.5 w-20" />
+              <Skeleton className="h-3 w-28 max-w-full" />
+            </div>
+            <div className="flex shrink-0 flex-col items-end gap-1.5">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-3 w-12" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PortfolioHeatmapSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-4 w-64 max-w-full" />
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
+          <Skeleton className="h-[240px] sm:h-[280px]" />
+          <div className="hidden space-y-3 lg:block">
+            <Skeleton className="h-24" />
+            <div className="space-y-2">
+              {[...Array(4)].map((_, index) => (
+                <Skeleton key={index} className="h-10" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ConcentrationCardSkeleton() {
+  return (
+    <Card data-testid="portfolio-concentration-skeleton">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-64 max-w-full" />
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
+        <div className="flex items-end justify-between gap-3 lg:flex-col lg:items-start lg:justify-start">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-6 w-28 rounded-full" />
+        </div>
+        <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
+          {[...Array(5)].map((_, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex justify-between gap-3">
+                <Skeleton className="h-3 w-32 max-w-[70%]" />
+                <Skeleton className="h-3 w-10" />
+              </div>
+              <Skeleton className="h-1.5 w-full rounded-full" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AccountsSummarySkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-5 w-40" />
+      <div className="space-y-3">
+        {[...Array(4)].map((_, index) => (
+          <Skeleton key={index} className="h-10" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/dashboard-skeleton.tsx
+++ b/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,57 +1,14 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AccountsSummarySkeleton,
+  ChartCardSkeleton,
+  ConcentrationCardSkeleton,
+  NetWorthSkeleton,
+  PortfolioHeatmapSkeleton,
+  WatchlistCardSkeleton,
+} from "@/components/dashboard/dashboard-section-skeletons";
 import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
-
-function ChartCardSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-32" />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className="h-[250px]" />
-      </CardContent>
-    </Card>
-  );
-}
-
-/** Net worth cards — mirrors NetWorthSkeleton in dashboard-content so the route
- *  skeleton and the streaming fallback are identical (no jump on reveal). */
-function NetWorthSkeleton() {
-  return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6">
-      {/* Primary: Net Worth — spans half the row, mirroring NetWorthCard's
-          col-span-2 in a 4-col grid. */}
-      <Card className="col-span-2 rounded-2xl">
-        <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-          <div className="flex items-center gap-2.5 mb-1.5">
-            <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-            <Skeleton className="h-3.5 sm:h-4 w-20" />
-          </div>
-          <Skeleton className="h-7 sm:h-8 w-40 max-w-full mt-1" />
-          <Skeleton className="h-6 w-28 rounded-full mt-3" />
-        </CardContent>
-      </Card>
-      {/* Secondary: Assets + Liabilities (with share bar + labels) */}
-      {[0, 1].map((i) => (
-        <Card key={i} className="col-span-1 rounded-2xl">
-          <CardContent className="h-full p-4 sm:p-6 flex flex-col justify-center">
-            <div className="flex items-center gap-1.5 sm:gap-2 mb-1">
-              <Skeleton className="h-3.5 w-3.5 sm:h-4 sm:w-4 rounded-sm shrink-0" />
-              <Skeleton className="h-3.5 sm:h-4 w-16" />
-            </div>
-            <Skeleton className="h-5 sm:h-6 w-24 max-w-full mt-1" />
-            <Skeleton className="h-1.5 w-full rounded-full mt-3 sm:mt-4" />
-            <div className="mt-1.5 flex items-center justify-between">
-              <Skeleton className="h-3 w-16" />
-              <Skeleton className="h-3 w-8" />
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}
 
 /** Planning rail card — GoalsMilestoneCard / ProjectionEntryCard shape:
  *  header (icon + title + view-all) over a goal name, progress bar, and bounds. */
@@ -73,96 +30,6 @@ function GoalsCardSkeleton() {
         <div className="flex items-center justify-between">
           <Skeleton className="h-3 w-16" />
           <Skeleton className="h-3 w-16" />
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-/** Watchlist rail card — header + three quote rows (symbol/name + change pill). */
-export function WatchlistCardSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-2">
-            <Skeleton className="h-4 w-4 rounded-sm shrink-0" />
-            <Skeleton className="h-5 w-24" />
-          </div>
-          <Skeleton className="h-4 w-14" />
-        </div>
-      </CardHeader>
-      <CardContent className="pt-0">
-        {[...Array(3)].map((_, i) => (
-          <div
-            key={i}
-            className="flex items-center justify-between gap-3 border-t border-border/50 py-2.5 first:border-t-0 first:pt-0 last:pb-0"
-          >
-            <div className="min-w-0 space-y-1.5">
-              <Skeleton className="h-3.5 w-20" />
-              <Skeleton className="h-3 w-28 max-w-full" />
-            </div>
-            <div className="flex shrink-0 flex-col items-end gap-1.5">
-              <Skeleton className="h-5 w-16 rounded-full" />
-              <Skeleton className="h-3 w-12" />
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
-
-/** Portfolio treemap — wide chart beside a desktop-only legend column. */
-function PortfolioHeatmapSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-36" />
-        <Skeleton className="h-4 w-64 max-w-full" />
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
-          <Skeleton className="h-[240px] sm:h-[280px]" />
-          <div className="hidden space-y-3 lg:block">
-            <Skeleton className="h-24" />
-            <div className="space-y-2">
-              {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-10" />
-              ))}
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-export function ConcentrationCardSkeleton() {
-  return (
-    <Card data-testid="portfolio-concentration-skeleton">
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-32" />
-        <Skeleton className="h-4 w-64 max-w-full" />
-      </CardHeader>
-      <CardContent className="grid gap-4 lg:grid-cols-[minmax(12rem,0.3fr)_minmax(0,1fr)] lg:gap-6">
-        <div className="flex items-end justify-between gap-3 lg:flex-col lg:items-start lg:justify-start">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-20" />
-            <Skeleton className="h-3 w-24" />
-          </div>
-          <Skeleton className="h-6 w-28 rounded-full" />
-        </div>
-        <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
-          {[...Array(5)].map((_, index) => (
-            <div key={index} className="space-y-2">
-              <div className="flex justify-between gap-3">
-                <Skeleton className="h-3 w-32 max-w-[70%]" />
-                <Skeleton className="h-3 w-10" />
-              </div>
-              <Skeleton className="h-1.5 w-full rounded-full" />
-            </div>
-          ))}
         </div>
       </CardContent>
     </Card>
@@ -195,30 +62,25 @@ export function DashboardSkeleton() {
         </div>
       </div>
 
-      {/* Tier 3 — aligned portfolio overview, then full-width concentration. */}
-      <div className="space-y-3 sm:space-y-6">
-        <div
-          data-testid="portfolio-overview-skeleton"
-          className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
-        >
-          <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
-            <ChartCardSkeleton />
-            <ChartCardSkeleton />
+      <div data-testid="dashboard-portfolio-disclosure-skeleton" className="space-y-4 md:space-y-8">
+        <Skeleton className="h-11 w-full rounded-xl md:hidden" />
+        <div className="hidden space-y-4 md:block md:space-y-8">
+          <div className="space-y-3 sm:space-y-6">
+            <div
+              data-testid="portfolio-overview-skeleton"
+              className="grid grid-cols-1 gap-3 sm:gap-6 lg:grid-cols-12"
+            >
+              <div className="flex min-w-0 flex-col gap-3 sm:gap-6 lg:col-span-4 lg:col-start-9 lg:row-start-1">
+                <ChartCardSkeleton />
+                <ChartCardSkeleton />
+              </div>
+              <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
+                <PortfolioHeatmapSkeleton />
+              </div>
+            </div>
+            <ConcentrationCardSkeleton />
           </div>
-          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
-            <PortfolioHeatmapSkeleton />
-          </div>
-        </div>
-        <ConcentrationCardSkeleton />
-      </div>
-
-      {/* Tier 4 — accounts summary (matches AccountsSummarySkeleton) */}
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-40" />
-        <div className="space-y-3">
-          {[...Array(4)].map((_, i) => (
-            <Skeleton key={i} className="h-10" />
-          ))}
+          <AccountsSummarySkeleton />
         </div>
       </div>
     </div>

--- a/src/components/dashboard/lazy-charts.tsx
+++ b/src/components/dashboard/lazy-charts.tsx
@@ -1,22 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ChartCardSkeleton } from "@/components/dashboard/dashboard-section-skeletons";
 import { TrendChartSkeleton } from "@/components/dashboard/trend-chart-skeleton";
-
-function ChartSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <Skeleton className="h-5 w-32" />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className="h-[250px]" />
-      </CardContent>
-    </Card>
-  );
-}
 
 export const LazyTrendChart = dynamic(() => import("./trend-chart").then((m) => m.TrendChart), {
   loading: () => <TrendChartSkeleton />,
@@ -24,10 +10,10 @@ export const LazyTrendChart = dynamic(() => import("./trend-chart").then((m) => 
 
 export const LazyAllocationChart = dynamic(
   () => import("./allocation-chart").then((m) => m.AllocationChart),
-  { loading: () => <ChartSkeleton /> },
+  { loading: () => <ChartCardSkeleton /> },
 );
 
 export const LazyCurrencyExposureChart = dynamic(
   () => import("./currency-exposure-chart").then((m) => m.CurrencyExposureChart),
-  { loading: () => <ChartSkeleton /> },
+  { loading: () => <ChartCardSkeleton /> },
 );

--- a/src/components/dashboard/net-worth-card.tsx
+++ b/src/components/dashboard/net-worth-card.tsx
@@ -117,7 +117,7 @@ export function NetWorthCard({
   const { density } = useDensity();
   const isCompact = density === "compact";
 
-  const animatedNetWorth = useCountUp(netWorth, 600);
+  const animatedNetWorth = useCountUp(netWorth, 600, { animateOnMount: false });
 
   const delta = previousNetWorth !== undefined ? netWorth - previousNetWorth : null;
   const pct =
@@ -170,6 +170,7 @@ export function NetWorthCard({
             </p>
           </div>
           <p
+            data-testid="net-worth-value"
             className="text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground mt-1 whitespace-nowrap tabular-nums truncate"
             style={{ letterSpacing: "-0.02em" }}
             title={privacyMode ? undefined : formatCurrency(netWorth, baseCurrency)}

--- a/src/hooks/use-count-up.ts
+++ b/src/hooks/use-count-up.ts
@@ -1,22 +1,28 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useReducedMotion } from "framer-motion";
 
-export function useCountUp(end: number, duration: number = 1000) {
+interface CountUpOptions {
+  animateOnMount?: boolean;
+}
+
+export function useCountUp(
+  end: number,
+  duration: number = 1000,
+  { animateOnMount = true }: CountUpOptions = {},
+) {
   const shouldReduceMotion = useReducedMotion();
-  const [count, setCount] = useState(0);
-  // The value the next animation starts from. 0 on first mount gives the intro
-  // count-up; afterward it holds the last displayed figure so a value change
-  // (e.g. net worth after a price refresh) rolls from the previous number to the
-  // new one — conveying the change — instead of snapping back to zero and
-  // replaying the load animation.
-  const fromRef = useRef(0);
+  const [count, setCount] = useState(() => (animateOnMount ? 0 : end));
+  const fromRef = useRef(animateOnMount ? 0 : end);
+  const mountedRef = useRef(false);
 
   useEffect(() => {
-    if (shouldReduceMotion) {
-      // The returned value is `end` via the ternary below, so there's nothing to
-      // animate or set here; just remember it as the next start point.
+    const firstRun = !mountedRef.current;
+    mountedRef.current = true;
+
+    if (shouldReduceMotion || (firstRun && !animateOnMount)) {
+      setCount(end);
       fromRef.current = end;
       return;
     }
@@ -28,7 +34,6 @@ export function useCountUp(end: number, duration: number = 1000) {
       if (cancelled) return;
       if (startTimestamp === null) startTimestamp = timestamp;
       const progress = Math.min((timestamp - startTimestamp) / duration, 1);
-      // easeOutCubic — decelerates the way iOS does
       const ease = 1 - Math.pow(1 - progress, 3);
       const value = from + (end - from) * ease;
       setCount(value);
@@ -43,7 +48,7 @@ export function useCountUp(end: number, duration: number = 1000) {
     return () => {
       cancelled = true;
     };
-  }, [end, duration, shouldReduceMotion]);
+  }, [animateOnMount, duration, end, shouldReduceMotion]);
 
   return shouldReduceMotion ? end : count;
 }

--- a/tests/e2e/dashboard-quick-scan.spec.ts
+++ b/tests/e2e/dashboard-quick-scan.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createDashboardAccount(page: Page, label: string) {
+  const response = await page.request.post("/api/accounts", {
+    data: {
+      name: `${label} ${Date.now()}`,
+      type: "ASSET",
+      category: "BANK",
+      currency: "USD",
+      cashBalance: 1_234,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as { data: { id: string } };
+  return body.data.id;
+}
+
+async function deleteDashboardAccount(page: Page, accountId: string) {
+  const response = await page.request.delete("/api/accounts", {
+    data: { ids: [accountId] },
+  });
+  expect(response.ok()).toBeTruthy();
+}
+
+async function waitForDashboardDisclosure(page: Page) {
+  const disclosure = page.getByTestId("dashboard-portfolio-details");
+  await expect(async () => {
+    if ((await disclosure.count()) === 0) await page.reload();
+    await expect(disclosure).toBeAttached();
+  }).toPass({ timeout: 20_000, intervals: [1_500, 2_000, 2_000] });
+  return disclosure;
+}
+
+test("portfolio details are compact on mobile and persistently visible on desktop", async ({
+  page,
+}, testInfo) => {
+  const accountId = await createDashboardAccount(page, "E2E Dashboard Disclosure");
+
+  try {
+    await page.goto("/");
+    const details = await waitForDashboardDisclosure(page);
+    const toggle = page.getByTestId("dashboard-portfolio-disclosure-toggle");
+
+    if (testInfo.project.name === "Mobile Chrome") {
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toHaveAttribute("aria-expanded", "false");
+      await expect(details).toBeHidden();
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-expanded", "true");
+      await expect(details).toBeVisible();
+
+      await toggle.focus();
+      await toggle.press("Enter");
+      await expect(toggle).toHaveAttribute("aria-expanded", "false");
+      await expect(details).toBeHidden();
+    } else {
+      await expect(toggle).toBeHidden();
+      await expect(details).toBeVisible();
+    }
+  } finally {
+    await deleteDashboardAccount(page, accountId);
+  }
+});

--- a/tests/e2e/dashboard-quick-scan.spec.ts
+++ b/tests/e2e/dashboard-quick-scan.spec.ts
@@ -62,3 +62,18 @@ test("portfolio details are compact on mobile and persistently visible on deskto
     await deleteDashboardAccount(page, accountId);
   }
 });
+
+test("net-worth hero paints its real value in the SSR response", async ({ page }) => {
+  const accountId = await createDashboardAccount(page, "E2E Dashboard First Paint");
+
+  try {
+    const response = await page.request.get("/");
+    expect(response.ok()).toBeTruthy();
+    const html = await response.text();
+    const match = html.match(/data-testid="net-worth-value"[^>]*>([^<]+)</);
+    expect(match?.[1]).toBeTruthy();
+    expect(match?.[1]).not.toBe("$0.00");
+  } finally {
+    await deleteDashboardAccount(page, accountId);
+  }
+});

--- a/tests/e2e/dashboard-quick-scan.spec.ts
+++ b/tests/e2e/dashboard-quick-scan.spec.ts
@@ -72,7 +72,7 @@ test("net-worth hero paints its real value in the SSR response", async ({ page }
     const html = await response.text();
     const match = html.match(/data-testid="net-worth-value"[^>]*>([^<]+)</);
     expect(match?.[1]).toBeTruthy();
-    expect(match?.[1]).not.toBe("$0.00");
+    expect(match?.[1]).not.toBe("$0");
   } finally {
     await deleteDashboardAccount(page, accountId);
   }

--- a/tests/unit/dashboard-loading-contract.test.ts
+++ b/tests/unit/dashboard-loading-contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const contentSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
+const lazyChartsSource = readFileSync("src/components/dashboard/lazy-charts.tsx", "utf8");
+const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
+const sectionSkeletonSource = readFileSync(
+  "src/components/dashboard/dashboard-section-skeletons.tsx",
+  "utf8",
+);
+
+const sharedSkeletons = [
+  "ChartCardSkeleton",
+  "NetWorthSkeleton",
+  "AccountsSummarySkeleton",
+  "PortfolioHeatmapSkeleton",
+  "WatchlistCardSkeleton",
+  "ConcentrationCardSkeleton",
+] as const;
+
+describe("dashboard loading contract", () => {
+  it("defines section skeletons in one module", () => {
+    for (const name of sharedSkeletons) {
+      expect(sectionSkeletonSource).toContain(`export function ${name}(`);
+      expect(contentSource).not.toContain(`function ${name}(`);
+      expect(skeletonSource).not.toContain(`function ${name}(`);
+    }
+    expect(contentSource).toContain('from "@/components/dashboard/dashboard-section-skeletons"');
+    expect(lazyChartsSource).toContain(
+      'import { ChartCardSkeleton } from "@/components/dashboard/dashboard-section-skeletons";',
+    );
+    expect(lazyChartsSource).not.toContain("function ChartSkeleton()");
+  });
+
+  it("keeps advanced route skeletons collapsed on mobile", () => {
+    expect(skeletonSource).toContain('data-testid="dashboard-portfolio-disclosure-skeleton"');
+    expect(skeletonSource).toContain('className="h-11 w-full rounded-xl md:hidden"');
+    expect(skeletonSource).toContain('className="hidden space-y-4 md:block md:space-y-8"');
+  });
+});

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -21,17 +21,7 @@ describe("dashboard portfolio layout", () => {
 
   it("separates concentration from the 8/4 portfolio overview row", () => {
     const overviewStart = dashboardSource.indexOf('data-testid="portfolio-overview-row"');
-    const concentrationBoundary = `            </Suspense>
-          </div>
-        </div>
-        <Suspense
-          fallback={
-            <div>
-              <ConcentrationCardSkeleton />
-            </div>
-          }
-        >`;
-    const concentrationStart = dashboardSource.indexOf(concentrationBoundary, overviewStart);
+    const concentrationStart = dashboardSource.indexOf("<ConcentrationSection", overviewStart);
 
     expect(overviewStart).toBeGreaterThan(-1);
     expect(concentrationStart).toBeGreaterThan(overviewStart);

--- a/tests/unit/dashboard-portfolio-layout.test.ts
+++ b/tests/unit/dashboard-portfolio-layout.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it } from "vitest";
 
 const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
 const skeletonSource = readFileSync("src/components/dashboard/dashboard-skeleton.tsx", "utf8");
+const disclosureSource = readFileSync(
+  "src/components/dashboard/dashboard-portfolio-disclosure.tsx",
+  "utf8",
+);
+const sectionSkeletonSource = readFileSync(
+  "src/components/dashboard/dashboard-section-skeletons.tsx",
+  "utf8",
+);
 const concentrationSource = readFileSync("src/components/dashboard/concentration-card.tsx", "utf8");
 const heatmapSource = readFileSync("src/components/analysis/portfolio-heatmap.tsx", "utf8");
 
@@ -65,13 +73,29 @@ describe("dashboard portfolio layout", () => {
     expect(overviewSource).toContain("lg:[&>*]:flex-1");
     expect(overviewSource).not.toContain("<ConcentrationCardSkeleton />");
     expect(skeletonSource)
-      .toContain(`          <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
-            <PortfolioHeatmapSkeleton />
-          </div>
-        </div>
-        <ConcentrationCardSkeleton />`);
-    expect(skeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
-    expect(skeletonSource).toContain("export function ConcentrationCardSkeleton()");
+      .toContain(`              <div className="flex min-w-0 flex-col lg:col-span-8 lg:col-start-1 lg:row-start-1 lg:min-h-0 lg:contain-size lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
+                <PortfolioHeatmapSkeleton />
+              </div>
+            </div>
+            <ConcentrationCardSkeleton />`);
+    expect(sectionSkeletonSource).toContain('data-testid="portfolio-concentration-skeleton"');
+  });
+
+  it("wraps portfolio analytics without changing the desktop 8/4 topology", () => {
+    const disclosureStart = dashboardSource.indexOf("<DashboardPortfolioDisclosure>");
+    const disclosureEnd = dashboardSource.indexOf(
+      "</DashboardPortfolioDisclosure>",
+      disclosureStart,
+    );
+    const disclosureChildren = dashboardSource.slice(disclosureStart, disclosureEnd);
+
+    expect(disclosureStart).toBeGreaterThan(-1);
+    expect(disclosureChildren).toContain('data-testid="portfolio-overview-row"');
+    expect(disclosureChildren).toContain("lg:col-span-8");
+    expect(disclosureChildren).toContain("lg:col-span-4");
+    expect(disclosureChildren).toContain("<ConcentrationSection");
+    expect(disclosureChildren).toContain("<AccountsSummarySection");
+    expect(disclosureSource).toContain('"space-y-4 md:block md:space-y-8"');
   });
 
   it("lays concentration out horizontally on desktop", () => {


### PR DESCRIPTION
## Summary

- Collapse advanced portfolio details on mobile while preserving the full desktop dashboard layout.
- Render the dashboard net-worth figure truthfully in SSR and reserve count-up motion for later updates.
- Share dashboard loading skeletons across route, streaming, and lazy-chart fallbacks.

## Why

Mobile quick check-ins should surface the net-worth, trend, goals, and watchlist first without a long portfolio stack. The dashboard also previously rendered its hero value from zero during its intro animation.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` — 45 files, 344 tests
- `pnpm exec playwright test tests/e2e/dashboard-quick-scan.spec.ts` — Chromium and Mobile Chrome
- `pnpm build`
- Bundle gzip comparison: +0.79% versus `c2c1487`, within the 5% CI limit
