### PR TITLE
fix(auth): stop trusting request headers for identity (#639)

### DIFF
--- a/src/lib/auth-headers.ts
+++ b/src/lib/auth-headers.ts
@@ -1,3 +1,0 @@
-export const AUTH_USER_ID_HEADER = "x-asset-user-id";
-export const AUTH_SOURCE_HEADER = "x-asset-auth-source";
-export const AUTH_SOURCE_PROXY = "proxy";

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { cache } from "react";
-import { headers } from "next/headers";
 import { auth } from "@/auth";
-import { AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY, AUTH_USER_ID_HEADER } from "@/lib/auth-headers";
-import { getAuthUser, userExists } from "@/lib/auth-user";
+import { userExists } from "@/lib/auth-user";
 
 type AppSession = {
   user?: {
@@ -14,25 +12,14 @@ type AppSession = {
   };
 } | null;
 
-async function getTrustedProxyUserId(): Promise<string | null> {
-  const requestHeaders = await headers();
-  if (requestHeaders.get(AUTH_SOURCE_HEADER) !== AUTH_SOURCE_PROXY) return null;
-  const userId = requestHeaders.get(AUTH_USER_ID_HEADER);
-  return userId && userId.trim() ? userId : null;
-}
-
 /**
- * Cached session wrapper. Proxy validates the JWT once and forwards only a
- * server-written user id header; normal page renders can then skip a second
- * JWT decode while still confirming the user exists in the database.
+ * Cached session wrapper. Identity always comes from the signed session cookie
+ * via `auth()` — never from a request header, which a client can forge whenever
+ * the middleware does not run (see #639). React `cache()` keeps this to one JWT
+ * decode per request across all call sites, and the database check makes sure a
+ * stale cookie cannot render a signed-in shell.
  */
 export const getSession = cache(async (): Promise<AppSession> => {
-  const proxyUserId = await getTrustedProxyUserId();
-  if (proxyUserId) {
-    const user = await getAuthUser(proxyUserId);
-    return user ? { user } : null;
-  }
-
   const session = await auth();
   if (!session?.user?.id) return session;
 

--- a/src/lib/auth-user.ts
+++ b/src/lib/auth-user.ts
@@ -1,13 +1,6 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
 
-export async function getAuthUser(userId: string) {
-  return prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true, name: true, email: true, image: true },
-  });
-}
-
 export async function userExists(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,5 @@
 import NextAuth from "next-auth";
 import authConfig from "./auth.config";
-import { AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY, AUTH_USER_ID_HEADER } from "@/lib/auth-headers";
 import { SESSION_COOKIE_NAMES } from "@/lib/auth-cookies";
 import { getClientIp } from "@/lib/rate-limit";
 import { NextResponse } from "next/server";
@@ -14,27 +13,51 @@ function hasSessionCookie(req: NextRequest): boolean {
   return SESSION_COOKIE_NAMES.some((name) => req.cookies.has(name));
 }
 
-function requestHeadersForApp(req: NextRequest, userId?: string): Headers {
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.delete(AUTH_USER_ID_HEADER);
-  requestHeaders.delete(AUTH_SOURCE_HEADER);
-
-  if (userId) {
-    requestHeaders.set(AUTH_USER_ID_HEADER, userId);
-    requestHeaders.set(AUTH_SOURCE_HEADER, AUTH_SOURCE_PROXY);
-  }
-
-  return requestHeaders;
-}
-
-function nextResponse(req: NextRequest, userId?: string): NextResponse {
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeadersForApp(req, userId),
-    },
-  });
+function nextResponse(req: NextRequest): NextResponse {
+  const response = NextResponse.next();
   setLocaleCookie(req, response);
   return response;
+}
+
+// Bot/scanner probes observed in production logs and in the wild. These used to
+// be excluded in `matcher`, but the extension tokens there carried a leading
+// `.*` and JS `.` matches `/`, so a probe token anywhere in the path skipped the
+// middleware entirely — including on real dynamic routes like /accounts/x.env
+// (#639). Filtering here keeps the check anchored to the first path segment, so
+// it can never swallow a dynamic segment deeper in the path.
+const BOT_PATH_PREFIXES = [
+  "wp-admin",
+  "wp-login",
+  "wp-content",
+  "wp-includes",
+  "wordpress",
+  "xmlrpc",
+  "cgi-bin",
+  "cmd_",
+  "phpmyadmin",
+  "adminer",
+  "vendor/phpunit",
+];
+
+const BOT_FILE_TOKENS = [
+  ".php",
+  ".asp",
+  ".aspx",
+  ".jsp",
+  ".cgi",
+  ".env",
+  ".git",
+  ".svn",
+  ".htaccess",
+  ".htpasswd",
+];
+
+function isBotProbe(pathname: string): boolean {
+  const path = pathname.replace(/^\/+/, "").toLowerCase();
+  if (BOT_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
+
+  const firstSegment = path.split("/", 1)[0];
+  return BOT_FILE_TOKENS.some((token) => firstSegment.includes(token));
 }
 
 // ---------------------------------------------------------------------------
@@ -114,7 +137,7 @@ const authMiddleware = auth((req) => {
     return Response.redirect(newUrl);
   }
 
-  return nextResponse(req, req.auth?.user?.id);
+  return nextResponse(req);
 });
 
 export default function middleware(req: NextRequest, event: NextFetchEvent) {
@@ -130,9 +153,16 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
     return;
   }
 
