### PR TITLE
Fix recurring materialization races with rule updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prepare": "husky",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",

--- a/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route.ts
@@ -26,7 +26,7 @@ export const PATCH = withAuth(
     // Scope ownership into the lookup so a foreign rule can't be edited.
     const existing = await prisma.recurringCashTransaction.findFirst({
       where: { id: recurringId, accountId: id, account: { userId } },
-      select: { id: true, startDate: true, endDate: true, frequency: true },
+      select: { id: true, startDate: true, endDate: true, frequency: true, updatedAt: true },
     });
     if (!existing) return failure("Recurring transaction not found", 404);
 
@@ -64,8 +64,7 @@ export const PATCH = withAuth(
     const [rule] = await prisma.recurringCashTransaction.updateManyAndReturn({
       where: {
         id: recurringId,
-        startDate: existing.startDate,
-        endDate: existing.endDate,
+        updatedAt: existing.updatedAt,
       },
       data,
     });

--- a/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
+++ b/src/app/api/accounts/[id]/recurring-investments/[recurringId]/route.ts
@@ -23,7 +23,7 @@ export const PATCH = withAuth(
 
     const existing = await prisma.recurringInvestment.findFirst({
       where: { id: recurringId, accountId: id, account: { userId } },
-      select: { id: true, startDate: true, endDate: true, frequency: true },
+      select: { id: true, startDate: true, endDate: true, frequency: true, updatedAt: true },
     });
     if (!existing) return failure("Recurring investment not found", 404);
 
@@ -60,8 +60,7 @@ export const PATCH = withAuth(
     const [rule] = await prisma.recurringInvestment.updateManyAndReturn({
       where: {
         id: recurringId,
-        startDate: existing.startDate,
-        endDate: existing.endDate,
+        updatedAt: existing.updatedAt,
       },
       data,
     });

--- a/src/lib/services/recurring-cash-service.ts
+++ b/src/lib/services/recurring-cash-service.ts
@@ -161,8 +161,13 @@ export async function materializeDueRecurringTransactions(
     // Expired rule that was still flagged active (e.g. endDate < nextRunDate):
     // nothing to post, just advance + deactivate.
     if (occurrences.length === 0) {
-      await prisma.recurringCashTransaction.update({
-        where: { id: rule.id },
+      await prisma.recurringCashTransaction.updateMany({
+        where: {
+          id: rule.id,
+          isActive: true,
+          nextRunDate: rule.nextRunDate,
+          updatedAt: rule.updatedAt,
+        },
         data: { nextRunDate, isActive: stillActive },
       });
       continue;
@@ -173,6 +178,20 @@ export async function materializeDueRecurringTransactions(
 
     try {
       const inserted = await prisma.$transaction(async (tx) => {
+        // Reserve this exact rule version before creating any side effects.
+        // PATCH and competing cron runs both advance updatedAt, so a stale
+        // sweep loses this CAS and exits without posting or overwriting state.
+        const reservation = await tx.recurringCashTransaction.updateMany({
+          where: {
+            id: rule.id,
+            isActive: true,
+            nextRunDate: rule.nextRunDate,
+            updatedAt: rule.updatedAt,
+          },
+          data: { nextRunDate, isActive: stillActive },
+        });
+        if (reservation.count === 0) return 0;
+
         const res = await tx.cashTransaction.createMany({
           data: occurrences.map((d) => ({
             accountId: rule.accountId,
@@ -192,10 +211,6 @@ export async function materializeDueRecurringTransactions(
             data: { cashBalance: { increment: signedUnit.times(res.count) } },
           });
         }
-        await tx.recurringCashTransaction.update({
-          where: { id: rule.id },
-          data: { nextRunDate, isActive: stillActive },
-        });
         return res.count;
       });
       created += inserted;

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -99,8 +99,13 @@ export async function materializeDueInvestments(
     const stillActive = !endUtc || nextRunDate.getTime() <= endUtc.getTime();
 
     if (occurrences.length === 0) {
-      await prisma.recurringInvestment.update({
-        where: { id: rule.id },
+      await prisma.recurringInvestment.updateMany({
+        where: {
+          id: rule.id,
+          isActive: true,
+          nextRunDate: rule.nextRunDate,
+          updatedAt: rule.updatedAt,
+        },
         data: { nextRunDate, isActive: stillActive },
       });
       continue;
@@ -151,6 +156,20 @@ export async function materializeDueInvestments(
 
     try {
       const inserted = await prisma.$transaction(async (tx) => {
+        // Reserve this exact rule version before creating a holding or any
+        // financial rows. If PATCH changed any mutable field while price/FX
+        // resolution was in flight, updatedAt makes this CAS lose cleanly.
+        const reservation = await tx.recurringInvestment.updateMany({
+          where: {
+            id: rule.id,
+            isActive: true,
+            nextRunDate: rule.nextRunDate,
+            updatedAt: rule.updatedAt,
+          },
+          data: { nextRunDate, isActive: stillActive },
+        });
+        if (reservation.count === 0) return 0;
+
         // Ensure the target holding exists (auto-create on first run).
         const holding = await tx.holding.upsert({
           where: { accountId_symbol: { accountId: rule.accountId, symbol: rule.symbol } },
@@ -196,10 +215,6 @@ export async function materializeDueInvestments(
           });
         }
 
-        await tx.recurringInvestment.update({
-          where: { id: rule.id },
-          data: { nextRunDate, isActive: stillActive },
-        });
         return res.count;
       });
       created += inserted;

--- a/tests/integration/recurring-cas.test.ts
+++ b/tests/integration/recurring-cas.test.ts
@@ -1,0 +1,303 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { PrismaPg } from "@prisma/adapter-pg";
+import pg from "pg";
+import { PrismaClient } from "@/generated/prisma/client";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("DATABASE_URL is required for recurring CAS integration tests");
+
+const parsedDatabaseUrl = new URL(DATABASE_URL);
+if (
+  !["localhost", "127.0.0.1"].includes(parsedDatabaseUrl.hostname) ||
+  !parsedDatabaseUrl.pathname.endsWith("_issue660_test")
+) {
+  throw new Error("Recurring CAS integration tests require a local *_issue660_test database");
+}
+
+type AfterRead = () => Promise<void>;
+let afterCashRead: AfterRead | undefined;
+let afterInvestmentRead: AfterRead | undefined;
+
+const servicePool = new pg.Pool({ connectionString: DATABASE_URL });
+const concurrentPool = new pg.Pool({ connectionString: DATABASE_URL });
+const serviceBase = new PrismaClient({ adapter: new PrismaPg(servicePool) });
+const concurrentPrisma = new PrismaClient({ adapter: new PrismaPg(concurrentPool) });
+const servicePrisma = serviceBase.$extends({
+  query: {
+    recurringCashTransaction: {
+      async findMany({ args, query }) {
+        const rules = await query(args);
+        const hook = afterCashRead;
+        afterCashRead = undefined;
+        await hook?.();
+        return rules;
+      },
+    },
+    recurringInvestment: {
+      async findMany({ args, query }) {
+        const rules = await query(args);
+        const hook = afterInvestmentRead;
+        afterInvestmentRead = undefined;
+        await hook?.();
+        return rules;
+      },
+    },
+  },
+});
+
+let materializeDueRecurringTransactions: typeof import("@/lib/services/recurring-cash-service").materializeDueRecurringTransactions;
+let materializeDueInvestments: typeof import("@/lib/services/recurring-investment-service").materializeDueInvestments;
+
+const OLD_UPDATED_AT = new Date("2026-06-01T01:00:00.000Z");
+const NEW_UPDATED_AT = new Date("2026-06-01T02:00:00.000Z");
+const DUE_DATE = new Date("2026-06-10T00:00:00.000Z");
+const RUN_DATE = new Date("2026-06-14T00:00:00.000Z");
+
+async function createAccount() {
+  const user = await concurrentPrisma.user.create({
+    data: { email: `issue660-${crypto.randomUUID()}@unit.test` },
+  });
+  return concurrentPrisma.account.create({
+    data: {
+      userId: user.id,
+      name: "Issue 660",
+      type: "ASSET",
+      category: "BROKERAGE",
+      currency: "USD",
+      cashBalance: 10_000,
+    },
+  });
+}
+
+async function createCashRule(accountId: string) {
+  return concurrentPrisma.recurringCashTransaction.create({
+    data: {
+      accountId,
+      type: "DEPOSIT",
+      amount: 100,
+      frequency: "MONTHLY",
+      startDate: DUE_DATE,
+      nextRunDate: DUE_DATE,
+      updatedAt: OLD_UPDATED_AT,
+    },
+  });
+}
+
+async function createInvestmentRule(accountId: string) {
+  await concurrentPrisma.priceCache.create({
+    data: { symbol: "VTI", price: 200, currency: "USD" },
+  });
+  return concurrentPrisma.recurringInvestment.create({
+    data: {
+      accountId,
+      symbol: "VTI",
+      name: "Vanguard Total Stock Market ETF",
+      assetType: "ETF",
+      holdingCurrency: "USD",
+      amount: 1000,
+      frequency: "MONTHLY",
+      startDate: DUE_DATE,
+      nextRunDate: DUE_DATE,
+      updatedAt: OLD_UPDATED_AT,
+    },
+  });
+}
+
+beforeAll(async () => {
+  (globalThis as { prisma?: unknown }).prisma = servicePrisma;
+  ({ materializeDueRecurringTransactions } = await import("@/lib/services/recurring-cash-service"));
+  ({ materializeDueInvestments } = await import("@/lib/services/recurring-investment-service"));
+
+  await concurrentPrisma.$executeRawUnsafe(`
+    CREATE OR REPLACE FUNCTION issue660_reject_insert()
+    RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION 'issue660 forced rollback';
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+});
+
+beforeEach(async () => {
+  afterCashRead = undefined;
+  afterInvestmentRead = undefined;
+  await concurrentPrisma.$executeRawUnsafe(
+    `DROP TRIGGER IF EXISTS issue660_reject_cash ON "CashTransaction"`,
+  );
+  await concurrentPrisma.$executeRawUnsafe(
+    `DROP TRIGGER IF EXISTS issue660_reject_holding ON "HoldingTransaction"`,
+  );
+  await concurrentPrisma.user.deleteMany({
+    where: { email: { startsWith: "issue660-" } },
+  });
+  await concurrentPrisma.priceCache.deleteMany({ where: { symbol: "VTI" } });
+});
+
+afterAll(async () => {
+  await concurrentPrisma.$executeRawUnsafe(
+    `DROP TRIGGER IF EXISTS issue660_reject_cash ON "CashTransaction"`,
+  );
+  await concurrentPrisma.$executeRawUnsafe(
+    `DROP TRIGGER IF EXISTS issue660_reject_holding ON "HoldingTransaction"`,
+  );
+  await concurrentPrisma.$executeRawUnsafe(`DROP FUNCTION IF EXISTS issue660_reject_insert()`);
+  await serviceBase.$disconnect();
+  await concurrentPrisma.$disconnect();
+  await servicePool.end();
+  await concurrentPool.end();
+  delete (globalThis as { prisma?: unknown }).prisma;
+});
+
+describe("recurring materializer CAS races", () => {
+  it("cash: a stale read cannot post or reactivate a concurrently disabled rule", async () => {
+    const account = await createAccount();
+    const rule = await createCashRule(account.id);
+    afterCashRead = async () => {
+      await concurrentPrisma.recurringCashTransaction.update({
+        where: { id: rule.id },
+        data: { isActive: false, updatedAt: NEW_UPDATED_AT },
+      });
+    };
+
+    const result = await materializeDueRecurringTransactions(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, transactions] = await Promise.all([
+      concurrentPrisma.recurringCashTransaction.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.cashTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(persistedRule.isActive).toBe(false);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+  });
+
+  it("cash: a stale read cannot post an amount changed concurrently", async () => {
+    const account = await createAccount();
+    const rule = await createCashRule(account.id);
+    afterCashRead = async () => {
+      await concurrentPrisma.recurringCashTransaction.update({
+        where: { id: rule.id },
+        data: { amount: 250, updatedAt: NEW_UPDATED_AT },
+      });
+    };
+
+    const result = await materializeDueRecurringTransactions(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, transactions] = await Promise.all([
+      concurrentPrisma.recurringCashTransaction.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.cashTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(Number(persistedRule.amount)).toBe(250);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+  });
+
+  it("DCA: a stale read cannot buy or reactivate a concurrently disabled rule", async () => {
+    const account = await createAccount();
+    const rule = await createInvestmentRule(account.id);
+    afterInvestmentRead = async () => {
+      await concurrentPrisma.recurringInvestment.update({
+        where: { id: rule.id },
+        data: { isActive: false, updatedAt: NEW_UPDATED_AT },
+      });
+    };
+
+    const result = await materializeDueInvestments(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, holdings, transactions] = await Promise.all([
+      concurrentPrisma.recurringInvestment.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.holding.findMany({ where: { accountId: account.id } }),
+      concurrentPrisma.holdingTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(holdings).toHaveLength(0);
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(persistedRule.isActive).toBe(false);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+  });
+
+  it("DCA: a stale read cannot buy with an amount changed concurrently", async () => {
+    const account = await createAccount();
+    const rule = await createInvestmentRule(account.id);
+    afterInvestmentRead = async () => {
+      await concurrentPrisma.recurringInvestment.update({
+        where: { id: rule.id },
+        data: { amount: 2500, updatedAt: NEW_UPDATED_AT },
+      });
+    };
+
+    const result = await materializeDueInvestments(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, holdings, transactions] = await Promise.all([
+      concurrentPrisma.recurringInvestment.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.holding.findMany({ where: { accountId: account.id } }),
+      concurrentPrisma.holdingTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(holdings).toHaveLength(0);
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(Number(persistedRule.amount)).toBe(2500);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+  });
+});
+
+describe("recurring materializer transaction rollback", () => {
+  it("cash: rolls back the reservation and balance when posting fails", async () => {
+    const account = await createAccount();
+    const rule = await createCashRule(account.id);
+    await concurrentPrisma.$executeRawUnsafe(`
+      CREATE CONSTRAINT TRIGGER issue660_reject_cash
+      AFTER INSERT ON "CashTransaction"
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION issue660_reject_insert()
+    `);
+
+    const result = await materializeDueRecurringTransactions(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, transactions] = await Promise.all([
+      concurrentPrisma.recurringCashTransaction.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.cashTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+    expect(persistedRule.isActive).toBe(true);
+  });
+
+  it("DCA: rolls back the reservation, holding, quantity, and balance when posting fails", async () => {
+    const account = await createAccount();
+    const rule = await createInvestmentRule(account.id);
+    await concurrentPrisma.$executeRawUnsafe(`
+      CREATE CONSTRAINT TRIGGER issue660_reject_holding
+      AFTER INSERT ON "HoldingTransaction"
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION issue660_reject_insert()
+    `);
+
+    const result = await materializeDueInvestments(RUN_DATE, rule.id);
+
+    const [persistedRule, persistedAccount, holdings, transactions] = await Promise.all([
+      concurrentPrisma.recurringInvestment.findUniqueOrThrow({ where: { id: rule.id } }),
+      concurrentPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      concurrentPrisma.holding.findMany({ where: { accountId: account.id } }),
+      concurrentPrisma.holdingTransaction.findMany({ where: { recurringId: rule.id } }),
+    ]);
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(holdings).toHaveLength(0);
+    expect(transactions).toHaveLength(0);
+    expect(Number(persistedAccount.cashBalance)).toBe(10_000);
+    expect(persistedRule.nextRunDate).toEqual(DUE_DATE);
+    expect(persistedRule.isActive).toBe(true);
+  });
+});

--- a/tests/unit/recurring-cash-service.test.ts
+++ b/tests/unit/recurring-cash-service.test.ts
@@ -9,6 +9,7 @@ const h = vi.hoisted(() => ({
   accountUpdates: [] as Array<{ where: unknown; data: unknown }>,
   ruleUpdates: [] as Array<{ where: unknown; data: Record<string, unknown> }>,
   createManyCount: null as number | null, // override inserted count (null = data.length)
+  reservationCount: 1,
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -22,6 +23,10 @@ vi.mock("@/lib/prisma", () => ({
       update: vi.fn(async (args: { where: unknown; data: Record<string, unknown> }) => {
         h.ruleUpdates.push(args);
         return {};
+      }),
+      updateMany: vi.fn(async (args: { where: unknown; data: Record<string, unknown> }) => {
+        h.ruleUpdates.push(args);
+        return { count: h.reservationCount };
       }),
     },
     cashTransaction: {
@@ -207,6 +212,7 @@ describe("materializeDueRecurringTransactions", () => {
     h.accountUpdates = [];
     h.ruleUpdates = [];
     h.createManyCount = null;
+    h.reservationCount = 1;
   });
 
   it("posts due occurrences and increments balance by the signed total", async () => {
@@ -299,6 +305,60 @@ describe("materializeDueRecurringTransactions", () => {
     expect(h.accountUpdates).toHaveLength(0);
     expect(h.ruleUpdates[0].data.isActive).toBe(false);
   });
+
+  it("does not post or reactivate a rule disabled after the due-rule read", async () => {
+    h.dueRules = [
+      {
+        id: "rule-disabled-race",
+        accountId: "acc1",
+        type: "DEPOSIT",
+        amount: 100,
+        note: null,
+        frequency: "MONTHLY",
+        startDate: d("2026-06-10"),
+        endDate: null,
+        nextRunDate: d("2026-06-10"),
+        isActive: true,
+        updatedAt: new Date("2026-06-01T01:00:00.000Z"),
+      },
+    ];
+    // The user's disable won before cron entered its posting transaction.
+    h.reservationCount = 0;
+
+    const result = await materializeDueRecurringTransactions(d("2026-06-14"));
+
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(h.createManyCalls).toHaveLength(0);
+    expect(h.accountUpdates).toHaveLength(0);
+    expect(h.ruleUpdates).toHaveLength(1);
+  });
+
+  it("does not post a stale amount changed after the due-rule read", async () => {
+    h.dueRules = [
+      {
+        id: "rule-amount-race",
+        accountId: "acc1",
+        type: "WITHDRAWAL",
+        amount: 50,
+        note: null,
+        frequency: "WEEKLY",
+        startDate: d("2026-06-10"),
+        endDate: null,
+        nextRunDate: d("2026-06-10"),
+        isActive: true,
+        updatedAt: new Date("2026-06-01T01:00:00.000Z"),
+      },
+    ];
+    // A concurrent PATCH changed amount (and therefore updatedAt).
+    h.reservationCount = 0;
+
+    const result = await materializeDueRecurringTransactions(d("2026-06-14"));
+
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(h.createManyCalls).toHaveLength(0);
+    expect(h.accountUpdates).toHaveLength(0);
+    expect(h.ruleUpdates).toHaveLength(1);
+  });
 });
 
 describe("materializeDueRecurringTransactions — cutoff & filtering", () => {
@@ -308,6 +368,7 @@ describe("materializeDueRecurringTransactions — cutoff & filtering", () => {
     h.accountUpdates = [];
     h.ruleUpdates = [];
     h.createManyCount = null;
+    h.reservationCount = 1;
   });
 
   it("uses the Taiwan calendar day as the due cutoff", async () => {

--- a/tests/unit/recurring-investment-service.test.ts
+++ b/tests/unit/recurring-investment-service.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   accountUpdates: [] as Array<{ where: unknown; data: { cashBalance: { decrement: unknown } } }>,
   ruleUpdates: [] as Array<{ where: unknown; data: Record<string, unknown> }>,
   createManyCount: null as number | null,
+  reservationCount: 1,
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -38,6 +39,10 @@ vi.mock("@/lib/prisma", () => ({
       update: vi.fn(async (args: { where: unknown; data: Record<string, unknown> }) => {
         h.ruleUpdates.push(args);
         return {};
+      }),
+      updateMany: vi.fn(async (args: { where: unknown; data: Record<string, unknown> }) => {
+        h.ruleUpdates.push(args);
+        return { count: h.reservationCount };
       }),
     },
     exchangeRate: {
@@ -86,7 +91,23 @@ vi.mock("@/lib/prisma", () => ({
     },
     $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
       const { prisma } = await import("@/lib/prisma");
-      return fn(prisma);
+      const before = {
+        upserts: h.upserts.length,
+        createManyCalls: h.createManyCalls.length,
+        holdingUpdates: h.holdingUpdates.length,
+        accountUpdates: h.accountUpdates.length,
+        ruleUpdates: h.ruleUpdates.length,
+      };
+      try {
+        return await fn(prisma);
+      } catch (error) {
+        h.upserts.length = before.upserts;
+        h.createManyCalls.length = before.createManyCalls;
+        h.holdingUpdates.length = before.holdingUpdates;
+        h.accountUpdates.length = before.accountUpdates;
+        h.ruleUpdates.length = before.ruleUpdates;
+        throw error;
+      }
     }),
   },
 }));
@@ -127,6 +148,7 @@ describe("materializeDueInvestments", () => {
     h.accountUpdates = [];
     h.ruleUpdates = [];
     h.createManyCount = null;
+    h.reservationCount = 1;
   });
 
   it("buys amount÷price shares and debits cash (same currency)", async () => {
@@ -227,7 +249,7 @@ describe("materializeDueInvestments", () => {
     const result = await materializeDueInvestments(d("2026-06-14"));
 
     expect(result).toEqual({ created: 0, rulesProcessed: 1 });
-    expect(h.upserts).toHaveLength(1);
+    expect(h.upserts).toHaveLength(0);
     expect(h.createManyCalls).toHaveLength(0);
     expect(h.holdingUpdates).toHaveLength(0);
     expect(h.accountUpdates).toHaveLength(0);
@@ -242,6 +264,45 @@ describe("materializeDueInvestments", () => {
     expect(result.created).toBe(1);
     expect(Number(h.holdingUpdates[0].data.quantity.increment)).toBe(5); // 5 * 1
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(1000);
+  });
+
+  it("does not create a holding or reactivate a rule disabled after price resolution", async () => {
+    h.dueRules = [
+      rule({
+        updatedAt: new Date("2026-06-01T01:00:00.000Z"),
+      }),
+    ];
+    // The user's disable won while DCA was awaiting price/holding reads.
+    h.reservationCount = 0;
+
+    const result = await materializeDueInvestments(d("2026-06-14"));
+
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(h.upserts).toHaveLength(0);
+    expect(h.createManyCalls).toHaveLength(0);
+    expect(h.holdingUpdates).toHaveLength(0);
+    expect(h.accountUpdates).toHaveLength(0);
+    expect(h.ruleUpdates).toHaveLength(1);
+  });
+
+  it("does not buy with an amount changed while DCA awaited price resolution", async () => {
+    h.dueRules = [
+      rule({
+        amount: 1000,
+        updatedAt: new Date("2026-06-01T01:00:00.000Z"),
+      }),
+    ];
+    // A concurrent PATCH changed amount (and therefore updatedAt).
+    h.reservationCount = 0;
+
+    const result = await materializeDueInvestments(d("2026-06-14"));
+
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(h.upserts).toHaveLength(0);
+    expect(h.createManyCalls).toHaveLength(0);
+    expect(h.holdingUpdates).toHaveLength(0);
+    expect(h.accountUpdates).toHaveLength(0);
+    expect(h.ruleUpdates).toHaveLength(1);
   });
 });
 

--- a/tests/unit/recurring-rule-routes.test.ts
+++ b/tests/unit/recurring-rule-routes.test.ts
@@ -217,7 +217,7 @@ describe("recurring rule PATCH routes", () => {
     }
   });
 
-  it("rejects a cash-rule edit when its date range changed concurrently", async () => {
+  it("rejects a cash-rule edit when its amount changed concurrently", async () => {
     h.cashUpdateManyAndReturnCount = 0;
     const { PATCH } =
       await import("@/app/api/accounts/[id]/recurring-cash-transactions/[recurringId]/route");
@@ -225,6 +225,8 @@ describe("recurring rule PATCH routes", () => {
     const response = await PATCH(jsonRequest({ note: "updated" }), params("cash-rule-1"));
 
     expect(response.status).toBe(409);
+    const call = h.cashUpdateManyAndReturnCalls[0] as { where: Record<string, unknown> };
+    expect(call.where.updatedAt).toEqual(date("2026-07-01"));
   });
 
   it("rejects an investment-rule end date before its persisted start date", async () => {
@@ -253,7 +255,7 @@ describe("recurring rule PATCH routes", () => {
     expect(h.investmentUpdateManyAndReturnCalls).toHaveLength(0);
   });
 
-  it("rejects an investment-rule edit when its date range changed concurrently", async () => {
+  it("rejects an investment-rule edit when it was disabled concurrently", async () => {
     h.investmentUpdateManyAndReturnCount = 0;
     const { PATCH } =
       await import("@/app/api/accounts/[id]/recurring-investments/[recurringId]/route");
@@ -261,6 +263,8 @@ describe("recurring rule PATCH routes", () => {
     const response = await PATCH(jsonRequest({ note: "updated" }), params("investment-rule-1"));
 
     expect(response.status).toBe(409);
+    const call = h.investmentUpdateManyAndReturnCalls[0] as { where: Record<string, unknown> };
+    expect(call.where.updatedAt).toEqual(date("2026-07-01"));
   });
 
   it("returns the cash rule from its guarded write without a follow-up read", async () => {

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/integration/**/*.test.ts"],
+    globals: false,
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "server-only": fileURLToPath(new URL("./tests/stubs/server-only.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Root cause and interleaving

Both recurring materializers selected due rules before their per-rule transaction, then used the stale rule snapshot to post financial rows and updated the schedule by `id` only. A PATCH could therefore change an amount or disable a rule after cron's read; cron would still post the stale occurrence and overwrite `nextRunDate` / `isActive`, including reactivating the rule. DCA widened the window while resolving price, FX, and holding state. PATCH itself only compared `startDate` and `endDate`, so other concurrent edits were not detected.

## CAS design

- Each materializer now begins its posting transaction with an `updateMany` reservation guarded by the due snapshot's `id`, `updatedAt`, `isActive`, and `nextRunDate`.
- The reservation atomically advances `nextRunDate` / `isActive`; a zero-row CAS exits before cash transactions, BUY transactions, account balances, holdings, or quantities are touched.
- Reservation, generated rows, balance/quantity changes, holding creation, and schedule advancement commit or roll back together.
- Expired-rule deactivation uses the same version/schedule guard.
- Cash and DCA PATCH routes now compare `updatedAt`, so any mutable rule change produces the existing 409 retry response.
- Existing catch-up, idempotency, no-price/no-FX retry, per-rule isolation, and immediate create/update materialization behavior remain intact.

## TDD evidence

RED against the old implementation:

- Focused unit run: 6 expected failures — cash/DCA disable and amount races still posted stale work; both PATCH predicates omitted `updatedAt`.
- PostgreSQL integration run: 4 expected failures — real rows, balances, holdings, and schedules showed the stale interleavings. The two pre-existing atomic rollback scenarios passed.

GREEN:

- Focused unit run: 3 files / 49 tests passed.
- PostgreSQL integration run: 1 file / 6 tests passed, covering four deterministic races plus two deferred-trigger failures that verify real transaction rollback after all mutations have executed.

## Validation

- `pnpm test:unit` — 65 files / 513 tests passed
- `pnpm test:integration` — 1 file / 6 tests passed against dedicated local PostgreSQL
- `pnpm format` and `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build` with non-sensitive CI placeholder environment — passed
- `git diff --check` and staged diff self-review — clean

Closes #660