### PR TITLE
fix(cron): snapshot from a fresh net-worth summary, not the stale cached read

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -151,12 +151,16 @@ export async function GET(request: Request) {
       include: { appSettings: true },
     });
 
-    // 3. Create snapshots for each user (in parallel)
+    // 3. Create snapshots for each user (in parallel).
+    // `fresh: true` — the tag bumps above are stale-while-revalidate ("max"), so
+    // reading the cached net-worth summary here would persist the PREVIOUS
+    // cycle's prices/FX/balances and shift the whole history one day (#640).
+    // The snapshot is computed from direct DB reads instead.
     const snapshotResults = await Promise.allSettled(
       users.map(async (user) => {
         const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
         log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
-        const snapshot = await createSnapshot(user.id, baseCurrency);
+        const snapshot = await createSnapshot(user.id, baseCurrency, { fresh: true });
         return { userId: user.id, snapshot };
       }),
     );

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -122,6 +122,24 @@ export const getAllExchangeRates = cache(async (): Promise<Map<string, number>> 
 });
 
 /**
+ * Load ALL exchange rates straight from the DB, bypassing the Cache
+ * Components layer. Same "FROM_TO" → rate shape as `getAllExchangeRates`.
+ *
+ * For background jobs that write rates and then need to read them back in the
+ * same run: the cron revalidates `exchange-rates` with `"max"`, which is
+ * stale-while-revalidate, so `getAllExchangeRates` would hand back the
+ * pre-refresh map. Render paths should keep using the cached reader.
+ */
+export async function getFreshExchangeRates(): Promise<Map<string, number>> {
+  const rows = await prisma.exchangeRate.findMany({
+    select: { fromCurrency: true, toCurrency: true, rate: true },
+  });
+  const map = new Map<string, number>();
+  for (const r of rows) map.set(`${r.fromCurrency}_${r.toCurrency}`, Number(r.rate));
+  return map;
+}
+
+/**
  * Derive a cross rate via USD from already-known rates, e.g.
  * TWD→EUR = (USD→EUR) / (USD→TWD). The daily cron warms USD rates for
  * every in-use currency, so this resolves most pairs that lack a direct

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { getAllExchangeRates, resolveRate } from "./exchange-rate-service";
+import { getAllExchangeRates, getFreshExchangeRates, resolveRate } from "./exchange-rate-service";
 import { serializeAccountWithHoldings } from "@/lib/types";
 import { log } from "@/lib/logger";
 import type {
@@ -28,6 +28,14 @@ async function fetchUserAccountsWithHoldingsInner(
   cacheTag("accounts");
   cacheTag(`accounts:${userId}`);
   cacheLife("hours");
+  return queryActiveAccountsWithHoldings(userId);
+}
+
+/** The uncached query behind the cached reader above; see the `fresh` path in
+ * `computeNetWorthSummary` for why background jobs need it directly. */
+async function queryActiveAccountsWithHoldings(
+  userId: string,
+): Promise<SerializedAccountWithHoldings[]> {
   const raw = await prisma.account.findMany({
     where: { userId, isActive: true },
     include: { holdings: { where: { quantity: { gt: 0 } } } },
@@ -57,16 +65,30 @@ export const fetchUserArchivedAccountsWithHoldings = cache(
   fetchUserArchivedAccountsWithHoldingsInner,
 );
 
-async function computeNetWorthSummary(
+/**
+ * Uncached net-worth computation.
+ *
+ * `fresh` swaps the two cached inputs (accounts/holdings and the FX map) for
+ * direct DB reads. Background jobs that write and then read in the same run
+ * must pass it: the snapshot cron refreshes prices/FX and materializes
+ * recurring cash + DCA rows, then revalidates `accounts` / `exchange-rates` /
+ * `net-worth` with `"max"` — stale-while-revalidate, so the cached readers hand
+ * back pre-refresh values and the persisted row lands one cron cycle behind
+ * (#640). Same reasoning as the direct price/FX reads in
+ * `recurring-investment-service`. PriceCache below is already read directly, so
+ * the price leg needs no switch. Render paths keep the cached readers.
+ */
+export async function computeNetWorthSummary(
   userId: string,
   baseCurrency: string,
+  opts: { fresh?: boolean } = {},
 ): Promise<NetWorthSummary> {
   // Load accounts and exchange rates in parallel.
-  // Both are React-cached, so if DashboardContent already fired these
-  // calls without awaiting, we get the memoised results here for free.
+  // On the cached path both are React-cached, so if DashboardContent already
+  // fired these calls without awaiting, we get the memoised results for free.
   const [accounts, allRatesMap] = await Promise.all([
-    fetchUserAccountsWithHoldings(userId),
-    getAllExchangeRates(),
+    opts.fresh ? queryActiveAccountsWithHoldings(userId) : fetchUserAccountsWithHoldings(userId),
+    opts.fresh ? getFreshExchangeRates() : getAllExchangeRates(),
   ]);
 
   // Phase 2: fetch only the prices needed for this user's holdings

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -4,7 +4,7 @@ import { log } from "@/lib/logger";
 import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { computeDueOccurrences, utcDateOnly } from "./recurring-cash-service";
 import { taiwanCalendarDay } from "@/lib/app-day";
-import { resolveRate } from "./exchange-rate-service";
+import { getFreshExchangeRates, resolveRate } from "./exchange-rate-service";
 import { fetchStockPrices, fetchCryptoPrices } from "./price-service";
 
 class HoldingCurrencyMismatchError extends Error {
@@ -33,18 +33,10 @@ class HoldingCurrencyMismatchError extends Error {
  * `getCachedPricesForSymbols` / `getAllExchangeRates`): the cron writes fresh
  * prices/rates just before this runs but only revalidates the `prices` /
  * `exchange-rates` cache tags afterward, so the cached readers would return
- * pre-refresh values and the buys would use stale price/FX.
+ * pre-refresh values and the buys would use stale price/FX. The FX half of that
+ * direct read lives in `exchange-rate-service.getFreshExchangeRates` — the
+ * snapshot cron path needs the same map (#640).
  */
-
-/** Loads all exchange rates straight from the DB as a "FROM_TO" → rate map. */
-async function loadFreshRateMap(): Promise<Map<string, number>> {
-  const rows = await prisma.exchangeRate.findMany({
-    select: { fromCurrency: true, toCurrency: true, rate: true },
-  });
-  const map = new Map<string, number>();
-  for (const r of rows) map.set(`${r.fromCurrency}_${r.toCurrency}`, Number(r.rate));
-  return map;
-}
 
 /** Resolves a usable market price (value + currency) for the rule's symbol. */
 async function resolvePrice(
@@ -98,7 +90,7 @@ export async function materializeDueInvestments(
   });
   if (dueRules.length === 0) return { created: 0, rulesProcessed: 0 };
 
-  const rateMap = await loadFreshRateMap();
+  const rateMap = await getFreshExchangeRates();
   let created = 0;
 
   for (const rule of dueRules) {

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,10 +1,27 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
-import { getCachedNetWorthSummary } from "./net-worth-service";
+import { computeNetWorthSummary, getCachedNetWorthSummary } from "./net-worth-service";
 import { taiwanCalendarDay } from "@/lib/app-day";
 
-export async function createSnapshot(userId: string, baseCurrency: string) {
-  const summary = await getCachedNetWorthSummary(userId, baseCurrency);
+/**
+ * Persists today's NetWorthSnapshot for one user.
+ *
+ * `fresh` computes the summary from direct DB reads instead of
+ * `getCachedNetWorthSummary`. The cron MUST pass it: it refreshes prices/FX and
+ * materializes recurring rows, then revalidates `net-worth` / `prices` /
+ * `exchange-rates` / `accounts` with `"max"` — stale-while-revalidate, so the
+ * cached summary (tagged with exactly those tags) serves the PREVIOUS cycle's
+ * numbers while the fresh value loads in the background. Snapshotting that read
+ * shifted the whole persisted history one day (#640).
+ */
+export async function createSnapshot(
+  userId: string,
+  baseCurrency: string,
+  opts: { fresh?: boolean } = {},
+) {
+  const summary = opts.fresh
+    ? await computeNetWorthSummary(userId, baseCurrency, { fresh: true })
+    : await getCachedNetWorthSummary(userId, baseCurrency);
   const snapshotTakenAt = new Date();
   // The cron fires at 21:30 UTC = 05:30 Taiwan time (#49) so the run lands just
   // after midnight local. Floor to the *Taiwan* calendar day (shift +8h before

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -227,6 +227,28 @@ describe("snapshot cron route", () => {
     expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
   });
 
+  // Regression #640: the tag bumps above are `"max"` (stale-while-revalidate),
+  // so a cached net-worth read here would persist the previous cycle's numbers.
+  // The cron must ask createSnapshot for the uncached computation.
+  it("asks for a fresh (uncached) summary when creating each snapshot", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "TWD" } },
+    ];
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+    const { createSnapshot } = await import("@/lib/services/snapshot-service");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith("user1", "USD", { fresh: true });
+    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith("user2", "TWD", { fresh: true });
+  });
+
   it("materializes recurring rules for the Taiwan calendar day", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-05T21:30:00.000Z")); // 07-06 05:30 Taipei

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Net-worth computation is exercised through its public cached entry point.
 // We neutralize the caching wrappers (React cache(), Next "use cache" tags)
@@ -81,6 +81,8 @@ const h = vi.hoisted(() => ({
   accounts: [] as unknown[],
   prices: [] as { symbol: string; price: number; currency: string }[],
   rates: new Map<string, number>(),
+  /** Rows behind the direct `prisma.exchangeRate` read the fresh path uses. */
+  freshRates: new Map<string, number>(),
   warnings: [] as { msg: string; meta: unknown }[],
   tags: [] as string[],
 }));
@@ -106,6 +108,14 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     account: { findMany: vi.fn(async () => h.accounts) },
     priceCache: { findMany: vi.fn(async () => h.prices) },
+    exchangeRate: {
+      findMany: vi.fn(async () =>
+        [...h.freshRates].map(([key, rate]) => {
+          const [fromCurrency, toCurrency] = key.split("_");
+          return { fromCurrency, toCurrency, rate };
+        }),
+      ),
+    },
   },
 }));
 vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
@@ -113,7 +123,8 @@ vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
   return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
 });
 
-const { getCachedNetWorthSummary } = await import("@/lib/services/net-worth-service");
+const { getCachedNetWorthSummary, computeNetWorthSummary } =
+  await import("@/lib/services/net-worth-service");
 
 describe("getCachedNetWorthSummary (two-pass valuation)", () => {
   it("prices holdings, converts currencies, and splits assets vs. liabilities", async () => {
@@ -274,5 +285,57 @@ describe("getCachedNetWorthSummary (two-pass valuation)", () => {
 
     // 5 * 2 contracts * 100 multiplier = 1000.
     expect(summary.totalAssets).toBeCloseTo(1000);
+  });
+});
+
+// Regression #640: the snapshot cron writes prices/FX and materializes recurring
+// rows, then revalidates with `"max"` — stale-while-revalidate, so the cached
+// account + FX readers hand back pre-refresh values. The `fresh` path must go
+// straight to the DB for both.
+describe("computeNetWorthSummary({ fresh: true })", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.warnings = [];
+    h.tags = [];
+    h.prices = [];
+  });
+
+  it("takes FX from the direct DB read, not the cached rate map", async () => {
+    const { getAllExchangeRates } = await import("@/lib/services/exchange-rate-service");
+    h.rates = new Map([["USD_TWD", 1]]); // stale: pre-refresh 1:1
+    h.freshRates = new Map([["USD_TWD", 30]]); // post-refresh
+    h.accounts = [account({ id: "B", type: "ASSET", currency: "TWD", cashBalance: 3000 })];
+
+    const summary = await computeNetWorthSummary("u1", "USD", { fresh: true });
+
+    // 3000 TWD / 30 = 100. The stale 1:1 map would have valued it at 3000.
+    expect(summary.totalAssets).toBeCloseTo(100);
+    expect(vi.mocked(getAllExchangeRates)).not.toHaveBeenCalled();
+  });
+
+  it("enters no cached reader at all, so no cache tag is registered", async () => {
+    h.rates = new Map();
+    h.freshRates = new Map();
+    h.accounts = [account({ id: "A", type: "ASSET", currency: "USD", cashBalance: 100 })];
+
+    const summary = await computeNetWorthSummary("u1", "USD", { fresh: true });
+
+    expect(summary.totalAssets).toBeCloseTo(100);
+    // The cached account reader calls cacheTag("accounts"); the fresh query does
+    // not. An empty list proves neither `"use cache"` body ran.
+    expect(h.tags).toEqual([]);
+  });
+
+  it("still uses the cached readers when fresh is not requested", async () => {
+    const { getAllExchangeRates } = await import("@/lib/services/exchange-rate-service");
+    h.rates = new Map([["USD_TWD", 1]]);
+    h.freshRates = new Map([["USD_TWD", 30]]);
+    h.accounts = [account({ id: "B", type: "ASSET", currency: "TWD", cashBalance: 3000 })];
+
+    const summary = await computeNetWorthSummary("u1", "USD");
+
+    expect(summary.totalAssets).toBeCloseTo(3000); // stale 1:1 map
+    expect(vi.mocked(getAllExchangeRates)).toHaveBeenCalled();
+    expect(h.tags).toContain("accounts");
   });
 });

