### PR TITLE
fix(prices): chunk Yahoo/CoinGecko batches and cap the failure fan-out

### DIFF
--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,13 +1,36 @@
 import "server-only";
 import { revalidateTag, unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { getYahooClient } from "@/lib/services/yahoo-client";
+import { getYahooClient, getYahooErrorStatus } from "@/lib/services/yahoo-client";
 import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log, withTiming } from "@/lib/logger";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
 const CLAIM_LOCK_TTL_MS = 30_000; // dead-instance TTL for refreshingAt claim
+
+// Batching limits. On the cron path the symbol list is the union of every
+// user's holdings and watchlist entries, so an unchunked request grows with the
+// instance rather than with any one user. Yahoo's `quote` is comfortable with
+// ~50 symbols per call; 3 chunks in flight keeps a 250-symbol universe to two
+// waves without presenting as a burst. The fallback cap is deliberately lower
+// than the number of symbols it replaces: answering one upstream failure with
+// one request per symbol is what turns a rate-limit into an outage.
+const YAHOO_CHUNK_SIZE = 50;
+const YAHOO_CHUNK_CONCURRENCY = 3;
+const YAHOO_FALLBACK_CONCURRENCY = 4;
+
+// CoinGecko's free tier rate-limits far more aggressively than Yahoo, so ids
+// are chunked mainly to bound the query string and are run only 2 at a time.
+const COINGECKO_CHUNK_SIZE = 50;
+const COINGECKO_CONCURRENCY = 2;
+
+// Wall-clock budgets. The cron route has a 60 s maxDuration and price refresh is
+// only its first step, so neither provider may consume the whole window. The
+// guard stops *queueing* work; one already-dispatched request can still run to
+// its FETCH_TIMEOUT_MS, which bounds the real ceiling at budget + 5 s.
+const YAHOO_BUDGET_MS = 15_000;
+const COINGECKO_BUDGET_MS = 8_000;
 
 export type RefreshPricesResult = {
   updated: number;
@@ -39,8 +62,73 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+// ponytail: `chunk` and `runPool` are deliberately local. PR #647 introduces
+// `src/lib/batch.ts` with equivalent `chunk`/`mapSettled` helpers; collapse
+// these into that module once it lands rather than keeping two copies.
+function chunk<T>(items: T[], size: number): T[][] {
+  const groups: T[][] = [];
+  for (let i = 0; i < items.length; i += size) groups.push(items.slice(i, i + size));
+  return groups;
+}
+
+/**
+ * Run `worker` over `items` with at most `limit` of them in flight. Per-item
+ * rejections are swallowed (the worker owns its own logging) so the pool always
+ * drains to the end instead of losing the remaining items to one failure.
+ *
+ * `shouldStop` is polled before each item is dispatched, so a blown wall-clock
+ * budget stops queueing new upstream calls instead of letting a slow tail run on
+ * past the caller's deadline.
+ */
+async function runPool<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+  shouldStop: () => boolean = () => false,
+): Promise<void> {
+  let next = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      if (shouldStop()) return;
+      const item = items[next++];
+      try {
+        await worker(item);
+      } catch {
+        // Worker-level concern; never let one item abort the pool.
+      }
+    }
+  });
+  await Promise.all(runners);
+}
+
+/** Returns a predicate that flips true once `budgetMs` of wall clock has elapsed. */
+function deadlineGuard(budgetMs: number): () => boolean {
+  const deadline = Date.now() + budgetMs;
+  return () => Date.now() >= deadline;
+}
+
+/**
+ * A rate-limit is the one failure class where retrying is strictly harmful: the
+ * ladder re-hits an endpoint that has explicitly told us to back off, and the
+ * upstream cool-off outlives our 500 ms / 1.5 s delays by orders of magnitude.
+ * Detected both from yahoo-finance2's numeric `code` and from message text, so
+ * CoinGecko's `HTTP 429` is covered by the same rule.
+ */
+function isRateLimited(err: unknown): boolean {
+  if (getYahooErrorStatus(err) === 429) return true;
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    /\b429\b/.test(err.message) || msg.includes("too many requests") || msg.includes("rate limit")
+  );
+}
+
 function isRetryable(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
+  // Checked before everything below: the 5xx regex would otherwise match a
+  // rate-limit message that merely carries a 5xx-looking token (a `Retry-After`
+  // hint, an edge-node id), turning one 429 into three.
+  if (isRateLimited(err)) return false;
   if (err.name === "AbortError" || err.name === "TimeoutError") return true;
   const msg = err.message.toLowerCase();
   return (
@@ -53,14 +141,20 @@ function isRetryable(err: unknown): boolean {
   );
 }
 
-async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  shouldStop: () => boolean = () => false,
+): Promise<T> {
   let lastError: unknown;
   for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
     try {
       return await fn();
     } catch (err) {
       lastError = err;
-      if (attempt < RETRY_DELAYS_MS.length && isRetryable(err)) {
+      // `shouldStop` keeps the ladder inside the caller's budget: without it a
+      // request dispatched just before the deadline could still add ~17 s of
+      // timeouts and backoff on top of it.
+      if (attempt < RETRY_DELAYS_MS.length && isRetryable(err) && !shouldStop()) {
         await sleep(RETRY_DELAYS_MS[attempt]);
       } else {
         break;
@@ -132,15 +226,22 @@ async function fetchYahooQuotes(
   if (symbols.length === 0) return results;
 
   const yahooFinance = await getYahooClient();
+  const outOfBudget = deadlineGuard(YAHOO_BUDGET_MS);
 
+  // The timeout is per request, so after chunking it applies per chunk.
   const fetchSymbols = async (syms: string[]) => {
-    const quotes = await withRetry(() =>
-      Promise.race([
-        yahooFinance.quote(syms),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Yahoo Finance request timed out")), FETCH_TIMEOUT_MS),
-        ),
-      ]),
+    const quotes = await withRetry(
+      () =>
+        Promise.race([
+          yahooFinance.quote(syms),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("Yahoo Finance request timed out")),
+              FETCH_TIMEOUT_MS,
+            ),
+          ),
+        ]),
+      outOfBudget,
     );
     for (const q of Array.isArray(quotes) ? quotes : [quotes]) {
       if (q?.regularMarketPrice && q.symbol) {
@@ -152,23 +253,47 @@ async function fetchYahooQuotes(
     }
   };
 
-  try {
-    await withTiming("price.yahoo.fetch", () => fetchSymbols(symbols), {
-      symbolCount: symbols.length,
-    });
-  } catch (batchErr) {
-    // Batch failed after retries — fall back to per-symbol to isolate bad tickers
-    log.error("price.yahoo.batch_failed", { error: String(batchErr) });
-    await Promise.allSettled(
-      symbols.map(async (symbol) => {
-        try {
-          await fetchSymbols([symbol]);
-        } catch (err) {
-          log.error("price.yahoo.symbol_failed", { symbol, error: String(err) });
-        }
-      }),
-    );
-  }
+  const groups = chunk(symbols, YAHOO_CHUNK_SIZE);
+
+  await withTiming(
+    "price.yahoo.fetch",
+    () =>
+      runPool(
+        groups,
+        YAHOO_CHUNK_CONCURRENCY,
+        async (group) => {
+          try {
+            await fetchSymbols(group);
+          } catch (batchErr) {
+            log.error("price.yahoo.batch_failed", {
+              error: String(batchErr),
+              symbolCount: group.length,
+            });
+            // Isolate bad tickers for *this chunk only*. Falling back over the
+            // whole symbol list is what made one failed request fan out to one
+            // request per symbol across every user's holdings.
+            //
+            // A single-symbol chunk is skipped outright: the per-symbol retry
+            // would repeat the exact call that just failed.
+            if (group.length === 1) return;
+            await runPool(
+              group,
+              YAHOO_FALLBACK_CONCURRENCY,
+              async (symbol) => {
+                try {
+                  await fetchSymbols([symbol]);
+                } catch (err) {
+                  log.error("price.yahoo.symbol_failed", { symbol, error: String(err) });
+                }
+              },
+              outOfBudget,
+            );
+          }
+        },
+        outOfBudget,
+      ),
+    { symbolCount: symbols.length, chunkCount: groups.length },
+  );
 
   return results;
 }
@@ -213,38 +338,53 @@ export async function fetchCryptoPrices(
       return { original: s, base, geckoId, quoteCurrency };
     });
 
-    const ids = symbolMap.map((s) => s.geckoId).filter(Boolean);
+    // Deduplicated: several pairs can share one id (BTC-USD and BTC-EUR are both
+    // "bitcoin"), and repeating it only inflates the query string.
+    const ids = [...new Set(symbolMap.map((s) => s.geckoId).filter(Boolean))];
     const vsCurrencies = [...new Set(symbolMap.map((s) => s.quoteCurrency.toLowerCase()))];
     if (ids.length > 0) {
-      const url = `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(",")}&vs_currencies=${vsCurrencies.join(",")}`;
-      try {
-        const data = await withTiming(
-          "price.coingecko.fetch",
-          () =>
-            withRetry(async () => {
-              const controller = new AbortController();
-              const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-              try {
-                const res = await fetch(url, {
-                  signal: controller.signal,
-                  next: { revalidate: 60, tags: ["prices:crypto"] },
-                } as RequestInit);
-                if (!res.ok) throw new Error(`CoinGecko returned HTTP ${res.status}`);
-                return res.json() as Promise<Record<string, Record<string, number>>>;
-              } finally {
-                clearTimeout(timeoutId);
-              }
-            }),
-          { idCount: ids.length },
-        );
-        for (const { original, geckoId, quoteCurrency } of symbolMap) {
-          const price = data[geckoId]?.[quoteCurrency.toLowerCase()];
-          if (price) {
-            results.set(original, { price, currency: quoteCurrency });
+      const data: Record<string, Record<string, number>> = {};
+      const outOfBudget = deadlineGuard(COINGECKO_BUDGET_MS);
+      // Chunked so the query string stays bounded regardless of how many
+      // distinct coins the instance holds. A chunk that fails no longer costs
+      // the run every other chunk's prices.
+      await runPool(
+        chunk(ids, COINGECKO_CHUNK_SIZE),
+        COINGECKO_CONCURRENCY,
+        async (idGroup) => {
+          const url = `https://api.coingecko.com/api/v3/simple/price?ids=${idGroup.join(",")}&vs_currencies=${vsCurrencies.join(",")}`;
+          try {
+            const part = await withTiming(
+              "price.coingecko.fetch",
+              () =>
+                withRetry(async () => {
+                  const controller = new AbortController();
+                  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+                  try {
+                    const res = await fetch(url, {
+                      signal: controller.signal,
+                      next: { revalidate: 60, tags: ["prices:crypto"] },
+                    } as RequestInit);
+                    if (!res.ok) throw new Error(`CoinGecko returned HTTP ${res.status}`);
+                    return res.json() as Promise<Record<string, Record<string, number>>>;
+                  } finally {
+                    clearTimeout(timeoutId);
+                  }
+                }, outOfBudget),
+              { idCount: idGroup.length },
+            );
+            Object.assign(data, part);
+          } catch (error) {
+            log.error("price.coingecko.failed", { error: String(error) });
           }
+        },
+        outOfBudget,
+      );
+      for (const { original, geckoId, quoteCurrency } of symbolMap) {
+        const price = data[geckoId]?.[quoteCurrency.toLowerCase()];
+        if (price) {
+          results.set(original, { price, currency: quoteCurrency });
         }
-      } catch (error) {
-        log.error("price.coingecko.failed", { error: String(error) });
       }
     }
   }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getYahooClient, getYahooErrorStatus } from "@/lib/services/yahoo-client";
 import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log, withTiming } from "@/lib/logger";
+import { chunk } from "@/lib/batch";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
@@ -23,6 +24,7 @@ const YAHOO_FALLBACK_CONCURRENCY = 4;
 // CoinGecko's free tier rate-limits far more aggressively than Yahoo, so ids
 // are chunked mainly to bound the query string and are run only 2 at a time.
 const COINGECKO_CHUNK_SIZE = 50;
+const COINGECKO_CURRENCY_CHUNK_SIZE = 50;
 const COINGECKO_CONCURRENCY = 2;
 
 // Wall-clock budgets. The cron route has a 60 s maxDuration and price refresh is
@@ -60,15 +62,6 @@ function decimalChangedAtDbScale(current: unknown, next: number): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-// ponytail: `chunk` and `runPool` are deliberately local. PR #647 introduces
-// `src/lib/batch.ts` with equivalent `chunk`/`mapSettled` helpers; collapse
-// these into that module once it lands rather than keeping two copies.
-function chunk<T>(items: T[], size: number): T[][] {
-  const groups: T[][] = [];
-  for (let i = 0; i < items.length; i += size) groups.push(items.slice(i, i + size));
-  return groups;
 }
 
 /**
@@ -156,6 +149,7 @@ async function withRetry<T>(
       // timeouts and backoff on top of it.
       if (attempt < RETRY_DELAYS_MS.length && isRetryable(err) && !shouldStop()) {
         await sleep(RETRY_DELAYS_MS[attempt]);
+        if (shouldStop()) break;
       } else {
         break;
       }
@@ -269,6 +263,9 @@ async function fetchYahooQuotes(
               error: String(batchErr),
               symbolCount: group.length,
             });
+            // A rate-limited batch must not fan out into one request per symbol:
+            // that would amplify the exact upstream signal telling us to stop.
+            if (isRateLimited(batchErr)) return;
             // Isolate bad tickers for *this chunk only*. Falling back over the
             // whole symbol list is what made one failed request fan out to one
             // request per symbol across every user's holdings.
@@ -345,14 +342,22 @@ export async function fetchCryptoPrices(
     if (ids.length > 0) {
       const data: Record<string, Record<string, number>> = {};
       const outOfBudget = deadlineGuard(COINGECKO_BUDGET_MS);
-      // Chunked so the query string stays bounded regardless of how many
-      // distinct coins the instance holds. A chunk that fails no longer costs
-      // the run every other chunk's prices.
+      const requests = chunk(ids, COINGECKO_CHUNK_SIZE).flatMap((idGroup) =>
+        chunk(vsCurrencies, COINGECKO_CURRENCY_CHUNK_SIZE).map((currencyGroup) => ({
+          idGroup,
+          currencyGroup,
+        })),
+      );
+      // Chunk both query dimensions so neither a large coin universe nor a
+      // large quote-currency set can grow the URL without bound. A request that
+      // fails no longer costs the run every other chunk's prices.
       await runPool(
-        chunk(ids, COINGECKO_CHUNK_SIZE),
+        requests,
         COINGECKO_CONCURRENCY,
-        async (idGroup) => {
-          const url = `https://api.coingecko.com/api/v3/simple/price?ids=${idGroup.join(",")}&vs_currencies=${vsCurrencies.join(",")}`;
+        async ({ idGroup, currencyGroup }) => {
+          const url = new URL("https://api.coingecko.com/api/v3/simple/price");
+          url.searchParams.set("ids", idGroup.join(","));
+          url.searchParams.set("vs_currencies", currencyGroup.join(","));
           try {
             const part = await withTiming(
               "price.coingecko.fetch",
@@ -371,9 +376,11 @@ export async function fetchCryptoPrices(
                     clearTimeout(timeoutId);
                   }
                 }, outOfBudget),
-              { idCount: idGroup.length },
+              { idCount: idGroup.length, currencyCount: currencyGroup.length },
             );
-            Object.assign(data, part);
+            for (const [id, prices] of Object.entries(part)) {
+              data[id] = { ...data[id], ...prices };
+            }
           } catch (error) {
             log.error("price.coingecko.failed", { error: String(error) });
           }
@@ -602,10 +609,24 @@ async function refreshPricesForHoldings(
   let updated = 0;
   let changed = 0;
 
-  const [stockPrices, cryptoPrices] = await Promise.all([
+  const [stockResult, cryptoResult] = await Promise.allSettled([
     fetchStockPrices(stockSymbols),
     fetchCryptoPrices(cryptoSymbols),
   ]);
+  const stockPrices =
+    stockResult.status === "fulfilled"
+      ? stockResult.value
+      : new Map<string, { price: number; currency: string }>();
+  const cryptoPrices =
+    cryptoResult.status === "fulfilled"
+      ? cryptoResult.value
+      : new Map<string, { price: number; currency: string }>();
+  if (stockResult.status === "rejected") {
+    errors.push(`Stock price fetch failed: ${String(stockResult.reason)}`);
+  }
+  if (cryptoResult.status === "rejected") {
+    errors.push(`Crypto price fetch failed: ${String(cryptoResult.reason)}`);
+  }
 
   const allPrices = new Map([...stockPrices, ...cryptoPrices]);
 
@@ -618,7 +639,7 @@ async function refreshPricesForHoldings(
       updated: 0,
       changed: 0,
       skippedFresh,
-      errors: [],
+      errors,
       nextRefreshAt: null,
       retryAfterSeconds: null,
     };

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -15,7 +15,13 @@ vi.mock("@/lib/logger", () => ({
   log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   withTiming: <T>(_: string, fn: () => Promise<T>) => fn(),
 }));
-vi.mock("@/lib/services/yahoo-client");
+// Partial mock: only the client factory is stubbed. `getYahooErrorStatus` must
+// stay real because price-service reads the upstream HTTP status through it to
+// classify 429s, and a blanket auto-mock would make every status `undefined`.
+vi.mock("@/lib/services/yahoo-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/services/yahoo-client")>()),
+  getYahooClient: vi.fn(),
+}));
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
   unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
@@ -218,4 +224,172 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     expect(releasedSymbols).toContain("MSFT");
     expect(releasedSymbols).not.toContain("AAPL");
   });
+});
+
+// --- Batching / fan-out control (issue #642) -------------------------------
+// Numbers below mirror the constants in price-service.ts: chunk size 50, 3
+// chunks in flight, 4 per-symbol fallback requests in flight.
+
+/** No PriceCache rows => every symbol is "stale new", so the claim UPDATE is
+ *  skipped and the whole list goes to the fetcher. */
+function stubAllSymbolsFetchable() {
+  vi.mocked(prisma.priceCache.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.$executeRawUnsafe).mockResolvedValue(1 as never);
+}
+
+const quoteFor = (symbol: string) => ({ symbol, regularMarketPrice: 100, currency: "USD" });
+
+describe("fetchYahooQuotes — request chunking and bounded concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("splits a multi-chunk symbol list into several quote calls, none over the chunk size", async () => {
+    stubAllSymbolsFetchable();
+    const symbols = Array.from({ length: 120 }, (_, i) => `SYM${i}`);
+    const quote = vi.fn(async (syms: string[]) => syms.map(quoteFor));
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(symbols);
+
+    expect(result.updated).toBe(120);
+    // 120 symbols at a chunk size of 50 => 50 + 50 + 20
+    expect(quote).toHaveBeenCalledTimes(3);
+    for (const [syms] of quote.mock.calls) {
+      expect(syms.length).toBeLessThanOrEqual(50);
+    }
+    // Every symbol is still requested, exactly once, across the chunks
+    expect(quote.mock.calls.flatMap(([syms]) => syms).sort()).toEqual([...symbols].sort());
+  });
+
+  it("holds chunk requests at the concurrency cap without serialising them", async () => {
+    stubAllSymbolsFetchable();
+    const symbols = Array.from({ length: 250 }, (_, i) => `SYM${i}`); // 5 chunks
+    let inFlight = 0;
+    let peak = 0;
+    const quote = vi.fn(async (syms: string[]) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return syms.map(quoteFor);
+    });
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    expect((await refreshPricesForStockSymbols(symbols)).updated).toBe(250);
+    expect(quote).toHaveBeenCalledTimes(5);
+    expect(peak).toBeLessThanOrEqual(3); // never exceeds the cap
+    expect(peak).toBeGreaterThanOrEqual(3); // ...and reaches it, so the pool really overlaps
+  });
+
+  it("falls back per-symbol only for the chunk that failed, within the fallback cap", async () => {
+    stubAllSymbolsFetchable();
+    const symbols = Array.from({ length: 120 }, (_, i) => `SYM${i}`);
+    const failingChunk = symbols.slice(50, 100); // the middle chunk
+    const poison = "SYM60";
+    let inFlight = 0;
+    let peak = 0;
+    const quote = vi.fn(async (syms: string[]) => {
+      if (syms.length > 1) {
+        if (syms.includes(poison)) throw new Error("Quote not found for symbol");
+        return syms.map(quoteFor);
+      }
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+      if (syms[0] === poison) throw new Error("Quote not found for symbol");
+      return syms.map(quoteFor);
+    });
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(symbols);
+
+    const perSymbol = quote.mock.calls
+      .filter(([syms]) => syms.length === 1)
+      .map(([syms]) => syms[0]);
+    // The other 70 symbols are never dragged into the per-symbol path
+    expect(perSymbol.sort()).toEqual([...failingChunk].sort());
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThanOrEqual(4);
+    // 50 + 20 from the healthy chunks, plus 49 of 50 recovered from the failed one
+    expect(result.updated).toBe(119);
+  });
+
+  it("keeps prices from the chunks that succeeded when another chunk fails outright", async () => {
+    stubAllSymbolsFetchable();
+    const symbols = Array.from({ length: 120 }, (_, i) => `SYM${i}`);
+    const failingChunk = new Set(symbols.slice(50, 100));
+    // Every call touching the middle chunk fails, batch or per-symbol
+    const quote = vi.fn(async (syms: string[]) => {
+      if (syms.some((s) => failingChunk.has(s))) throw new Error("upstream unavailable");
+      return syms.map(quoteFor);
+    });
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(symbols);
+
+    // 50 from the first chunk + 20 from the last survive the middle chunk's loss
+    expect(result.updated).toBe(70);
+    const perSymbol = quote.mock.calls
+      .filter(([syms]) => syms.length === 1)
+      .map(([syms]) => syms[0]);
+    expect(perSymbol).toHaveLength(50);
+    expect(perSymbol.every((s) => failingChunk.has(s))).toBe(true);
+  });
+});
+
+describe("fetchYahooQuotes — a rate limit is not amplified by the retry ladder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Long timeouts so that on the pre-fix code these fail on the call-count
+  // assertion rather than on the ~4 s of retry backoff they would sit through.
+  it("does not retry a 429 reported through the error's numeric code", async () => {
+    stubAllSymbolsFetchable();
+    // yahoo-finance2's HTTPError shape. The message deliberately carries no 429
+    // text, only tokens the retryable-error test matches ("fetch failed", 503),
+    // so the rate limit is recognised solely from `code`.
+    const rateLimited = Object.assign(new Error("edge fetch failed (backend 503)"), { code: 429 });
+    const quote = vi.fn().mockRejectedValue(rateLimited);
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    // Exactly one attempt: no retry ladder, and no per-symbol fallback for a
+    // chunk that is already a single symbol.
+    expect(quote).toHaveBeenCalledTimes(1);
+    expect(result.updated).toBe(0);
+  }, 20_000);
+
+  it("does not retry a 429 reported only in the message text", async () => {
+    stubAllSymbolsFetchable();
+    // No numeric code — just the wire text, whose Retry-After hint contains a
+    // 5xx-looking token that the bare /\b5\d\d\b/ test would treat as retryable.
+    const quote = vi
+      .fn()
+      .mockRejectedValue(new Error("Request failed: 429 Too Many Requests (retry after 500 s)"));
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    expect(quote).toHaveBeenCalledTimes(1);
+    expect(result.updated).toBe(0);
+  }, 20_000);
+
+  it("still retries a genuine 5xx", async () => {
+    stubAllSymbolsFetchable();
+    const quote = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Yahoo returned HTTP 503"))
+      .mockResolvedValueOnce([quoteFor("AAPL")]);
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    // The 429 short-circuit must not have disarmed the ladder for real outages
+    expect(quote).toHaveBeenCalledTimes(2);
+    expect(result.updated).toBe(1);
+  }, 20_000);
 });

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // price-service imports server-only modules and external clients.
 // Stub them all so the unit suite needs no DB or network.
