### PR TITLE
fix: make backup export/import round trips

### DIFF
--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { after } from "next/server";
+import { createGunzip, gzip } from "node:zlib";
+import { promisify } from "node:util";
 import type { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
@@ -18,11 +20,17 @@ const MISSING_ACCOUNT_GOAL_MESSAGE =
   "Import backup contains an account-scoped goal that references a missing account.";
 const MISSING_EXCHANGE_RATE_MESSAGE =
   "Import backup contains mixed-currency snapshots, but the required exchange rate could not be loaded.";
-const MAX_IMPORT_BODY_BYTES = 4 * 1024 * 1024;
+// Vercel Functions accept at most 4.5 MB request and response bodies. Keep a
+// margin for HTTP overhead, while using gzip for the app's backup transport.
+// The decompressed cap bounds the memory consumed while parsing an archive.
+const MAX_COMPRESSED_BACKUP_BYTES = 4 * 1024 * 1024;
+const MAX_UNCOMPRESSED_BACKUP_BYTES = 16 * 1024 * 1024;
+const gzipAsync = promisify(gzip);
 
 type ImportData = z.infer<typeof dataImportSchema>;
 type ImportGoal = NonNullable<ImportData["goals"]>[number];
 type ImportSnapshot = NonNullable<ImportData["snapshots"]>[number];
+class BackupTooLargeError extends Error {}
 
 async function readImportJson(
   request: Request,
@@ -30,7 +38,7 @@ async function readImportJson(
   const contentLength = request.headers.get("content-length");
   if (contentLength) {
     const declaredBytes = Number(contentLength);
-    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_IMPORT_BODY_BYTES) {
+    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_COMPRESSED_BACKUP_BYTES) {
       return { ok: false, response: failure("Import backup is too large", 413) };
     }
   }
@@ -40,26 +48,72 @@ async function readImportJson(
   }
 
   const reader = request.body.getReader();
-  const decoder = new TextDecoder();
   let receivedBytes = 0;
-  let text = "";
+  const chunks: Uint8Array[] = [];
 
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
     receivedBytes += value.byteLength;
-    if (receivedBytes > MAX_IMPORT_BODY_BYTES) {
+    if (receivedBytes > MAX_COMPRESSED_BACKUP_BYTES) {
       return { ok: false, response: failure("Import backup is too large", 413) };
     }
-    text += decoder.decode(value, { stream: true });
+    chunks.push(value);
   }
-  text += decoder.decode();
+
+  const bytes = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim();
+  let jsonBytes: Uint8Array<ArrayBufferLike> = bytes;
+  if (contentType === "application/gzip" || contentType === "application/x-gzip") {
+    try {
+      jsonBytes = await decompressBackup(bytes);
+    } catch (error) {
+      if (error instanceof BackupTooLargeError) {
+        return { ok: false, response: failure("Import backup is too large", 413) };
+      }
+      return { ok: false, response: failure("Import backup must be valid JSON", 400) };
+    }
+  }
 
   try {
-    return { ok: true, body: JSON.parse(text) };
+    return { ok: true, body: JSON.parse(new TextDecoder().decode(jsonBytes)) };
   } catch {
     return { ok: false, response: failure("Import backup must be valid JSON", 400) };
   }
+}
+
+async function decompressBackup(compressed: Uint8Array): Promise<Uint8Array> {
+  const gunzip = createGunzip();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+
+  return new Promise((resolve, reject) => {
+    gunzip.on("data", (chunk: Uint8Array) => {
+      length += chunk.byteLength;
+      if (length > MAX_UNCOMPRESSED_BACKUP_BYTES) {
+        gunzip.destroy(new BackupTooLargeError());
+        return;
+      }
+      chunks.push(chunk);
+    });
+    gunzip.on("error", reject);
+    gunzip.on("end", () => {
+      const result = new Uint8Array(length);
+      let offset = 0;
+      for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      resolve(result);
+    });
+    gunzip.end(compressed);
+  });
 }
 
 function validateAccountGoalReferences(importData: ImportData) {
@@ -247,10 +301,23 @@ export const GET = withAuth(async (request, _ctx, userId) => {
       calendarEntries: data.calendarEntries.map(serializeCalendarEntry),
     };
 
-    // Return as a raw JSON file download — NOT wrapped in ok() so the blob
-    // content matches the dataImportSchema format for round-trip import.
-    return NextResponse.json(exportData, {
+    const json = JSON.stringify(exportData);
+    if (Buffer.byteLength(json) > MAX_UNCOMPRESSED_BACKUP_BYTES) {
+      return failure("Export backup is too large", 413);
+    }
+
+    const compressed = await gzipAsync(json);
+    if (compressed.byteLength > MAX_COMPRESSED_BACKUP_BYTES) {
+      return failure("Export backup is too large", 413);
+    }
+
+    // The download remains a JSON file after the browser decodes this standard
+    // content encoding. Its wire representation stays below Vercel's function
+    // limit, and the settings UI uploads it with the same gzip transport.
+    return new NextResponse(compressed, {
       headers: {
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json",
         "Content-Disposition": `attachment; filename="assets-tracker-backup-${new Date().toISOString().split("T")[0]}.json"`,
       },
     });

--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -69,6 +69,18 @@ function formatBackupDate(value: string | null, locale: string) {
   return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(date);
 }
 
+async function compressBackup(data: unknown) {
+  const json = JSON.stringify(data);
+  if (typeof CompressionStream === "undefined") {
+    return new Blob([json], { type: "application/json" });
+  }
+
+  const stream = new Blob([json], { type: "application/json" })
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  return new Response(stream, { headers: { "Content-Type": "application/gzip" } }).blob();
+}
+
 function buildImportPreview(data: unknown, file: File): ImportPreview | null {
   if (!isRecord(data) || !Array.isArray(data.accounts)) return null;
 
@@ -211,10 +223,11 @@ export function DataManagement() {
       setShowConfirm(false);
       setImportError(null);
 
+      const backup = await compressBackup(parsedImport);
       const response = await fetch("/api/settings/data", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(parsedImport),
+        headers: { "Content-Type": backup.type },
+        body: backup,
       });
 
       if (!response.ok) {

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { gzipSync, gunzipSync } from "node:zlib";
 
 const h = vi.hoisted(() => {
   const makeTx = () => ({
     account: { deleteMany: vi.fn(), create: vi.fn(async () => ({ id: "new_account_1" })) },
+    cashTransaction: { createMany: vi.fn() },
+    holding: { create: vi.fn() },
+    holdingTransaction: { createMany: vi.fn() },
     netWorthSnapshot: { deleteMany: vi.fn(), createMany: vi.fn() },
     goal: { deleteMany: vi.fn(), createMany: vi.fn() },
+    recurringCashTransaction: { create: vi.fn() },
+    recurringInvestment: { create: vi.fn() },
     stockWatchItem: { deleteMany: vi.fn(), createMany: vi.fn() },
     calendarEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
     setting: { upsert: vi.fn() },
@@ -81,14 +87,14 @@ const exportedCalendarFixture = {
   updatedAt: "2026-07-24T02:00:00.000Z",
 };
 
-const exportedUserFixture = {
+let exportedUserFixture = {
   id: "user_1",
   name: "Unit Test User",
   email: "unit@example.com",
   emailVerified: null,
   image: null,
   appSettings: null,
-  appAccounts: [],
+  appAccounts: [] as unknown[],
   snapshots: [],
   goals: [],
   stockWatchItems: [],
@@ -121,19 +127,103 @@ async function importBackup(body: unknown) {
   );
 }
 
+async function exportedJson(response: Response) {
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const text =
+    response.headers.get("content-encoding") === "gzip"
+      ? gunzipSync(bytes).toString("utf8")
+      : new TextDecoder().decode(bytes);
+  return { text, json: JSON.parse(text) };
+}
+
+function makeExportCompatibleAccount(accountNumber: number) {
+  return {
+    id: `account_${accountNumber}`,
+    userId: "user_1",
+    name: `Cash account ${accountNumber}`,
+    type: "ASSET" as const,
+    category: "BANK" as const,
+    currency: "USD",
+    cashBalance: "10000",
+    isActive: true,
+    isPinned: false,
+    sortOrder: accountNumber,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    holdings: [],
+    recurringCashTransactions: [],
+    recurringInvestments: [],
+    cashTransactions: Array.from({ length: 10_000 }, (_, transactionNumber) => ({
+      id: `cash_${accountNumber}_${transactionNumber}`,
+      accountId: `account_${accountNumber}`,
+      type: "DEPOSIT" as const,
+      amount: "1.00",
+      note: `Cash transaction ${transactionNumber}: ${"backup fixture ".repeat(8)}`,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      occurrenceDate: null,
+      recurringId: null,
+    })),
+  };
+}
+
 describe("Calendar whole-app backup", () => {
   beforeEach(() => {
     h.tx = h.makeTx();
     h.priceRefreshResult = undefined;
+    exportedUserFixture = {
+      id: "user_1",
+      name: "Unit Test User",
+      email: "unit@example.com",
+      emailVerified: null,
+      image: null,
+      appSettings: null,
+      appAccounts: [] as unknown[],
+      snapshots: [],
+      goals: [],
+      stockWatchItems: [],
+      calendarEntries: [calendarFixture],
+    };
     vi.clearAllMocks();
   });
 
   it("exports calendar entries in backup v1.4", async () => {
     const response = await GET(new Request("http://unit.test/api/settings/data"), undefined);
-    const json = await response.json();
+    const { json } = await exportedJson(response);
 
     expect(json.version).toBe("1.4");
     expect(json.calendarEntries).toEqual([exportedCalendarFixture]);
+  });
+
+  it("round-trips an export-compatible backup larger than 4 MiB through the compressed import workflow", async () => {
+    exportedUserFixture.appAccounts = [
+      makeExportCompatibleAccount(1),
+      makeExportCompatibleAccount(2),
+      makeExportCompatibleAccount(3),
+    ];
+
+    const exported = await GET(new Request("http://unit.test/api/settings/data"), undefined);
+    expect(exported.headers.get("content-encoding")).toBe("gzip");
+    const { text } = await exportedJson(exported);
+    expect(Buffer.byteLength(text)).toBeGreaterThan(4 * 1024 * 1024);
+    const compressed = gzipSync(text);
+    expect(compressed.byteLength).toBeLessThanOrEqual(4 * 1024 * 1024);
+
+    const response = await POST(
+      new Request("http://unit.test/api/settings/data", {
+        method: "POST",
+        headers: { "content-type": "application/gzip" },
+        body: compressed,
+      }),
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenCalledTimes(3);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([expect.objectContaining({ amount: "1.00" })]),
+      }),
+    );
   });
 
   it("replaces calendar entries inside the import transaction", async () => {


### PR DESCRIPTION
## Root cause
The export endpoint could emit schema-valid JSON larger than the import route's 4 MiB body cap. Raising that cap would still fail on Vercel's 4.5 MB Function request/response limit.

## Behavior
- Export responses use standard gzip content encoding while downloads remain JSON after browser decoding.
- Settings import uploads gzip payloads; the server accepts gzip and existing JSON backups.
- A 4 MiB compressed-wire cap and a 16 MiB decompressed cap keep request parsing bounded. Exports above either cap fail clearly without truncation.

## TDD evidence
Added a regression that builds a realistic 3-account × 10,000 cash-transaction export, proves its JSON is over 4 MiB, verifies the compressed export stays within the transport cap, and imports it successfully through the route.

## Validation
- `pnpm exec vitest run tests/unit/calendar-backup-route.test.ts` — 6 passed
- `pnpm test:unit` — 65 files / 510 tests passed
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `CI=1 AUTH_SECRET=… CRON_SECRET=… AUTH_SELF_HOST_PASSWORD=… DATABASE_URL=… AUTH_TRUST_HOST=true pnpm build`
- `git diff --check`

Closes #656