--- a/tests/unit/snapshot-service.test.ts
+++ b/tests/unit/snapshot-service.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
 const h = vi.hoisted(() => ({
   upsertArgs: [] as unknown[],
+  cachedCalls: [] as unknown[],
+  computeCalls: [] as unknown[],
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -15,13 +17,20 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+// The two readers return DIFFERENT numbers on purpose: 100 stands for the
+// pre-refresh value the cached (stale-while-revalidate) summary still holds
+// during a cron run, 250 for what a direct DB read sees after the refresh.
 vi.mock("@/lib/services/net-worth-service", () => ({
-  getCachedNetWorthSummary: vi.fn(async () => ({
-    totalAssets: 100,
-    totalLiabilities: 0,
-    netWorth: 100,
-    accounts: [],
-  })),
+  getCachedNetWorthSummary: vi.fn(async (userId: string, baseCurrency: string) => {
+    h.cachedCalls.push({ userId, baseCurrency });
+    return { totalAssets: 100, totalLiabilities: 0, netWorth: 100, accounts: [] };
+  }),
+  computeNetWorthSummary: vi.fn(
+    async (userId: string, baseCurrency: string, opts?: { fresh?: boolean }) => {
+      h.computeCalls.push({ userId, baseCurrency, opts });
+      return { totalAssets: 250, totalLiabilities: 0, netWorth: 250, accounts: [] };
+    },
+  ),
 }));
 
 import { createSnapshot } from "@/lib/services/snapshot-service";
@@ -45,5 +54,43 @@ describe("createSnapshot date bucketing", () => {
 
     const args = h.upsertArgs[0] as { create: { date: Date } };
     expect(args.create.date.toISOString().split("T")[0]).toBe("2026-07-06");
+  });
+});
+
+// Regression #640: the cron refreshes prices/FX and materializes recurring rows,
+// then revalidates `net-worth` / `prices` / `exchange-rates` / `accounts` with
+// `"max"` — stale-while-revalidate, i.e. "the stale content is served while
+// fresh content is fetched in the background" (Next 16 revalidateTag docs). The
+// cached summary is tagged with exactly those tags, so snapshotting it persisted
+// the PREVIOUS cron cycle's numbers and shifted the whole history one day.
+describe("createSnapshot summary source", () => {
+  beforeEach(() => {
+    h.upsertArgs.length = 0;
+    h.cachedCalls.length = 0;
+    h.computeCalls.length = 0;
+  });
+
+  it("persists the uncached summary on the fresh path and never touches the cached read", async () => {
+    await createSnapshot("u1", "USD", { fresh: true });
+
+    expect(h.computeCalls).toEqual([{ userId: "u1", baseCurrency: "USD", opts: { fresh: true } }]);
+    expect(h.cachedCalls).toEqual([]);
+    const args = h.upsertArgs[0] as {
+      create: { netWorth: number; totalAssets: number };
+      update: { netWorth: number };
+    };
+    // 250 = post-refresh. 100 would mean the stale cached summary was persisted.
+    expect(args.create.netWorth).toBe(250);
+    expect(args.create.totalAssets).toBe(250);
+    expect(args.update.netWorth).toBe(250);
+  });
+
+  it("still reads through the cached summary by default (render/manual callers)", async () => {
+    await createSnapshot("u1", "USD");
+
+    expect(h.cachedCalls).toEqual([{ userId: "u1", baseCurrency: "USD" }]);
+    expect(h.computeCalls).toEqual([]);
+    const args = h.upsertArgs[0] as { create: { netWorth: number } };
+    expect(args.create.netWorth).toBe(100);
   });
 });


### PR DESCRIPTION
## What was wrong

`/api/cron/snapshot` refreshes prices + FX, materializes recurring cash / DCA rows, then calls `revalidateTag(tag, "max")` for `exchange-rates` / `prices` / `net-worth` / `accounts` — and only *then* loops `createSnapshot`, which read `getCachedNetWorthSummary`.

That cached reader (`net-worth-service.ts`) is a `"use cache"` function tagged with **exactly those four tags**. Per the Next 16 docs shipped in `node_modules/next/dist/docs/01-app/03-api-reference/04-functions/revalidateTag.md:20`:

> **With `profile="max"` (recommended)**: The tag entry is marked as stale, and the next time a resource with that tag is visited, it will use stale-while-revalidate semantics. This means the stale content is served while fresh content is fetched in the background.

The snapshot loop **is** that next visit, so it received the pre-refresh value and `prisma.netWorthSnapshot.upsert` persisted it. Every `NetWorthSnapshot` row was therefore written from the *previous* cron cycle's prices/FX/balances — the app's entire history, trend chart, heatmap, analysis, goal ETA and drawdown series shifted one day, plus a permanently wrong `getSnapshotReconciliationWarning` delta. It's invisible in the UI because the dashboard renders the live summary.

`"max"` makes it worse rather than better: `cacheLife.md:146` gives the `max` profile an `expire` of 1 year, so the entry can never age out into a blocking recompute.

The repo already documented and worked around this exact failure mode for the sibling DCA feature (`recurring-investment-service.ts` header: *"the cached readers would return pre-refresh values"*). The snapshot path never got the same treatment.

## What changed

The direct-read approach, mirroring `recurring-investment-service.ts`. **Not** `revalidateTag(tag, { expire: 0 })` — that forces a blocking recompute for every reader across all users and still races the background refresh. The `"max"` (cron) vs `{ expire: 0 }` (user mutation) convention documented in `src/app/api/accounts/route.ts:10-13` is left intact.

- **`net-worth-service.ts`** — `computeNetWorthSummary` is now exported and takes `{ fresh?: boolean }`. When `fresh`, both cached inputs are swapped for direct DB reads. The raw account query was extracted into `queryActiveAccountsWithHoldings` so the cached reader and the fresh path share one query.
- **`snapshot-service.ts`** — `createSnapshot(userId, baseCurrency, opts)`; `fresh` picks `computeNetWorthSummary(..., { fresh: true })`, default keeps `getCachedNetWorthSummary`.
- **`cron/snapshot/route.ts`** — passes `{ fresh: true }`. One-line call-site change.
- **`exchange-rate-service.ts`** — `loadFreshRateMap` was hoisted out of `recurring-investment-service.ts` into `getFreshExchangeRates()`, next to its cached sibling `getAllExchangeRates()`. Both cron legs now share one helper rather than duplicating a second one; the DCA path is behaviour-identical (same query, same `Map<"FROM_TO", rate>` shape).

## How far the fresh path goes, and what stays cached

`computeNetWorthSummary` has three inputs. All three are now correct on the cron path:

| Leg | Reader | Status |
|---|---|---|
| Prices | `prisma.priceCache.findMany` | **Already direct** — needed no change. This is why the bug was subtle: fresh prices *were* in the DB, they just never reached the persisted row because the whole summary was served from cache. |
| FX | `getAllExchangeRates()` — `"use cache"` + React `cache()`, tagged `exchange-rates` | **Switched to fresh.** Same staleness problem, and the cron bumps this tag with `"max"` itself. |
| Accounts / holdings | `fetchUserAccountsWithHoldings()` — `"use cache"`, tagged `accounts` | **Switched to fresh.** The recurring-cash and DCA materialisation earlier in the same run mutates `Account.cashBalance` and `Holding.quantity`, and `accounts` is bumped with `"max"` only when `structuralChanged` — so this leg was stale for exactly the rows the cron had just written. |

Nothing is deliberately left cached on the cron path — a half-fresh snapshot would still be wrong, just less obviously. Two conscious non-changes:

- **Render paths are untouched.** Every dashboard/accounts/goals/history caller keeps the cached readers and the default `createSnapshot` signature; `fresh` is opt-in and only the cron opts in.
- **`getFreshExchangeRates()` is not React-`cache()`-wrapped**, so it costs one `ExchangeRate` scan per user per cron run rather than one per run. Deliberate: memoizing a reader whose whole purpose is "don't hand me a memoized value" invites the next version of this bug, and the row count and user count are both small. The per-user `PriceCache` query already had this shape.
- **The `revalidateTag` calls before the loop are kept as-is.** They are still needed for real readers (dashboards, list pages); they're simply no longer load-bearing for snapshot correctness.

## Preserved semantics

Taiwan-calendar-day bucketing (`taiwanCalendarDay`, +8h) and the `userId_date_baseCurrency` upsert key are unchanged, as is the 05:30-Taipei cron schedule. The existing bucketing regression test still passes untouched.

## How this was verified

`pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (58 files, 427 tests), `pnpm format:check` — all green on Node 24.6.0 / pnpm 11.6.0.

The new tests were confirmed to be genuine regression tests, not tautologies: with `src/` stashed and only the test changes applied, **5 of the 6 fail** (the 6th is the "default path still uses the cache" control, which passes both ways by design). Restoring the fix turns them green.

### Tests added

`tests/unit/snapshot-service.test.ts` — new `describe("createSnapshot summary source")`. The two mocked readers deliberately return *different* net worth (cached = 100 "stale", uncached = 250 "post-refresh") so the assertion is about the value that actually lands in the upsert, not just which function was called:
- `persists the uncached summary on the fresh path and never touches the cached read`
- `still reads through the cached summary by default (render/manual callers)`

`tests/unit/net-worth-service.test.ts` — new `describe("computeNetWorthSummary({ fresh: true })")`, pinning the second-order FX/accounts legs:
- `takes FX from the direct DB read, not the cached rate map` (stale map says TWD 1:1, fresh DB says 30; asserts the 30 was used and `getAllExchangeRates` was never called)
- `enters no cached reader at all, so no cache tag is registered` (an empty `cacheTag` log proves neither `"use cache"` body ran)
- `still uses the cached readers when fresh is not requested`

`tests/unit/cron-snapshot-route.test.ts` — the pre-existing wholesale `createSnapshot` mock is why this shipped untested, so it now asserts the argument:
- `asks for a fresh (uncached) summary when creating each snapshot` (both users, `{ fresh: true }`)

Not reproduced against a live deployment — the mechanism is static (Next cache semantics + tag overlap), matching the issue's own verification method.

Fixes #640

https://claude.ai/code/session_01Yb6TkdYpoQiyKKMgUixeAQ
