### PR TITLE
Fix liability cash-flow direction

### DIFF
--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -440,8 +440,9 @@ export function computePerformanceAttribution(
 
   return accounts
     .map((account) => {
-      const startValue = startSnap.accountValues[account.id] ?? 0;
-      const endValue = endSnap.accountValues[account.id] ?? 0;
+      const netWorthDirection = account.type === "LIABILITY" ? -1 : 1;
+      const startValue = (startSnap.accountValues[account.id] ?? 0) * netWorthDirection;
+      const endValue = (endSnap.accountValues[account.id] ?? 0) * netWorthDirection;
       const totalDelta = endValue - startValue;
       const cashContribution = cashByAccount.get(account.id) ?? 0;
       const marketPerformance = totalDelta - cashContribution;

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -370,6 +370,7 @@ export interface AccountMeta {
   id: string;
   name: string;
   category: string;
+  type: "ASSET" | "LIABILITY";
 }
 
 export interface RawHistoryData {
@@ -399,7 +400,7 @@ export async function getRawHistoryWithBreakdown(
     }),
     prisma.account.findMany({
       where: { userId },
-      select: { id: true, name: true, category: true },
+      select: { id: true, name: true, category: true, type: true },
     }),
     getAllExchangeRates(),
   ]);
@@ -436,12 +437,11 @@ export async function getRawHistoryWithBreakdown(
       return { date, accountValues };
     });
 
