### PR TITLE
fix: surface total price refresh failures

### DIFF
--- a/prisma/migrations/20260728000000_add_holding_asset_type_index/migration.sql
+++ b/prisma/migrations/20260728000000_add_holding_asset_type_index/migration.sql
@@ -1,0 +1,2 @@
+-- Supports the empty-PriceCache health probe's priceable-holding existence query.
+CREATE INDEX IF NOT EXISTS "Holding_assetType_idx" ON "Holding" ("assetType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,7 @@ model Holding {
   transactions       HoldingTransaction[]
 
   @@unique([accountId, symbol])
+  @@index([assetType])
 }
 
 enum TransactionType {

--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -138,6 +138,14 @@ export async function GET(request: Request) {
       ratesUpdated,
       ratesChanged,
     });
+    // A total refresh failure means every snapshot below would be calculated
+    // from stale PriceCache rows. Abort before any snapshot write so neither the
+    // CronRun audit nor /api/health can mistake stale valuations for success.
+    if (priceResult.outcome === "total_failure") {
+      const details = priceResult.errors.join(" | ") || "no usable prices returned";
+      log.error("cron.prices.refresh_failed", { errors: priceResult.errors });
+      throw new Error(`Price refresh failed: ${details}`);
+    }
 
     // 1b. Materialize due recurring cash transactions (F6) before snapshots, so
     // the day's snapshot reflects the posted cash. This piggybacks on the daily

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -50,6 +50,7 @@ export async function GET(request: Request) {
   let cronAgeMs: number | null = null;
   let latestPriceAt: string | null = null;
   let priceAgeMs: number | null = null;
+  let emptyCacheHasPriceableAssets = false;
 
   try {
     // Lightweight liveness check + most-recent snapshot freshness + latest
@@ -83,6 +84,20 @@ export async function GET(request: Request) {
     if (latestPrice._max.updatedAt) {
       latestPriceAt = latestPrice._max.updatedAt.toISOString();
       priceAgeMs = now - latestPrice._max.updatedAt.getTime();
+    } else {
+      // An empty cache is healthy only when there is nothing that should have
+      // fetched a market quote. Keep this to two `SELECT ... LIMIT 1`-shaped
+      // existence queries, and run them only on the empty-cache path.
+      const [priceableHolding, priceableWatch] = await Promise.all([
+        prisma.holding.findFirst({
+          where: { assetType: { in: ["STOCK", "ETF", "CRYPTO", "MUTUAL_FUND", "BOND", "OPTION"] } },
+          select: { id: true },
+        }),
+        prisma.stockWatchItem.findFirst({ select: { id: true } }),
+      ]);
+      if (priceableHolding || priceableWatch) {
+        emptyCacheHasPriceableAssets = true;
+      }
     }
   } catch (error) {
     log.error("health.db_unreachable", { error: String(error) });
@@ -90,14 +105,18 @@ export async function GET(request: Request) {
 
   const snapshotFresh = snapshotAgeMs !== null && snapshotAgeMs <= FRESHNESS_MAX_AGE_MS;
   const cronFresh = cronAgeMs !== null && cronAgeMs <= FRESHNESS_MAX_AGE_MS;
-  const priceFresh = priceAgeMs === null || priceAgeMs <= FRESHNESS_MAX_AGE_MS;
+  const priceFresh =
+    priceAgeMs === null ? !emptyCacheHasPriceableAssets : priceAgeMs <= FRESHNESS_MAX_AGE_MS;
 
-  // An empty PriceCache is healthy for a new/asset-free installation; once it
-  // has data, its newest quote must be within the same freshness window.
+  // An empty PriceCache is healthy only for an asset-free installation. If a
+  // holding/watchlist needs a quote but the cache is empty, it is an
+  // operator-visible stale condition.
   const priceCache = !dbOk
     ? "unknown"
     : priceAgeMs === null
-      ? "empty"
+      ? emptyCacheHasPriceableAssets
+        ? "stale"
+        : "empty"
       : priceFresh
         ? "ok"
         : "stale";

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -72,7 +72,6 @@ export async function GET(request: Request) {
         _max: { updatedAt: true },
       }),
     ]);
-    dbOk = true;
     if (latestSnapshot) {
       latestSnapshotAt = latestSnapshot.createdAt.toISOString();
       snapshotAgeMs = now - latestSnapshot.createdAt.getTime();
@@ -99,6 +98,8 @@ export async function GET(request: Request) {
         emptyCacheHasPriceableAssets = true;
       }
     }
+    // Set readiness only after every conditional DB read above has completed.
+    dbOk = true;
   } catch (error) {
     log.error("health.db_unreachable", { error: String(error) });
   }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -11,22 +11,26 @@ import { log } from "@/lib/logger";
  * age, the latest successful cron run timestamp + age, and the response
  * timestamp. No user data is exposed.
  *
- * Three independent signals are reported and rolled up into `status`:
+ * Four independent signals are reported and rolled up into `status`:
  *   - db       → DB reachability ("ok" / "error").
  *   - cron     → freshness of the latest *successful* CronRun (name "snapshot").
  *                This is the E18 pull-based alarm: it goes stale when no cron has
  *                succeeded within the freshness window — even if old snapshot
  *                rows still exist. Free-plan compatible (no extra cron needed).
  *   - snapshot → freshness of the most recent NetWorthSnapshot (the E17 signal).
+ *   - priceCache → freshness of the newest cached market quote. Only aggregate
+ *                   freshness metadata is exposed; no symbols, prices, or user
+ *                   data leave this endpoint. An empty cache is valid for a new
+ *                   or genuinely asset-free installation.
  *
- * Overall `status` is the worst of the three:
+ * Overall `status` is the worst of the four:
  *   - "unhealthy" → DB unreachable. HTTP 503.
  *   - "degraded"  → DB reachable but the cron OR the latest snapshot is
  *                   stale/absent (> 36 h). HTTP 503.
