### PR TITLE
perf(cron): bulk-load snapshot inputs and bound the sweep's fan-out (#641)

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -3,10 +3,12 @@ import { timingSafeEqual } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { createSnapshot } from "@/lib/services/snapshot-service";
 import { refreshAllPrices } from "@/lib/services/price-service";
-import { refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { getFreshExchangeRates, refreshExchangeRates } from "@/lib/services/exchange-rate-service";
+import { loadNetWorthInputsForUsers } from "@/lib/services/net-worth-service";
 import { materializeDueRecurringTransactions } from "@/lib/services/recurring-cash-service";
 import { materializeDueInvestments } from "@/lib/services/recurring-investment-service";
 import { taiwanCalendarDay } from "@/lib/app-day";
+import { chunk, mapSettled } from "@/lib/batch";
 import { ok, failure } from "@/lib/api-responses";
 import { CRON_SECRET } from "@/lib/env";
 import { log } from "@/lib/logger";
@@ -20,6 +22,18 @@ function hasValidCronSecret(authHeader: string | null): boolean {
 
 /** Name used for this cron's CronRun audit rows; E18's /api/health alarm keys on it. */
 const CRON_NAME = "snapshot";
+
+// Fan-out bounds for the sweep (#641). Each is a ceiling, not a target: a small
+// instance never reaches them, so nothing gets slower until the point where the
+// unbounded version would have fallen over.
+// ponytail: fixed numbers, not config — tune here if a real instance outgrows
+// them rather than adding env plumbing nobody sets.
+/** Concurrent external FX round-trips. Low: the source throttles by IP. */
+const RATE_REFRESH_CONCURRENCY = 5;
+/** Concurrent snapshot upserts. Bounds writes against the Neon pool. */
+const SNAPSHOT_CONCURRENCY = 10;
+/** Users whose accounts/holdings are held in memory at once. */
+const USER_PAGE_SIZE = 200;
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -96,10 +110,24 @@ export async function GET(request: Request) {
     log.info("cron.prices.refresh");
     // force: snapshots must be computed from current rates; the manual-refresh
     // freshness gate doesn't apply to the cron.
-    const [rateResults, priceResult] = await Promise.all([
-      Promise.all([...sourceCurrencies].map((c) => refreshExchangeRates(c, { force: true }))),
+    //
+    // Bounded concurrency (#641): every currency here is an external FX
+    // round-trip, and the count grows with the instance. Firing them all at once
+    // is what gets the source IP throttled, and a throttled source is worse than
+    // a slightly longer sweep — each call is capped at RATE_FETCH_TIMEOUT_MS, so
+    // the wall-clock cost of waves is bounded and small. Settled rather than
+    // all-or-nothing so one currency's failure can't abort the whole run.
+    const [rateSettled, priceResult] = await Promise.all([
+      mapSettled([...sourceCurrencies], RATE_REFRESH_CONCURRENCY, (c) =>
+        refreshExchangeRates(c, { force: true }),
+      ),
       refreshAllPrices(),
     ]);
+    const rateResults = rateSettled.flatMap((result) => {
+      if (result.status === "fulfilled") return [result.value];
+      log.warn("cron.rates.currency_failed", { error: String(result.reason) });
+      return [];
+    });
     const ratesUpdated = rateResults.reduce((sum, result) => sum + result.updated, 0);
     const ratesChanged = rateResults.reduce((sum, result) => sum + result.changed, 0);
     log.info("cron.revalidate.gate", {
@@ -148,36 +176,61 @@ export async function GET(request: Request) {
 
     // 2. Get all users and their settings
     const users = await prisma.user.findMany({
-      include: { appSettings: true },
+      select: { id: true, appSettings: { select: { baseCurrency: true } } },
     });
 
-    // 3. Create snapshots for each user (in parallel).
-    // `fresh: true` — the tag bumps above are stale-while-revalidate ("max"), so
-    // reading the cached net-worth summary here would persist the PREVIOUS
-    // cycle's prices/FX/balances and shift the whole history one day (#640).
-    // The snapshot is computed from direct DB reads instead.
-    const snapshotResults = await Promise.allSettled(
-      users.map(async (user) => {
-        const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
-        log.info("cron.snapshot.create", { userId: user.id, baseCurrency });
-        const snapshot = await createSnapshot(user.id, baseCurrency, { fresh: true });
-        return { userId: user.id, snapshot };
-      }),
-    );
+    // 3. Snapshot every user.
+    //
+    // All reads are bulk (#641): the FX map is global so it is loaded once for
+    // the whole run, and each page of users costs one accounts+holdings query
+    // plus one price query — not three queries per user, unbounded in flight,
+    // which exhausted the connection pool and the 60 s budget as the instance
+    // grew. Paging also bounds how many users' holdings are held in memory.
+    //
+    // Everything here reads directly, never through a cached reader. The tag
+    // bumps above are stale-while-revalidate ("max"), so a cached net-worth read
+    // would persist the PREVIOUS cycle's prices/FX/balances and shift the whole
+    // history one day (#640).
+    const ratesMap = await getFreshExchangeRates();
     const snapshots: Awaited<ReturnType<typeof createSnapshot>>[] = [];
     const successfulUserIds: string[] = [];
     const failedUserIds: string[] = [];
-    for (let i = 0; i < snapshotResults.length; i++) {
-      const result = snapshotResults[i];
-      const userId = users[i].id;
-      if (result.status === "fulfilled") {
-        snapshots.push(result.value.snapshot);
-        successfulUserIds.push(result.value.userId);
-      } else {
-        failedUserIds.push(userId);
-        log.warn("cron.snapshot.user_failed", { userId, error: String(result.reason) });
+
+    for (const page of chunk(users, USER_PAGE_SIZE)) {
+      const inputs = await loadNetWorthInputsForUsers(
+        page.map((user) => user.id),
+        ratesMap,
+      );
+      // Only the upsert is left per user, so the cap here bounds concurrent
+      // writes rather than whole read-compute-write pipelines.
+      const pageResults = await mapSettled(page, SNAPSHOT_CONCURRENCY, async (user) => {
+        const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
+        const snapshot = await createSnapshot(user.id, baseCurrency, {
+          fresh: true,
+          preloaded: inputs.get(user.id),
+        });
+        return { userId: user.id, snapshot };
+      });
+
+      for (let i = 0; i < pageResults.length; i++) {
+        const result = pageResults[i];
+        if (result.status === "fulfilled") {
+          snapshots.push(result.value.snapshot);
+          successfulUserIds.push(result.value.userId);
+        } else {
+          failedUserIds.push(page[i].id);
+          log.warn("cron.snapshot.user_failed", {
+            userId: page[i].id,
+            error: String(result.reason),
+          });
+        }
       }
     }
+    log.info("cron.snapshot.summary", {
+      users: users.length,
+      created: snapshots.length,
+      failed: failedUserIds.length,
+    });
     if (users.length > 0 && failedUserIds.length === users.length) {
       throw new Error(`Snapshot failed for users: ${failedUserIds.join(", ")}`);
     }

--- a/src/lib/batch.ts
+++ b/src/lib/batch.ts
@@ -1,0 +1,52 @@
+/**
+ * Bounded-concurrency helpers for background jobs.
+ *
+ * The snapshot cron used to fan out with `Promise.all` / `Promise.allSettled`
+ * over every user and every in-use currency at once (#641). That works until the
+ * instance grows: N concurrent multi-query snapshot computations exhaust the
+ * Neon pool, and N concurrent external FX fetches get the source IP throttled.
+ * Neither has a natural upper bound, and the handler only has 60 s.
+ */
+
+/** Split `items` into fixed-size pages, so a job can bound how much it holds at once. */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  if (size < 1) throw new Error("chunk size must be >= 1");
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    pages.push(items.slice(i, i + size));
+  }
+  return pages;
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` calls in flight.
+ *
+ * Returns `PromiseSettledResult`s in input order — same contract as
+ * `Promise.allSettled`, so a single failing item never aborts the rest and
+ * callers can keep reporting per-item success/failure.
+ */
+export async function mapSettled<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  if (limit < 1) throw new Error("concurrency limit must be >= 1");
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let cursor = 0;
+
+  // Shared cursor rather than fixed slices: one slow item can't leave a whole
+  // worker's tail idle while other workers have already drained.
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      try {
+        results[index] = { status: "fulfilled", value: await fn(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}

--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -325,8 +325,12 @@ export async function refreshExchangeRates(
   // multi-row upserts taking the same locks in different orders can deadlock.
   rows.sort(([aFrom, aTo], [bFrom, bTo]) => `${aFrom}_${aTo}`.localeCompare(`${bFrom}_${bTo}`));
 
+  // Two clauses, not one per pair: every row we are about to write has
+  // `baseCurrency` on one side or the other, so this covers all of them. The
+  // per-pair `OR` this replaced generated ~320 clauses per call (#641) — and the
+  // cron issues one call per currency in use.
   const currentRows = await prisma.exchangeRate.findMany({
-    where: { OR: rows.map(([fromCurrency, toCurrency]) => ({ fromCurrency, toCurrency })) },
+    where: { OR: [{ fromCurrency: baseCurrency }, { toCurrency: baseCurrency }] },
     select: { fromCurrency: true, toCurrency: true, rate: true },
   });
   const currentByPair = new Map(

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -65,6 +65,78 @@ export const fetchUserArchivedAccountsWithHoldings = cache(
   fetchUserArchivedAccountsWithHoldingsInner,
 );
 
+/** Price rows keyed by symbol, in whatever currency the provider quoted. */
+type PriceMap = Record<string, { price: number; currency: string }>;
+
+async function queryPriceMap(symbols: string[]): Promise<PriceMap> {
+  if (symbols.length === 0) return {};
+  const prices = await prisma.priceCache.findMany({
+    where: { symbol: { in: [...new Set(symbols)] } },
+    select: { symbol: true, price: true, currency: true },
+  });
+  return Object.fromEntries(
+    prices.map((p) => [p.symbol, { price: Number(p.price), currency: p.currency }]),
+  );
+}
+
+/**
+ * Everything `computeNetWorthSummary` needs from the database for ONE user.
+ * Pass it when a caller has already loaded these in bulk — see
+ * `loadNetWorthInputsForUsers`.
+ */
+export type NetWorthInputs = {
+  accounts: SerializedAccountWithHoldings[];
+  ratesMap: Map<string, number>;
+  priceMap: PriceMap;
+};
+
+/**
+ * Bulk-load net-worth inputs for MANY users in a fixed number of queries
+ * (two, plus one shared rate map), instead of three per user.
+ *
+ * The snapshot cron used to call `computeNetWorthSummary` once per user, so its
+ * database round-trips grew linearly with the instance and ran with no
+ * concurrency bound — the pool-exhaustion half of #641. Everything here is read
+ * directly (no `"use cache"`), so the result is fresh by construction, which is
+ * what the cron needs after it refreshes prices/FX (#640).
+ *
+ * `ratesMap` is passed in rather than fetched: it is global, so the caller loads
+ * it once for the whole run instead of once per user or per page.
+ */
+export async function loadNetWorthInputsForUsers(
+  userIds: string[],
+  ratesMap: Map<string, number>,
+): Promise<Map<string, NetWorthInputs>> {
+  const byUser = new Map<string, NetWorthInputs>();
+  if (userIds.length === 0) return byUser;
+
+  const raw = await prisma.account.findMany({
+    where: { userId: { in: userIds }, isActive: true },
+    include: { holdings: { where: { quantity: { gt: 0 } } } },
+    // Same ordering as the single-user query. Bucketing below preserves it
+    // within each user, so per-user account order is unchanged.
+    orderBy: [{ isPinned: "desc" }, { sortOrder: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+  });
+
+  const accountsByUser = new Map<string, SerializedAccountWithHoldings[]>();
+  for (const account of raw) {
+    const list = accountsByUser.get(account.userId);
+    if (list) list.push(serializeAccountWithHoldings(account));
+    else accountsByUser.set(account.userId, [serializeAccountWithHoldings(account)]);
+  }
+
+  const priceMap = await queryPriceMap(
+    raw.flatMap((account) => account.holdings.map((h) => h.symbol)),
+  );
+
+  // Users with no active accounts still get an entry, so callers snapshot them
+  // (a zeroed row) exactly as the per-user path did.
+  for (const userId of userIds) {
+    byUser.set(userId, { accounts: accountsByUser.get(userId) ?? [], ratesMap, priceMap });
+  }
+  return byUser;
+}
+
 /**
  * Uncached net-worth computation.
  *
@@ -77,33 +149,32 @@ export const fetchUserArchivedAccountsWithHoldings = cache(
  * (#640). Same reasoning as the direct price/FX reads in
  * `recurring-investment-service`. PriceCache below is already read directly, so
  * the price leg needs no switch. Render paths keep the cached readers.
+ *
+ * `preloaded` short-circuits all three reads for callers that already loaded
+ * them in bulk (#641). It must carry fresh data, so pass it together with
+ * `fresh` to keep the intent legible at the call site.
  */
 export async function computeNetWorthSummary(
   userId: string,
   baseCurrency: string,
-  opts: { fresh?: boolean } = {},
+  opts: { fresh?: boolean; preloaded?: NetWorthInputs } = {},
 ): Promise<NetWorthSummary> {
   // Load accounts and exchange rates in parallel.
   // On the cached path both are React-cached, so if DashboardContent already
   // fired these calls without awaiting, we get the memoised results for free.
-  const [accounts, allRatesMap] = await Promise.all([
-    opts.fresh ? queryActiveAccountsWithHoldings(userId) : fetchUserAccountsWithHoldings(userId),
-    opts.fresh ? getFreshExchangeRates() : getAllExchangeRates(),
-  ]);
+  const [accounts, allRatesMap] = opts.preloaded
+    ? [opts.preloaded.accounts, opts.preloaded.ratesMap]
+    : await Promise.all([
+        opts.fresh
+          ? queryActiveAccountsWithHoldings(userId)
+          : fetchUserAccountsWithHoldings(userId),
+        opts.fresh ? getFreshExchangeRates() : getAllExchangeRates(),
+      ]);
 
   // Phase 2: fetch only the prices needed for this user's holdings
-  const userSymbols = accounts.flatMap((a) => a.holdings.map((h) => h.symbol));
-  const prices =
-    userSymbols.length > 0
-      ? await prisma.priceCache.findMany({
-          where: { symbol: { in: userSymbols } },
-          select: { symbol: true, price: true, currency: true },
-        })
-      : [];
-
-  const priceMap = Object.fromEntries(
-    prices.map((p) => [p.symbol, { price: Number(p.price), currency: p.currency }]),
-  );
+  const priceMap =
+    opts.preloaded?.priceMap ??
+    (await queryPriceMap(accounts.flatMap((a) => a.holdings.map((h) => h.symbol))));
 
   let totalAssets = 0;
   let totalLiabilities = 0;

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,6 +1,10 @@
 import "server-only";
 import { prisma } from "@/lib/prisma";
-import { computeNetWorthSummary, getCachedNetWorthSummary } from "./net-worth-service";
+import {
+  computeNetWorthSummary,
+  getCachedNetWorthSummary,
+  type NetWorthInputs,
+} from "./net-worth-service";
 import { taiwanCalendarDay } from "@/lib/app-day";
 
 /**
@@ -13,15 +17,23 @@ import { taiwanCalendarDay } from "@/lib/app-day";
  * cached summary (tagged with exactly those tags) serves the PREVIOUS cycle's
  * numbers while the fresh value loads in the background. Snapshotting that read
  * shifted the whole persisted history one day (#640).
+ *
+ * `preloaded` carries inputs the caller already bulk-loaded, so a multi-user
+ * sweep costs a fixed number of queries instead of three per user (#641). It
+ * only changes where the data comes from, never the arithmetic.
  */
 export async function createSnapshot(
   userId: string,
   baseCurrency: string,
-  opts: { fresh?: boolean } = {},
+  opts: { fresh?: boolean; preloaded?: NetWorthInputs } = {},
 ) {
-  const summary = opts.fresh
-    ? await computeNetWorthSummary(userId, baseCurrency, { fresh: true })
-    : await getCachedNetWorthSummary(userId, baseCurrency);
+  const summary =
+    opts.fresh || opts.preloaded
+      ? await computeNetWorthSummary(userId, baseCurrency, {
+          fresh: true,
+          preloaded: opts.preloaded,
+        })
+      : await getCachedNetWorthSummary(userId, baseCurrency);
   const snapshotTakenAt = new Date();
   // The cron fires at 21:30 UTC = 05:30 Taiwan time (#49) so the run lands just
   // after midnight local. Floor to the *Taiwan* calendar day (shift +8h before

--- a/tests/unit/batch.test.ts
+++ b/tests/unit/batch.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { chunk, mapSettled } from "@/lib/batch";
+
+describe("chunk", () => {
+  it("splits into fixed-size pages, last page short", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns no pages for an empty input", () => {
+    expect(chunk([], 10)).toEqual([]);
+  });
+
+  it("rejects a nonsensical size rather than looping forever", () => {
+    expect(() => chunk([1], 0)).toThrow(/size must be >= 1/);
+  });
+});
+
+describe("mapSettled", () => {
+  it("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapSettled(
+      Array.from({ length: 30 }, (_, i) => i),
+      4,
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 1));
+        inFlight -= 1;
+      },
+    );
+
+    expect(peak).toBeLessThanOrEqual(4);
+    // Guard against the cap being applied so aggressively it serialises: with 30
+    // items and a limit of 4 the pool should genuinely saturate.
+    expect(peak).toBe(4);
+  });
+
+  it("returns results in input order, not completion order", async () => {
+    const results = await mapSettled([30, 1, 20, 2], 4, async (delay) => {
+      await new Promise((r) => setTimeout(r, delay));
+      return delay;
+    });
+
+    expect(results.map((r) => (r.status === "fulfilled" ? r.value : null))).toEqual([30, 1, 20, 2]);
+  });
+
+  it("isolates failures — same contract as Promise.allSettled", async () => {
+    const results = await mapSettled([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error("boom");
+      return n;
+    });
+
+    expect(results.map((r) => r.status)).toEqual(["fulfilled", "rejected", "fulfilled"]);
+    expect(results[1].status === "rejected" && String(results[1].reason)).toContain("boom");
+  });
+
+  it("keeps draining after a failure instead of stopping the pool", async () => {
+    const seen: number[] = [];
+
+    await mapSettled([1, 2, 3, 4, 5], 1, async (n) => {
+      seen.push(n);
+      if (n <= 2) throw new Error("early failure");
+      return n;
+    });
+
+    expect(seen).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("handles an empty input without hanging", async () => {
+    await expect(mapSettled([], 4, async () => 1)).resolves.toEqual([]);
+  });
+
+  it("rejects a nonsensical limit rather than hanging on zero workers", async () => {
+    await expect(mapSettled([1], 0, async () => 1)).rejects.toThrow(/limit must be >= 1/);
+  });
+});

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -6,6 +6,14 @@ const h = vi.hoisted(() => ({
   optionSweepGuardFails: false,
   users: [{ id: "user1", appSettings: { baseCurrency: "USD" } }],
   snapshotFailures: new Set<string>(),
+  /** #641 — how many times the global FX map was loaded across the whole run. */
+  rateMapLoads: 0,
+  /** #641 — one entry per bulk input load, holding that page's user ids. */
+  inputLoads: [] as string[][],
+  /** Opts each createSnapshot call received, to prove preloaded inputs are used. */
+  snapshotOpts: [] as unknown[],
+  rateRefreshes: [] as string[],
+  rateRefreshFailures: new Set<string>(),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -28,7 +36,22 @@ vi.mock("@/lib/sentry-cron", () => ({
 }));
 
 vi.mock("@/lib/services/exchange-rate-service", () => ({
-  refreshExchangeRates: vi.fn(async () => ({ updated: 0, changed: 0 })),
+  refreshExchangeRates: vi.fn(async (currency: string) => {
+    h.rateRefreshes.push(currency);
+    if (h.rateRefreshFailures.has(currency)) throw new Error(`rate refresh failed for ${currency}`);
+    return { updated: 0, changed: 0 };
+  }),
+  getFreshExchangeRates: vi.fn(async () => {
+    h.rateMapLoads += 1;
+    return new Map<string, number>();
+  }),
+}));
+
+vi.mock("@/lib/services/net-worth-service", () => ({
+  loadNetWorthInputsForUsers: vi.fn(async (userIds: string[]) => {
+    h.inputLoads.push(userIds);
+    return new Map(userIds.map((id) => [id, { accounts: [], ratesMap: new Map(), priceMap: {} }]));
+  }),
 }));
 
 vi.mock("@/lib/services/price-service", () => ({
@@ -44,8 +67,9 @@ vi.mock("@/lib/services/recurring-investment-service", () => ({
 }));
 
 vi.mock("@/lib/services/snapshot-service", () => ({
-  createSnapshot: vi.fn(async (userId: string) => {
+  createSnapshot: vi.fn(async (userId: string, _baseCurrency: string, opts?: unknown) => {
     h.events.push(`snapshot:${userId}`);
+    h.snapshotOpts.push(opts);
     if (h.snapshotFailures.has(userId)) throw new Error(`snapshot failed for ${userId}`);
     return { id: `snapshot-${userId}` };
   }),
@@ -92,6 +116,11 @@ describe("snapshot cron route", () => {
     h.optionSweepGuardFails = false;
     h.users = [{ id: "user1", appSettings: { baseCurrency: "USD" } }];
     h.snapshotFailures = new Set();
+    h.rateMapLoads = 0;
+    h.inputLoads = [];
+    h.snapshotOpts = [];
+    h.rateRefreshes = [];
+    h.rateRefreshFailures = new Set();
   });
 
   it("invalidates net worth before snapshot creation when options expire", async () => {
@@ -245,8 +274,85 @@ describe("snapshot cron route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith("user1", "USD", { fresh: true });
-    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith("user2", "TWD", { fresh: true });
+    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith(
+      "user1",
+      "USD",
+      expect.objectContaining({ fresh: true }),
+    );
+    expect(vi.mocked(createSnapshot)).toHaveBeenCalledWith(
+      "user2",
+      "TWD",
+      expect.objectContaining({ fresh: true }),
+    );
+    // The bulk loader reads directly (no `"use cache"`), so preloaded inputs are
+    // fresh by construction — but they must actually be handed over, or
+    // createSnapshot silently falls back to per-user queries.
+    for (const opts of h.snapshotOpts) {
+      expect(opts).toHaveProperty("preloaded");
+      expect((opts as { preloaded?: unknown }).preloaded).toBeDefined();
+    }
+  });
+
+  // Regression #641: reads used to be per-user and unbounded in flight, so the
+  // cron's round-trips grew linearly with the instance and exhausted the pool.
+  describe("bulk loading (#641)", () => {
+    const manyUsers = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `user${i}`,
+        appSettings: { baseCurrency: "USD" },
+      }));
+
+    it("loads the global FX map once for the whole run, not once per user", async () => {
+      h.users = manyUsers(25);
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(h.rateMapLoads).toBe(1);
+    });
+
+    it("bulk-loads net-worth inputs once per page, covering every user exactly once", async () => {
+      h.users = manyUsers(25);
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+
+      await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      // 25 users fit in one page (USER_PAGE_SIZE = 200), so one load — the point
+      // is that it is a fixed count, not 25.
+      expect(h.inputLoads).toHaveLength(1);
+      expect(h.inputLoads.flat()).toEqual(h.users.map((u) => u.id));
+      expect(h.events.filter((e) => e.startsWith("snapshot:"))).toHaveLength(25);
+    });
+
+    it("keeps sweeping when one currency's rate refresh throws", async () => {
+      h.rateRefreshFailures = new Set(["USD"]);
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { log } = await import("@/lib/logger");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      // Previously a single rejected currency aborted the entire run via
+      // Promise.all, losing that day's snapshot for everyone.
+      expect(response.status).toBe(200);
+      expect(h.events).toContain("snapshot:user1");
+      expect(log.warn).toHaveBeenCalledWith(
+        "cron.rates.currency_failed",
+        expect.objectContaining({ error: expect.stringContaining("USD") }),
+      );
+    });
   });
 
   it("materializes recurring rules for the Taiwan calendar day", async () => {

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -123,7 +123,7 @@ vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
   return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
 });
 
-const { getCachedNetWorthSummary, computeNetWorthSummary } =
+const { getCachedNetWorthSummary, computeNetWorthSummary, loadNetWorthInputsForUsers } =
   await import("@/lib/services/net-worth-service");
 
 describe("getCachedNetWorthSummary (two-pass valuation)", () => {
@@ -337,5 +337,106 @@ describe("computeNetWorthSummary({ fresh: true })", () => {
     expect(summary.totalAssets).toBeCloseTo(3000); // stale 1:1 map
     expect(vi.mocked(getAllExchangeRates)).toHaveBeenCalled();
     expect(h.tags).toContain("accounts");
+  });
+});
+
+// Regression #641: the cron used to call computeNetWorthSummary once per user,
+// so its DB round-trips grew linearly with the instance and ran unbounded in
+// flight. Inputs are now bulk-loaded and injected. The refactor is only allowed
+// to change WHERE the data comes from — never the arithmetic.
+describe("loadNetWorthInputsForUsers (bulk path)", () => {
+  const fixture = () => {
+    h.rates = new Map();
+    h.freshRates = new Map([["USD_TWD", 30]]);
+    h.prices = [
+      { symbol: "AAPL", price: 200, currency: "USD" },
+      { symbol: "2330.TW", price: 900, currency: "TWD" },
+    ];
+    h.accounts = [
+      account({
+        id: "brokerage",
+        type: "ASSET",
+        currency: "USD",
+        cashBalance: 500,
+        holdings: [
+          holding({ id: "h1", accountId: "brokerage", symbol: "AAPL", quantity: 3 }),
+          holding({
+            id: "h2",
+            accountId: "brokerage",
+            symbol: "2330.TW",
+            quantity: 10,
+            currency: "TWD",
+          }),
+        ],
+      }),
+      account({ id: "loan", type: "LIABILITY", currency: "TWD", cashBalance: 6000 }),
+    ];
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.warnings = [];
+    h.tags = [];
+  });
+
+  it("produces byte-identical summaries to the per-user fresh path", async () => {
+    fixture();
+    const perUser = await computeNetWorthSummary("u1", "USD", { fresh: true });
+
+    fixture();
+    const { getFreshExchangeRates } = await import("@/lib/services/exchange-rate-service");
+    const inputs = await loadNetWorthInputsForUsers(["u1"], await getFreshExchangeRates());
+    const bulk = await computeNetWorthSummary("u1", "USD", {
+      fresh: true,
+      preloaded: inputs.get("u1"),
+    });
+
+    expect(bulk).toEqual(perUser);
+    // Sanity: the fixture actually exercises FX + prices, so "identical" means
+    // something. 500 cash + 3*200 AAPL + 10*900 TWD/30 = 1400.
+    expect(bulk.totalAssets).toBeCloseTo(1400);
+    expect(bulk.totalLiabilities).toBeCloseTo(200);
+  });
+
+  it("costs a fixed number of queries regardless of user count", async () => {
+    fixture();
+    const { prisma } = await import("@/lib/prisma");
+    const { getFreshExchangeRates } = await import("@/lib/services/exchange-rate-service");
+    const userIds = Array.from({ length: 50 }, (_, i) => `u${i}`);
+
+    const ratesMap = await getFreshExchangeRates();
+    vi.clearAllMocks();
+    await loadNetWorthInputsForUsers(userIds, ratesMap);
+
+    // One accounts query + one price query for all 50 users. The per-user path
+    // would have issued 50 of each, plus 50 ExchangeRate scans.
+    expect(vi.mocked(prisma.account.findMany)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(prisma.priceCache.findMany)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(prisma.exchangeRate.findMany)).not.toHaveBeenCalled();
+  });
+
+  it("gives users with no active accounts an entry, so they still get snapshotted", async () => {
+    h.accounts = [];
+    h.prices = [];
+    h.freshRates = new Map();
+
+    const inputs = await loadNetWorthInputsForUsers(["ghost"], new Map());
+
+    expect(inputs.get("ghost")).toEqual({ accounts: [], ratesMap: new Map(), priceMap: {} });
+    const summary = await computeNetWorthSummary("ghost", "USD", {
+      fresh: true,
+      preloaded: inputs.get("ghost"),
+    });
+    expect(summary.netWorth).toBe(0);
+  });
+
+  it("skips the price query entirely when no user holds anything", async () => {
+    h.accounts = [account({ id: "cash", type: "ASSET", currency: "USD", cashBalance: 10 })];
+    const { prisma } = await import("@/lib/prisma");
+    vi.clearAllMocks();
+
+    await loadNetWorthInputsForUsers(["u1"], new Map());
+
+    expect(vi.mocked(prisma.priceCache.findMany)).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Stacked on #646 — **base is `fix/640-cron-stale-snapshot`, so merge #646 first.** This PR's own diff is the two commits above that branch.

Fixes #641. Also folds in the follow-up flagged in #646's review: `getFreshExchangeRates()` was called once per user per run.

## The problem

The cron had three unbounded fan-outs inside a 60 s `maxDuration`: one external FX round-trip per currency in use, and (after #646) three DB queries per user, all in flight at once. Round-trips grew linearly with the instance, so a large enough tenant exhausts the Neon pool or blows the budget — and a blown budget loses that day's snapshot for **every** user, permanently, since `createSnapshot` always stamps *today* and nothing backfills.

## Approach: batch the reads, don't just cap concurrency

A concurrency cap alone trades throughput for stability — strictly slower. Batching the reads makes this a net win, so the caps only ever matter at the point where the old code would have fallen over.

- **FX map loaded once per run** and passed down, instead of one full `ExchangeRate` scan per user.
- **`loadNetWorthInputsForUsers()`** — one accounts+holdings query and one price query per *page* of users, instead of three queries each.
- `computeNetWorthSummary` / `createSnapshot` accept `preloaded` inputs. Arithmetic untouched; only the data source changes.
- **Users paged (200)** so memory is bounded too, and the remaining per-user work — now just the upsert — capped at 10 concurrent writes.
- **FX refreshes capped at 5** and *settled* instead of `Promise.all`, so one currency's failure can no longer abort the whole run.
- **The ~320-clause per-pair `OR`** in `refreshExchangeRates` replaced with two clauses; every row written has `baseCurrency` on one side.
- Users selected as `id + baseCurrency` only, and one run-summary log line instead of one per user.

### Query count, measured

| Users | Before | After |
|---|---|---|
| 1 | 3 | 3 |
| 50 | 150 | 3 |
| 200 | 600 | 3 |

Asserted in `net-worth-service.test.ts` → *"costs a fixed number of queries regardless of user count"*.

## Does anything get slower?

- **Render paths: unchanged.** They keep the cached readers; `preloaded` is cron-only.
- **Small instances: unchanged.** All three bounds are ceilings, not targets. With ≤5 currencies and ≤200 users nothing waits on anything.
- **Large instances: the FX refresh may take one or two extra waves.** Each call is capped at `RATE_FETCH_TIMEOUT_MS` (1.2 s), so 20 currencies at 5 concurrent is ~4 waves ≈ 5 s worst case vs ~1.2 s unbounded. That is bought back many times over by dropping 3N reads to 3, and an unbounded fan-out is what gets the FX source to throttle us by IP in the first place.

## Behaviour changes worth reviewing

1. **A rejected FX currency no longer aborts the run** (was `Promise.all`). It is logged as `cron.rates.currency_failed` and excluded from the updated/changed totals. This matches how per-user snapshot failures were already isolated. Test: *"keeps sweeping when one currency's rate refresh throws"*.
2. **Per-user `cron.snapshot.create` log line removed**, replaced by one `cron.snapshot.summary`. At N users the per-user line was noise.
3. `#646`'s cron assertion relaxed from `toHaveBeenCalledWith(..., { fresh: true })` to `objectContaining({ fresh: true })`, since opts now also carry `preloaded`. The freshness guarantee is **not** weakened — the same test additionally asserts every call receives `preloaded`, and `loadNetWorthInputsForUsers` reads directly with no `"use cache"`, so it is fresh by construction.

## Verification

`pnpm typecheck` / `lint` / `format:check` clean; `pnpm test:unit` 443/443 on Node 24.6.0. `git status` clean after each commit (the lint-staged re-stage bug did not bite — files were pre-formatted before staging).

**Tests proven to fail without the fix.** With `src/` reverted to the #646 baseline and only the test changes applied, 4 of the cron tests fail:

```
× asks for a fresh (uncached) summary when creating each snapshot
× loads the global FX map once for the whole run, not once per user
× bulk-loads net-worth inputs once per page, covering every user exactly once
× keeps sweeping when one currency's rate refresh throws
```

New coverage: 12 tests across `batch.test.ts` (concurrency ceiling actually saturates, input ordering, failure isolation, pool keeps draining after a failure, empty input, invalid limit) and the parity/query-count/no-accounts/no-holdings cases above.

## Not done

- **No live cron run.** Query counts are asserted against mocked Prisma, and the concurrency ceiling is asserted against `mapSettled` directly — but no real deployment was exercised. The numbers to watch on the first real run are `cron.snapshot.summary` and the `durationMs` on the `CronRun` row.
- The concurrency numbers are fixed constants, not config. Marked with a `ponytail:` comment — tune in place rather than adding env plumbing nobody sets.
- `#642` (Yahoo batch amplification) is untouched and still the largest remaining risk to this cron's budget: `refreshAllPrices()` still sends every symbol in one request and, on failure, retries each individually in parallel.

https://claude.ai/code/session_01Yb6TkdYpoQiyKKMgUixeAQ
