### PR TITLE
feat(settings): release v1.1.0 notes and an About card stating the MIT license

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -15,7 +15,8 @@
     "projections": "Projections",
     "calendar": "Calendar",
     "settings": "Settings",
-    "changelog": "What's New"
+    "changelog": "What's New",
+    "sourceCode": "View source on GitHub"
   },
   "calendar": {
     "title": "Calendar",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -226,6 +226,7 @@
     "signOut": "Sign Out",
     "signOutDesc": "Securely log out of your account on this device.",
     "dangerZone": "Danger Zone",
+    "openSourceBadge": "Open source · MIT",
     "versionTitle": "About",
     "versionCurrent": "Current version",
     "versionReleased": "Released {date}",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -230,7 +230,9 @@
     "versionCurrent": "Current version",
     "versionReleased": "Released {date}",
     "versionWhatsNew": "What's new in {version}",
-    "versionViewChangelog": "View changelog"
+    "versionViewChangelog": "View changelog",
+    "versionSourceCode": "Source code",
+    "versionOpenSource": "Assets Tracker is open source under the MIT License. Star the repo, report an issue, or self-host your own copy."
   },
   "languages": {
     "en-US": "English",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -226,13 +226,14 @@
     "signOut": "Sign Out",
     "signOutDesc": "Securely log out of your account on this device.",
     "dangerZone": "Danger Zone",
-    "versionTitle": "Version",
+    "versionTitle": "About",
     "versionCurrent": "Current version",
     "versionReleased": "Released {date}",
     "versionWhatsNew": "What's new in {version}",
     "versionViewChangelog": "View changelog",
     "versionSourceCode": "Source code",
-    "versionOpenSource": "Assets Tracker is open source under the MIT License. Star the repo, report an issue, or self-host your own copy."
+    "versionOpenSourceTitle": "Open source",
+    "versionOpenSource": "Assets Tracker is free, open-source software released under the <license>MIT License</license>. Anyone can read the code, self-host their own copy, or contribute."
   },
   "languages": {
     "en-US": "English",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -226,6 +226,7 @@
     "signOut": "登出",
     "signOutDesc": "安全地登出此裝置上的帳戶。",
     "dangerZone": "危險區域",
+    "openSourceBadge": "開源專案 · MIT",
     "versionTitle": "關於",
     "versionCurrent": "目前版本",
     "versionReleased": "發布於 {date}",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -14,6 +14,7 @@
     "history": "歷史紀錄",
     "projections": "財務預測",
     "calendar": "行事曆",
+    "sourceCode": "在 GitHub 上查看原始碼",
     "settings": "設定",
     "changelog": "更新內容"
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -230,7 +230,9 @@
     "versionCurrent": "目前版本",
     "versionReleased": "發布於 {date}",
     "versionWhatsNew": "{version} 的更新內容",
-    "versionViewChangelog": "查看更新紀錄"
+    "versionViewChangelog": "查看更新紀錄",
+    "versionSourceCode": "原始碼",
+    "versionOpenSource": "資產追蹤器以 MIT 授權開源。歡迎給予星星、回報問題，或自行部署一份專屬版本。"
   },
   "languages": {
     "en-US": "English",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -226,13 +226,14 @@
     "signOut": "登出",
     "signOutDesc": "安全地登出此裝置上的帳戶。",
     "dangerZone": "危險區域",
-    "versionTitle": "版本",
+    "versionTitle": "關於",
     "versionCurrent": "目前版本",
     "versionReleased": "發布於 {date}",
     "versionWhatsNew": "{version} 的更新內容",
     "versionViewChangelog": "查看更新紀錄",
     "versionSourceCode": "原始碼",
-    "versionOpenSource": "資產追蹤器以 MIT 授權開源。歡迎給予星星、回報問題，或自行部署一份專屬版本。"
+    "versionOpenSourceTitle": "開源專案",
+    "versionOpenSource": "資產追蹤器是免費的開源軟體，以 <license>MIT 授權</license> 發布。任何人都可以閱讀原始碼、自行部署專屬版本，或參與貢獻。"
   },
   "languages": {
     "en-US": "English",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -3,6 +3,8 @@ import { DataManagement } from "@/components/settings/data-management";
 import { InstallAppCard } from "@/components/settings/install-app-card";
 import { PrivacySecurity } from "@/components/settings/privacy-security";
 import { VersionCard } from "@/components/settings/version-card";
+import { GitHubMark } from "@/components/settings/github-mark";
+import { REPO_URL } from "@/lib/repo";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";
 import { prisma } from "@/lib/prisma";
@@ -43,7 +45,21 @@ async function SettingsContent() {
   return (
     <NextIntlClientProvider messages={pickMessages(allMessages, CLIENT_NAMESPACES)}>
       <div className="space-y-8 max-w-2xl lg:max-w-6xl pb-16 animate-in fade-in duration-200">
-        <LargeTitleHeading>{t("title")}</LargeTitleHeading>
+        {/* The About card carries the full license statement, but it sits in the
+            third grid row — below the fold on landing. This badge puts the
+            open-source signal in the header, where it is seen without scrolling. */}
+        <div className="space-y-3">
+          <LargeTitleHeading>{t("title")}</LargeTitleHeading>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-medium text-foreground/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <GitHubMark className="h-3.5 w-3.5" />
+            {t("openSourceBadge")}
+          </a>
+        </div>
 
         {/* Single column on mobile. On desktop a 2x3 section grid: each section
             is placed explicitly so its title sits on a shared row line across

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -3,7 +3,7 @@ import { DataManagement } from "@/components/settings/data-management";
 import { InstallAppCard } from "@/components/settings/install-app-card";
 import { PrivacySecurity } from "@/components/settings/privacy-security";
 import { VersionCard } from "@/components/settings/version-card";
-import { GitHubMark } from "@/components/settings/github-mark";
+import { GitHubMark } from "@/components/layout/github-mark";
 import { REPO_URL } from "@/lib/repo";
 import { signOut } from "@/auth";
 import { getSession } from "@/lib/auth-session";

--- a/src/components/layout/github-mark.tsx
+++ b/src/components/layout/github-mark.tsx
@@ -1,6 +1,7 @@
 /**
  * GitHub mark. Ships inline because lucide-react v1 no longer bundles brand
- * icons, and it is shared by the Settings header badge and the About card.
+ * icons. Shared by the sidebar footer, the Settings header badge, and the
+ * About card.
  */
 export function GitHubMark({ className = "h-4 w-4" }: { className?: string }) {
   return (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -34,6 +34,8 @@ import {
   useTransition,
 } from "react";
 import { AppIcon } from "./app-icon";
+import { GitHubMark } from "./github-mark";
+import { REPO_URL } from "@/lib/repo";
 
 const SIDEBAR_STORAGE_KEY = "asset-tracker:sidebar-collapsed";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
@@ -269,6 +271,16 @@ export function Sidebar({
                   {privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
                 <ThemeToggle />
+                <a
+                  href={REPO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={t("nav.sourceCode")}
+                  aria-label={t("nav.sourceCode")}
+                  className="inline-flex items-center justify-center rounded-md p-1.5 text-sm text-muted-foreground hover:text-foreground transition-all motion-fast"
+                >
+                  <GitHubMark className="h-4 w-4" />
+                </a>
               </>
             )}
           </div>

--- a/src/components/settings/github-mark.tsx
+++ b/src/components/settings/github-mark.tsx
@@ -1,0 +1,17 @@
+/**
+ * GitHub mark. Ships inline because lucide-react v1 no longer bundles brand
+ * icons, and it is shared by the Settings header badge and the About card.
+ */
+export function GitHubMark({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`${className} shrink-0`}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}

--- a/src/components/settings/version-card.tsx
+++ b/src/components/settings/version-card.tsx
@@ -3,7 +3,23 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { ArrowRightIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { APP_VERSION, CHANGELOG, resolveChangeText } from "@/lib/changelog";
+import { REPO_URL } from "@/lib/repo";
 import type { Locale } from "@/i18n/config";
+
+/** GitHub mark — lucide dropped brand icons, so it ships inline. */
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-4 w-4 shrink-0"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
 
 export async function VersionCard() {
   const [t, locale] = await Promise.all([getTranslations("settings"), getLocale()]);
@@ -51,14 +67,26 @@ export async function VersionCard() {
             </ul>
           </div>
 
-          <Link
-            href="/changelog"
-            prefetch={false}
-            className="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
-          >
-            {t("versionViewChangelog")}
-            <ArrowRightIcon className="h-3.5 w-3.5" />
-          </Link>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+            <Link
+              href="/changelog"
+              prefetch={false}
+              className="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+            >
+              {t("versionViewChangelog")}
+              <ArrowRightIcon className="h-3.5 w-3.5" />
+            </Link>
+            <a
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+            >
+              <GitHubIcon />
+              {t("versionSourceCode")}
+            </a>
+          </div>
+          <p className="text-xs text-muted-foreground text-pretty">{t("versionOpenSource")}</p>
         </CardContent>
       </Card>
     </section>

--- a/src/components/settings/version-card.tsx
+++ b/src/components/settings/version-card.tsx
@@ -1,18 +1,18 @@
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, ArrowUpRightIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { APP_VERSION, CHANGELOG, resolveChangeText } from "@/lib/changelog";
-import { REPO_URL } from "@/lib/repo";
+import { LICENSE_URL, REPO_URL } from "@/lib/repo";
 import type { Locale } from "@/i18n/config";
 
 /** GitHub mark — lucide dropped brand icons, so it ships inline. */
-function GitHubIcon() {
+function GitHubIcon({ className = "h-4 w-4" }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
-      className="h-4 w-4 shrink-0"
+      className={`${className} shrink-0`}
       fill="currentColor"
       aria-hidden="true"
     >
@@ -67,6 +67,30 @@ export async function VersionCard() {
             </ul>
           </div>
 
+          {/* The license claim is the point of this block, so it reads as a
+              sentence rather than a bare link, and "MIT License" resolves to the
+              license text itself so the claim is verifiable. */}
+          <div className="flex gap-3 rounded-md border border-primary/20 bg-primary/5 p-4">
+            <GitHubIcon className="mt-0.5 h-4 w-4 text-foreground/70" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">{t("versionOpenSourceTitle")}</p>
+              <p className="text-sm text-muted-foreground text-pretty">
+                {t.rich("versionOpenSource", {
+                  license: (chunks) => (
+                    <a
+                      href={LICENSE_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-primary underline underline-offset-2 transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                    >
+                      {chunks}
+                    </a>
+                  ),
+                })}
+              </p>
+            </div>
+          </div>
+
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
             <Link
               href="/changelog"
@@ -80,13 +104,12 @@ export async function VersionCard() {
               href={REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+              className="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
             >
-              <GitHubIcon />
               {t("versionSourceCode")}
+              <ArrowUpRightIcon className="h-3.5 w-3.5" />
             </a>
           </div>
-          <p className="text-xs text-muted-foreground text-pretty">{t("versionOpenSource")}</p>
         </CardContent>
       </Card>
     </section>

--- a/src/components/settings/version-card.tsx
+++ b/src/components/settings/version-card.tsx
@@ -4,22 +4,8 @@ import { ArrowRightIcon, ArrowUpRightIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { APP_VERSION, CHANGELOG, resolveChangeText } from "@/lib/changelog";
 import { LICENSE_URL, REPO_URL } from "@/lib/repo";
+import { GitHubMark } from "./github-mark";
 import type { Locale } from "@/i18n/config";
-
-/** GitHub mark — lucide dropped brand icons, so it ships inline. */
-function GitHubIcon({ className = "h-4 w-4" }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      xmlns="http://www.w3.org/2000/svg"
-      className={`${className} shrink-0`}
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
-    </svg>
-  );
-}
 
 export async function VersionCard() {
   const [t, locale] = await Promise.all([getTranslations("settings"), getLocale()]);
@@ -71,7 +57,7 @@ export async function VersionCard() {
               sentence rather than a bare link, and "MIT License" resolves to the
               license text itself so the claim is verifiable. */}
           <div className="flex gap-3 rounded-md border border-primary/20 bg-primary/5 p-4">
-            <GitHubIcon className="mt-0.5 h-4 w-4 text-foreground/70" />
+            <GitHubMark className="mt-0.5 h-4 w-4 text-foreground/70" />
             <div className="space-y-1">
               <p className="text-sm font-medium text-foreground">{t("versionOpenSourceTitle")}</p>
               <p className="text-sm text-muted-foreground text-pretty">

--- a/src/components/settings/version-card.tsx
+++ b/src/components/settings/version-card.tsx
@@ -4,7 +4,7 @@ import { ArrowRightIcon, ArrowUpRightIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { APP_VERSION, CHANGELOG, resolveChangeText } from "@/lib/changelog";
 import { LICENSE_URL, REPO_URL } from "@/lib/repo";
-import { GitHubMark } from "./github-mark";
+import { GitHubMark } from "@/components/layout/github-mark";
 import type { Locale } from "@/i18n/config";
 
 export async function VersionCard() {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,70 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "1.1.0",
+    date: "2026-07-26",
+    summary: {
+      "en-US": "A financial calendar, linked history charts, and leaner self-host images.",
+      "zh-TW": "新增財經行事曆、連動的歷史圖表，以及更精簡的自架映像檔。",
+    },
+    changes: [
+      {
+        type: "added",
+        text: {
+          "en-US":
+            "Calendar: a new page for earnings, economic releases, dividends, filings, and reminders, with a month grid and a day agenda. It has its own desktop tab and lives in the mobile Plan hub, and entries are included in backup export and restore.",
+          "zh-TW":
+            "行事曆：新增頁面，可記錄財報、經濟數據、配息、申報與提醒，並提供月曆與當日行程檢視。桌面版有獨立分頁，行動版收錄於「計畫」頁，行事曆項目也會納入備份匯出與還原。",
+        },
+      },
+      {
+        type: "added",
+        text: {
+          "en-US":
+            "Activity heatmap and net-worth trend are now linked on both History and the Dashboard: hovering or selecting a day in the heatmap marks that same day on the trend chart.",
+          "zh-TW":
+            "歷史頁與儀表板的活動熱力圖現在與淨值趨勢圖連動：在熱力圖上懸停或選取某一天，趨勢圖會同步標記該日。",
+        },
+      },
+      {
+        type: "improved",
+        text: {
+          "en-US":
+            "Self-hosting: container images are slimmer and hardened, built natively per architecture, and published to GitHub Container Registry.",
+          "zh-TW":
+            "自行部署：容器映像檔更精簡且更安全，改為各架構原生建置，並發布至 GitHub Container Registry。",
+        },
+      },
+      {
+        type: "improved",
+        text: {
+          "en-US":
+            "Clearer disclosures for figures that can't be recomputed: unresolved exchange rates now raise an app-wide banner, history rows converted from another base currency are labeled, and backdated transactions state that they don't rewrite past snapshots.",
+          "zh-TW":
+            "對無法重新計算的數字提供更明確的說明：匯率無法取得時會顯示全站橫幅、歷史紀錄中由其他基準貨幣換算的列會加註標示，補登交易也會說明不會回頭改寫既有快照。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "The dashboard net-worth trend chart now matches the History tab, unrealized gain is computed only over holdings with a cost basis, and cost basis values its market leg in the price-cache currency like net worth does.",
+          "zh-TW":
+            "儀表板的淨值趨勢圖現在與歷史頁一致；未實現損益僅計算具成本基礎的持倉；成本基礎的市值部分改以價格快取的幣別計價，與淨值一致。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Recurring rules now materialize due occurrences when created or edited and roll over on the Taiwan business day, editing a start date re-anchors the schedule without replaying history, renaming a holding fetches a price for the new symbol, and imported symbols get their prices warmed right away.",
+          "zh-TW":
+            "定期規則在建立或編輯時會立即產生到期的交易，並依台灣營業日換日；調整起始日期會重新錨定排程而不會回放歷史；重新命名持倉會取得新代號的報價；匯入的代號也會立即預熱價格快取。",
+        },
+      },
+    ],
+  },
+  {
     version: "1.0.1",
     date: "2026-07-15",
     summary: {

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -4,3 +4,6 @@
  * source, releases, and issue tracker from inside the app.
  */
 export const REPO_URL = "https://github.com/mike840609/assets_tracker";
+
+/** The MIT license text itself, so the license claim in Settings is verifiable. */
+export const LICENSE_URL = `${REPO_URL}/blob/master/LICENSE`;

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -1,0 +1,6 @@
+/**
+ * Public home of the project. Assets Tracker is open source (MIT), and the
+ * Settings "Version" card links here so a self-hoster can always find the
+ * source, releases, and issue tracker from inside the app.
+ */
+export const REPO_URL = "https://github.com/mike840609/assets_tracker";


### PR DESCRIPTION
## Description

Two changes, both landing in the Settings page's version card:

1. **Release v1.1.0.** Prepends a `1.1.0` release (2026-07-26) to `CHANGELOG` in `src/lib/changelog.ts` and bumps `package.json` to match, so the sidebar, the Settings card, and the `/changelog` timeline all move in lockstep. The release covers everything merged since `1.0.1`; per `docs/VERSIONING.md` the `added` entries make this a MINOR bump.
   - **added** — Calendar: earnings, economic releases, dividends, filings, and reminders, with a month grid and day agenda; its own desktop tab, a slot in the mobile Plan hub, and inclusion in backup export/restore.
   - **added** — Activity heatmap linked to the net-worth trend chart on both History and the Dashboard.
   - **improved** — Slimmer, hardened container images, built natively per architecture and published to GHCR.
   - **improved** — Clearer disclosures: app-wide banner for unresolved exchange rates, labels on history rows converted from another base currency, and a note that backdated transactions don't rewrite past snapshots.
   - **fixed** — Dashboard trend parity with History, unrealized gain over costed holdings only, cost basis valued in the price-cache currency.
   - **fixed** — Recurring rule materialization and start-date re-anchoring, price fetch on holding rename, price warm-up for imported symbols.

   All entries are authored bilingually (`en-US` + `zh-TW`) as the changelog format requires.

2. **Tell users the project is MIT open source.** The goal here is a disclosure, not just a link — a bare repo link says where the code lives, not that the project is theirs to use. So the section renames from "Version" to "About" and gains an "Open source" block stating that Assets Tracker is free software released under the MIT License, with "MIT License" resolving to the license text itself so the claim is verifiable rather than merely asserted. A "Source code" link to the repository sits alongside "View changelog".

   Both URLs live in a new `src/lib/repo.ts` so other surfaces can reuse them. The GitHub mark ships as an inline SVG because lucide-react v1 no longer bundles brand icons, matching the existing inline-icon pattern in `install-app-card.tsx`. The sentence uses `t.rich` for its inline link, as `option-builder.tsx` already does.

   This stays inside the existing card rather than becoming a seventh Settings section: `settings/page.tsx` lays out an explicit 2×3 grid whose sections are placed so their titles align across both columns, and a seventh would sit alone in row 4 with an empty column beside it.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests
- [x] All tests pass

Ran locally: `tsc --noEmit`, `eslint`, `prettier --check` on the touched files, and the full unit suite (58 files, 421 tests, all passing). The existing `changelog` test already asserts that `APP_VERSION`, `CHANGELOG[0].version`, and `package.json` stay aligned, and it passes with the bump. A production build was not run locally; CI covers it.

## Screenshots (if applicable)

n/a — the change is a heading rename plus a bordered block and a link row inside the existing card.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [ ] I have updated documentation
- [x] No new warnings generated

`docs/VERSIONING.md` needed no update — it already documents this exact release flow, and this PR follows it.

## Related Issues

n/a