-  const accounts: AccountMeta[] = (
-    accountsRaw as { id: string; name: string; category: string }[]
-  ).map((a) => ({
+  const accounts: AccountMeta[] = accountsRaw.map((a) => ({
     id: a.id,
     name: a.name,
     category: a.category,
+    type: a.type,
   }));
 
   return { snapshots, accounts };
@@ -452,7 +452,7 @@ export interface AccountMonthlyContribution {
   accountId: string;
   /** "YYYY-MM" */
   monthKey: string;
-  /** Net DEPOSIT − WITHDRAWAL in baseCurrency. */
+  /** Net-worth impact in baseCurrency (liability balance changes are inverted). */
   contributions: number;
 }
 
@@ -471,7 +471,10 @@ export async function getAccountMonthlyCashFlow(
   cacheLife("hours");
 
   const [accounts, allRatesMap, firstSnapshot] = await Promise.all([
-    prisma.account.findMany({ where: { userId }, select: { id: true, currency: true } }),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, currency: true, type: true },
+    }),
     getAllExchangeRates(),
     prisma.netWorthSnapshot.findFirst({
       where: { userId },
@@ -480,7 +483,9 @@ export async function getAccountMonthlyCashFlow(
     }),
   ]);
 
-  const accountCurrencyMap = new Map(accounts.map((a) => [a.id, a.currency]));
+  const accountMetaMap = new Map(
+    accounts.map((account) => [account.id, { currency: account.currency, type: account.type }]),
+  );
 
   // #509 — floor the transaction scan to the user's earliest snapshot instant,
   // exclusive. The first analysis bucket uses its own first snapshot as the
@@ -522,10 +527,12 @@ export async function getAccountMonthlyCashFlow(
     // back to createdAt for legacy rows that never recorded one (#498).
     const monthKey = (tx.occurrenceDate ?? tx.createdAt).toISOString().slice(0, 7);
     const key = `${tx.accountId}::${monthKey}`;
-    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    const account = accountMetaMap.get(tx.accountId);
+    const currency = account?.currency ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
     const amount = Number(tx.amount) * rate;
-    const signed = tx.type === "DEPOSIT" ? amount : -amount;
+    const balanceDelta = tx.type === "DEPOSIT" ? amount : -amount;
+    const signed = account?.type === "LIABILITY" ? -balanceDelta : balanceDelta;
     byKey.set(key, (byKey.get(key) ?? 0) + signed);
   }
 

--- a/src/lib/services/projection-service.ts
+++ b/src/lib/services/projection-service.ts
@@ -68,12 +68,15 @@ export async function getProjectionData(
     .sort(([a], [b]) => a - b)
     .map(([year, netWorth]) => ({ year, netWorth }));
 
-  // Trailing 12-month net cash (DEPOSIT − WITHDRAWAL)
+  // Trailing 12-month net-worth cash impact. Liability balance changes run in
+  // the opposite direction from assets.
   const twelveMonthsAgo = new Date();
   twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
 
   const accountIds = accountsRaw.map((a) => a.id);
-  const accountCurrencyMap = new Map(accountsRaw.map((a) => [a.id, a.currency]));
+  const accountMetaMap = new Map(
+    accountsRaw.map((account) => [account.id, { currency: account.currency, type: account.type }]),
+  );
 
   const transactions = await prisma.cashTransaction.findMany({
     where: {
@@ -91,10 +94,12 @@ export async function getProjectionData(
 
   let trailing12mSavings = 0;
   for (const tx of transactions) {
-    const currency = accountCurrencyMap.get(tx.accountId) ?? "USD";
+    const account = accountMetaMap.get(tx.accountId);
+    const currency = account?.currency ?? "USD";
     const rate = resolveRate(allRatesMap, currency, baseCurrency) ?? 1;
     const amount = Number(tx.amount) * rate;
-    trailing12mSavings += tx.type === "DEPOSIT" ? amount : -amount;
+    const balanceDelta = tx.type === "DEPOSIT" ? amount : -amount;
+    trailing12mSavings += account?.type === "LIABILITY" ? -balanceDelta : balanceDelta;
   }
 
   return { latestNetWorth, trailing12mSavings, annualSnapshots, hasData: true };

--- a/tests/unit/analysis-service.test.ts
+++ b/tests/unit/analysis-service.test.ts
@@ -271,9 +271,9 @@ describe("buildCumulativeGrowth", () => {
 
 describe("aggregateCategoryHistory", () => {
   const accounts: AccountMeta[] = [
-    { id: "a1", name: "Brokerage", category: "INVESTMENT" },
-    { id: "a2", name: "Savings", category: "CASH" },
-    { id: "a3", name: "401k", category: "INVESTMENT" },
+    { id: "a1", name: "Brokerage", category: "INVESTMENT", type: "ASSET" },
+    { id: "a2", name: "Savings", category: "CASH", type: "ASSET" },
+    { id: "a3", name: "401k", category: "INVESTMENT", type: "ASSET" },
   ];
 
   it("sums account values per category, keeping the last snapshot of each month", () => {
@@ -292,7 +292,9 @@ describe("aggregateCategoryHistory", () => {
 });
 
 describe("computePerformanceAttribution", () => {
-  const accounts: AccountMeta[] = [{ id: "a1", name: "Brokerage", category: "INVESTMENT" }];
+  const accounts: AccountMeta[] = [
+    { id: "a1", name: "Brokerage", category: "INVESTMENT", type: "ASSET" },
+  ];
 
   it("splits totalDelta into cash contribution and market performance", () => {
     const snapshots: SnapshotBreakdown[] = [
@@ -311,6 +313,58 @@ describe("computePerformanceAttribution", () => {
     });
   });
 
+  it("uses net-worth-signed values for asset, loan, and credit-card attribution", () => {
+    const mixedAccounts: AccountMeta[] = [
+      { id: "asset", name: "Brokerage", category: "BROKERAGE", type: "ASSET" },
+      { id: "loan", name: "Car loan", category: "LOAN", type: "LIABILITY" },
+      {
+        id: "credit-card",
+        name: "Credit card",
+        category: "CREDIT_CARD",
+        type: "LIABILITY",
+      },
+    ];
+    const snapshots: SnapshotBreakdown[] = [
+      {
+        date: "2026-01-01",
+        accountValues: { asset: 1_000, loan: 10_000, "credit-card": 1_000 },
+      },
+      {
+        date: "2026-03-01",
+        accountValues: { asset: 1_500, loan: 15_000, "credit-card": 400 },
+      },
+    ];
+    const cashFlows: AccountMonthlyContribution[] = [
+      { accountId: "asset", monthKey: "2026-02", contributions: 200 },
+      { accountId: "loan", monthKey: "2026-02", contributions: -5_000 },
+      { accountId: "credit-card", monthKey: "2026-02", contributions: 600 },
+    ];
+
+    const items = computePerformanceAttribution(snapshots, mixedAccounts, cashFlows, "2026-01");
+
+    expect(items.find((item) => item.accountId === "asset")).toMatchObject({
+      startValue: 1_000,
+      endValue: 1_500,
+      totalDelta: 500,
+      cashContribution: 200,
+      marketPerformance: 300,
+    });
+    expect(items.find((item) => item.accountId === "loan")).toMatchObject({
+      startValue: -10_000,
+      endValue: -15_000,
+      totalDelta: -5_000,
+      cashContribution: -5_000,
+      marketPerformance: 0,
+    });
+    expect(items.find((item) => item.accountId === "credit-card")).toMatchObject({
+      startValue: -1_000,
+      endValue: -400,
+      totalDelta: 600,
+      cashContribution: 600,
+      marketPerformance: 0,
+    });
+  });
+
   it("returns [] when fewer than two snapshots", () => {
     expect(computePerformanceAttribution([], accounts, [], "2026-01")).toEqual([]);
   });
@@ -318,9 +372,9 @@ describe("computePerformanceAttribution", () => {
 
 describe("computeInvestmentReturn", () => {
   const accounts: AccountMeta[] = [
-    { id: "a1", name: "Brokerage", category: "BROKERAGE" },
-    { id: "a2", name: "Checking", category: "BANK" },
-    { id: "a3", name: "Cold Wallet", category: "CRYPTO_WALLET" },
+    { id: "a1", name: "Brokerage", category: "BROKERAGE", type: "ASSET" },
+    { id: "a2", name: "Checking", category: "BANK", type: "ASSET" },
+    { id: "a3", name: "Cold Wallet", category: "CRYPTO_WALLET", type: "ASSET" },
   ];
 
   it("computes Modified-Dietz return over investment accounts only", () => {
@@ -381,7 +435,9 @@ describe("computeInvestmentReturn", () => {
   });
 
   it("returns null when the user has no investment accounts", () => {
-    const bankOnly: AccountMeta[] = [{ id: "a2", name: "Checking", category: "BANK" }];
+    const bankOnly: AccountMeta[] = [
+      { id: "a2", name: "Checking", category: "BANK", type: "ASSET" },
+    ];
     const snapshots: SnapshotBreakdown[] = [
       { date: "2026-01-01", accountValues: { a2: 5000 } },
       { date: "2026-03-01", accountValues: { a2: 6000 } },
@@ -392,8 +448,8 @@ describe("computeInvestmentReturn", () => {
 
 describe("computeInvestmentReturnSeries", () => {
   const accounts: AccountMeta[] = [
-    { id: "a1", name: "Brokerage", category: "BROKERAGE" },
-    { id: "a2", name: "Checking", category: "BANK" },
+    { id: "a1", name: "Brokerage", category: "BROKERAGE", type: "ASSET" },
+    { id: "a2", name: "Checking", category: "BANK", type: "ASSET" },
   ];
 
   it("computes monthly Dietz returns and a chained cumulative index", () => {
@@ -525,7 +581,9 @@ describe("computeInvestmentReturnSeries", () => {
         "en-US",
       ),
     ).toEqual([]);
-    const bankOnly: AccountMeta[] = [{ id: "a2", name: "Checking", category: "BANK" }];
+    const bankOnly: AccountMeta[] = [
+      { id: "a2", name: "Checking", category: "BANK", type: "ASSET" },
+    ];
     const snaps: SnapshotBreakdown[] = [
       { date: "2026-01-31", accountValues: { a2: 500 } },
       { date: "2026-02-28", accountValues: { a2: 600 } },

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -393,6 +393,30 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     expect(result).toEqual([{ accountId: "acc", monthKey: "2026-06", contributions: 60 }]);
   });
 
+  it("uses each account's net-worth direction for asset, loan, and credit-card cash flows", async () => {
+    h.accounts = [
+      account({ id: "asset", type: "ASSET", category: "BANK" }),
+      account({ id: "loan", type: "LIABILITY", category: "LOAN" }),
+      account({ id: "credit-card", type: "LIABILITY", category: "CREDIT_CARD" }),
+    ];
+    h.cashTransactions = [
+      cashTx({ accountId: "asset", amount: 100, type: "DEPOSIT" }),
+      cashTx({ accountId: "asset", amount: 25, type: "WITHDRAWAL" }),
+      cashTx({ accountId: "loan", amount: 100, type: "DEPOSIT" }),
+      cashTx({ accountId: "loan", amount: 25, type: "WITHDRAWAL" }),
+      cashTx({ accountId: "credit-card", amount: 40, type: "DEPOSIT" }),
+      cashTx({ accountId: "credit-card", amount: 10, type: "WITHDRAWAL" }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([
+      { accountId: "asset", monthKey: "2026-07", contributions: 75 },
+      { accountId: "credit-card", monthKey: "2026-07", contributions: -30 },
+      { accountId: "loan", monthKey: "2026-07", contributions: -75 },
+    ]);
+  });
+
   it("floors the effective date to the first snapshot instant, exclusive (#509)", async () => {
     h.accounts = [account()];
     h.latestSnapshot = row({

--- a/tests/unit/projection-service.test.ts
+++ b/tests/unit/projection-service.test.ts
@@ -13,9 +13,15 @@ interface SnapshotFixture {
   label: string | null;
   note: string | null;
 }
+interface CashTransactionFixture {
+  amount: number;
+  type: "DEPOSIT" | "WITHDRAWAL";
+  accountId: string;
+}
 const h = vi.hoisted(() => ({
   snapshots: [] as SnapshotFixture[],
   accounts: [] as { id: string; currency: string; type: "ASSET" | "LIABILITY" }[],
+  cashTransactions: [] as CashTransactionFixture[],
   rates: new Map<string, number>(),
 }));
 
@@ -42,7 +48,7 @@ vi.mock("@/lib/prisma", () => ({
       ),
     },
     account: { findMany: vi.fn(async () => h.accounts) },
-    cashTransaction: { findMany: vi.fn(async () => []) },
+    cashTransaction: { findMany: vi.fn(async () => h.cashTransactions) },
   },
 }));
 // Keep resolveRate real (identity path returns 1 for same-currency); only stub
@@ -58,6 +64,7 @@ describe("getProjectionData annual bucketing", () => {
   beforeEach(() => {
     h.snapshots = [];
     h.accounts = [];
+    h.cashTransactions = [];
     h.rates = new Map<string, number>();
   });
 
@@ -191,5 +198,39 @@ describe("getProjectionData annual bucketing", () => {
 
     expect(result.latestNetWorth).toBe(200);
     expect(result.annualSnapshots).toEqual([{ year: 2026, netWorth: 200 }]);
+  });
+
+  it("uses asset, loan, and credit-card directions for trailing savings", async () => {
+    h.snapshots = [
+      {
+        id: "latest",
+        date: new Date("2026-03-01T00:00:00.000Z"),
+        createdAt: new Date("2026-03-01T12:00:00.000Z"),
+        netWorth: 1_000,
+        totalAssets: 1_000,
+        totalLiabilities: 0,
+        baseCurrency: "USD",
+        breakdown: null,
+        label: null,
+        note: null,
+      },
+    ];
+    h.accounts = [
+      { id: "asset", currency: "USD", type: "ASSET" },
+      { id: "loan", currency: "USD", type: "LIABILITY" },
+      { id: "credit-card", currency: "USD", type: "LIABILITY" },
+    ];
+    h.cashTransactions = [
+      { accountId: "asset", amount: 100, type: "DEPOSIT" },
+      { accountId: "asset", amount: 20, type: "WITHDRAWAL" },
+      { accountId: "loan", amount: 200, type: "DEPOSIT" },
+      { accountId: "loan", amount: 50, type: "WITHDRAWAL" },
+      { accountId: "credit-card", amount: 40, type: "DEPOSIT" },
+      { accountId: "credit-card", amount: 10, type: "WITHDRAWAL" },
+    ];
+
+    const result = await getProjectionData("u1", "USD");
+
+    expect(result.trailing12mSavings).toBe(-100);
   });
 });


### PR DESCRIPTION
## Description

Fix liability cash-flow and account-value direction across Analysis attribution and projection savings.

The root cause was that monthly cash flow and trailing savings only carried account currency, so every `DEPOSIT` was treated as positive and every `WITHDRAWAL` as negative. Raw breakdown metadata also omitted `Account.type`, leaving attribution unable to convert positive liability balances into their net-worth direction.

The corrected convention is:

- Asset: `DEPOSIT` positive, `WITHDRAWAL` negative.
- Liability: `DEPOSIT` negative, `WITHDRAWAL` positive.
- Liability snapshot values are signed negative before attribution deltas and market performance are calculated.

Account type now travels with raw-history and cash-flow metadata. Currency conversion still happens before direction is applied, preserving the mixed-currency and history normalization behavior merged in #665.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## TDD evidence

- RED: focused run had 3 expected failures and 76 passes. Loan/credit-card monthly flows had asset signs, a loan attribution delta was `+5,000` instead of `-5,000`, and projection savings was `+260` instead of `-100`.
- GREEN: focused run passed 79/79 tests across `history-service`, `analysis-service`, and `projection-service`.
- Regression coverage includes asset, loan, and credit-card calculations.

## Testing

- [x] Focused unit tests: 79 passed (3 files)
- [x] Full unit suite: 523 passed (65 files)
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff HEAD^ HEAD --check`
- [x] Production `pnpm build` with documented non-sensitive placeholder environment values (38 static pages generated)

## Screenshots (if applicable)

Not applicable; this changes calculation inputs and outputs without UI structure changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [x] Documentation changes are not required
- [x] No new warnings generated

## Related Issues

Closes #659