+  // Bot probes get routing's own 404 rather than a /login redirect, and never
+  // pay for NextAuth work. This check lives here, not in `matcher`, so that
+  // every app path is matched and no route can opt itself out of the middleware.
+  if (isBotProbe(req.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
   // P4 fast path: no session cookie means the request is anonymous — decide
   // redirect vs. pass-through from the cookie header alone, without invoking
-  // NextAuth's JWT decode. Bot traffic that survives the matcher lands here.
+  // NextAuth's JWT decode.
   if (!hasSessionCookie(req)) {
     if (!PUBLIC_ROUTES.includes(req.nextUrl.pathname)) {
       return Response.redirect(new URL("/login", req.nextUrl.origin));
@@ -149,7 +179,9 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
   );
 }
 
-// Negative-lookahead exclusions:
+// Negative-lookahead exclusions. Every token here is a fixed, non-routable
+// asset or public page anchored at position 1 — nothing uses a leading `.*`, so
+// no exclusion can span path segments and quietly skip a routable app page:
 //   - Next/Vercel internals + cron + file-based metadata (already excluded before P1).
 //   - robots.txt / sitemap.xml served from `public/`.
 //   - PWA assets sw.js + manifest.webmanifest: the browser fetches these without
@@ -157,16 +189,10 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
 //     installability check fails and the install prompt never appears.
 //   - Public login/legal pages, so they can render without NextAuth cookie work.
 //     The signed-in /login redirect lives in the login page itself.
-//   - Common bot/scanner probes observed in production logs and in the wild:
-//     wp-admin/wp-login/wp-content/wp-includes/wordpress, xmlrpc, cgi-bin,
-//     phpmyadmin/adminer, cmd_*, vendor/phpunit, plus any path containing
-//     .php/.asp/.aspx/.jsp/.cgi/.env/.git/.svn/.htaccess/.htpasswd.
-// Bot tokens are anchored at position 1 (no leading `.*`) so we don't
-// accidentally skip legitimate routes that happen to contain these
-// substrings deeper in the path; extension/dotfile tokens use `.*` so any
-// component carrying them is excluded.
+// Bot/scanner probes are NOT excluded here — they are filtered by `isBotProbe`
+// inside `middleware()` above, so every app path reaches the middleware (#639).
 export const config = {
   matcher: [
-    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|sw\\.js|manifest\\.webmanifest|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|login|privacy|terms|wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|cgi-bin|cmd_|phpmyadmin|adminer|vendor/phpunit|.*\\.php|.*\\.aspx?|.*\\.jsp|.*\\.cgi|.*\\.env|.*\\.git|.*\\.svn|.*\\.htaccess|.*\\.htpasswd).*)",
+    "/((?!api/(?!auth)|_next/static|_next/image|_vercel|favicon\\.ico|sw\\.js|manifest\\.webmanifest|apple-icon|icon|opengraph-image|twitter-image|robots\\.txt|sitemap\\.xml|login|privacy|terms).*)",
   ],
 };

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from "next/server";
 import type { NextFetchEvent } from "next/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authMock, userExistsMock, headersMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  userExistsMock: vi.fn(),
