### PR TITLE
fix(import): preserve snapshot breakdown currencies

### DIFF
--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -181,36 +181,6 @@ function normalizeSnapshotBreakdown(
   return value as Prisma.InputJsonValue;
 }
 
-function normalizeSnapshotBreakdownCurrency(
-  value: ImportSnapshot["breakdown"],
-  rateMap: Map<string, number>,
-  targetBaseCurrency: string,
-): ImportSnapshot["breakdown"] {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-
-  const normalized: Record<string, unknown> = {};
-  for (const [accountId, entry] of Object.entries(value)) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      normalized[accountId] = entry;
-      continue;
-    }
-
-    const rawEntry = entry as { value?: unknown; currency?: unknown };
-    const currency = typeof rawEntry.currency === "string" ? rawEntry.currency : "USD";
-    const rate = resolveRate(rateMap, currency, targetBaseCurrency);
-    const valueNumber =
-      typeof rawEntry.value === "number" ? rawEntry.value : Number(rawEntry.value ?? 0);
-
-    normalized[accountId] = {
-      ...rawEntry,
-      value: rate ? valueNumber * rate : rawEntry.value,
-      currency: rate ? targetBaseCurrency : currency,
-    };
-  }
-
-  return normalized;
-}
-
 function normalizeSnapshotAmount(
   value: string | number,
   fromCurrency: string,
@@ -507,11 +477,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                 ),
                 baseCurrency: targetBaseCurrency,
                 breakdown: normalizeSnapshotBreakdown(
-                  normalizeSnapshotBreakdownCurrency(
-                    remapSnapshotBreakdown(s.breakdown, accountIdMap),
-                    rateMap,
-                    targetBaseCurrency,
-                  ),
+                  remapSnapshotBreakdown(s.breakdown, accountIdMap),
                 ),
                 label: s.label?.trim() || null,
                 note: s.note?.trim() || null,

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => {
   const makeTx = () => ({
-    account: { deleteMany: vi.fn() },
+    account: { deleteMany: vi.fn(), create: vi.fn(async () => ({ id: "new_account_1" })) },
     netWorthSnapshot: { deleteMany: vi.fn(), createMany: vi.fn() },
     goal: { deleteMany: vi.fn(), createMany: vi.fn() },
     stockWatchItem: { deleteMany: vi.fn(), createMany: vi.fn() },
@@ -51,7 +51,9 @@ vi.mock("@/lib/rate-limit", () => ({
 
 vi.mock("@/lib/services/exchange-rate-service", () => ({
   refreshExchangeRates: vi.fn(async () => undefined),
-  resolveRate: vi.fn(() => 1),
+  resolveRate: vi.fn((_rateMap: Map<string, number>, fromCurrency: string, toCurrency: string) =>
+    fromCurrency === toCurrency ? 1 : 30,
+  ),
 }));
 
 vi.mock("@/lib/services/price-service", () => ({
@@ -169,6 +171,53 @@ describe("Calendar whole-app backup", () => {
     expect(response.status).toBe(200);
     expect(h.tx.calendarEntry.deleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
     expect(h.tx.calendarEntry.createMany).not.toHaveBeenCalled();
+  });
+
+  it("preserves remapped mixed-currency snapshot breakdown entries for later FX revaluation", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      settings: { baseCurrency: "TWD", locale: "en-US" },
+      accounts: [
+        {
+          id: "exported_usd_account",
+          name: "US savings",
+          type: "ASSET",
+          category: "BANK",
+          currency: "USD",
+          cashBalance: 100,
+          isActive: true,
+          isPinned: false,
+          sortOrder: 0,
+        },
+      ],
+      snapshots: [
+        {
+          date: "2026-07-01T00:00:00.000Z",
+          totalAssets: 100,
+          totalLiabilities: 0,
+          netWorth: 100,
+          baseCurrency: "USD",
+          breakdown: {
+            exported_usd_account: { value: 100, currency: "USD", type: "CASH" },
+          },
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.netWorthSnapshot.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          totalAssets: 3000,
+          totalLiabilities: 0,
+          netWorth: 3000,
+          baseCurrency: "TWD",
+          breakdown: {
+            new_account_1: { value: 100, currency: "USD", type: "CASH" },
+          },
+        }),
+      ],
+    });
   });
 
   it("logs a resolved total price-refresh failure after import warm-up", async () => {


### PR DESCRIPTION
## Summary

- preserve each imported snapshot breakdown entry's original `value`, `currency`, and additional fields after account-ID remapping
- keep aggregate `totalAssets`, `totalLiabilities`, `netWorth`, and snapshot `baseCurrency` normalization unchanged
- add a route-level mixed-currency regression proving USD breakdown data remains lossless when importing into a TWD target

## Root cause

The import path normalized both aggregate snapshot totals and every per-account breakdown entry to the target base currency. Overwriting the breakdown denomination destroyed the original source amount/currency required for later lossless FX revaluation.

## User impact

Export → import no longer permanently flattens mixed-currency snapshot history into the current base currency. Future history normalization can still identify and revalue each original account denomination.

## Validation

- TDD RED: regression received `{ value: 3000, currency: "TWD" }` instead of the preserved `{ value: 100, currency: "USD" }`
- focused route tests: 5/5 passed
- full unit suite: 65 files, 509 tests passed
- Prettier: passed
- ESLint: passed
- TypeScript: passed
- production Next.js build: passed with non-sensitive CI placeholder environment
- two independent subagent reviews: no Critical or Important findings; final assessment Ready to merge

Closes #655