### PR TITLE
fix(dashboard): align net-worth trend chart with the History tab

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -12,10 +12,7 @@ import {
 } from "@/lib/services/net-worth-service";
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { getOrCreateSettings } from "@/lib/services/settings-service";
-import {
-  getCurrentYearNormalizedHistory,
-  getNormalizedHistory,
-} from "@/lib/services/history-service";
+import { getFullNormalizedHistory } from "@/lib/services/history-service";
 import { HistoryHeatmap } from "@/components/history/history-heatmap";
 import { ActiveDayBoundary } from "@/components/history/active-day-context";
 import { computeGoalsWithProgress } from "@/lib/services/goal-service";
@@ -314,14 +311,17 @@ async function GoalsMilestoneSection({
 
 /**
  * Trend chart + history heatmap — streams behind its Suspense boundary so the
- * dashboard shell never waits on snapshot history. getNormalizedHistory is
- * "use cache" with cacheLife("hours"), so the chart stays on the fast 90-day
- * window while the heatmap gets a year-to-date calendar window.
+ * dashboard shell never waits on snapshot history. Uses the same full-history
+ * fetcher as the History tab: both render the same TrendChart behind one shared
+ * range key, so a capped window here silently truncated 6M/YTD/1Y/All on the
+ * dashboard only. `getFullNormalizedHistory` is "use cache" with
+ * cacheLife("hours") and never selects the heavy `breakdown` column, and the
+ * heatmap clips to the current year itself — so one fetch feeds both children
+ * and the RSC payload carries the series once instead of twice.
  */
 async function TrendSection({ userId, baseCurrency }: { userId: string; baseCurrency: string }) {
-  const [trendSnapshots, heatmapSnapshots, t] = await Promise.all([
-    getNormalizedHistory(userId, baseCurrency),
-    getCurrentYearNormalizedHistory(userId, baseCurrency),
+  const [snapshots, t] = await Promise.all([
+    getFullNormalizedHistory(userId, baseCurrency),
     getTranslations("dashboard"),
   ]);
 
@@ -329,10 +329,10 @@ async function TrendSection({ userId, baseCurrency }: { userId: string; baseCurr
     <ActiveDayBoundary>
       <TrendChartSection
         baseCurrency={baseCurrency}
-        snapshots={trendSnapshots}
+        snapshots={snapshots}
         footer={
           <>
-            <HistoryHeatmap snapshots={heatmapSnapshots} baseCurrency={baseCurrency} />
+            <HistoryHeatmap snapshots={snapshots} baseCurrency={baseCurrency} />
             {/* Mobile-only entry point — the trend chart is the preview; this
               names the History destination inline. Desktop uses the sidebar route. */}
             <Link

--- a/src/components/dashboard/trend-chart-utils.ts
+++ b/src/components/dashboard/trend-chart-utils.ts
@@ -1,3 +1,22 @@
+export type TrendRange = { label: string; days: number; ytd?: true };
+
+/** Selectable windows for the net-worth trend chart, narrowest first. */
+export const TREND_RANGES: TrendRange[] = [
+  { label: "1M", days: 30 },
+  { label: "3M", days: 90 },
+  { label: "6M", days: 180 },
+  { label: "YTD", days: 0, ytd: true },
+  { label: "1Y", days: 365 },
+  { label: "All", days: Infinity },
+];
+
+/**
+ * Opening window. The chart is handed the full snapshot series (dashboard and
+ * History tab alike), so this is purely about what reads well first: recent
+ * movement, with the wider windows one tap away.
+ */
+export const DEFAULT_TREND_RANGE = "3M";
+
 /**
  * Find the chart point matching an externally-driven active date (e.g. a
  * hovered heatmap cell). Returns undefined when there is no active date or no

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -28,7 +28,11 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { usePersistedRange } from "@/hooks/use-persisted-range";
 import { useChartCrosshair } from "@/hooks/use-chart-crosshair";
 import { useActiveDate } from "@/components/history/active-day-context";
-import { findChartPoint } from "@/components/dashboard/trend-chart-utils";
+import {
+  DEFAULT_TREND_RANGE,
+  TREND_RANGES,
+  findChartPoint,
+} from "@/components/dashboard/trend-chart-utils";
 
 type SnapshotData = {
   date: string;
@@ -149,15 +153,6 @@ function CrosshairLines() {
   );
 }
 
-const ranges: { label: string; days: number; ytd?: true }[] = [
-  { label: "1M", days: 30 },
-  { label: "3M", days: 90 },
-  { label: "6M", days: 180 },
-  { label: "YTD", days: 0, ytd: true },
-  { label: "1Y", days: 365 },
-  { label: "All", days: Infinity },
-];
-
 export function TrendChart({
   snapshots,
   baseCurrency = "USD",
@@ -171,7 +166,7 @@ export function TrendChart({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width: containerWidth, height: containerHeight } = useContainerSize(containerRef);
-  const [range, setRange] = usePersistedRange<string>("trend-chart", "All");
+  const [range, setRange] = usePersistedRange<string>("trend-chart", DEFAULT_TREND_RANGE);
   const [pctMode, setPctMode] = usePersistedRange<string>("trend-pct-mode", "off");
   const t = useTranslations("trendChart");
   const { privacyMode } = usePrivacyMode();
@@ -182,7 +177,7 @@ export function TrendChart({
     ? { duration: 0 }
     : { duration: 0.18, ease: [0.16, 1, 0.3, 1] as const };
 
-  const selectedRange = ranges.find((r) => r.label === range)!;
+  const selectedRange = TREND_RANGES.find((r) => r.label === range)!;
   const isPercentMode = pctMode === "on";
   const currencySymbol = getCurrencySymbol(baseCurrency);
 
@@ -333,7 +328,7 @@ export function TrendChart({
             <SegmentedControl
               variant="pill"
               size="xs"
-              options={ranges.map((r) => ({ value: r.label, label: r.label }))}
+              options={TREND_RANGES.map((r) => ({ value: r.label, label: r.label }))}
               value={range}
               onValueChange={setRange}
               aria-label={t("title")}

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -150,50 +150,6 @@ export async function getNormalizedHistory(
 }
 
 /**
- * Current-year history for the activity heatmap. Includes the latest snapshot
- * before Jan 1, when present, so the first visible day can compute its delta
- * the same way full-history views do.
- */
-export async function getCurrentYearNormalizedHistory(
-  userId: string,
-  targetBaseCurrency: string,
-): Promise<NormalizedSnapshot[]> {
-  "use cache";
-  cacheTag("snapshots");
-  cacheTag("net-worth");
-  cacheTag(`history:${userId}`);
-  cacheTag("exchange-rates");
-  cacheLife("hours");
-
-  const now = new Date();
-  const yearStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
-
-  const [currentYearRows, previousDateRow, allRatesMap] = await Promise.all([
-    prisma.netWorthSnapshot.findMany({
-      where: { userId, date: { gte: yearStart } },
-      select: SNAPSHOT_SELECT,
-      orderBy: { date: "asc" },
-    }),
-    prisma.netWorthSnapshot.findFirst({
-      where: { userId, date: { lt: yearStart } },
-      select: { date: true },
-      orderBy: { date: "desc" },
-    }),
-    getAllExchangeRates(),
-  ]);
-
-  const previousRows = previousDateRow
-    ? await prisma.netWorthSnapshot.findMany({
-        where: { userId, date: previousDateRow.date },
-        select: SNAPSHOT_SELECT,
-        orderBy: { createdAt: "asc" },
-      })
-    : [];
-
-  return normalizeSnapshots([...previousRows, ...currentYearRows], allRatesMap, targetBaseCurrency);
-}
-
-/**
  * Full history fetch for pages that need the complete history.
  * Uses `"use cache"` only when no custom range is supplied; a custom
  * range short-circuits to a raw DB call so the cache key isn't

--- a/tests/unit/dashboard-history-parity.test.ts
+++ b/tests/unit/dashboard-history-parity.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The dashboard and the History tab render the same `TrendChart`. They used to
+ * feed it from different fetchers — the dashboard from `getNormalizedHistory`
+ * (hard-capped at DEFAULT_HISTORY_DAYS = 90) and History from
+ * `getFullNormalizedHistory` (everything). Because both charts share one
+ * sessionStorage range key (`asset-tracker:range:trend-chart`, see
+ * use-persisted-range.ts), picking 6M/YTD/1Y/All showed the full series on
+ * History and a silently truncated one on the dashboard, along with a
+ * mismatched period-change badge and Y-axis domain.
+ *
+ * These assertions lock the two views onto one fetcher and one array.
+ */
+const dashboardSource = readFileSync("src/components/dashboard/dashboard-content.tsx", "utf8");
+const historyPageSource = readFileSync("src/app/(main)/history/page.tsx", "utf8");
+
+function trendSectionSource(): string {
+  const start = dashboardSource.indexOf("async function TrendSection(");
+  expect(start).toBeGreaterThan(-1);
+  const end = dashboardSource.indexOf("async function WatchlistSection(", start);
+  expect(end).toBeGreaterThan(start);
+  return dashboardSource.slice(start, end);
+}
+
+describe("dashboard / history trend chart parity", () => {
+  it("feeds the dashboard trend chart from the same fetcher as the History tab", () => {
+    const trendSection = trendSectionSource();
+
+    expect(historyPageSource).toContain("getFullNormalizedHistory");
+    expect(trendSection).toContain("getFullNormalizedHistory(userId, baseCurrency)");
+  });
+
+  it("never reaches for the 90-day window from the dashboard trend chart", () => {
+    const trendSection = trendSectionSource();
+
+    // `getNormalizedHistory` is not a substring of `getFullNormalizedHistory`,
+    // so this catches a regression to the capped fetcher without false hits.
+    expect(trendSection).not.toContain("getNormalizedHistory(");
+    expect(trendSection).not.toContain("getCurrentYearNormalizedHistory");
+    expect(dashboardSource).not.toContain("getCurrentYearNormalizedHistory");
+  });
+
+  it("hands the trend chart and its heatmap footer the same array", () => {
+    const trendSection = trendSectionSource();
+
+    // One binding, serialized into the RSC payload once. HistoryHeatmap clips
+    // to the current year internally (isOutsideYear), exactly as it already
+    // does on the History tab, which passes it the full array too.
+    expect(trendSection).toContain("snapshots={snapshots}");
+    expect(trendSection).toContain("<HistoryHeatmap snapshots={snapshots}");
+    expect(trendSection).not.toContain("heatmapSnapshots");
+    expect(trendSection).not.toContain("trendSnapshots");
+  });
+
+  it("keeps the year-window fetcher retired so the divergence cannot return", () => {
+    const historyServiceSource = readFileSync("src/lib/services/history-service.ts", "utf8");
+
+    // HistoryHeatmap clips to the current year itself, so a dedicated
+    // year-window fetcher has no caller — and reintroducing one is how the
+    // dashboard drifted away from the History tab in the first place.
+    expect(historyServiceSource).not.toContain("getCurrentYearNormalizedHistory");
+  });
+
+  it("keeps the 90-day window available for the goal projections that want it", () => {
+    const goalServiceSource = readFileSync("src/lib/services/goal-service.ts", "utf8");
+    const historyServiceSource = readFileSync("src/lib/services/history-service.ts", "utf8");
+
+    // CAGR/linear projections deliberately look at recent trend only, so the
+    // capped fetcher stays — it just must not be what the dashboard chart uses.
+    expect(goalServiceSource).toContain("getNormalizedHistory(userId, baseCurrency)");
+    expect(historyServiceSource).toContain("const DEFAULT_HISTORY_DAYS = 90");
+  });
+});

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -22,9 +22,6 @@ interface CashTransactionFixture {
 }
 const h = vi.hoisted(() => ({
   rows: [] as SnapshotRowFixture[],
-  currentYearRows: [] as SnapshotRowFixture[],
-  previousRows: [] as SnapshotRowFixture[],
-  previousDateRow: null as { date: Date } | null,
   latestSnapshot: null as SnapshotRowFixture | null,
   foreignCurrencySnapshot: null as { id: string } | null,
   accounts: [] as unknown[],
@@ -46,19 +43,11 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     account: { findMany: vi.fn(async () => h.accounts) },
     netWorthSnapshot: {
-      findMany: vi.fn(async (args?: { where?: { date?: Date | { gte?: Date } } }) => {
-        const dateWhere = args?.where?.date;
-        if (dateWhere instanceof Date) return h.previousRows;
-        if (dateWhere && "gte" in dateWhere) return h.currentYearRows;
-        return h.rows;
+      findMany: vi.fn(async () => h.rows),
+      findFirst: vi.fn(async (args?: { where?: { baseCurrency?: { not?: string } } }) => {
+        if (args?.where?.baseCurrency?.not) return h.foreignCurrencySnapshot;
+        return h.latestSnapshot;
       }),
-      findFirst: vi.fn(
-        async (args?: { where?: { date?: { lt?: Date }; baseCurrency?: { not?: string } } }) => {
-          if (args?.where?.baseCurrency?.not) return h.foreignCurrencySnapshot;
-          if (args?.where?.date?.lt) return h.previousDateRow;
-          return h.latestSnapshot;
-        },
-      ),
     },
     cashTransaction: {
       findMany: vi.fn(async (args?: { where?: { OR?: Array<Record<string, unknown>> } }) => {
@@ -99,7 +88,6 @@ vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
 const {
   getAccountMonthlyCashFlow,
   getMonthlyCashFlow,
-  getCurrentYearNormalizedHistory,
   getFullNormalizedHistory,
   getSnapshotReconciliationWarning,
   hasForeignCurrencySnapshots,
@@ -148,9 +136,6 @@ function account(over: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.useRealTimers();
   h.rows = [];
-  h.currentYearRows = [];
-  h.previousRows = [];
-  h.previousDateRow = null;
   h.latestSnapshot = null;
   h.foreignCurrencySnapshot = null;
   h.accounts = [];
@@ -252,38 +237,6 @@ describe("getFullNormalizedHistory (normalize + dedupe — locks E2)", () => {
       label: "Bonus paid",
       note: "Annual bonus landed in brokerage cash.",
     });
-  });
-});
-
-describe("getCurrentYearNormalizedHistory", () => {
-  it("returns current-year snapshots plus the latest prior day for delta context", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
-
-    const priorDate = new Date("2025-12-31T00:00:00.000Z");
-    h.previousDateRow = { date: priorDate };
-    h.previousRows = [row({ id: "prior", date: priorDate, netWorth: 90 })];
-    h.currentYearRows = [
-      row({ id: "jan", date: new Date("2026-01-01T00:00:00.000Z"), netWorth: 100 }),
-      row({ id: "today", date: new Date("2026-06-14T00:00:00.000Z"), netWorth: 120 }),
-    ];
-
-    const result = await getCurrentYearNormalizedHistory("u1", "USD");
-
-    expect(result.map((s) => s.date)).toEqual(["2025-12-31", "2026-01-01", "2026-06-14"]);
-  });
-
-  it("returns only current-year snapshots when there is no prior history", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
-
-    h.currentYearRows = [
-      row({ id: "jan", date: new Date("2026-01-01T00:00:00.000Z"), netWorth: 100 }),
-    ];
-
-    const result = await getCurrentYearNormalizedHistory("u1", "USD");
-
-    expect(result.map((s) => s.date)).toEqual(["2026-01-01"]);
   });
 });
 

--- a/tests/unit/trend-chart-utils.test.ts
+++ b/tests/unit/trend-chart-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findChartPoint } from "@/components/dashboard/trend-chart-utils";
+import {
+  DEFAULT_TREND_RANGE,
+  TREND_RANGES,
+  findChartPoint,
+} from "@/components/dashboard/trend-chart-utils";
 
 const data = [
   { date: "2026-01-01", netWorth: 100 },
@@ -17,5 +21,21 @@ describe("findChartPoint", () => {
 
   it("returns undefined when there is no active date", () => {
     expect(findChartPoint(data, null)).toBeUndefined();
+  });
+});
+
+describe("trend range table", () => {
+  it("opens on the latest 90 days", () => {
+    const initial = TREND_RANGES.find((r) => r.label === DEFAULT_TREND_RANGE);
+
+    expect(initial).toBeDefined();
+    expect(initial?.days).toBe(90);
+    expect(initial?.ytd).toBeUndefined();
+  });
+
+  it("offers windows from one month through the full series", () => {
+    expect(TREND_RANGES.map((r) => r.label)).toEqual(["1M", "3M", "6M", "YTD", "1Y", "All"]);
+    expect(TREND_RANGES.find((r) => r.label === "All")?.days).toBe(Infinity);
+    expect(TREND_RANGES.find((r) => r.label === "YTD")?.ytd).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

The dashboard and the History tab render the **same** `TrendChart` behind **one shared** sessionStorage range key (`asset-tracker:range:trend-chart`, see `use-persisted-range.ts:12`) — but they fed it from different fetchers:

| | Dashboard | History tab |
|---|---|---|
| Fetcher | `getNormalizedHistory` | `getFullNormalizedHistory` |
| SQL | `where: { userId, date: { gte: now - 90d } }` | `where: { userId }` |

`DEFAULT_HISTORY_DAYS = 90` is hard-coded in `history-service.ts`. The normalization path (dedupe, FX conversion) is identical, so the divergence was purely the time window:

- **1M / 3M** → identical on both pages
- **6M / YTD / 1Y / All** → History showed the full series, the dashboard **silently truncated at 90 days**, with no indication in the UI

The header's period-change badge (`trend-chart.tsx:265`) and the Y-axis domain (`trend-chart.tsx:278`) are both computed from the filtered array, so those disagreed between the two pages too.

## Fix

Point `TrendSection` at `getFullNormalizedHistory` — the same fetcher the History tab uses.

The 90-day cap wasn't buying much:

- The same `Promise.all` **already** fetched a full current year for the heatmap via `getCurrentYearNormalizedHistory`
- The fetcher is `"use cache"` with `cacheLife("hours")`, so it isn't a per-request DB roundtrip
- `SNAPSHOT_SELECT` never selects the heavy `breakdown` JSON column
- `TrendSection` streams behind its own Suspense boundary and never blocks the shell

Passing **one** array to both children also drops a duplicate array from the RSC payload — a net *reduction* for anyone with under a year of history.

## Follow-on cleanup

- **Removed `getCurrentYearNormalizedHistory`** — now callerless. `HistoryHeatmap` clips to the current year itself (`isOutsideYear`), exactly as it already does on the History tab, which passes it the full array too. Its test fixtures and the prisma mock branches that only served it are gone as well.
- **Range table moved to `trend-chart-utils.ts`** — pure data, no React imports, so it is testable without mocking recharts / framer-motion / next-intl.
- **Default range is now `3M`.** The chart holds the whole series either way, so the default is purely about what reads well first: recent movement, wider windows one tap away.

`getNormalizedHistory` (90 days) stays — `goal-service.ts:71` uses it for CAGR/linear projections, which deliberately want recent trend only.

## Tests

New `tests/unit/dashboard-history-parity.test.ts` locks the invariant: same fetcher on both pages, no regression to the capped window, trend chart and heatmap share one array, the year-window fetcher stays retired, and the 90-day window stays available to goal projections.

`tests/unit/trend-chart-utils.test.ts` gains coverage that the default range resolves to a 90-day window and that the six range options keep their semantics (`All` = Infinity, `YTD` carries the `ytd` flag).

These are source-level wiring assertions, matching the existing house pattern (`dashboard-portfolio-layout.test.ts`, `calendar-page-source.test.ts`) — the change *is* wiring, and the repo has no React render harness (node env, no jsdom/testing-library).

```
vitest run        58 files, 421 tests passed
tsc --noEmit      clean
eslint src tests  clean
```

## Reviewer notes

- **Visible behavior change on the dashboard:** the trend chart now opens on 3M and can be widened to the full series, where before it opened on All but could never show more than 90 days.
- **`usePersistedRange` writes to sessionStorage**, so the new default only applies to sessions without a stored value — an open tab that already selected a range keeps it.
- The 3M default applies to **both** pages, since they share the range key. That is consistent with the parity this PR establishes; say the word if History should keep opening on All (needs a separate key or a prop).
- Not verified by running the app — the unit layer only reaches the wiring here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)