### PR TITLE
fix(cron): page users and honor snapshot budget (#641)

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -34,6 +34,8 @@ const RATE_REFRESH_CONCURRENCY = 5;
 const SNAPSHOT_CONCURRENCY = 10;
 /** Users whose accounts/holdings are held in memory at once. */
 const USER_PAGE_SIZE = 200;
+/** Stop scheduling work before Vercel's 60 s hard kill so audit writes can finish. */
+const SNAPSHOT_BUDGET_MS = 50_000;
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -174,12 +176,7 @@ export async function GET(request: Request) {
       revalidateTag("accounts", "max");
     }
 
-    // 2. Get all users and their settings
-    const users = await prisma.user.findMany({
-      select: { id: true, appSettings: { select: { baseCurrency: true } } },
-    });
-
-    // 3. Snapshot every user.
+    // 2. Snapshot users page by page.
     //
     // All reads are bulk (#641): the FX map is global so it is loaded once for
     // the whole run, and each page of users costs one accounts+holdings query
@@ -195,43 +192,70 @@ export async function GET(request: Request) {
     const snapshots: Awaited<ReturnType<typeof createSnapshot>>[] = [];
     const successfulUserIds: string[] = [];
     const failedUserIds: string[] = [];
+    let usersDiscovered = 0;
+    let userCursor: string | undefined;
+    let budgetExhausted = false;
 
-    for (const page of chunk(users, USER_PAGE_SIZE)) {
+    while (true) {
+      if (Date.now() - startedAt.getTime() >= SNAPSHOT_BUDGET_MS) {
+        budgetExhausted = true;
+        break;
+      }
+      const page = await prisma.user.findMany({
+        select: { id: true, appSettings: { select: { baseCurrency: true } } },
+        orderBy: { id: "asc" },
+        take: USER_PAGE_SIZE,
+        ...(userCursor && { cursor: { id: userCursor }, skip: 1 }),
+      });
+      if (page.length === 0) break;
+      usersDiscovered += page.length;
+
       const inputs = await loadNetWorthInputsForUsers(
         page.map((user) => user.id),
         ratesMap,
       );
-      // Only the upsert is left per user, so the cap here bounds concurrent
-      // writes rather than whole read-compute-write pipelines.
-      const pageResults = await mapSettled(page, SNAPSHOT_CONCURRENCY, async (user) => {
-        const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
-        const snapshot = await createSnapshot(user.id, baseCurrency, {
-          fresh: true,
-          preloaded: inputs.get(user.id),
-        });
-        return { userId: user.id, snapshot };
-      });
 
-      for (let i = 0; i < pageResults.length; i++) {
-        const result = pageResults[i];
-        if (result.status === "fulfilled") {
-          snapshots.push(result.value.snapshot);
-          successfulUserIds.push(result.value.userId);
-        } else {
-          failedUserIds.push(page[i].id);
-          log.warn("cron.snapshot.user_failed", {
-            userId: page[i].id,
-            error: String(result.reason),
+      // Only the upsert is left per user. Fixed waves bound concurrent writes
+      // and give the wall-clock guard a chance to stop between waves.
+      for (const wave of chunk(page, SNAPSHOT_CONCURRENCY)) {
+        if (Date.now() - startedAt.getTime() >= SNAPSHOT_BUDGET_MS) {
+          budgetExhausted = true;
+          break;
+        }
+        const waveResults = await mapSettled(wave, SNAPSHOT_CONCURRENCY, async (user) => {
+          const baseCurrency = user.appSettings?.baseCurrency ?? "USD";
+          const snapshot = await createSnapshot(user.id, baseCurrency, {
+            fresh: true,
+            preloaded: inputs.get(user.id),
           });
+          return { userId: user.id, snapshot };
+        });
+
+        for (let i = 0; i < waveResults.length; i++) {
+          const result = waveResults[i];
+          if (result.status === "fulfilled") {
+            snapshots.push(result.value.snapshot);
+            successfulUserIds.push(result.value.userId);
+          } else {
+            failedUserIds.push(wave[i].id);
+            log.warn("cron.snapshot.user_failed", {
+              userId: wave[i].id,
+              error: String(result.reason),
+            });
+          }
         }
       }
+      if (budgetExhausted) break;
+      if (page.length < USER_PAGE_SIZE) break;
+      userCursor = page[page.length - 1].id;
     }
     log.info("cron.snapshot.summary", {
-      users: users.length,
+      users: usersDiscovered,
       created: snapshots.length,
       failed: failedUserIds.length,
+      budgetExhausted,
     });
-    if (users.length > 0 && failedUserIds.length === users.length) {
+    if (!budgetExhausted && usersDiscovered > 0 && failedUserIds.length === usersDiscovered) {
       throw new Error(`Snapshot failed for users: ${failedUserIds.join(", ")}`);
     }
 
@@ -242,25 +266,31 @@ export async function GET(request: Request) {
     }
 
     const finishedAt = new Date();
-    const snapshotError =
-      failedUserIds.length > 0 ? `Snapshot failed for users: ${failedUserIds.join(", ")}` : null;
+    const processedUsers = successfulUserIds.length + failedUserIds.length;
+    const snapshotError = budgetExhausted
+      ? `Snapshot budget exhausted after processing ${processedUsers} of at least ${usersDiscovered} users`
+      : failedUserIds.length > 0
+        ? `Snapshot failed for users: ${failedUserIds.join(", ")}`
+        : null;
     await prisma.cronRun.update({
       where: { id: cronRun.id },
       data: {
-        ok: true,
+        ok: !budgetExhausted,
         finishedAt,
         durationMs: finishedAt.getTime() - startedAt.getTime(),
         ...(snapshotError && { error: snapshotError }),
       },
     });
-    finishSnapshotCronCheckIn(checkIn, "ok");
+    finishSnapshotCronCheckIn(checkIn, budgetExhausted ? "error" : "ok");
 
-    return ok({
-      success: true,
-      snapshotIds: snapshots.map((s) => s.id),
-      failedUserIds,
-      timestamp: finishedAt.toISOString(),
-    });
+    return budgetExhausted
+      ? failure(snapshotError ?? "Snapshot budget exhausted", 503)
+      : ok({
+          success: true,
+          snapshotIds: snapshots.map((s) => s.id),
+          failedUserIds,
+          timestamp: finishedAt.toISOString(),
+        });
   } catch (error) {
     log.error("cron.snapshot.failed", { error: String(error) });
     const finishedAt = new Date();

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -14,6 +14,8 @@ const h = vi.hoisted(() => ({
   snapshotOpts: [] as unknown[],
   rateRefreshes: [] as string[],
   rateRefreshFailures: new Set<string>(),
+  snapshotTimeJumpUser: null as string | null,
+  snapshotTimeJumpMs: 0,
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -70,6 +72,9 @@ vi.mock("@/lib/services/snapshot-service", () => ({
   createSnapshot: vi.fn(async (userId: string, _baseCurrency: string, opts?: unknown) => {
     h.events.push(`snapshot:${userId}`);
     h.snapshotOpts.push(opts);
+    if (h.snapshotTimeJumpUser === userId) {
+      vi.setSystemTime(new Date(Date.now() + h.snapshotTimeJumpMs));
+    }
     if (h.snapshotFailures.has(userId)) throw new Error(`snapshot failed for ${userId}`);
     return { id: `snapshot-${userId}` };
   }),
@@ -98,7 +103,13 @@ vi.mock("@/lib/prisma", () => {
       findMany: vi.fn(async () => []),
     },
     user: {
-      findMany: vi.fn(async () => h.users),
+      findMany: vi.fn(async (args?: { take?: number; cursor?: { id: string }; skip?: number }) => {
+        const cursorIndex = args?.cursor
+          ? h.users.findIndex((user) => user.id === args.cursor?.id)
+          : -1;
+        const start = cursorIndex < 0 ? 0 : cursorIndex + (args?.skip ?? 0);
+        return h.users.slice(start, args?.take ? start + args.take : undefined);
+      }),
     },
     $transaction: vi.fn(async (work: unknown) => {
       if (Array.isArray(work)) return Promise.all(work);
@@ -121,6 +132,8 @@ describe("snapshot cron route", () => {
     h.snapshotOpts = [];
     h.rateRefreshes = [];
     h.rateRefreshFailures = new Set();
+    h.snapshotTimeJumpUser = null;
+    h.snapshotTimeJumpMs = 0;
   });
 
   it("invalidates net worth before snapshot creation when options expire", async () => {
@@ -331,6 +344,80 @@ describe("snapshot cron route", () => {
       expect(h.inputLoads).toHaveLength(1);
       expect(h.inputLoads.flat()).toEqual(h.users.map((u) => u.id));
       expect(h.events.filter((e) => e.startsWith("snapshot:"))).toHaveLength(25);
+    });
+
+    it("cursor-pages users instead of loading the whole table before chunking", async () => {
+      h.users = manyUsers(201);
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { prisma } = await import("@/lib/prisma");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(h.inputLoads.map((ids) => ids.length)).toEqual([200, 1]);
+      expect(vi.mocked(prisma.user.findMany)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(prisma.user.findMany)).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          take: 200,
+          orderBy: { id: "asc" },
+        }),
+      );
+      expect(vi.mocked(prisma.user.findMany)).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          take: 200,
+          orderBy: { id: "asc" },
+          cursor: { id: "user199" },
+          skip: 1,
+        }),
+      );
+    });
+
+    it("stops scheduling snapshot waves before the platform deadline and records partial failure", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-05T21:30:00.000Z"));
+      try {
+        h.users = manyUsers(25);
+        // Simulate upstream + two write waves consuming the safe cron budget.
+        // The third wave must never be scheduled, leaving time to persist the
+        // CronRun failure and return before Vercel's 60-second hard kill.
+        h.snapshotTimeJumpUser = "user19";
+        h.snapshotTimeJumpMs = 51_000;
+        const { GET } = await import("@/app/api/cron/snapshot/route");
+        const { prisma } = await import("@/lib/prisma");
+        const { log } = await import("@/lib/logger");
+        const { finishSnapshotCronCheckIn } = await import("@/lib/sentry-cron");
+
+        const response = await GET(
+          new Request("http://unit.test/api/cron/snapshot", {
+            headers: { authorization: "Bearer test-secret" },
+          }),
+        );
+
+        expect(response.status).toBe(503);
+        expect(h.events.filter((event) => event.startsWith("snapshot:"))).toHaveLength(20);
+        expect(h.events).toContain("revalidate:snapshots");
+        expect(h.events).toContain("revalidate:history:user0");
+        expect(h.events).not.toContain("snapshot:user20");
+        expect(prisma.cronRun.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              ok: false,
+              error: expect.stringMatching(/budget.*20.*25/i),
+            }),
+          }),
+        );
+        expect(prisma.cronRun.update).toHaveBeenCalledTimes(1);
+        expect(log.error).not.toHaveBeenCalledWith("cron.snapshot.failed", expect.anything());
+        expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("keeps sweeping when one currency's rate refresh throws", async () => {


### PR DESCRIPTION
## Summary

Follow up on #647 to close the two remaining #641 availability gaps:

- cursor-page users in batches of 200 instead of loading the entire User table before in-memory chunking
- process snapshot upserts in fixed waves of 10 and stop scheduling new work at a 50 s soft deadline, leaving 10 s before Vercel's 60 s hard kill for cache invalidation, CronRun audit, and the response
- record budget exhaustion as `ok: false`, finish the Sentry check-in as an error, and return 503 while preserving partial snapshots and their cache invalidations

The budget is measured from `startedAt`, before the initial CronRun write and all option/FX/price/recurring work, so it covers the full cron execution rather than only the user loop. The controlled budget response returns directly (it does not throw into the catch path), and regression coverage asserts the audit is updated exactly once.

## Root cause

PR #647 bounded FX and snapshot concurrency and bulk-loaded net-worth inputs, but `prisma.user.findMany()` still read every user into memory before `chunk(users, 200)`. It also had no wall-clock guard, so a large run could still cross the platform's 60 s limit and be killed before its failure audit was finalized.

## Validation

- TDD red: the new cursor-pagination test observed one unbounded User query; the budget test observed all snapshots scheduled and HTTP 200 after simulated exhaustion
- targeted: `pnpm exec vitest run tests/unit/cron-snapshot-route.test.ts tests/unit/net-worth-service.test.ts tests/unit/batch.test.ts` — 3 files, 35 tests passed
- full unit: `pnpm test:unit` — 60 files, 477 tests passed
- `pnpm check` — Prettier, ESLint, TypeScript, and Next.js production build passed (with documented local placeholder env values)

## Behavior

Existing failure semantics remain intact: isolated per-user failures still return success with failed IDs; all attempted users failing still returns 500; one FX currency failure remains isolated. Budget exhaustion is a controlled partial failure (503) with completed snapshots retained and invalidated.