- *   - "ok"        → all three healthy. HTTP 200.
+ *   - "ok"        → all applicable signals healthy. HTTP 200.
  *
- * The 36 h freshness window is shared across both the snapshot and the cron
- * signals so the two layers can't drift.
+ * The 36 h freshness window is shared across snapshot, cron, and prices so
+ * the three freshness signals can't drift.
  */
 const FRESHNESS_MAX_AGE_MS = 36 * 60 * 60 * 1000;
 
@@ -44,11 +48,15 @@ export async function GET(request: Request) {
   let snapshotAgeMs: number | null = null;
   let lastCronSuccessAt: string | null = null;
   let cronAgeMs: number | null = null;
+  let latestPriceAt: string | null = null;
+  let priceAgeMs: number | null = null;
 
   try {
     // Lightweight liveness check + most-recent snapshot freshness + latest
-    // successful cron run, in one parallel round.
-    const [, latestSnapshot, latestCron] = await Promise.all([
+    // successful cron run, and newest PriceCache timestamp in one parallel
+    // round. PriceCache.updatedAt has its own index, so the aggregate stays a
+    // lightweight freshness probe rather than loading any market data.
+    const [, latestSnapshot, latestCron, latestPrice] = await Promise.all([
       prisma.$queryRaw`SELECT 1`,
       prisma.netWorthSnapshot.findFirst({
         orderBy: { createdAt: "desc" },
@@ -58,6 +66,9 @@ export async function GET(request: Request) {
         where: { name: SNAPSHOT_CRON_NAME, ok: true },
         orderBy: { startedAt: "desc" },
         select: { startedAt: true },
+      }),
+      prisma.priceCache.aggregate({
+        _max: { updatedAt: true },
       }),
     ]);
     dbOk = true;
@@ -69,15 +80,29 @@ export async function GET(request: Request) {
       lastCronSuccessAt = latestCron.startedAt.toISOString();
       cronAgeMs = now - latestCron.startedAt.getTime();
     }
+    if (latestPrice._max.updatedAt) {
+      latestPriceAt = latestPrice._max.updatedAt.toISOString();
+      priceAgeMs = now - latestPrice._max.updatedAt.getTime();
+    }
   } catch (error) {
     log.error("health.db_unreachable", { error: String(error) });
   }
 
   const snapshotFresh = snapshotAgeMs !== null && snapshotAgeMs <= FRESHNESS_MAX_AGE_MS;
   const cronFresh = cronAgeMs !== null && cronAgeMs <= FRESHNESS_MAX_AGE_MS;
+  const priceFresh = priceAgeMs === null || priceAgeMs <= FRESHNESS_MAX_AGE_MS;
 
-  // Overall status is the worst of {db, cron, snapshot}.
-  const status = !dbOk ? "unhealthy" : snapshotFresh && cronFresh ? "ok" : "degraded";
+  // An empty PriceCache is healthy for a new/asset-free installation; once it
+  // has data, its newest quote must be within the same freshness window.
+  const priceCache = !dbOk
+    ? "unknown"
+    : priceAgeMs === null
+      ? "empty"
+      : priceFresh
+        ? "ok"
+        : "stale";
+  // Overall status is the worst of {db, cron, snapshot, priceCache}.
+  const status = !dbOk ? "unhealthy" : snapshotFresh && cronFresh && priceFresh ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
 
   return Response.json(
@@ -86,10 +111,13 @@ export async function GET(request: Request) {
       db: dbOk ? "ok" : "error",
       cron: !dbOk ? "unknown" : cronFresh ? "ok" : "stale",
       snapshot: !dbOk ? "unknown" : snapshotFresh ? "ok" : "stale",
+      priceCache,
       latestSnapshotAt,
       snapshotAgeMs,
       lastCronSuccessAt,
       cronAgeMs,
+      latestPriceAt,
+      priceAgeMs,
       timestamp: new Date(now).toISOString(),
     },
     { status: httpStatus },

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -82,6 +82,8 @@ export const POST = withAuth(async (request, _ctx, userId) => {
 
   return ok({
     prices: {
+      outcome: priceResult.outcome,
+      fetchFailed: priceResult.outcome === "total_failure",
       updated: priceResult.updated,
       changed: priceResult.changed,
       skippedFresh: priceResult.skippedFresh,

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -586,9 +586,16 @@ export const POST = withAuth(async (request, _ctx, userId) => {
     // Imported holdings may reference symbols with no PriceCache row yet —
     // without this they render unpriced until the next manual refresh / cron.
     after(() =>
-      refreshPricesForUser(userId).catch((error) =>
-        log.error("import.price_warm_failed", { error: String(error) }),
-      ),
+      refreshPricesForUser(userId)
+        .then((result) => {
+          if (result?.outcome === "total_failure") {
+            log.error("import.price_warm_failed", {
+              outcome: result.outcome,
+              errors: result.errors,
+            });
+          }
+        })
+        .catch((error) => log.error("import.price_warm_failed", { error: String(error) })),
     );
 
     const response = ok({ ok: true });

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -54,6 +54,7 @@ import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { hapticTick } from "@/lib/haptics";
 import { formatAmountInput } from "@/lib/amount-input";
 import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
+import { stockManualRefreshFeedback, type PriceRefreshPayload } from "@/lib/price-refresh-contract";
 import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
 
@@ -775,15 +776,19 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
         return;
       }
       if (!res.ok) throw new Error("refresh failed");
-      const { data }: { data: { updated: number; changed?: number; skippedFresh?: number } } =
-        await res.json();
+      const { data }: { data: PriceRefreshPayload } = await res.json();
       startCooldown(Math.ceil(CLIENT_REFRESH_COOLDOWN_MS / 1000));
-      if (data.updated === 0 && (data.skippedFresh ?? 0) > 0) {
+      const feedback = stockManualRefreshFeedback(data);
+      if (feedback === "error") {
+        toast.error(t("refreshFailed"));
+        return;
+      }
+      if (feedback === "fresh") {
         toast.info(t("alreadyFresh"));
         return;
       }
-      toast.success(t("refreshSuccess", { count: data.updated }));
-      if ((data.changed ?? data.updated) > 0) {
+      toast.success(t("refreshSuccess", { count: data.updated ?? 0 }));
+      if ((data.changed ?? data.updated ?? 0) > 0) {
         window.dispatchEvent(new CustomEvent("prices:refreshed"));
         startTransition(() => router.refresh());
       }

--- a/src/lib/price-refresh-contract.ts
+++ b/src/lib/price-refresh-contract.ts
@@ -1,0 +1,26 @@
+/** Stable client/server contract for a completed price refresh. */
+export type PriceRefreshOutcome =
+  | "no_due_symbols"
+  | "deferred"
+  | "success"
+  | "partial_success"
+  | "total_failure";
+
+export type PriceRefreshPayload = {
+  outcome?: PriceRefreshOutcome;
+  updated?: number;
+  changed?: number;
+  skippedFresh?: number;
+};
+
+export function isTotalPriceRefreshFailure(outcome: PriceRefreshOutcome | undefined): boolean {
+  return outcome === "total_failure";
+}
+
+/** Maps the stock refresh API contract to the user-visible manual-refresh state. */
+export function stockManualRefreshFeedback(
+  data: PriceRefreshPayload,
+): "error" | "fresh" | "success" {
+  if (isTotalPriceRefreshFailure(data.outcome)) return "error";
+  return data.updated === 0 && (data.skippedFresh ?? 0) > 0 ? "fresh" : "success";
+}

--- a/src/lib/refresh-client.ts
+++ b/src/lib/refresh-client.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
+import { isTotalPriceRefreshFailure, type PriceRefreshOutcome } from "@/lib/price-refresh-contract";
 
 /**
  * Shared client-side entry point for the dashboard/settings "refresh market
@@ -47,6 +48,7 @@ type RefreshPayload = {
   skippedFresh?: number | boolean;
   retryAfterSeconds?: number | null;
   fetchFailed?: boolean;
+  outcome?: PriceRefreshOutcome;
 };
 
 export async function refreshMarketData(): Promise<RefreshOutcome> {
@@ -75,6 +77,7 @@ export async function refreshMarketData(): Promise<RefreshOutcome> {
 
     const pricesUpdated = priceData.updated ?? 0;
     const ratesUpdated = ratesData.updated ?? 0;
+    if (isTotalPriceRefreshFailure(priceData.outcome)) return { status: "error" };
     const changed = (priceData.changed ?? pricesUpdated) + (ratesData.changed ?? ratesUpdated);
     const anySkipped = Boolean(priceData.skippedFresh) || Boolean(ratesData.skippedFresh);
     const ratesFetchFailed = Boolean(ratesData.fetchFailed);

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -5,6 +5,7 @@ import { getYahooClient, getYahooErrorStatus } from "@/lib/services/yahoo-client
 import { PRICE_REFRESH_TTL_MS } from "@/lib/refresh-policy";
 import { log, withTiming } from "@/lib/logger";
 import { chunk } from "@/lib/batch";
+import type { PriceRefreshOutcome } from "@/lib/price-refresh-contract";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const RETRY_DELAYS_MS = [500, 1_500]; // 2 retries: 500 ms then 1.5 s
@@ -36,7 +37,7 @@ const COINGECKO_BUDGET_MS = 8_000;
 
 export type RefreshPricesResult = {
   /** Whether no price work was due, some or all due quotes persisted, or the refresh failed. */
-  outcome: "no_due_symbols" | "deferred" | "success" | "partial_success" | "total_failure";
+  outcome: PriceRefreshOutcome;
   updated: number;
   /** Persisted rows whose price/currency changed compared with the previous value. */
   changed: number;
@@ -712,18 +713,29 @@ async function refreshPricesForHoldings(
     );
     updated = entries.length;
     changed = pendingChanged;
-    if (changed > 0) revalidateTag("prices", "max");
+  } catch (error) {
+    bulkUpsertFailed = true;
+    errors.push(`Bulk upsert failed: ${String(error)}`);
+    // Release claims so the next request can retry immediately.
+    await releaseClaims(claimedSymbols);
+  }
+
+  if (!bulkUpsertFailed) {
+    // Cache invalidation happens after the write boundary: a cache-provider
+    // failure cannot turn already-persisted prices into a total refresh failure.
+    if (changed > 0) {
+      try {
+        revalidateTag("prices", "max");
+      } catch (error) {
+        log.error("price.refresh.revalidate_failed", { error: String(error) });
+      }
+    }
 
     // Partial fetch: symbols we claimed but got no price for (bad/transient
     // ticker) keep their refreshingAt set by the upsert (it only clears rows it
     // touched). Release them so a retry isn't blocked for the full 30s TTL.
     const fetchedSet = new Set(entries.map(([symbol]) => symbol));
     await releaseClaims(claimedSymbols.filter((symbol) => !fetchedSet.has(symbol)));
-  } catch (error) {
-    bulkUpsertFailed = true;
-    errors.push(`Bulk upsert failed: ${String(error)}`);
-    // Release claims so the next request can retry immediately.
-    await releaseClaims(claimedSymbols);
   }
 
   return {

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -35,6 +35,8 @@ const YAHOO_BUDGET_MS = 15_000;
 const COINGECKO_BUDGET_MS = 8_000;
 
 export type RefreshPricesResult = {
+  /** Whether no price work was due, some or all due quotes persisted, or the refresh failed. */
+  outcome: "no_due_symbols" | "deferred" | "success" | "partial_success" | "total_failure";
   updated: number;
   /** Persisted rows whose price/currency changed compared with the previous value. */
   changed: number;
@@ -215,6 +217,7 @@ export function normalizeMinorCurrencyQuote(
 
 async function fetchYahooQuotes(
   symbols: string[],
+  providerErrors?: string[],
 ): Promise<Map<string, { price: number; currency: string }>> {
   const results = new Map<string, { price: number; currency: string }>();
   if (symbols.length === 0) return results;
@@ -259,6 +262,7 @@ async function fetchYahooQuotes(
           try {
             await fetchSymbols(group);
           } catch (batchErr) {
+            providerErrors?.push(`Yahoo Finance batch failed: ${String(batchErr)}`);
             log.error("price.yahoo.batch_failed", {
               error: String(batchErr),
               symbolCount: group.length,
@@ -280,6 +284,7 @@ async function fetchYahooQuotes(
                 try {
                   await fetchSymbols([symbol]);
                 } catch (err) {
+                  providerErrors?.push(`Yahoo Finance fallback failed: ${String(err)}`);
                   log.error("price.yahoo.symbol_failed", { symbol, error: String(err) });
                 }
               },
@@ -297,8 +302,9 @@ async function fetchYahooQuotes(
 
 export async function fetchStockPrices(
   symbols: string[],
+  providerErrors?: string[],
 ): Promise<Map<string, { price: number; currency: string }>> {
-  return fetchYahooQuotes(symbols);
+  return fetchYahooQuotes(symbols, providerErrors);
 }
 
 // Strip currency suffix from crypto symbol (e.g. "BTC-USD" -> "BTC")
@@ -315,11 +321,12 @@ function extractQuoteCurrency(symbol: string): string {
 
 export async function fetchCryptoPrices(
   symbols: string[],
+  providerErrors?: string[],
 ): Promise<Map<string, { price: number; currency: string }>> {
   if (symbols.length === 0) return new Map();
 
   // Primary: Yahoo Finance (handles crypto pairs like BTC-USD)
-  const results = await fetchYahooQuotes(symbols);
+  const results = await fetchYahooQuotes(symbols, providerErrors);
 
   // Fallback: CoinGecko for any symbols not found via Yahoo Finance
   const missing = symbols.filter((s) => !results.has(s));
@@ -382,6 +389,7 @@ export async function fetchCryptoPrices(
               data[id] = { ...data[id], ...prices };
             }
           } catch (error) {
+            providerErrors?.push(`CoinGecko fetch failed: ${String(error)}`);
             log.error("price.coingecko.failed", { error: String(error) });
           }
         },
@@ -463,6 +471,7 @@ export async function refreshPricesForStockSymbols(
   const uniqueSymbols = [...new Set(symbols.map((symbol) => symbol.toUpperCase()))];
   if (uniqueSymbols.length === 0) {
     return {
+      outcome: "no_due_symbols",
       updated: 0,
       changed: 0,
       skippedFresh: 0,
@@ -496,6 +505,7 @@ async function refreshPricesForHoldings(
 ): Promise<RefreshPricesResult> {
   if (holdings.length === 0) {
     return {
+      outcome: "no_due_symbols",
       updated: 0,
       changed: 0,
       skippedFresh: 0,
@@ -543,6 +553,7 @@ async function refreshPricesForHoldings(
         ? new Date(earliestFreshUpdatedAt.getTime() + PRICE_REFRESH_TTL_MS)
         : null;
       return {
+        outcome: "no_due_symbols",
         updated: 0,
         changed: 0,
         skippedFresh,
@@ -585,6 +596,7 @@ async function refreshPricesForHoldings(
       // All existing stale symbols are being refreshed by another instance.
       // Tell the client when the claim lock expires so it knows when to retry.
       return {
+        outcome: "deferred",
         updated: 0,
         changed: 0,
         skippedFresh,
@@ -605,13 +617,29 @@ async function refreshPricesForHoldings(
 
   const cryptoSymbols = holdings.filter((h) => h.assetType === "CRYPTO").map((h) => h.symbol);
 
+  // OTHER holdings intentionally have no market-data provider. They are not a
+  // failed refresh target; release any stale-row claim and preserve the normal
+  // no-work success semantics.
+  if (stockSymbols.length === 0 && cryptoSymbols.length === 0) {
+    await releaseClaims(claimedSymbols);
+    return {
+      outcome: "no_due_symbols",
+      updated: 0,
+      changed: 0,
+      skippedFresh,
+      errors: [],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
+  }
+
   const errors: string[] = [];
   let updated = 0;
   let changed = 0;
 
   const [stockResult, cryptoResult] = await Promise.allSettled([
-    fetchStockPrices(stockSymbols),
-    fetchCryptoPrices(cryptoSymbols),
+    fetchStockPrices(stockSymbols, errors),
+    fetchCryptoPrices(cryptoSymbols, errors),
   ]);
   const stockPrices =
     stockResult.status === "fulfilled"
@@ -635,7 +663,11 @@ async function refreshPricesForHoldings(
     // No prices came back (all fetches failed). Release claims so the next
     // request can retry rather than waiting for the 30s dead-instance TTL.
     await releaseClaims(claimedSymbols);
+    if (errors.length === 0) {
+      errors.push(`No usable prices returned for ${holdings.length} due symbols`);
+    }
     return {
+      outcome: "total_failure",
       updated: 0,
       changed: 0,
       skippedFresh,
@@ -691,5 +723,17 @@ async function refreshPricesForHoldings(
     await releaseClaims(claimedSymbols);
   }
 
-  return { updated, changed, skippedFresh, errors, nextRefreshAt: null, retryAfterSeconds: null };
+  return {
+    outcome: errors.some((error) => error.startsWith("Bulk upsert failed"))
+      ? "total_failure"
+      : entries.length < holdings.length
+        ? "partial_success"
+        : "success",
+    updated,
+    changed,
+    skippedFresh,
+    errors,
+    nextRefreshAt: null,
+    retryAfterSeconds: null,
+  };
 }

--- a/src/lib/services/price-service.ts
+++ b/src/lib/services/price-service.ts
@@ -616,11 +616,12 @@ async function refreshPricesForHoldings(
     .map((h) => h.symbol);
 
   const cryptoSymbols = holdings.filter((h) => h.assetType === "CRYPTO").map((h) => h.symbol);
+  const supportedDueSymbols = new Set([...stockSymbols, ...cryptoSymbols]);
 
   // OTHER holdings intentionally have no market-data provider. They are not a
   // failed refresh target; release any stale-row claim and preserve the normal
   // no-work success semantics.
-  if (stockSymbols.length === 0 && cryptoSymbols.length === 0) {
+  if (supportedDueSymbols.size === 0) {
     await releaseClaims(claimedSymbols);
     return {
       outcome: "no_due_symbols",
@@ -658,13 +659,13 @@ async function refreshPricesForHoldings(
 
   const allPrices = new Map([...stockPrices, ...cryptoPrices]);
 
-  const entries = [...allPrices];
+  const entries = [...allPrices].filter(([symbol]) => supportedDueSymbols.has(symbol));
   if (entries.length === 0) {
     // No prices came back (all fetches failed). Release claims so the next
     // request can retry rather than waiting for the 30s dead-instance TTL.
     await releaseClaims(claimedSymbols);
     if (errors.length === 0) {
-      errors.push(`No usable prices returned for ${holdings.length} due symbols`);
+      errors.push(`No usable prices returned for ${supportedDueSymbols.size} due symbols`);
     }
     return {
       outcome: "total_failure",
@@ -677,6 +678,7 @@ async function refreshPricesForHoldings(
     };
   }
 
+  let bulkUpsertFailed = false;
   try {
     const currentRows = await prisma.priceCache.findMany({
       where: { symbol: { in: entries.map(([symbol]) => symbol) } },
@@ -718,15 +720,16 @@ async function refreshPricesForHoldings(
     const fetchedSet = new Set(entries.map(([symbol]) => symbol));
     await releaseClaims(claimedSymbols.filter((symbol) => !fetchedSet.has(symbol)));
   } catch (error) {
+    bulkUpsertFailed = true;
     errors.push(`Bulk upsert failed: ${String(error)}`);
     // Release claims so the next request can retry immediately.
     await releaseClaims(claimedSymbols);
   }
 
   return {
-    outcome: errors.some((error) => error.startsWith("Bulk upsert failed"))
+    outcome: bulkUpsertFailed
       ? "total_failure"
-      : entries.length < holdings.length
+      : entries.length < supportedDueSymbols.size
         ? "partial_success"
         : "success",
     updated,

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => {
   return {
     makeTx,
     tx: makeTx(),
+    priceRefreshResult: undefined as unknown,
   };
 });
 
@@ -54,7 +55,7 @@ vi.mock("@/lib/services/exchange-rate-service", () => ({
 }));
 
 vi.mock("@/lib/services/price-service", () => ({
-  refreshPricesForUser: vi.fn(async () => undefined),
+  refreshPricesForUser: vi.fn(async () => h.priceRefreshResult),
 }));
 
 const calendarFixture = {
@@ -121,6 +122,7 @@ async function importBackup(body: unknown) {
 describe("Calendar whole-app backup", () => {
   beforeEach(() => {
     h.tx = h.makeTx();
+    h.priceRefreshResult = undefined;
     vi.clearAllMocks();
   });
 
@@ -167,5 +169,19 @@ describe("Calendar whole-app backup", () => {
     expect(response.status).toBe(200);
     expect(h.tx.calendarEntry.deleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
     expect(h.tx.calendarEntry.createMany).not.toHaveBeenCalled();
+  });
+
+  it("logs a resolved total price-refresh failure after import warm-up", async () => {
+    h.priceRefreshResult = { outcome: "total_failure", errors: ["Yahoo Finance unavailable"] };
+    const { log } = await import("@/lib/logger");
+
+    const response = await importBackup({ version: "1.4", accounts: [] });
+    await Promise.resolve();
+
+    expect(response.status).toBe(200);
+    expect(log.error).toHaveBeenCalledWith(
+      "import.price_warm_failed",
+      expect.objectContaining({ outcome: "total_failure" }),
+    );
   });
 });

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   snapshotOpts: [] as unknown[],
   rateRefreshes: [] as string[],
   rateRefreshFailures: new Set<string>(),
+  priceRefreshResult: { updated: 0, changed: 0, outcome: "success", errors: [] as string[] },
   snapshotTimeJumpUser: null as string | null,
   snapshotTimeJumpMs: 0,
 }));
@@ -57,7 +58,7 @@ vi.mock("@/lib/services/net-worth-service", () => ({
 }));
 
 vi.mock("@/lib/services/price-service", () => ({
-  refreshAllPrices: vi.fn(async () => ({ updated: 0, changed: 0 })),
+  refreshAllPrices: vi.fn(async () => h.priceRefreshResult),
 }));
 
 vi.mock("@/lib/services/recurring-cash-service", () => ({
@@ -132,6 +133,7 @@ describe("snapshot cron route", () => {
     h.snapshotOpts = [];
     h.rateRefreshes = [];
     h.rateRefreshFailures = new Set();
+    h.priceRefreshResult = { updated: 0, changed: 0, outcome: "success", errors: [] };
     h.snapshotTimeJumpUser = null;
     h.snapshotTimeJumpMs = 0;
   });
@@ -265,6 +267,36 @@ describe("snapshot cron route", () => {
           error: expect.stringContaining("user1"),
         }),
       }),
+    );
+    expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
+  });
+
+  it("fails the audit and skips stale-price snapshots when every due price fetch fails", async () => {
+    h.priceRefreshResult = {
+      updated: 0,
+      changed: 0,
+      outcome: "total_failure",
+      errors: ["Yahoo Finance batch failed: Error: upstream unavailable"],
+    };
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+    const { prisma } = await import("@/lib/prisma");
+    const { log } = await import("@/lib/logger");
+    const { finishSnapshotCronCheckIn } = await import("@/lib/sentry-cron");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(h.events.filter((event) => event.startsWith("snapshot:"))).toEqual([]);
+    expect(log.error).toHaveBeenCalledWith(
+      "cron.prices.refresh_failed",
+      expect.objectContaining({ errors: h.priceRefreshResult.errors }),
+    );
+    expect(prisma.cronRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ ok: false }) }),
     );
     expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
   });

--- a/tests/unit/health-index-contract.test.ts
+++ b/tests/unit/health-index-contract.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+describe("health priceable-holding existence index", () => {
+  it("indexes Holding.assetType in both schema and migration", () => {
+    const schema = readFileSync(resolve(root, "prisma/schema.prisma"), "utf8");
+    const holdingModel = schema.match(/model Holding \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(holdingModel).toContain("@@index([assetType])");
+
+    const migration = readFileSync(
+      resolve(root, "prisma/migrations/20260728000000_add_holding_asset_type_index/migration.sql"),
+      "utf8",
+    );
+    expect(migration).toContain('CREATE INDEX IF NOT EXISTS "Holding_assetType_idx"');
+  });
+});

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   latestPriceAt: null as Date | null,
   hasPriceableHolding: false,
   hasPriceableWatch: false,
+  assetExistenceError: false,
 }));
 
 vi.mock("@/lib/rate-limit", () => ({ rateLimitCheckWithPrune: vi.fn(() => null) }));
@@ -29,7 +30,10 @@ vi.mock("@/lib/prisma", () => ({
       aggregate: vi.fn(async () => ({ _max: { updatedAt: h.latestPriceAt } })),
     },
     holding: {
-      findFirst: vi.fn(async () => (h.hasPriceableHolding ? { id: "holding-1" } : null)),
+      findFirst: vi.fn(async () => {
+        if (h.assetExistenceError) throw new Error("holding existence query unavailable");
+        return h.hasPriceableHolding ? { id: "holding-1" } : null;
+      }),
     },
     stockWatchItem: {
       findFirst: vi.fn(async () => (h.hasPriceableWatch ? { id: "watch-1" } : null)),
@@ -50,6 +54,7 @@ describe("health route price freshness", () => {
     h.latestPriceAt = now;
     h.hasPriceableHolding = false;
     h.hasPriceableWatch = false;
+    h.assetExistenceError = false;
   });
 
   afterEach(() => {
@@ -110,6 +115,20 @@ describe("health route price freshness", () => {
       priceCache: "empty",
       latestPriceAt: null,
       priceAgeMs: null,
+    });
+  });
+
+  it("returns unhealthy when an empty-cache asset-existence query fails", async () => {
+    h.latestPriceAt = null;
+    h.assetExistenceError = true;
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "unhealthy",
+      db: "error",
+      priceCache: "unknown",
     });
   });
 

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -5,6 +5,8 @@ const h = vi.hoisted(() => ({
   latestSnapshotAt: null as Date | null,
   latestCronAt: null as Date | null,
   latestPriceAt: null as Date | null,
+  hasPriceableHolding: false,
+  hasPriceableWatch: false,
 }));
 
 vi.mock("@/lib/rate-limit", () => ({ rateLimitCheckWithPrune: vi.fn(() => null) }));
@@ -26,6 +28,12 @@ vi.mock("@/lib/prisma", () => ({
     priceCache: {
       aggregate: vi.fn(async () => ({ _max: { updatedAt: h.latestPriceAt } })),
     },
+    holding: {
+      findFirst: vi.fn(async () => (h.hasPriceableHolding ? { id: "holding-1" } : null)),
+    },
+    stockWatchItem: {
+      findFirst: vi.fn(async () => (h.hasPriceableWatch ? { id: "watch-1" } : null)),
+    },
   },
 }));
 
@@ -40,6 +48,8 @@ describe("health route price freshness", () => {
     h.latestSnapshotAt = now;
     h.latestCronAt = now;
     h.latestPriceAt = now;
+    h.hasPriceableHolding = false;
+    h.hasPriceableWatch = false;
   });
 
   afterEach(() => {
@@ -74,7 +84,22 @@ describe("health route price freshness", () => {
     });
   });
 
-  it("reports an empty cache without degrading a genuinely empty installation", async () => {
+  it("degrades an empty cache when a priceable holding exists", async () => {
+    h.latestPriceAt = null;
+    h.hasPriceableHolding = true;
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      priceCache: "stale",
+      latestPriceAt: null,
+      priceAgeMs: null,
+    });
+  });
+
+  it("reports an empty cache without degrading an installation with no priceable assets", async () => {
     h.latestPriceAt = null;
     const { GET } = await import("@/app/api/health/route");
     const response = await GET(new Request("http://unit.test/api/health"));

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  dbError: false,
+  latestSnapshotAt: null as Date | null,
+  latestCronAt: null as Date | null,
+  latestPriceAt: null as Date | null,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({ rateLimitCheckWithPrune: vi.fn(() => null) }));
+vi.mock("@/lib/logger", () => ({
+  log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: vi.fn(async () => {
+      if (h.dbError) throw new Error("database unavailable");
+      return [{ "?column?": 1 }];
+    }),
+    netWorthSnapshot: {
+      findFirst: vi.fn(async () => (h.latestSnapshotAt ? { createdAt: h.latestSnapshotAt } : null)),
+    },
+    cronRun: {
+      findFirst: vi.fn(async () => (h.latestCronAt ? { startedAt: h.latestCronAt } : null)),
+    },
+    priceCache: {
+      aggregate: vi.fn(async () => ({ _max: { updatedAt: h.latestPriceAt } })),
+    },
+  },
+}));
+
+describe("health route price freshness", () => {
+  const now = new Date("2026-07-28T12:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    h.dbError = false;
+    h.latestSnapshotAt = now;
+    h.latestCronAt = now;
+    h.latestPriceAt = now;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports fresh price-cache health without exposing sensitive market or user data", async () => {
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ status: "ok", priceCache: "ok", priceAgeMs: 0 });
+    expect(body).not.toHaveProperty("symbol");
+    expect(body).not.toHaveProperty("symbols");
+    expect(body).not.toHaveProperty("price");
+    expect(body).not.toHaveProperty("prices");
+    expect(body).not.toHaveProperty("holdings");
+    expect(body).not.toHaveProperty("users");
+    expect(body).not.toHaveProperty("userId");
+  });
+
+  it("degrades when cached prices are stale", async () => {
+    h.latestPriceAt = new Date(now.getTime() - 36 * 60 * 60 * 1000 - 1);
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      priceCache: "stale",
+    });
+  });
+
+  it("reports an empty cache without degrading a genuinely empty installation", async () => {
+    h.latestPriceAt = null;
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ok",
+      priceCache: "empty",
+      latestPriceAt: null,
+      priceAgeMs: null,
+    });
+  });
+
+  it("returns unhealthy when the lightweight health query fails", async () => {
+    h.dbError = true;
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "unhealthy",
+      db: "error",
+      priceCache: "unknown",
+    });
+  });
+});

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -130,6 +130,19 @@ describe("refreshAllPrices — cron-wide symbol collection", () => {
     expect(fetched).toContain("TSLA");
     expect(fetched.filter((symbol) => symbol === "AAPL")).toHaveLength(1);
   });
+
+  it("treats unpriceable holdings as no due symbols", async () => {
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([
+      { symbol: "PRIVATE-LOAN", assetType: "OTHER" },
+    ] as never);
+    vi.mocked(prisma.stockWatchItem.findMany).mockResolvedValueOnce([] as never);
+
+    const result = await refreshAllPrices();
+
+    expect(result.outcome).toBe("no_due_symbols");
+    expect(result.updated).toBe(0);
+    expect(getYahooClient).not.toHaveBeenCalled();
+  });
 });
 
 describe("refreshPricesForStockSymbols — claim deduplication", () => {
@@ -153,6 +166,26 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     expect(result.updated).toBe(0);
     expect(result.errors).toHaveLength(0);
     expect(getYahooClient).not.toHaveBeenCalled();
+  });
+
+  it("reports no_due_symbols when every requested symbol is still fresh", async () => {
+    vi.mocked(prisma.priceCache.findMany).mockResolvedValueOnce([
+      { symbol: "AAPL", updatedAt: new Date() },
+    ] as never);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    expect(result.outcome).toBe("no_due_symbols");
+    expect(result.updated).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(getYahooClient).not.toHaveBeenCalled();
+  });
+
+  it("reports no_due_symbols when there are no requested symbols", async () => {
+    const result = await refreshPricesForStockSymbols([]);
+
+    expect(result.outcome).toBe("no_due_symbols");
+    expect(result.updated).toBe(0);
   });
 
   it("releases the claim when Yahoo returns no prices (fetch failure)", async () => {
@@ -182,6 +215,10 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     expect(getYahooClient).toHaveBeenCalled();
     expect(cleanupCall).toBeDefined();
     expect(result.updated).toBe(0);
+    expect(result.outcome).toBe("total_failure");
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining("Yahoo Finance batch failed")]),
+    );
   });
 
   it("releases the claim when the Yahoo client fails to initialize", async () => {
@@ -234,6 +271,7 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     const result = await refreshPricesForStockSymbols(["AAPL", "MSFT"]);
 
     expect(result.updated).toBe(1);
+    expect(result.outcome).toBe("partial_success");
 
     // The release call must target MSFT only, never AAPL (whose claim the
     // upsert already cleared).

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -143,6 +143,27 @@ describe("refreshAllPrices — cron-wide symbol collection", () => {
     expect(result.updated).toBe(0);
     expect(getYahooClient).not.toHaveBeenCalled();
   });
+
+  it("reports success when supported due symbols refresh alongside unsupported or duplicate holdings", async () => {
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([
+      { symbol: "AAPL", assetType: "STOCK" },
+      { symbol: "AAPL", assetType: "STOCK" },
+      { symbol: "PRIVATE-LOAN", assetType: "OTHER" },
+    ] as never);
+    vi.mocked(prisma.stockWatchItem.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.priceCache.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi
+        .fn()
+        .mockResolvedValue([{ symbol: "AAPL", regularMarketPrice: 100, currency: "USD" }]),
+    } as never);
+    vi.mocked(prisma.$executeRawUnsafe).mockResolvedValueOnce(1 as never);
+
+    const result = await refreshAllPrices();
+
+    expect(result.updated).toBe(1);
+    expect(result.outcome).toBe("success");
+  });
 });
 
 describe("refreshPricesForStockSymbols — claim deduplication", () => {
@@ -241,6 +262,29 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     expect(cleanupCall).toBeDefined();
     expect(result.updated).toBe(0);
     expect(result.errors).toEqual([expect.stringContaining("client initialization failed")]);
+  });
+
+  it("returns total_failure when the bulk price upsert fails", async () => {
+    const staleDate = new Date(Date.now() - PRICE_REFRESH_TTL_MS - 5_000);
+    vi.mocked(prisma.priceCache.findMany)
+      .mockResolvedValueOnce([{ symbol: "AAPL", updatedAt: staleDate }] as never)
+      .mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce([{ symbol: "AAPL" }]);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi
+        .fn()
+        .mockResolvedValue([{ symbol: "AAPL", regularMarketPrice: 100, currency: "USD" }]),
+    } as never);
+    vi.mocked(prisma.$executeRawUnsafe)
+      .mockRejectedValueOnce(new Error("database write unavailable"))
+      .mockResolvedValueOnce(1 as never);
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    expect(result.outcome).toBe("total_failure");
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining("Bulk upsert failed")]),
+    );
   });
 
   it("releases only the unfetched claim on a partial fetch (one ticker missing)", async () => {

--- a/tests/unit/price-service.test.ts
+++ b/tests/unit/price-service.test.ts
@@ -287,6 +287,33 @@ describe("refreshPricesForStockSymbols — claim deduplication", () => {
     );
   });
 
+  it("keeps a persisted refresh successful when cache revalidation throws", async () => {
+    const staleDate = new Date(Date.now() - PRICE_REFRESH_TTL_MS - 5_000);
+    vi.mocked(prisma.priceCache.findMany)
+      .mockResolvedValueOnce([{ symbol: "AAPL", updatedAt: staleDate }] as never)
+      .mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce([{ symbol: "AAPL" }]);
+    vi.mocked(getYahooClient).mockResolvedValue({
+      quote: vi
+        .fn()
+        .mockResolvedValue([{ symbol: "AAPL", regularMarketPrice: 100, currency: "USD" }]),
+    } as never);
+    vi.mocked(prisma.$executeRawUnsafe).mockResolvedValueOnce(1 as never);
+    const { revalidateTag } = await import("next/cache");
+    const { log } = await import("@/lib/logger");
+    vi.mocked(revalidateTag).mockImplementationOnce(() => {
+      throw new Error("cache unavailable");
+    });
+
+    const result = await refreshPricesForStockSymbols(["AAPL"]);
+
+    expect(result).toMatchObject({ outcome: "success", updated: 1, changed: 1 });
+    expect(log.error).toHaveBeenCalledWith(
+      "price.refresh.revalidate_failed",
+      expect.objectContaining({ error: expect.stringContaining("cache unavailable") }),
+    );
+  });
+
   it("releases only the unfetched claim on a partial fetch (one ticker missing)", async () => {
     const staleDate = new Date(Date.now() - PRICE_REFRESH_TTL_MS - 5_000);
 

--- a/tests/unit/refresh-client.test.ts
+++ b/tests/unit/refresh-client.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("refreshMarketData", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns error instead of an updated/fresh outcome for a total price refresh failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          data: {
+            prices: { updated: 0, changed: 0, outcome: "total_failure", fetchFailed: true },
+            rates: { updated: 0, changed: 0, fetchFailed: false },
+          },
+        }),
+      ),
+    );
+    const { refreshMarketData } = await import("@/lib/refresh-client");
+
+    await expect(refreshMarketData()).resolves.toEqual({ status: "error" });
+  });
+});

--- a/tests/unit/refresh-route.test.ts
+++ b/tests/unit/refresh-route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  priceResult: {
+    outcome: "total_failure",
+    updated: 0,
+    changed: 0,
+    skippedFresh: 0,
+    errors: ["Yahoo Finance batch failed"],
+    nextRefreshAt: null,
+    retryAfterSeconds: null,
+  },
+}));
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+vi.mock("@/lib/api-handler", () => ({
+  withAuth:
+    (handler: (request: Request, context: unknown, userId: string) => Promise<Response>) =>
+    (request: Request, context: unknown) =>
+      handler(request, context, "user-1"),
+}));
+vi.mock("@/lib/rate-limit", () => ({ rateLimitCheckWithPrune: vi.fn(() => null) }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    setting: { findUnique: vi.fn(async () => ({ baseCurrency: "USD" })) },
+    account: { findMany: vi.fn(async () => []) },
+  },
+}));
+vi.mock("@/lib/services/price-service", () => ({
+  refreshPricesForUser: vi.fn(async () => h.priceResult),
+}));
+vi.mock("@/lib/services/exchange-rate-service", () => ({
+  refreshExchangeRates: vi.fn(async () => ({
+    updated: 0,
+    changed: 0,
+    skippedFresh: false,
+    fetchFailed: false,
+    nextRefreshAt: null,
+  })),
+}));
+
+describe("unified market refresh route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.priceResult = {
+      outcome: "total_failure",
+      updated: 0,
+      changed: 0,
+      skippedFresh: 0,
+      errors: ["Yahoo Finance batch failed"],
+      nextRefreshAt: null,
+      retryAfterSeconds: null,
+    };
+  });
+
+  it("returns the total price-refresh failure outcome to clients", async () => {
+    const { POST } = await import("@/app/api/refresh/route");
+    const response = await POST(
+      new Request("http://unit.test/api/refresh", { method: "POST" }),
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { prices: { outcome: "total_failure", fetchFailed: true } },
+    });
+  });
+});

--- a/tests/unit/stock-manual-refresh.test.ts
+++ b/tests/unit/stock-manual-refresh.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { stockManualRefreshFeedback } from "@/lib/price-refresh-contract";
+
+describe("stock manual refresh feedback", () => {
+  it("classifies a total provider failure as an error, never a success toast", () => {
+    expect(stockManualRefreshFeedback({ updated: 0, outcome: "total_failure" })).toBe("error");
+  });
+
+  it("keeps partial provider success on the successful refresh path", () => {
+    expect(stockManualRefreshFeedback({ updated: 1, outcome: "partial_success" })).toBe("success");
+  });
+});


### PR DESCRIPTION
## Summary

- distinguish no-work, deferred, partial-success, and total price-refresh outcomes while retaining provider failure context
- fail the snapshot cron before stale-price snapshots, record a failed audit/Sentry check-in, and surface total failures in manual refresh and import warm-up consumers
- expose indexed, non-sensitive PriceCache freshness in health checks, including empty-cache installations with priceable assets
- keep partial refreshes successful and isolate cache-revalidation failures from completed price persistence
- add the `Holding.assetType` index used by the empty-cache readiness probe

## Verification

- `pnpm test:unit` — 65 files / 508 tests
- `pnpm exec prisma validate`
- `pnpm check` with repository CI placeholder environment
- GitHub CI, Docker smoke, Playwright smoke/preview, and Vercel preview

Closes #649
