### PR TITLE
fix: value account holdings in cached quote currency

### DIFF
--- a/src/app/(main)/accounts/[id]/page.tsx
+++ b/src/app/(main)/accounts/[id]/page.tsx
@@ -1,7 +1,11 @@
 import { notFound } from "next/navigation";
 import { AccountDetail } from "@/components/accounts/account-detail";
 import { AccountsNavPanel } from "@/components/accounts/accounts-nav-panel";
-import { getAccountDetail, getAccountPriceMap } from "@/lib/services/account-service";
+import {
+  getAccountDetail,
+  getAccountPriceMap,
+  type AccountPriceMap,
+} from "@/lib/services/account-service";
 import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
 import { getSession } from "@/lib/auth-session";
 import { getAllExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
@@ -36,7 +40,7 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
   const allAccountsP = sessionP.then((s) =>
     s?.user?.id ? fetchUserAccountsWithHoldings(s.user.id) : [],
   );
-  const priceMapP = detailP.then((d) =>
+  const priceMapP: Promise<AccountPriceMap> = detailP.then((d) =>
     d ? getAccountPriceMap(d.holdings.map((h) => h.symbol)) : {},
   );
 
@@ -59,11 +63,11 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
   const warnedPairs = new Set<string>();
 
   for (const holding of serialized.holdings) {
-    const hc = holding.currency || "USD";
-    if (hc === serialized.currency) continue;
-    const key = `${hc}_${serialized.currency}`;
+    const quoteCurrency = priceMap[holding.symbol]?.currency || holding.currency || "USD";
+    if (quoteCurrency === serialized.currency) continue;
+    const key = `${quoteCurrency}_${serialized.currency}`;
     if (ratesMap[key] !== undefined) continue;
-    const rate = resolveRate(allRatesMap, hc, serialized.currency);
+    const rate = resolveRate(allRatesMap, quoteCurrency, serialized.currency);
     if (rate !== undefined) {
       ratesMap[key] = rate;
       continue;
@@ -71,7 +75,7 @@ async function AccountDetailContent({ params }: { params: Promise<{ id: string }
     ratesMap[key] = 1;
     if (!warnedPairs.has(key)) {
       warnedPairs.add(key);
-      log.warn("rates.unresolved", { from: hc, to: serialized.currency });
+      log.warn("rates.unresolved", { from: quoteCurrency, to: serialized.currency });
     }
   }
 

--- a/src/app/(main)/accounts/page.tsx
+++ b/src/app/(main)/accounts/page.tsx
@@ -84,9 +84,9 @@ async function AccountsContent() {
       fillRate(account.currency, baseCurrency);
     }
     for (const holding of account.holdings) {
-      const hc = holding.currency || "USD";
-      if (hc !== account.currency) {
-        fillRate(hc, account.currency);
+      const quoteCurrency = priceMap[holding.symbol]?.currency || holding.currency || "USD";
+      if (quoteCurrency !== account.currency) {
+        fillRate(quoteCurrency, account.currency);
       }
     }
   }

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -44,6 +44,7 @@ import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import type { SerializedAccountWithHoldings, SerializedHolding } from "@/lib/types";
 import { showUndoDeleteToast } from "@/lib/undo-delete";
+import type { AccountPriceMap } from "@/lib/services/account-service";
 
 type SortOrder = "asc" | "desc";
 
@@ -53,7 +54,7 @@ export function AccountDetail({
   ratesMap = {},
 }: {
   account: SerializedAccountWithHoldings;
-  priceMap: Record<string, number>;
+  priceMap: AccountPriceMap;
   ratesMap?: Record<string, number>;
 }) {
   const router = useRouter();
@@ -118,9 +119,13 @@ export function AccountDetail({
   const holdingsWithValue: HoldingWithPrice[] = useMemo(
     () =>
       account.holdings.map((h) => {
-        const price = priceMap[h.symbol] ?? null;
-        const hc = h.currency || "USD";
-        const rate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
+        const quote = priceMap[h.symbol];
+        const price = quote?.price ?? null;
+        const quoteCurrency = quote?.currency || h.currency || "USD";
+        const rate =
+          quoteCurrency === account.currency
+            ? 1
+            : (ratesMap[`${quoteCurrency}_${account.currency}`] ?? 1);
         const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
         const marketValue = price !== null ? price * h.quantity * multiplier * rate : null;
         return { ...h, currentPrice: price, marketValue };

--- a/src/components/accounts/account-detail.tsx
+++ b/src/components/accounts/account-detail.tsx
@@ -128,7 +128,12 @@ export function AccountDetail({
             : (ratesMap[`${quoteCurrency}_${account.currency}`] ?? 1);
         const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
         const marketValue = price !== null ? price * h.quantity * multiplier * rate : null;
-        return { ...h, currentPrice: price, marketValue };
+        return {
+          ...h,
+          currentPrice: price,
+          currentPriceCurrency: price !== null ? quoteCurrency : null,
+          marketValue,
+        };
       }),
     [account.holdings, account.currency, priceMap, ratesMap],
   );

--- a/src/components/accounts/accounts-list.tsx
+++ b/src/components/accounts/accounts-list.tsx
@@ -54,6 +54,7 @@ import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import { AccountsOnboarding } from "./accounts-onboarding";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
+import type { AccountPriceMap } from "@/lib/services/account-service";
 
 const AccountForm = dynamic(() => import("./account-form").then((m) => m.AccountForm));
 const QuickAddHolding = dynamic(() => import("./quick-add-holding").then((m) => m.QuickAddHolding));
@@ -137,13 +138,17 @@ type ReorderDraftAccount = {
 
 function getAccountValue(
   account: SerializedAccountWithHoldings,
-  priceMap: Record<string, number>,
+  priceMap: AccountPriceMap,
   ratesMap: Record<string, number>,
 ): number {
   const holdingsValue = account.holdings.reduce((sum, h) => {
-    const price = (priceMap || {})[h.symbol] ?? 0;
-    const hc = h.currency || "USD";
-    const rate = hc === account.currency ? 1 : (ratesMap[`${hc}_${account.currency}`] ?? 1);
+    const quote = (priceMap || {})[h.symbol];
+    const price = quote?.price ?? 0;
+    const quoteCurrency = quote?.currency || h.currency || "USD";
+    const rate =
+      quoteCurrency === account.currency
+        ? 1
+        : (ratesMap[`${quoteCurrency}_${account.currency}`] ?? 1);
     const multiplier = h.assetType === "OPTION" ? (h.contractMultiplier ?? 100) : 1;
     return sum + price * h.quantity * multiplier * rate;
   }, 0);
@@ -190,7 +195,7 @@ export function AccountsList({
 }: {
   accounts: SerializedAccountWithHoldings[];
   archivedAccounts: SerializedAccountWithHoldings[];
-  priceMap: Record<string, number>;
+  priceMap: AccountPriceMap;
   ratesMap?: Record<string, number>;
   baseCurrency?: string;
   /** Optional overview block (e.g. portfolio composition) rendered before the
@@ -993,7 +998,7 @@ function DesktopAccountRow({
   account: SerializedAccountWithHoldings;
   baseValue: number;
   baseCurrency: string;
-  priceMap: Record<string, number>;
+  priceMap: AccountPriceMap;
   ratesMap: Record<string, number>;
   onNavigate: () => void;
   onDelete: (id: string) => void;
@@ -1160,7 +1165,7 @@ function MobileAccountRow({
 }: {
   account: SerializedAccountWithHoldings;
   index: number;
-  priceMap: Record<string, number>;
+  priceMap: AccountPriceMap;
   ratesMap: Record<string, number>;
   baseCurrency: string;
   onDelete: (id: string) => void;

--- a/src/components/accounts/holding-row.tsx
+++ b/src/components/accounts/holding-row.tsx
@@ -20,6 +20,7 @@ const HIDDEN = "***";
 
 export interface HoldingWithPrice extends SerializedHolding {
   currentPrice: number | null;
+  currentPriceCurrency: string | null;
   marketValue: number | null;
 }
 
@@ -87,7 +88,7 @@ export function HoldingRow({
           {isOption && <span className="ml-1">contracts</span>}
           {!privacyMode && h.currentPrice !== null && (
             <span className="ml-2">
-              @ {formatCurrency(h.currentPrice, h.currency || "USD")}
+              @ {formatCurrency(h.currentPrice, h.currentPriceCurrency || h.currency || "USD")}
               {isOption && <span>/share</span>}
             </span>
           )}

--- a/src/components/accounts/holdings-table.tsx
+++ b/src/components/accounts/holdings-table.tsx
@@ -149,7 +149,10 @@ export function HoldingsTable({
                   {privacyMode
                     ? HIDDEN
                     : h.currentPrice !== null
-                      ? formatCurrency(h.currentPrice, h.currency || "USD")
+                      ? formatCurrency(
+                          h.currentPrice,
+                          h.currentPriceCurrency || h.currency || "USD",
+                        )
                       : "—"}
                 </td>
                 <td className={`px-3 ${tdPy} text-right tabular-nums font-medium`}>

--- a/src/lib/services/account-service.ts
+++ b/src/lib/services/account-service.ts
@@ -5,6 +5,8 @@ import { prisma } from "@/lib/prisma";
 import { fetchUserAccountsWithHoldings } from "@/lib/services/net-worth-service";
 import type { SerializedAccountWithHoldings } from "@/lib/types";
 
+export type AccountPriceMap = Record<string, { price: number; currency?: string | null }>;
+
 /**
  * Cached active-account count. Gates the first paint of the dashboard and
  * the empty states of /history, /projections, /analysis, so it must not
@@ -29,20 +31,25 @@ export const getAccountDetail = cache(
 );
 
 const getAccountPriceMapForSymbolKey = cache(
-  async (symbolsKey: string): Promise<Record<string, number>> => {
+  async (symbolsKey: string): Promise<AccountPriceMap> => {
     const symbols = JSON.parse(symbolsKey) as string[];
     if (symbols.length === 0) return {};
 
     const cachedPrices = await prisma.priceCache.findMany({
       where: { symbol: { in: symbols } },
-      select: { symbol: true, price: true },
+      select: { symbol: true, price: true, currency: true },
     });
 
-    return Object.fromEntries(cachedPrices.map((price) => [price.symbol, Number(price.price)]));
+    return Object.fromEntries(
+      cachedPrices.map((quote) => [
+        quote.symbol,
+        { price: Number(quote.price), currency: quote.currency },
+      ]),
+    );
   },
 );
 
-export function getAccountPriceMap(symbols: string[]): Promise<Record<string, number>> {
+export function getAccountPriceMap(symbols: string[]): Promise<AccountPriceMap> {
   const stableSymbols = [...new Set(symbols)].sort();
   return getAccountPriceMapForSymbolKey(JSON.stringify(stableSymbols));
 }

--- a/tests/unit/account-page-quote-currency.test.ts
+++ b/tests/unit/account-page-quote-currency.test.ts
@@ -1,0 +1,194 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { SerializedAccountWithHoldings } from "@/lib/types";
+import type { AccountPriceMap } from "@/lib/services/account-service";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: { defaultValue?: string }) =>
+    values?.defaultValue ?? key,
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({ children }: { children: React.ReactNode }) =>
+          React.createElement(tag, null, children),
+    },
+  ),
+  Reorder: {
+    Group: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    Item: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+  },
+  useDragControls: () => ({ start: vi.fn() }),
+  useMotionValue: (value: number) => ({ get: () => value }),
+  useReducedMotion: () => true,
+  useTransform: () => 1,
+  animate: vi.fn(),
+}));
+
+vi.mock("@/components/layout/privacy-mode-context", () => ({
+  usePrivacyMode: () => ({ privacyMode: false }),
+}));
+
+vi.mock("@/components/layout/density-context", () => ({
+  useDensity: () => ({ density: "comfortable" }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/undo-delete", () => ({
+  showUndoDeleteToast: vi.fn(),
+}));
+
+const account: SerializedAccountWithHoldings = {
+  id: "account-usd",
+  userId: "user-1",
+  name: "Crypto wallet",
+  type: "ASSET",
+  category: "CRYPTO_WALLET",
+  currency: "USD",
+  cashBalance: 0,
+  isActive: true,
+  isPinned: false,
+  sortOrder: 0,
+  createdAt: "2026-07-28T00:00:00.000Z",
+  updatedAt: "2026-07-28T00:00:00.000Z",
+  holdings: [
+    {
+      id: "holding-btc",
+      accountId: "account-usd",
+      symbol: "BTC-EUR",
+      name: "Bitcoin",
+      quantity: 1,
+      currency: "USD",
+      assetType: "CRYPTO",
+      underlyingSymbol: null,
+      optionType: null,
+      strike: null,
+      expiration: null,
+      contractMultiplier: null,
+      createdAt: "2026-07-28T00:00:00.000Z",
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    },
+  ],
+};
+
+const quotedInEuros: AccountPriceMap = {
+  "BTC-EUR": { price: 50_000, currency: "EUR" },
+};
+const euroToUsd = { EUR_USD: 1.1 };
+
+describe("account pages use the cached quote currency", () => {
+  it("renders the accounts-list value in account currency", async () => {
+    const { AccountsList } = await import("@/components/accounts/accounts-list");
+
+    const html = renderToStaticMarkup(
+      React.createElement(AccountsList, {
+        accounts: [account],
+        archivedAccounts: [],
+        priceMap: quotedInEuros,
+        ratesMap: euroToUsd,
+        baseCurrency: "USD",
+      }),
+    );
+
+    expect(html).toContain("$55,000");
+    expect(html).not.toContain("$50,000");
+  });
+
+  it("renders the account-detail holding value in account currency", async () => {
+    const { AccountDetail } = await import("@/components/accounts/account-detail");
+
+    const html = renderToStaticMarkup(
+      React.createElement(AccountDetail, {
+        account,
+        priceMap: quotedInEuros,
+        ratesMap: euroToUsd,
+      }),
+    );
+
+    expect(html).toContain("$55,000");
+  });
+
+  it("falls back to the holding currency when a cached quote has no currency", async () => {
+    const { AccountsList } = await import("@/components/accounts/accounts-list");
+
+    const html = renderToStaticMarkup(
+      React.createElement(AccountsList, {
+        accounts: [account],
+        archivedAccounts: [],
+        priceMap: { "BTC-EUR": { price: 50_000 } },
+        ratesMap: euroToUsd,
+        baseCurrency: "USD",
+      }),
+    );
+
+    expect(html).toContain("$50,000");
+    expect(html).not.toContain("$55,000");
+  });
+
+  it("keeps non-investment account cash independent of cached quotes", async () => {
+    const { AccountsList } = await import("@/components/accounts/accounts-list");
+    const bankAccount: SerializedAccountWithHoldings = {
+      ...account,
+      id: "account-bank",
+      name: "Checking",
+      category: "BANK",
+      cashBalance: 1_234,
+      holdings: [],
+    };
+
+    const html = renderToStaticMarkup(
+      React.createElement(AccountsList, {
+        accounts: [bankAccount],
+        archivedAccounts: [],
+        priceMap: {},
+        ratesMap: euroToUsd,
+        baseCurrency: "USD",
+      }),
+    );
+
+    expect(html).toContain("$1,234");
+  });
+
+  it("keeps detail cash value when a holding has no cached quote", async () => {
+    const { AccountDetail } = await import("@/components/accounts/account-detail");
+    const accountWithCash: SerializedAccountWithHoldings = {
+      ...account,
+      cashBalance: 123,
+    };
+
+    const html = renderToStaticMarkup(
+      React.createElement(AccountDetail, {
+        account: accountWithCash,
+        priceMap: {},
+        ratesMap: euroToUsd,
+      }),
+    );
+
+    expect(html).toContain("$123");
+    expect(html).not.toContain("$50,000");
+  });
+});

--- a/tests/unit/account-page-quote-currency.test.ts
+++ b/tests/unit/account-page-quote-currency.test.ts
@@ -118,7 +118,7 @@ describe("account pages use the cached quote currency", () => {
     expect(html).not.toContain("$50,000");
   });
 
-  it("renders the account-detail holding value in account currency", async () => {
+  it("renders detail market value in account currency and raw quotes in quote currency", async () => {
     const { AccountDetail } = await import("@/components/accounts/account-detail");
 
     const html = renderToStaticMarkup(
@@ -130,6 +130,8 @@ describe("account pages use the cached quote currency", () => {
     );
 
     expect(html).toContain("$55,000");
+    expect(html.match(/€50,000/g)).toHaveLength(2);
+    expect(html).not.toContain("$50,000");
   });
 
   it("falls back to the holding currency when a cached quote has no currency", async () => {

--- a/tests/unit/account-service.test.ts
+++ b/tests/unit/account-service.test.ts
@@ -14,7 +14,7 @@ vi.mock("next/cache", () => ({
 }));
 
 const h = vi.hoisted(() => ({
-  prices: [] as { symbol: string; price: number }[],
+  prices: [] as { symbol: string; price: number; currency?: string }[],
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -38,7 +38,7 @@ describe("getAccountPriceMap", () => {
   });
 
   it("scopes the query to the requested symbols instead of scanning the table", async () => {
-    h.prices = [{ symbol: "AAPL", price: 200 }];
+    h.prices = [{ symbol: "AAPL", price: 200, currency: "USD" }];
     const { prisma } = await import("@/lib/prisma");
 
     await getAccountPriceMap(["AAPL", "2330.TW"]);
@@ -50,7 +50,7 @@ describe("getAccountPriceMap", () => {
     // An unfiltered findMany — the shape of the bug — has no `where` at all.
     expect(args.where?.symbol?.in).toBeDefined();
     expect(args.where?.symbol?.in).toEqual(["2330.TW", "AAPL"]);
-    expect(args.select).toEqual({ symbol: true, price: true });
+    expect(args.select).toEqual({ symbol: true, price: true, currency: true });
   });
 
   it("dedupes and sorts symbols so the cache key is stable across orderings", async () => {
@@ -64,24 +64,32 @@ describe("getAccountPriceMap", () => {
     expect(args.where.symbol.in).toEqual(["AAPL", "MSFT"]);
   });
 
-  it("returns a symbol -> number map, coercing the Decimal column", async () => {
+  it("returns symbol -> quote records, coercing the Decimal column", async () => {
     h.prices = [
-      { symbol: "AAPL", price: 200.5 },
-      { symbol: "MSFT", price: 410 },
+      { symbol: "AAPL", price: 200.5, currency: "USD" },
+      { symbol: "MSFT", price: 410, currency: "USD" },
     ];
 
     await expect(getAccountPriceMap(["AAPL", "MSFT"])).resolves.toEqual({
-      AAPL: 200.5,
-      MSFT: 410,
+      AAPL: { price: 200.5, currency: "USD" },
+      MSFT: { price: 410, currency: "USD" },
+    });
+  });
+
+  it("keeps each cached price coupled to the currency it was quoted in", async () => {
+    h.prices = [{ symbol: "BTC-EUR", price: 50_000, currency: "EUR" }];
+
+    await expect(getAccountPriceMap(["BTC-EUR"])).resolves.toEqual({
+      "BTC-EUR": { price: 50_000, currency: "EUR" },
     });
   });
 
   it("omits symbols with no cached price rather than inventing a zero", async () => {
-    h.prices = [{ symbol: "AAPL", price: 200 }];
+    h.prices = [{ symbol: "AAPL", price: 200, currency: "USD" }];
 
     const map = await getAccountPriceMap(["AAPL", "NOPRICE"]);
 
-    expect(map).toEqual({ AAPL: 200 });
+    expect(map).toEqual({ AAPL: { price: 200, currency: "USD" } });
     expect("NOPRICE" in map).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- keep cached market prices coupled to their `PriceCache.currency` through the account list/detail data path
- resolve and apply FX from the cached quote currency into the account currency, matching canonical net-worth valuation semantics
- render raw current prices in their cached quote currency on both mobile holding rows and the desktop holdings table
- preserve holding-currency/USD fallback behavior when quote currency is unavailable, missing-quote behavior, non-investment cash values, and the scoped symbol query introduced for #643

## Root cause

`getAccountPriceMap` selected and returned only `PriceCache.price`. The account list and detail components therefore treated each quote as though it were denominated in `Holding.currency`. When those currencies disagreed—such as a BTC-EUR quote stored as EUR for a USD holding—the account pages could miss the entire FX multiplier even though dashboard net worth correctly trusted `PriceCache.currency`.

## Canonical behavior

A cached quote now travels as `{ price, currency }`. Account-page FX pairs and rendered market values use that quote currency first, then fall back to the holding currency (and USD) when necessary. For BTC-EUR at EUR 50,000 with EUR/USD 1.1, both list and detail render USD 55,000, while the raw current price renders as EUR 50,000. The adjacent holding-currency badge continues to represent stored holding metadata.

## TDD evidence

- RED: quote-map regression failed 1/1 because the helper returned `50000` instead of `{ price: 50000, currency: "EUR" }`
- RED: list/detail rendering regressions failed 2/2 because the numeric-map consumers did not render USD 55,000
- RED (review follow-up): detail rendering failed 1/1 because the raw quote appeared as `@ $50,000` instead of `@ €50,000`
- GREEN: focused suite passed 2 files / 13 tests; the detail regression requires both mobile and desktop raw prices in EUR while retaining the USD 55,000 market value, plus missing quote/currency and non-investment fallbacks

## Validation

- `pnpm test:unit` — 66 files, 526 tests passed
- `pnpm format:check` — passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- production `pnpm build` with safe placeholder environment — passed (38/38 static pages generated)

Closes #653