@@ -29,8 +29,12 @@ vi.mock("next/cache", () => ({
 
 const { prisma } = await import("@/lib/prisma");
 const { getYahooClient } = await import("@/lib/services/yahoo-client");
-const { refreshPricesForStockSymbols, refreshAllPrices, normalizeMinorCurrencyQuote } =
-  await import("@/lib/services/price-service");
+const {
+  fetchCryptoPrices,
+  refreshPricesForStockSymbols,
+  refreshAllPrices,
+  normalizeMinorCurrencyQuote,
+} = await import("@/lib/services/price-service");
 const { PRICE_REFRESH_TTL_MS } = await import("@/lib/refresh-policy");
 
 describe("normalizeMinorCurrencyQuote — minor-unit (pence/cents) normalization", () => {
@@ -178,6 +182,28 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     expect(getYahooClient).toHaveBeenCalled();
     expect(cleanupCall).toBeDefined();
     expect(result.updated).toBe(0);
+  });
+
+  it("releases the claim when the Yahoo client fails to initialize", async () => {
+    const staleDate = new Date(Date.now() - PRICE_REFRESH_TTL_MS - 5_000);
+
+    vi.mocked(prisma.priceCache.findMany).mockResolvedValueOnce([
+      { symbol: "AAPL", updatedAt: staleDate },
+    ] as never);
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce([{ symbol: "AAPL" }]);
+    vi.mocked(getYahooClient).mockRejectedValueOnce(new Error("client initialization failed"));
+    vi.mocked(prisma.$executeRawUnsafe).mockResolvedValueOnce(1);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    const cleanupCall = vi
+      .mocked(prisma.$executeRawUnsafe)
+      .mock.calls.find(
+        ([sql]) => typeof sql === "string" && /refreshingAt/i.test(sql) && /NULL/i.test(sql),
+      );
+    expect(cleanupCall).toBeDefined();
+    expect(result.updated).toBe(0);
+    expect(result.errors).toEqual([expect.stringContaining("client initialization failed")]);
   });
 
   it("releases only the unfetched claim on a partial fetch (one ticker missing)", async () => {
@@ -344,6 +370,10 @@ describe("fetchYahooQuotes — a rate limit is not amplified by the retry ladder
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // Long timeouts so that on the pre-fix code these fail on the call-count
   // assertion rather than on the ~4 s of retry backoff they would sit through.
   it("does not retry a 429 reported through the error's numeric code", async () => {
@@ -378,6 +408,41 @@ describe("fetchYahooQuotes — a rate limit is not amplified by the retry ladder
     expect(result.updated).toBe(0);
   }, 20_000);
 
+  it("does not fan a rate-limited batch out into per-symbol requests", async () => {
+    stubAllSymbolsFetchable();
+    const symbols = Array.from({ length: 50 }, (_, i) => `SYM${i}`);
+    const quote = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("edge fetch failed"), { code: 429 }));
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const result = await refreshPricesForStockSymbols(symbols);
+
+    expect(quote).toHaveBeenCalledTimes(1);
+    expect(result.updated).toBe(0);
+  });
+
+  it("does not start a retry after its backoff crosses the wall-clock budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    stubAllSymbolsFetchable();
+    const quote = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        vi.setSystemTime(new Date(Date.now() + 14_800));
+        return Promise.reject(new Error("Yahoo returned HTTP 503"));
+      })
+      .mockResolvedValueOnce([quoteFor("AAPL")]);
+    vi.mocked(getYahooClient).mockResolvedValue({ quote } as never);
+
+    const pending = refreshPricesForStockSymbols(["AAPL"]);
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await pending;
+
+    expect(quote).toHaveBeenCalledTimes(1);
+    expect(result.updated).toBe(0);
+  });
+
   it("still retries a genuine 5xx", async () => {
     stubAllSymbolsFetchable();
     const quote = vi
@@ -392,4 +457,92 @@ describe("fetchYahooQuotes — a rate limit is not amplified by the retry ladder
     expect(quote).toHaveBeenCalledTimes(2);
     expect(result.updated).toBe(1);
   }, 20_000);
+});
+
+function currencyCode(index: number): string {
+  return [2, 1, 0]
+    .map((power) => String.fromCharCode(65 + (Math.floor(index / 26 ** power) % 26)))
+    .join("");
+}
+
+function coinGeckoPayload(url: URL, price = 100): Record<string, Record<string, number>> {
+  const ids = url.searchParams.get("ids")?.split(",") ?? [];
+  const currencies = url.searchParams.get("vs_currencies")?.split(",") ?? [];
+  return Object.fromEntries(
+    ids.map((id) => [id, Object.fromEntries(currencies.map((currency) => [currency, price]))]),
+  );
+}
+
+describe("fetchCryptoPrices — bounded CoinGecko requests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds both ids and quote currencies while keeping at most two requests in flight", async () => {
+    const symbols = Array.from({ length: 55 }, (_, i) => `COIN${i}-${currencyCode(i)}`);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      inFlight--;
+      const url = new URL(String(input));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => coinGeckoPayload(url),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchCryptoPrices(symbols);
+
+    expect(result.size).toBe(55);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(peak).toBeGreaterThanOrEqual(2);
+    for (const [input] of fetchMock.mock.calls) {
+      const url = new URL(String(input));
+      expect(url.searchParams.get("ids")?.split(",").length).toBeLessThanOrEqual(50);
+      expect(url.searchParams.get("vs_currencies")?.split(",").length).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("keeps healthy CoinGecko chunks when one chunk is rate-limited without retrying it", async () => {
+    const symbols = Array.from({ length: 120 }, (_, i) => `COIN${i}-USD`);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      const ids = url.searchParams.get("ids")?.split(",") ?? [];
+      if (ids.includes("coin50")) {
+        return { ok: false, status: 429, json: async () => ({}) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => coinGeckoPayload(url),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchCryptoPrices(symbols);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.size).toBe(70);
+    expect(result.has("COIN0-USD")).toBe(true);
+    expect(result.has("COIN50-USD")).toBe(false);
+    expect(result.has("COIN119-USD")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Root cause

The cron-wide price refresh passes the union of every user's holdings and watchlist symbols into the provider layer. The old Yahoo path sent that whole universe in one `quote` call; after a batch failure it launched one request per symbol with `Promise.allSettled`, and every request could run its own retry ladder. A single upstream failure could therefore become as many as `3 × N` requests. CoinGecko likewise put every id into one URL.

## What changed

### Yahoo

- Split symbols into chunks of 50 using the shared `src/lib/batch.ts` helper.
- Run at most 3 Yahoo chunks concurrently.
- Scope per-symbol isolation to the failed chunk and cap it at 4 concurrent requests.
- Never enter per-symbol fallback when the failed batch is a 429. A 50-symbol rate-limited batch now produces 1 request, not 51.
- Treat numeric Yahoo `code: 429` and message-based rate limits as non-retryable, while retaining retries for genuine 5xx/network failures.
- Apply a 15 s scheduling budget and re-check the deadline after retry backoff, so a delay that crosses the deadline cannot start another request.

### CoinGecko

- Deduplicate CoinGecko ids.
- Chunk both URL dimensions: at most 50 ids and 50 `vs_currencies` per request.
- Build query parameters with `URLSearchParams` and run at most 2 requests concurrently.
- Deep-merge the id/currency response matrix across chunks.
- Preserve healthy chunk results when another chunk fails or returns 429; a 429 is not retried.
- Apply an 8 s scheduling/retry budget.

### Partial failures and claims

- Use `Promise.allSettled` for the stock and crypto provider branches so one unexpected provider rejection does not discard the other's successful prices.
- Surface unexpected provider failures in `RefreshPricesResult.errors`.
- Release all unfetched `refreshingAt` claims when a provider rejects, including Yahoo client initialization failures; successful/upserted symbols continue to clear their own claims normally.

## Limits

| Path | Chunk size | Concurrency | Budget |
| --- | ---: | ---: | ---: |
| Yahoo batch | 50 symbols | 3 | 15 s |
| Yahoo per-symbol isolation | failed chunk only | 4 | shared Yahoo budget |
| CoinGecko | 50 ids × 50 quote currencies | 2 | 8 s |

The stock and crypto Yahoo pools remain independent, so one refresh can have up to 6 Yahoo requests in flight. A cross-run circuit breaker remains out of scope because it requires state beyond one request.

## Regression coverage

`tests/unit/price-service.test.ts` now covers:

- Yahoo chunk size and 3-wide overlap.
- Failure isolation to one chunk and 4-wide fallback.
- Healthy Yahoo chunks surviving a failed chunk.
- Numeric and message-based 429s skipping retry.
- A multi-symbol 429 batch skipping per-symbol fan-out (51 calls before the follow-up fix, 1 after).
- Genuine 503 retry behavior.
- Retry backoff crossing the wall-clock deadline without starting a new attempt.
- CoinGecko id/currency URL bounds and 2-wide overlap.
- Deep merging of the CoinGecko id/currency request matrix.
- Healthy CoinGecko chunks surviving a 429 chunk with no retry.
- Claim cleanup when Yahoo returns no prices, partially returns prices, or fails during client initialization.

The new review tests were run against the prior PR head first: rate-limited batch fan-out, unbounded `vs_currencies`, provider-rejection claim cleanup, and retry-after-deadline all failed before their production fixes.

## Validation

- `pnpm vitest run tests/unit/price-service.test.ts` — 22 passed
- `pnpm test:unit` — 487 passed / 60 files
- `pnpm check` — format, ESLint, TypeScript, and production build passed using the repository CI placeholder environment
- No new dependencies; public price-service APIs remain unchanged

Fixes #642