### PR TITLE
Fix analysis ranges in UTC+ timezones

### DIFF
--- a/src/components/analysis/analysis-range.ts
+++ b/src/components/analysis/analysis-range.ts
@@ -1,0 +1,52 @@
+export interface AnalysisRange<T extends { date: string }> {
+  filteredSnapshots: T[];
+  rangeStart: Date;
+  rangeEnd: Date;
+  rangeStartIso: string;
+}
+
+export function resolveAnalysisRange<T extends { date: string }>(
+  snapshots: T[],
+  months: number,
+  now = new Date(),
+): AnalysisRange<T> {
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const rangeEnd = new Date(Date.UTC(year, month, 1));
+
+  if (months === 0) {
+    const rangeStart = new Date(Date.UTC(year, 0, 1));
+    const rangeStartIso = `${year}-01-01`;
+    return {
+      filteredSnapshots: snapshots.filter((snapshot) => snapshot.date >= rangeStartIso),
+      rangeStart,
+      rangeEnd,
+      rangeStartIso,
+    };
+  }
+
+  if (months === Infinity) {
+    const firstDate = snapshots.length > 0 ? new Date(snapshots[0].date) : now;
+    const rangeStart =
+      snapshots.length > 0
+        ? new Date(Date.UTC(firstDate.getUTCFullYear(), firstDate.getUTCMonth(), 1))
+        : rangeEnd;
+    return {
+      filteredSnapshots: snapshots,
+      rangeStart,
+      rangeEnd,
+      rangeStartIso: snapshots.length > 0 ? snapshots[0].date : "1970-01-01",
+    };
+  }
+
+  // Keep the user's current calendar month, but construct the date-only
+  // boundary at UTC midnight so serializing it cannot roll back a day/month.
+  const rangeStart = new Date(Date.UTC(year, month - months, 1));
+  const rangeStartIso = rangeStart.toISOString().slice(0, 10);
+  return {
+    filteredSnapshots: snapshots.filter((snapshot) => snapshot.date >= rangeStartIso),
+    rangeStart,
+    rangeEnd,
+    rangeStartIso,
+  };
+}

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -41,6 +41,7 @@ import {
   LazyReturnTrendChart,
   LazyDrawdownChart,
 } from "./lazy-analysis-charts";
+import { resolveAnalysisRange } from "./analysis-range";
 import { KpiTiles } from "./kpi-tiles";
 import { AnalysisEmptyState } from "./analysis-empty-state";
 
@@ -64,14 +65,6 @@ const ranges = [
 ] as const;
 
 type RangeLabel = (typeof ranges)[number]["label"];
