### PR TITLE
Fix lossless mixed-currency history normalization

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,9 @@ When history is displayed, the service:
 3. Falls back to converting legacy snapshot totals when no lossless breakdown exists.
 
 This preserves a continuous chart without discarding the source amounts that produced earlier snapshots.
+Reconstructing signed totals also requires current account-type metadata. If any breakdown entry is
+malformed or its account has been deleted, the service converts that snapshot's stored aggregates
+instead of guessing whether the unclassified value was an asset or liability.
 
 ## Market-data pipeline
 

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -35,6 +35,7 @@ const SNAPSHOT_SELECT = {
   totalAssets: true,
   totalLiabilities: true,
   baseCurrency: true,
+  breakdown: true,
   label: true,
   note: true,
 } as const;
@@ -49,8 +50,14 @@ interface SnapshotRow {
   totalAssets: Decimal;
   totalLiabilities: Decimal;
   baseCurrency: string;
+  breakdown: unknown;
   label: string | null;
   note: string | null;
+}
+
+export interface SnapshotAccountMeta {
+  id: string;
+  type: "ASSET" | "LIABILITY";
 }
 
 /** Tie-break metadata for same-day snapshot dedupes. */
@@ -84,20 +91,25 @@ export function normalizeSnapshots(
   snapshots: SnapshotRow[],
   allRatesMap: Map<string, number>,
   targetBaseCurrency: string,
+  accounts: SnapshotAccountMeta[],
 ): NormalizedSnapshot[] {
   const normalizedMap = new Map<string, DedupeCandidate & { normalized: NormalizedSnapshot }>();
+  const accountTypeMap = new Map(accounts.map((account) => [account.id, account.type]));
 
   for (const s of snapshots) {
     const dateStr = s.date.toISOString().split("T")[0];
-    const rate = resolveRate(allRatesMap, s.baseCurrency, targetBaseCurrency) ?? 1;
+    const breakdownTotals = normalizeBreakdown(
+      s.breakdown,
+      accountTypeMap,
+      allRatesMap,
+      targetBaseCurrency,
+    );
 
     const normalized: NormalizedSnapshot = {
       id: s.id,
       date: dateStr,
       createdAt: s.createdAt.toISOString(),
-      netWorth: Number(s.netWorth) * rate,
-      totalAssets: Number(s.totalAssets) * rate,
-      totalLiabilities: Number(s.totalLiabilities) * rate,
+      ...(breakdownTotals ?? normalizeLegacyAggregates(s, allRatesMap, targetBaseCurrency)),
       baseCurrency: targetBaseCurrency,
       label: s.label,
       note: s.note,
@@ -118,6 +130,67 @@ export function normalizeSnapshots(
 }
 
 /**
+ * Revalue a lossless breakdown only when every entry can be classified.
+ *
+ * Deleted accounts have no trustworthy sign: guessing ASSET or LIABILITY could
+ * silently invert their contribution to net worth. A missing/malformed entry
+ * therefore makes the whole breakdown unusable and preserves the snapshot's
+ * signed aggregate relationship through the legacy conversion path.
+ */
+function normalizeBreakdown(
+  breakdown: unknown,
+  accountTypeMap: Map<string, SnapshotAccountMeta["type"]>,
+  allRatesMap: Map<string, number>,
+  targetBaseCurrency: string,
+): Pick<NormalizedSnapshot, "netWorth" | "totalAssets" | "totalLiabilities"> | null {
+  if (!breakdown || typeof breakdown !== "object" || Array.isArray(breakdown)) return null;
+
+  const entries = Object.entries(breakdown);
+  if (entries.length === 0) return null;
+
+  let totalAssets = 0;
+  let totalLiabilities = 0;
+
+  for (const [accountId, rawEntry] of entries) {
+    if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) return null;
+
+    const entry = rawEntry as { value?: unknown; currency?: unknown };
+    const hasNumericValue =
+      typeof entry.value === "number" ||
+      (typeof entry.value === "string" && entry.value.trim().length > 0);
+    const value = hasNumericValue ? Number(entry.value) : Number.NaN;
+    const currency = typeof entry.currency === "string" ? entry.currency.trim() : "";
+    const accountType = accountTypeMap.get(accountId);
+
+    if (!Number.isFinite(value) || !currency || !accountType) return null;
+
+    const rate = resolveRate(allRatesMap, currency, targetBaseCurrency) ?? 1;
+    const convertedValue = value * rate;
+    if (accountType === "ASSET") totalAssets += convertedValue;
+    else totalLiabilities += convertedValue;
+  }
+
+  return {
+    netWorth: totalAssets - totalLiabilities,
+    totalAssets,
+    totalLiabilities,
+  };
+}
+
+function normalizeLegacyAggregates(
+  snapshot: SnapshotRow,
+  allRatesMap: Map<string, number>,
+  targetBaseCurrency: string,
+): Pick<NormalizedSnapshot, "netWorth" | "totalAssets" | "totalLiabilities"> {
+  const rate = resolveRate(allRatesMap, snapshot.baseCurrency, targetBaseCurrency) ?? 1;
+  return {
+    netWorth: Number(snapshot.netWorth) * rate,
+    totalAssets: Number(snapshot.totalAssets) * rate,
+    totalLiabilities: Number(snapshot.totalLiabilities) * rate,
+  };
+}
+
+/**
  * Cache Components read of the default (last-90-day) normalized
  * history. Tagged both globally (`snapshots`, `net-worth`) and
  * per-user (`history:${userId}`) so cron snapshot + account mutations
@@ -131,22 +204,28 @@ export async function getNormalizedHistory(
   cacheTag("snapshots");
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
+  cacheTag("accounts");
+  cacheTag(`accounts:${userId}`);
   cacheTag("exchange-rates");
   cacheLife("hours");
 
   const fromDate = new Date();
   fromDate.setDate(fromDate.getDate() - DEFAULT_HISTORY_DAYS);
 
-  const [snapshotsRaw, allRatesMap] = await Promise.all([
+  const [snapshotsRaw, accountsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId, date: { gte: fromDate } },
       select: SNAPSHOT_SELECT,
       orderBy: { date: "asc" },
     }),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, type: true },
+    }),
     getAllExchangeRates(),
   ]);
 
-  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency, accountsRaw);
 }
 
 /**
@@ -174,19 +253,25 @@ async function fetchFullHistoryCached(
   cacheTag("snapshots");
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
+  cacheTag("accounts");
+  cacheTag(`accounts:${userId}`);
   cacheTag("exchange-rates");
   cacheLife("hours");
 
-  const [snapshotsRaw, allRatesMap] = await Promise.all([
+  const [snapshotsRaw, accountsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where: { userId },
       select: SNAPSHOT_SELECT,
       orderBy: { date: "asc" },
     }),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, type: true },
+    }),
     getAllExchangeRates(),
   ]);
 
-  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency, accountsRaw);
 }
 
 async function fetchFullHistoryRange(
@@ -199,16 +284,20 @@ async function fetchFullHistoryRange(
   if (options.from) where.date.gte = options.from;
   if (options.to) where.date.lte = options.to;
 
-  const [snapshotsRaw, allRatesMap] = await Promise.all([
+  const [snapshotsRaw, accountsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findMany({
       where,
       select: SNAPSHOT_SELECT,
       orderBy: { date: "asc" },
     }),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, type: true },
+    }),
     getAllExchangeRates(),
   ]);
 
-  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency);
+  return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency, accountsRaw);
 }
 
 export async function getSnapshotReconciliationWarning(
@@ -220,27 +309,33 @@ export async function getSnapshotReconciliationWarning(
   cacheTag("net-worth");
   cacheTag(`history:${userId}`);
   cacheTag(`net-worth:${userId}`);
+  cacheTag("accounts");
+  cacheTag(`accounts:${userId}`);
   cacheTag("exchange-rates");
   cacheLife("minutes");
 
-  const [latestSnapshot, currentSummary, allRatesMap] = await Promise.all([
+  const [latestSnapshot, currentSummary, accountsRaw, allRatesMap] = await Promise.all([
     prisma.netWorthSnapshot.findFirst({
       where: { userId },
       select: SNAPSHOT_SELECT,
       orderBy: [{ date: "desc" }, { createdAt: "desc" }],
     }),
     getCachedNetWorthSummary(userId, targetBaseCurrency),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, type: true },
+    }),
     getAllExchangeRates(),
   ]);
 
   if (!latestSnapshot) return null;
 
-  const rate =
-    resolveRate(allRatesMap, latestSnapshot.baseCurrency, targetBaseCurrency) ??
-    (latestSnapshot.baseCurrency === targetBaseCurrency ? 1 : undefined);
-  if (rate === undefined) return null;
-
-  const snapshotNetWorth = Number(latestSnapshot.netWorth) * rate;
+  const snapshotNetWorth = normalizeSnapshots(
+    [latestSnapshot],
+    allRatesMap,
+    targetBaseCurrency,
+    accountsRaw,
+  )[0].netWorth;
   const currentNetWorth = currentSummary.netWorth;
   const difference = currentNetWorth - snapshotNetWorth;
   const denominator = Math.max(Math.abs(snapshotNetWorth), 1);

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -35,12 +35,16 @@ export async function getProjectionData(
         totalAssets: true,
         totalLiabilities: true,
         baseCurrency: true,
+        breakdown: true,
         label: true,
         note: true,
       },
       orderBy: { date: "asc" },
     }),
-    prisma.account.findMany({ where: { userId }, select: { id: true, currency: true } }),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, currency: true, type: true },
+    }),
     getAllExchangeRates(),
   ]);
 
@@ -48,7 +52,7 @@ export async function getProjectionData(
     return { latestNetWorth: 0, trailing12mSavings: 0, annualSnapshots: [], hasData: false };
   }
 
-  const normalized = normalizeSnapshots(snapshotsRaw, allRatesMap, baseCurrency);
+  const normalized = normalizeSnapshots(snapshotsRaw, allRatesMap, baseCurrency, accountsRaw);
 
   const latestNetWorth = normalized[normalized.length - 1].netWorth;
 

--- a/tests/unit/goal-service.test.ts
+++ b/tests/unit/goal-service.test.ts
@@ -62,11 +62,13 @@ vi.mock("@/lib/prisma", () => ({
             totalAssets: s.totalAssets,
             totalLiabilities: 0,
             baseCurrency: s.baseCurrency ?? "USD",
+            breakdown: null,
             label: null,
             note: null,
           })),
       ),
     },
+    account: { findMany: vi.fn(async () => []) },
   },
 }));
 vi.mock("@/lib/services/net-worth-service", () => ({

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -10,6 +10,7 @@ interface SnapshotRowFixture {
   totalAssets: number;
   totalLiabilities: number;
   baseCurrency: string;
+  breakdown: unknown;
   label: string | null;
   note: string | null;
 }
@@ -89,6 +90,7 @@ const {
   getAccountMonthlyCashFlow,
   getMonthlyCashFlow,
   getFullNormalizedHistory,
+  getNormalizedHistory,
   getSnapshotReconciliationWarning,
   hasForeignCurrencySnapshots,
   isBetterDuplicate,
@@ -106,6 +108,7 @@ function row(
     totalAssets: 100,
     totalLiabilities: 0,
     baseCurrency: "USD",
+    breakdown: null,
     label: null,
     note: null,
     ...over,
@@ -145,6 +148,113 @@ beforeEach(() => {
 });
 
 describe("getFullNormalizedHistory (normalize + dedupe — locks E2)", () => {
+  it.each([
+    ["default history", () => getNormalizedHistory("u1", "USD")],
+    ["full history", () => getFullNormalizedHistory("u1", "USD")],
+    [
+      "range history",
+      () =>
+        getFullNormalizedHistory("u1", "USD", {
+          from: new Date("2026-01-01T00:00:00.000Z"),
+          to: new Date("2026-01-31T00:00:00.000Z"),
+        }),
+    ],
+  ])("revalues mixed-currency breakdown entries for %s", async (_name, loadHistory) => {
+    h.rows = [
+      row({
+        id: "mixed",
+        date: new Date("2026-01-15T00:00:00.000Z"),
+        netWorth: 170,
+        totalAssets: 250,
+        totalLiabilities: 80,
+        breakdown: {
+          usd: { value: 100, currency: "USD" },
+          eur: { value: 100, currency: "EUR" },
+          debt: { value: 10_000, currency: "JPY" },
+        },
+        label: "Mixed portfolio",
+        note: "Values retain their original currencies.",
+      }),
+    ];
+    h.accounts = [
+      account({ id: "usd", type: "ASSET", currency: "USD" }),
+      account({ id: "eur", type: "ASSET", currency: "EUR" }),
+      account({ id: "debt", type: "LIABILITY", currency: "JPY" }),
+    ];
+    h.rates = new Map([
+      ["USD_EUR", 0.5],
+      ["USD_JPY", 100],
+    ]);
+
+    const result = await loadHistory();
+
+    expect(result).toEqual([
+      {
+        id: "mixed",
+        date: "2026-01-15",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        netWorth: 200,
+        totalAssets: 300,
+        totalLiabilities: 100,
+        baseCurrency: "USD",
+        label: "Mixed portfolio",
+        note: "Values retain their original currencies.",
+      },
+    ]);
+  });
+
+  it("falls back to aggregate conversion when a breakdown account has been deleted", async () => {
+    h.rows = [
+      row({
+        id: "deleted-account",
+        date: new Date("2026-01-15T00:00:00.000Z"),
+        netWorth: 3000,
+        totalAssets: 3300,
+        totalLiabilities: 300,
+        baseCurrency: "TWD",
+        breakdown: {
+          active: { value: 100, currency: "USD" },
+          deleted: { value: 300, currency: "TWD" },
+        },
+      }),
+    ];
+    h.accounts = [account({ id: "active", type: "ASSET" })];
+    h.rates = new Map([["USD_TWD", 30]]);
+
+    const result = await getFullNormalizedHistory("u1", "USD");
+
+    expect(result[0]).toMatchObject({
+      netWorth: 100,
+      totalAssets: 110,
+      totalLiabilities: 10,
+    });
+  });
+
+  it("falls back to aggregate conversion when a breakdown entry is malformed", async () => {
+    h.rows = [
+      row({
+        id: "malformed",
+        date: new Date("2026-01-15T00:00:00.000Z"),
+        netWorth: 3000,
+        totalAssets: 3000,
+        baseCurrency: "TWD",
+        breakdown: {
+          active: { value: null, currency: "USD" },
+        },
+      }),
+    ];
+    h.accounts = [account({ id: "active", type: "ASSET" })];
+    h.rates = new Map([["USD_TWD", 30]]);
+
+    const result = await getFullNormalizedHistory("u1", "USD");
+
+    expect(result[0]).toMatchObject({
+      netWorth: 100,
+      totalAssets: 100,
+      totalLiabilities: 0,
+    });
+  });
+
   it("sorts ascending by date", async () => {
     h.rows = [
       row({ id: "b", date: new Date("2026-02-01T00:00:00.000Z") }),
@@ -395,6 +505,28 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
 });
 
 describe("getSnapshotReconciliationWarning", () => {
+  it("compares current balances with a latest-rate revaluation of the snapshot breakdown", async () => {
+    h.latestSnapshot = row({
+      id: "mixed",
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      netWorth: 500,
+      totalAssets: 500,
+      breakdown: {
+        acc: { value: 500, currency: "EUR" },
+      },
+    });
+    h.accounts = [account({ cashBalance: 1100 })];
+    h.rates = new Map([["USD_EUR", 0.5]]);
+
+    const warning = await getSnapshotReconciliationWarning("u1", "USD");
+
+    expect(warning).toMatchObject({
+      difference: 100,
+      baseCurrency: "USD",
+    });
+    expect(warning?.differencePercent).toBeCloseTo(0.1);
+  });
+
   it("returns a non-mutating warning when current balances drift past the threshold", async () => {
     h.latestSnapshot = row({
       id: "snap",

--- a/tests/unit/projection-service.test.ts
+++ b/tests/unit/projection-service.test.ts
@@ -1,14 +1,22 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
 
 // Hoisted fixtures so the vi.mock factories can close over them.
 interface SnapshotFixture {
+  id: string;
   date: Date;
   createdAt: Date;
   netWorth: number;
+  totalAssets: number;
+  totalLiabilities: number;
   baseCurrency: string;
+  breakdown: unknown;
+  label: string | null;
+  note: string | null;
 }
 const h = vi.hoisted(() => ({
   snapshots: [] as SnapshotFixture[],
+  accounts: [] as { id: string; currency: string; type: "ASSET" | "LIABILITY" }[],
+  rates: new Map<string, number>(),
 }));
 
 vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
@@ -20,14 +28,20 @@ vi.mock("@/lib/prisma", () => ({
     netWorthSnapshot: {
       findMany: vi.fn(async () =>
         h.snapshots.map((s) => ({
+          id: s.id,
           date: s.date,
           createdAt: s.createdAt,
           netWorth: s.netWorth,
+          totalAssets: s.totalAssets,
+          totalLiabilities: s.totalLiabilities,
           baseCurrency: s.baseCurrency,
+          breakdown: s.breakdown,
+          label: s.label,
+          note: s.note,
         })),
       ),
     },
-    account: { findMany: vi.fn(async () => []) },
+    account: { findMany: vi.fn(async () => h.accounts) },
     cashTransaction: { findMany: vi.fn(async () => []) },
   },
 }));
@@ -35,12 +49,18 @@ vi.mock("@/lib/prisma", () => ({
 // the bulk loader so no DB/network is hit.
 vi.mock("@/lib/services/exchange-rate-service", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/services/exchange-rate-service")>();
-  return { ...actual, getAllExchangeRates: vi.fn(async () => new Map<string, number>()) };
+  return { ...actual, getAllExchangeRates: vi.fn(async () => h.rates) };
 });
 
 import { getProjectionData } from "@/lib/services/projection-service";
 
 describe("getProjectionData annual bucketing", () => {
+  beforeEach(() => {
+    h.snapshots = [];
+    h.accounts = [];
+    h.rates = new Map<string, number>();
+  });
+
   // Regression for #514: snapshots are stored at UTC-midnight and deduped by
   // their UTC date (`toISOString().split("T")[0]`), so the per-year bucket key
   // must also be UTC. Read with a local getter, a Jan-1-UTC snapshot lands in
@@ -59,16 +79,28 @@ describe("getProjectionData annual bucketing", () => {
     it("buckets a 2026-01-01T00:00:00Z snapshot into year 2026", async () => {
       h.snapshots = [
         {
+          id: "2025",
           date: new Date("2025-06-01T00:00:00.000Z"),
           createdAt: new Date("2025-06-01T00:00:00.000Z"),
           netWorth: 500,
+          totalAssets: 500,
+          totalLiabilities: 0,
           baseCurrency: "USD",
+          breakdown: null,
+          label: null,
+          note: null,
         },
         {
+          id: "2026",
           date: new Date("2026-01-01T00:00:00.000Z"),
           createdAt: new Date("2026-01-01T00:00:00.000Z"),
           netWorth: 1000,
+          totalAssets: 1000,
+          totalLiabilities: 0,
           baseCurrency: "USD",
+          breakdown: null,
+          label: null,
+          note: null,
         },
       ];
       const result = await getProjectionData("u1", "USD");
@@ -83,22 +115,40 @@ describe("getProjectionData annual bucketing", () => {
   it("dedupes same-day snapshots by target base currency, then latest createdAt", async () => {
     h.snapshots = [
       {
+        id: "matching-late",
         date: new Date("2026-03-01T00:00:00.000Z"),
         createdAt: new Date("2026-03-01T12:00:00.000Z"),
         netWorth: 500,
+        totalAssets: 500,
+        totalLiabilities: 0,
         baseCurrency: "USD",
+        breakdown: null,
+        label: null,
+        note: null,
       },
       {
+        id: "nonmatching-latest",
         date: new Date("2026-03-01T00:00:00.000Z"),
         createdAt: new Date("2026-03-01T13:00:00.000Z"),
         netWorth: 999,
+        totalAssets: 999,
+        totalLiabilities: 0,
         baseCurrency: "EUR",
+        breakdown: null,
+        label: null,
+        note: null,
       },
       {
+        id: "matching-early",
         date: new Date("2026-03-01T00:00:00.000Z"),
         createdAt: new Date("2026-03-01T10:00:00.000Z"),
         netWorth: 300,
+        totalAssets: 300,
+        totalLiabilities: 0,
         baseCurrency: "USD",
+        breakdown: null,
+        label: null,
+        note: null,
       },
     ];
 
@@ -106,5 +156,40 @@ describe("getProjectionData annual bucketing", () => {
 
     expect(result.latestNetWorth).toBe(500);
     expect(result.annualSnapshots).toEqual([{ year: 2026, netWorth: 500 }]);
+  });
+
+  it("builds projections from latest-rate mixed-currency breakdown values", async () => {
+    h.snapshots = [
+      {
+        id: "mixed",
+        date: new Date("2026-03-01T00:00:00.000Z"),
+        createdAt: new Date("2026-03-01T12:00:00.000Z"),
+        netWorth: 170,
+        totalAssets: 250,
+        totalLiabilities: 80,
+        baseCurrency: "USD",
+        breakdown: {
+          usd: { value: 100, currency: "USD" },
+          eur: { value: 100, currency: "EUR" },
+          debt: { value: 10_000, currency: "JPY" },
+        },
+        label: null,
+        note: null,
+      },
+    ];
+    h.accounts = [
+      { id: "usd", currency: "USD", type: "ASSET" },
+      { id: "eur", currency: "EUR", type: "ASSET" },
+      { id: "debt", currency: "JPY", type: "LIABILITY" },
+    ];
+    h.rates = new Map([
+      ["USD_EUR", 0.5],
+      ["USD_JPY", 100],
+    ]);
+
+    const result = await getProjectionData("u1", "USD");
+
+    expect(result.latestNetWorth).toBe(200);
+    expect(result.annualSnapshots).toEqual([{ year: 2026, netWorth: 200 }]);
   });
 });


### PR DESCRIPTION
## Root cause

The primary history readers omitted `NetWorthSnapshot.breakdown` and normalized old snapshots by multiplying the stored net-worth/assets/liabilities aggregates by one snapshot-base-to-target rate. That retained stale embedded FX for mixed-currency portfolios. Reconciliation and projections consumed the same lossy arithmetic.

## Design and fallbacks

- Select each snapshot breakdown and current account-type metadata on the server, then revalue every original entry from its own currency with the latest exchange-rate map.
- Recompute total assets, total liabilities, and signed net worth from account types in one shared normalizer used by default/full/range history, reconciliation, and projections.
- Preserve the existing whole-snapshot aggregate conversion for absent/empty legacy breakdowns.
- Treat a malformed entry or missing/deleted account metadata as an unusable breakdown and fall back for the whole snapshot. This avoids guessing an unknown account's asset/liability sign.
- Preserve same-day dedupe precedence and the existing snapshot IDs, dates, labels, and notes. The normalized client payload is unchanged.

## TDD evidence

RED before implementation:

`pnpm vitest run tests/unit/history-service.test.ts tests/unit/projection-service.test.ts`

- 5 failed / 20 passed: default, full, and range history returned stale 170/250/80 instead of 200/300/100; reconciliation compared against the stale aggregate; projection retained stale net worth.
- A follow-up malformed-entry regression also failed with 0 instead of the aggregate-fallback 100.

GREEN after implementation:

- Focused history/projection tests: 26 passed / 26.
- Nearby history consumers: 83 passed / 83.

## Validation

- `pnpm test:unit` — 65 files, 516 tests passed.
- `pnpm format` and `pnpm format:check` — passed.
- `pnpm lint` — passed.
- `pnpm typecheck` — passed.
- Production `pnpm build` with the repository's non-sensitive CI placeholder environment — passed.
- `git diff --check` — passed.
- Complete diff self-review — scoped to six history/projection/docs/test files.

Closes #654