+  headersMock: vi.fn(),
+}));
 
 vi.mock("next-auth", () => ({
   default: () => ({
@@ -9,8 +15,12 @@ vi.mock("next-auth", () => ({
 }));
 
 vi.mock("../../src/auth.config", () => ({ default: {} }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/auth-user", () => ({ userExists: userExistsMock }));
+vi.mock("next/headers", () => ({ headers: headersMock }));
 
-import proxy from "@/proxy";
+import proxy, { config } from "@/proxy";
+import { getSession } from "@/lib/auth-session";
 
 const TUNNEL_PATH = "/a1b2c3d4";
 
@@ -46,6 +56,98 @@ describe("Sentry tunnel proxy bypass", () => {
 
     expect(response.headers.get("x-middleware-next")).toBeNull();
     expect(response.headers.get("location")).toBe("https://astt.app/login");
+  });
+});
+
+// Regression cover for #639: the matcher's bot-probe exclusions carried a
+// leading `.*`, and JS `.` matches `/`, so any path containing `.env`/`.php`/…
+// skipped the middleware — including real dynamic routes like /accounts/x.env.
+describe("middleware matcher covers dynamic routes (#639)", () => {
+  const matcher = new RegExp(`^${config.matcher[0]}$`);
+
+  it.each(["clx123", "x.env", "x.php", "x.git", "x.htaccess"])(
+    "matches /accounts/%s so the middleware always runs",
+    (accountId) => {
+      expect(matcher.test(`/accounts/${accountId}`)).toBe(true);
+    },
+  );
+
+  it("uses no segment-spanning exclusion token", () => {
+    expect(config.matcher[0]).not.toContain(".*\\.");
+  });
+
+  it.each([
+    "/sw.js",
+    "/manifest.webmanifest",
+    "/robots.txt",
+    "/sitemap.xml",
+    "/favicon.ico",
+    "/login",
+    "/privacy",
+    "/terms",
+    "/_next/static/chunk.js",
+    "/api/accounts",
+  ])("still excludes the non-routable or public path %s", (pathname) => {
+    expect(matcher.test(pathname)).toBe(false);
+  });
+});
+
+describe("bot probe filtering inside the middleware", () => {
+  it.each(["/wp-admin", "/xmlrpc.php", "/x.php", "/.env", "/vendor/phpunit/run"])(
+    "passes the probe %s through to routing instead of redirecting to login",
+    (pathname) => {
+      const response = executeAnonymousRequest(pathname);
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("location")).toBeNull();
+    },
+  );
+
+  it("does not mistake a dotted dynamic account id for a bot probe", () => {
+    const response = executeAnonymousRequest("/accounts/x.env");
+
+    expect(response.headers.get("location")).toBe("https://astt.app/login");
+  });
+});
+
+describe("getSession identity source (#639)", () => {
+  const VICTIM_ID = "clvictim000000000000000";
+
+  beforeEach(() => {
+    authMock.mockReset();
+    userExistsMock.mockReset();
+    headersMock.mockReset();
+    headersMock.mockResolvedValue(
+      new Headers({
+        "x-asset-auth-source": "proxy",
+        "x-asset-user-id": VICTIM_ID,
+      }),
+    );
+  });
+
+  it("returns no session for forged proxy identity headers without a session cookie", async () => {
+    authMock.mockResolvedValue(null);
+
+    await expect(getSession()).resolves.toBeNull();
+
+    expect(userExistsMock).not.toHaveBeenCalledWith(VICTIM_ID);
+  });
+
+  it("never reads request headers to establish identity", async () => {
+    authMock.mockResolvedValue(null);
+
+    await getSession();
+
+    expect(headersMock).not.toHaveBeenCalled();
+  });
+
+  it("still resolves the cookie-backed session from auth()", async () => {
+    const session = { user: { id: "clowner0000000000000000", email: "owner@example.com" } };
+    authMock.mockResolvedValue(session);
+    userExistsMock.mockResolvedValue(true);
+
+    await expect(getSession()).resolves.toEqual(session);
+    expect(userExistsMock).toHaveBeenCalledWith(session.user.id);
   });
 });
 


### PR DESCRIPTION
## The vulnerability

`getSession()` derived the caller's identity from two **plain request headers** (`x-asset-user-id`, `x-asset-auth-source`). The only defence was `src/proxy.ts` stripping them via `requestHeadersForApp()` — which depends entirely on "middleware always runs".

It didn't. The middleware `matcher` excluded bot-probe extension tokens with a **leading `.*`** (`.*\.php|.*\.env|.*\.git|…`), and JS `.` matches `/`, so those alternatives matched at *any* path depth. `/accounts/[id]` is a dynamic route, so `/accounts/x.env` was a real, routable page that the middleware never saw: no header stripping, and no anonymous `/login` redirect. An unauthenticated request with forged headers then passed the `(main)/layout.tsx` auth gate as any user, and every user-scoped query in that render ran under the attacker-chosen id.

Same trust model as CVE-2025-29927: a header-based identity whose only defence is middleware coverage.

## Part A — chose deletion, not HMAC

**Deleted the proxy fast path** so `getSession()` always calls `auth()`. Identity now only ever comes from the signed session cookie.

Why deletion over the HMAC alternative: I found no evidence the JWT decode is load-bearing.
- `getSession` is already wrapped in React `cache()`, so its 13 call sites collapse to **one** decode per request.
- Both branches did exactly **one** DB query — the fast path's `getAuthUser()` vs. `userExists()` — so the fast path saved no database work either.
- The only reference to the optimisation anywhere in the repo is the `// P4 fast path` comment itself; no benchmark or perf doc backs it.

So the entire saving was one JWT decode per request, against an authentication bypass. Adding HMAC machinery would have kept a header as an identity source and added a new signing/verification surface to maintain; deleting the path removes the class of bug outright.

Cleaned up what this made dead: `getTrustedProxyUserId()`, `src/lib/auth-headers.ts` (whole file), `getAuthUser()` in `src/lib/auth-user.ts`, the `requestHeadersForApp()` set/delete calls, and the now-unused `next/headers` + auth-headers imports. `setLocaleCookie` behaviour is unchanged — `nextResponse()` still sets it, it just no longer rewrites request headers.

## Part B — bot filtering moved out of `matcher`

Took the second option from the issue, since it removes the whole class of bug rather than patching one instance of it. Bot-probe filtering now lives in `isBotProbe()` in the `middleware()` body, anchored to the **first path segment**, so it can never span segments again.

The documented intent above the matcher is preserved:
- **PWA assets** (`sw.js`, `manifest.webmanifest`), file-based metadata, `robots.txt`/`sitemap.xml`, and the public `login`/`privacy`/`terms` pages stay excluded in `matcher` — they are fixed, non-routable, position-1 tokens with no leading `.*`, so they cannot swallow a dynamic segment. Chrome's installability check keeps getting its 200s.
- **Bot probes** keep their observable behaviour: `isBotProbe()` returns `NextResponse.next()`, so they still get routing's own 404 rather than a `/login` redirect, and still pay no NextAuth work.
- The full documented token list (`wp-admin`/`wp-login`/`wp-content`/`wp-includes`/`wordpress`, `xmlrpc`, `cgi-bin`, `cmd_`, `phpmyadmin`, `adminer`, `vendor/phpunit`, plus `.php`/`.asp`/`.aspx`/`.jsp`/`.cgi`/`.env`/`.git`/`.svn`/`.htaccess`/`.htpasswd`) carries over intact.

The narrowing is deliberate: extension tokens used to match at any depth and now match only the first segment. A deep probe like `/uploads/shell.php` now reaches the middleware and gets a `/login` redirect instead of a 404 — one extra Edge invocation for junk traffic, which is the price of never letting a route opt itself out of the auth gate.

`/api/*` is untouched — those routes authenticate via `withAuth` → `auth()` and were never affected.

## Verification

Shipped matcher regex, run against the adversarial paths **before**:

```
true   middleware runs: /accounts/clx123
false  middleware runs: /accounts/x.env        <-- real route, middleware skipped
false  middleware runs: /accounts/x.php        <-- real route, middleware skipped
false  middleware runs: /accounts/foo.git      <-- real route, middleware skipped
false  middleware runs: /accounts/x.htaccess   <-- real route, middleware skipped
true   middleware runs: /settings
```

**After**:

```
true   middleware runs: /accounts/clx123
true   middleware runs: /accounts/x.env
true   middleware runs: /accounts/x.php
true   middleware runs: /accounts/foo.git
true   middleware runs: /accounts/x.htaccess
true   middleware runs: /settings
true   middleware runs: /wp-admin              <-- now filtered in middleware() body
true   middleware runs: /x.php                 <-- now filtered in middleware() body
false  middleware runs: /sw.js                 <-- PWA exclusion preserved
false  middleware runs: /manifest.webmanifest  <-- PWA exclusion preserved
false  middleware runs: /robots.txt
false  middleware runs: /login
false  middleware runs: /api/accounts
false  middleware runs: /_next/static/x.js
```

Gates: `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (446 passed / 58 files), `pnpm format:check` all pass on Node 24.6.0.

Not exercised against a running deployment — worth confirming with the issue's `curl` against a preview before merge.

## Tests added (`tests/unit/proxy.test.ts`)

`describe("middleware matcher covers dynamic routes (#639)")`
- `matches /accounts/%s so the middleware always runs` — parameterised over `clx123`, `x.env`, `x.php`, `x.git`, `x.htaccess`
- `uses no segment-spanning exclusion token` — pins that no `.*\.` alternative comes back
- `still excludes the non-routable or public path %s` — parameterised over `/sw.js`, `/manifest.webmanifest`, `/robots.txt`, `/sitemap.xml`, `/favicon.ico`, `/login`, `/privacy`, `/terms`, `/_next/static/chunk.js`, `/api/accounts`

`describe("bot probe filtering inside the middleware")`
- `passes the probe %s through to routing instead of redirecting to login` — parameterised over `/wp-admin`, `/xmlrpc.php`, `/x.php`, `/.env`, `/vendor/phpunit/run`
- `does not mistake a dotted dynamic account id for a bot probe`

`describe("getSession identity source (#639)")`
- `returns no session for forged proxy identity headers without a session cookie`
- `never reads request headers to establish identity`
- `still resolves the cookie-backed session from auth()` (positive control)

All three `getSession` tests fail against the pre-fix code.

Fixes #639

https://claude.ai/code/session_01Yb6TkdYpoQiyKKMgUixeAQ
