### PR TITLE
perf(prices): scope the accounts price read instead of scanning PriceCache (#643)

### DIFF
--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -12,7 +12,7 @@ import {
   fetchUserArchivedAccountsWithHoldings,
   getCachedNetWorthSummary,
 } from "@/lib/services/net-worth-service";
-import { getCachedPricesForSymbols } from "@/lib/services/price-service";
+import { getAccountPriceMap } from "@/lib/services/account-service";
 import { log } from "@/lib/logger";
 
 const CLIENT_NAMESPACES = [
@@ -36,7 +36,7 @@ async function AccountsContent() {
   // settings/accounts reads rather than blocking the whole batch.
   const settingsP = getOrCreateSettings(userId);
   const accountsP = fetchUserAccountsWithHoldings(userId);
-  const [t, messages, accounts, archivedAccounts, settings, allRatesMap, summary, cachedPrices] =
+  const [t, messages, accounts, archivedAccounts, settings, allRatesMap, summary, priceMap] =
     await Promise.all([
       getTranslations("accounts"),
       getMessages(),
@@ -45,20 +45,18 @@ async function AccountsContent() {
       settingsP,
       getAllExchangeRates(),
       settingsP.then((s) => getCachedNetWorthSummary(userId, s.baseCurrency)),
+      // Scoped `symbol IN (...)`, the same helper /accounts/[id] uses. The call
+      // this replaced read the whole PriceCache table and filtered in JS (#643).
+      // Symbol set is unchanged — active accounts only — so archived-only
+      // holdings stay unpriced here exactly as they were before.
       accountsP.then((accounts) =>
-        getCachedPricesForSymbols([
-          ...new Set(accounts.flatMap((a) => a.holdings.map((h) => h.symbol))),
-        ]),
+        getAccountPriceMap(accounts.flatMap((a) => a.holdings.map((h) => h.symbol))),
       ),
     ]);
 
   const baseCurrency = settings.baseCurrency;
   const hasAssetAccounts = summary.accounts.some(
     (account) => account.type === "ASSET" && account.totalValueInBaseCurrency > 0,
-  );
-
-  const priceMap: Record<string, number> = Object.fromEntries(
-    cachedPrices.map((p) => [p.symbol, p.price]),
   );
 
   // Build rates map from the bulk-loaded rates. Render path is read-only

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { revalidateTag, unstable_cache } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { getYahooClient } from "@/lib/services/yahoo-client";
 import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
@@ -252,32 +252,17 @@ export async function fetchCryptoPrices(
   return results;
 }
 
-// Fetch all cached prices once and hold in a single stable cache entry.
-// Using unstable_cache (not "use cache") so slow-query logs from Neon cold
-// starts are NOT replayed on cache hits.
-const fetchAllCachedPrices = unstable_cache(
-  async () => {
-    const results = await prisma.priceCache.findMany({
-      select: { symbol: true, price: true, currency: true },
-    });
-    return results.map((p) => ({
-      symbol: p.symbol,
-      price: Number(p.price),
-      currency: p.currency,
-    }));
-  },
-  ["all-prices"],
-  { tags: ["prices"], revalidate: 300 },
-);
-
-export async function getCachedPricesForSymbols(
-  symbols: string[],
-): Promise<{ symbol: string; price: number; currency: string }[]> {
-  if (symbols.length === 0) return [];
-  const all = await fetchAllCachedPrices();
-  const symbolSet = new Set(symbols);
-  return all.filter((p) => symbolSet.has(p.symbol));
-}
+// `getCachedPricesForSymbols` used to live here. It read the ENTIRE PriceCache
+// — every symbol of every user on the instance — and filtered down to one
+// user's holdings in JS, behind a cache entry tagged `prices`. That is the most
+// frequently invalidated tag in the codebase (every holding write, watchlist
+// add, manual refresh and cron run busts it, globally for all users), so the
+// full-table read re-ran on close to every /accounts render (#643).
+//
+// Its single caller now uses `account-service.getAccountPriceMap`, which was
+// already doing the scoped `symbol IN (...)` lookup for /accounts/[id] — the
+// same shape net-worth-service and stock-watch-service use. There is no reason
+// for a second way to read prices by symbol.
 
 export async function refreshAllPrices(): Promise<RefreshPricesResult> {
   const [holdings, trackedStocks] = await Promise.all([

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -29,8 +29,8 @@ class HoldingCurrencyMismatchError extends Error {
  * normal daily operation each occurrence is same-day, so this only affects
  * recovery after a cron outage.
  *
- * Price and FX are read DIRECTLY from the DB here (not via the cached
- * `getCachedPricesForSymbols` / `getAllExchangeRates`): the cron writes fresh
+ * Price and FX are read DIRECTLY from the DB here (not via a cached reader such
+ * as `getAllExchangeRates`): the cron writes fresh
  * prices/rates just before this runs but only revalidates the `prices` /
  * `exchange-rates` cache tags afterward, so the cached readers would return
  * pre-refresh values and the buys would use stale price/FX. The FX half of that

--- a/tests/unit/account-service.test.ts
+++ b/tests/unit/account-service.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// React cache() is per-render memoization; neutralize it so each call in a test
+// reaches the query and we can assert on what was actually sent.
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, cache: <T>(fn: T): T => fn };
+});
+vi.mock("next/cache", () => ({
+  cacheTag: () => {},
+  cacheLife: () => {},
+}));
+
+const h = vi.hoisted(() => ({
+  prices: [] as { symbol: string; price: number }[],
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    account: { count: vi.fn(async () => 0), findMany: vi.fn(async () => []) },
+    priceCache: { findMany: vi.fn(async () => h.prices) },
+  },
+}));
+
+const { getAccountPriceMap } = await import("@/lib/services/account-service");
+
+// Regression #643: the /accounts page used to reach prices through
+// `price-service.getCachedPricesForSymbols`, which read the ENTIRE PriceCache
+// table (all users' symbols) and filtered in JS behind the `prices` tag — the
+// most frequently invalidated tag in the app. It now shares this helper, whose
+// contract is that the database only ever returns the symbols asked for.
+describe("getAccountPriceMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.prices = [];
+  });
+
+  it("scopes the query to the requested symbols instead of scanning the table", async () => {
+    h.prices = [{ symbol: "AAPL", price: 200 }];
+    const { prisma } = await import("@/lib/prisma");
+
+    await getAccountPriceMap(["AAPL", "2330.TW"]);
+
+    const args = vi.mocked(prisma.priceCache.findMany).mock.calls[0][0] as {
+      where?: { symbol?: { in?: string[] } };
+      select?: Record<string, boolean>;
+    };
+    // An unfiltered findMany — the shape of the bug — has no `where` at all.
+    expect(args.where?.symbol?.in).toBeDefined();
+    expect(args.where?.symbol?.in).toEqual(["2330.TW", "AAPL"]);
+    expect(args.select).toEqual({ symbol: true, price: true });
+  });
+
+  it("dedupes and sorts symbols so the cache key is stable across orderings", async () => {
+    const { prisma } = await import("@/lib/prisma");
+
+    await getAccountPriceMap(["MSFT", "AAPL", "MSFT", "AAPL"]);
+
+    const args = vi.mocked(prisma.priceCache.findMany).mock.calls[0][0] as {
+      where: { symbol: { in: string[] } };
+    };
+    expect(args.where.symbol.in).toEqual(["AAPL", "MSFT"]);
+  });
+
+  it("returns a symbol -> number map, coercing the Decimal column", async () => {
+    h.prices = [
+      { symbol: "AAPL", price: 200.5 },
+      { symbol: "MSFT", price: 410 },
+    ];
+
+    await expect(getAccountPriceMap(["AAPL", "MSFT"])).resolves.toEqual({
+      AAPL: 200.5,
+      MSFT: 410,
+    });
+  });
+
+  it("omits symbols with no cached price rather than inventing a zero", async () => {
+    h.prices = [{ symbol: "AAPL", price: 200 }];
+
+    const map = await getAccountPriceMap(["AAPL", "NOPRICE"]);
+
+    expect(map).toEqual({ AAPL: 200 });
+    expect("NOPRICE" in map).toBe(false);
+  });
+
+  it("issues no query at all for an empty symbol list", async () => {
+    const { prisma } = await import("@/lib/prisma");
+
+    await expect(getAccountPriceMap([])).resolves.toEqual({});
+    expect(vi.mocked(prisma.priceCache.findMany)).not.toHaveBeenCalled();
+  });
+});
+
+// Source-level guard for the shape of the bug itself. The unit tests above pin
+// the helper's contract, but the actual #643 defect was a *convenient*
+// whole-table read added next to the scoped ones — easy to reintroduce, and
+// invisible until the table is big. Same source-inspection approach as
+// calendar-page-source.test.ts.
+describe("price reads stay scoped (#643)", () => {
+  const read = (rel: string) => fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+
+  it("routes the accounts page through the scoped helper", () => {
+    const page = read("src/app/(main)/accounts/page.tsx");
+    expect(page).toContain("getAccountPriceMap");
+    expect(page).not.toContain("getCachedPricesForSymbols");
+  });
+
+  it("leaves no unfiltered PriceCache read in price-service", () => {
+    const source = read("src/lib/services/price-service.ts");
+    const reads = [...source.matchAll(/priceCache\.(findMany|findFirst)\(/g)];
+    expect(reads.length).toBeGreaterThan(0); // guard the guard: the file still reads prices
+    for (const match of reads) {
+      const call = source.slice(match.index, match.index + 300);
+      expect(call, `unscoped ${match[0]} at index ${match.index}`).toContain("where:");
+    }
+  });
+});


### PR DESCRIPTION
Fixes #643. Base `master`, independent of #648 — both touch `price-service.ts` but different regions, and `git merge-tree` confirms they merge cleanly in either order.

## The problem

`getCachedPricesForSymbols` read the **entire `PriceCache` table** — every symbol of every user on the instance — and filtered down to one user's holdings in JavaScript:

```ts
const fetchAllCachedPrices = unstable_cache(
  async () => prisma.priceCache.findMany({ select: { symbol, price, currency } }),  // no WHERE
  ["all-prices"],
  { tags: ["prices"], revalidate: 300 },
);

export async function getCachedPricesForSymbols(symbols) {
  const all = await fetchAllCachedPrices();
  const symbolSet = new Set(symbols);
  return all.filter((p) => symbolSet.has(p.symbol));   // filtered in JS
}
```

The 300 s TTL never got a chance to amortise it: the entry is tagged `prices`, which is invalidated from seven call sites — holding writes, watchlist adds, DCA rule edits, manual refresh, and the cron — and those are **global** tags, not per-user. So one user adding a holding busts the entry for everyone, and the next `/accounts` render anywhere re-reads the whole table to serve a user who owns a dozen symbols.

## The fix: delete it

No new code. Its single caller now uses **`account-service.getAccountPriceMap`**, which was already doing the scoped `symbol IN (...)` lookup for `/accounts/[id]`:

```ts
const cachedPrices = await prisma.priceCache.findMany({
  where: { symbol: { in: symbols } },
  select: { symbol: true, price: true },
});
```

That is the same shape `net-worth-service`, `stock-watch-service` and `investment-cost-basis-service` already use — `getCachedPricesForSymbols` was the only one doing it differently. It also returns `Record<string, number>` directly, so the page's `Object.fromEntries(...)` remapping goes away too, and the `unstable_cache` entry disappears with the function.

Net: −33 lines of source, one fewer way to read prices by symbol, one fewer cache entry.

## Behaviour

**Unchanged.** The symbol set passed in is identical (active accounts only, via the same `accountsP` promise), so archived-only holdings stay unpriced on this page exactly as before — `getAccountValue` already falls back to `0` for a missing symbol.

**Is anything slower?** One case: when the `prices` tag happened to be *un*-busted for the full 300 s, the old code served from cache with zero queries, whereas this always issues a query. That trade is worth taking — the new query is a primary-key `IN` lookup for ~12 symbols instead of a full-table read of the instance's entire symbol universe, and it runs inside the page's existing `Promise.all` alongside `getCachedNetWorthSummary`, so it adds no latency to the critical path. The cache-hit case was also rare in practice, which is the whole point of the issue.

It also removes a mild cross-tenant smell: one user's page render no longer pulls every other user's tracked symbols into process memory.

## Tests

`tests/unit/account-service.test.ts` (new, 7 tests). Being honest about what they cover, since they are not all the same kind:

**2 are genuine regression tests** — verified failing against master's `src/`:
- `routes the accounts page through the scoped helper`
- `leaves no unfiltered PriceCache read in price-service` — walks every `priceCache.findMany`/`findFirst` in the file and asserts each carries a `where:`, with a guard-the-guard assertion that the file still reads prices at all

These are source-inspection tests, following the existing `calendar-page-source.test.ts` pattern. They target the *shape* of the defect: a convenient whole-table read sitting next to the scoped ones is easy to reintroduce and invisible until the table is large.

**5 are contract tests** pinning `getAccountPriceMap`, the helper the page now depends on — scoped `where`, dedupe + sort of the symbol list (which is what makes its React `cache()` key stable), `Decimal` → `number` coercion, missing symbols omitted rather than zero-filled, and no query at all for an empty list. These pass both before and after by design; that helper was already correct. They exist so a future "optimisation" of it can't quietly become this bug again.

## Verification

`pnpm typecheck` / `lint` / `format:check` clean; `pnpm test:unit` 475/475 on Node 24.6.0. `git status` clean after commit (files pre-formatted before staging, so the lint-staged re-stage bug didn't bite). Merges clean onto `master` and against `fix/642-yahoo-batching`.

## Also in this PR

One line in `recurring-investment-service.ts`: its file-header comment named `getCachedPricesForSymbols` as an example of a cached reader to avoid. Reworded to point at `getAllExchangeRates` instead, so the comment doesn't reference a deleted symbol.

## Not done

- **Not verified against a running app.** `/accounts` was not loaded in a browser; the symbol-set equivalence argument is from reading `accounts-list.tsx`'s `priceMap` usage, not from a rendered page. Worth a quick manual check of an account with archived holdings before merge.
- Deriving `priceMap` from `summary.accounts[].holdings[].currentPrice` would remove the query entirely — the data is already loaded in the same `Promise.all`. Skipped deliberately: it couples the page to the summary's internal price semantics (that `currentPrice` is the raw cached price, pre-conversion), which is a subtler contract than "look up these symbols".

https://claude.ai/code/session_01Yb6TkdYpoQiyKKMgUixeAQ