-
-function rangeCutoff(months: number): Date {
-  const d = new Date();
-  d.setMonth(d.getMonth() - months);
-  d.setDate(1);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
 
 // First-visit default. YTD is the conventional choice, but it reads as a near-empty
 // chart when there is little history or the year just started, so widen in those cases.
@@ -138,52 +131,7 @@ export function AnalysisView({
 
   const { filteredSnapshots, rangeStart, rangeEnd, rangeStartIso } = useMemo(() => {
     const selected = ranges.find((r) => r.label === range)!;
-    const now = new Date();
-
-    if (selected.months === 0) {
-      const year = now.getFullYear();
-      const rangeStart = new Date(Date.UTC(year, 0, 1));
-      // End at the current month, not December, so the axis doesn't pad half a
-      // year of empty future months into the chart.
-      const rangeEnd = new Date(Date.UTC(year, now.getMonth(), 1));
-      const rangeStartIso = `${year}-01-01`;
-      return {
-        filteredSnapshots: snapshots.filter((s) => s.date >= rangeStartIso),
-        rangeStart,
-        rangeEnd,
-        rangeStartIso,
-      };
-    }
-
-    const rangeEnd = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
-
-    if (selected.months === Infinity) {
-      const firstDate = snapshots.length > 0 ? new Date(snapshots[0].date) : now;
-      // firstDate from a snapshot is UTC-midnight; use UTC getters so the range
-      // starts on its UTC month (matching the snapshot buckets) rather than a
-      // phantom prior month west of UTC. The `now` fallback is a local instant,
-      // but with no snapshots the range is unused.
-      const rangeStart =
-        snapshots.length > 0
-          ? new Date(Date.UTC(firstDate.getUTCFullYear(), firstDate.getUTCMonth(), 1))
-          : new Date(Date.UTC(firstDate.getFullYear(), firstDate.getMonth(), 1));
-      return {
-        filteredSnapshots: snapshots,
-        rangeStart,
-        rangeEnd,
-        rangeStartIso: snapshots.length > 0 ? snapshots[0].date : "1970-01-01",
-      };
-    }
-
-    const cutoff = rangeCutoff(selected.months);
-    const rangeStartIso = cutoff.toISOString().split("T")[0];
-    const rangeStart = new Date(Date.UTC(cutoff.getFullYear(), cutoff.getMonth(), 1));
-    return {
-      filteredSnapshots: snapshots.filter((s) => s.date >= rangeStartIso),
-      rangeStart,
-      rangeEnd,
-      rangeStartIso,
-    };
+    return resolveAnalysisRange(snapshots, selected.months);
   }, [snapshots, range]);
 
   const buckets = useMemo(() => {

--- a/tests/unit/analysis-range.test.ts
+++ b/tests/unit/analysis-range.test.ts
@@ -1,11 +1,7 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { computePerformanceAttribution } from "@/lib/services/analysis-service";
 import { resolveAnalysisRange } from "@/components/analysis/analysis-range";
-import type {
-  AccountMeta,
-  AccountMonthlyContribution,
-  SnapshotBreakdown,
-} from "@/lib/services/history-service";
+import type { AccountMonthlyContribution, SnapshotBreakdown } from "@/lib/services/history-service";
 
 const originalTimezone = process.env.TZ;
 
@@ -47,7 +43,9 @@ describe("resolveAnalysisRange", () => {
       { date: "2026-01-01", accountValues: { brokerage: 100 } },
       { date: "2026-07-28", accountValues: { brokerage: 160 } },
     ];
-    const accounts: AccountMeta[] = [{ id: "brokerage", name: "Brokerage", category: "BROKERAGE" }];
+    const accounts = [
+      { id: "brokerage", name: "Brokerage", category: "BROKERAGE", type: "ASSET" as const },
+    ];
     const cashFlows: AccountMonthlyContribution[] = [
       { accountId: "brokerage", monthKey: "2025-12", contributions: 1_000 },
     ];

--- a/tests/unit/analysis-range.test.ts
+++ b/tests/unit/analysis-range.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { computePerformanceAttribution } from "@/lib/services/analysis-service";
+import { resolveAnalysisRange } from "@/components/analysis/analysis-range";
+import type {
+  AccountMeta,
+  AccountMonthlyContribution,
+  SnapshotBreakdown,
+} from "@/lib/services/history-service";
+
+const originalTimezone = process.env.TZ;
+
+afterAll(() => {
+  if (originalTimezone === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTimezone;
+  }
+});
+
+describe("resolveAnalysisRange", () => {
+  it("keeps 6M, 1Y, and 2Y boundaries on the intended month in UTC+8 and UTC-7", () => {
+    const cases = [
+      { timezone: "Asia/Taipei", months: 6, expected: "2026-01-01" },
+      { timezone: "Asia/Taipei", months: 12, expected: "2025-07-01" },
+      { timezone: "Asia/Taipei", months: 24, expected: "2024-07-01" },
+      { timezone: "America/Los_Angeles", months: 6, expected: "2026-01-01" },
+      { timezone: "America/Los_Angeles", months: 12, expected: "2025-07-01" },
+      { timezone: "America/Los_Angeles", months: 24, expected: "2024-07-01" },
+    ];
+
+    for (const { timezone, months, expected } of cases) {
+      process.env.TZ = timezone;
+      const result = resolveAnalysisRange([], months, new Date(2026, 6, 28, 12));
+
+      expect(result.rangeStartIso, `${timezone} ${months}M ISO boundary`).toBe(expected);
+      expect(
+        `${result.rangeStart.getUTCFullYear()}-${String(result.rangeStart.getUTCMonth() + 1).padStart(2, "0")}-01`,
+        `${timezone} ${months}M chart boundary`,
+      ).toBe(expected);
+    }
+  });
+
+  it("excludes the prior month from both the baseline and attribution cash flows in UTC+8", () => {
+    process.env.TZ = "Asia/Taipei";
+    const snapshots: SnapshotBreakdown[] = [
+      { date: "2025-12-31", accountValues: { brokerage: 50 } },
+      { date: "2026-01-01", accountValues: { brokerage: 100 } },
+      { date: "2026-07-28", accountValues: { brokerage: 160 } },
+    ];
+    const accounts: AccountMeta[] = [{ id: "brokerage", name: "Brokerage", category: "BROKERAGE" }];
+    const cashFlows: AccountMonthlyContribution[] = [
+      { accountId: "brokerage", monthKey: "2025-12", contributions: 1_000 },
+    ];
+
+    const range = resolveAnalysisRange(snapshots, 6, new Date(2026, 6, 28, 12));
+    const attribution = computePerformanceAttribution(
+      range.filteredSnapshots,
+      accounts,
+      cashFlows,
+      range.rangeStartIso.slice(0, 7),
+    );
+
+    expect(attribution).toEqual([
+      expect.objectContaining({
+        startValue: 100,
+        endValue: 160,
+        cashContribution: 0,
+        marketPerformance: 60,
+      }),
+    ]);
+    expect(range.filteredSnapshots.map((snapshot) => snapshot.date)).toEqual([
+      "2026-01-01",
+      "2026-07-28",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve analysis range boundaries in one pure helper shared by every downstream analysis consumer
- construct 6M, 1Y, and 2Y month starts directly with `Date.UTC`, then derive the date-only ISO boundary from that UTC month start
- preserve the existing YTD and All behavior
- add deterministic UTC+8 and negative-offset regression coverage, including a visible performance-attribution outcome

## Root cause

The fixed-period cutoff was created at local midnight and then serialized with `toISOString()`. In positive-offset timezones, local midnight is still the previous UTC date, so a January cutoff became December 31. Snapshot and raw-history filtering then admitted the prior-day baseline, while month-key filtering admitted the entire prior month's cash flows. Attribution and return calculations could therefore report phantom gains or losses.

The new resolver starts from the user's current calendar year/month but creates the boundary as UTC midnight on day 1. Its `rangeStart`, `rangeStartIso`, filtered snapshots, monthly cash-flow key, attribution boundary, return KPI/trend inputs, and drawdown boundary now all refer to the same intended calendar month.

## TDD evidence

RED against the old local-midnight algorithm: 2/2 regression tests failed.

- Asia/Taipei 6M returned `2025-12-31` instead of `2026-01-01`.
- The consumer-visible attribution fixture included a December contribution, producing `cashContribution: 1000` and `marketPerformance: -890` instead of `0` and `60`.

GREEN after the UTC month-start fix: 2 focused files / 52 tests passed.

## Validation

- `pnpm test:unit`: 66 files / 522 tests passed
- `pnpm format:check`: passed
- `pnpm lint`: passed
- `pnpm typecheck`: passed
- `git diff --check`: passed
- production `pnpm build` with non-sensitive command-scoped placeholder environment values: passed; 38 routes generated

Closes #657