### PR TITLE
Surface partial snapshot cron failures

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -280,24 +280,40 @@ export async function GET(request: Request) {
       : failedUserIds.length > 0
         ? `Snapshot failed for users: ${failedUserIds.join(", ")}`
         : null;
+    const partiallyFailed = failedUserIds.length > 0;
     await prisma.cronRun.update({
       where: { id: cronRun.id },
       data: {
-        ok: !budgetExhausted,
+        ok: !budgetExhausted && !partiallyFailed,
         finishedAt,
         durationMs: finishedAt.getTime() - startedAt.getTime(),
         ...(snapshotError && { error: snapshotError }),
       },
     });
-    finishSnapshotCronCheckIn(checkIn, budgetExhausted ? "error" : "ok");
+    finishSnapshotCronCheckIn(checkIn, budgetExhausted || partiallyFailed ? "error" : "ok");
 
-    return budgetExhausted
-      ? failure(snapshotError ?? "Snapshot budget exhausted", 503)
+    if (budgetExhausted) {
+      return failure(snapshotError ?? "Snapshot budget exhausted", 503);
+    }
+    const result = {
+      success: !partiallyFailed,
+      snapshotIds: snapshots.map((s) => s.id),
+      failedUserIds,
+      timestamp: finishedAt.toISOString(),
+    };
+    return partiallyFailed
+      ? Response.json(
+          {
+            error: { message: "Snapshot partially completed" },
+            data: result,
+          },
+          { status: 503 },
+        )
       : ok({
           success: true,
-          snapshotIds: snapshots.map((s) => s.id),
+          snapshotIds: result.snapshotIds,
           failedUserIds,
-          timestamp: finishedAt.toISOString(),
+          timestamp: result.timestamp,
         });
   } catch (error) {
     log.error("cron.snapshot.failed", { error: String(error) });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -8,15 +8,14 @@ import { log } from "@/lib/logger";
  * Unauthenticated by design (health checks must work without a session) but
  * rate-limited per IP so it can't be abused as a free DB-ping endpoint. Returns
  * only non-sensitive status: DB connectivity, the latest snapshot timestamp +
- * age, the latest successful cron run timestamp + age, and the response
+ * age, the latest cron attempt and successful run timestamps, and the response
  * timestamp. No user data is exposed.
  *
  * Four independent signals are reported and rolled up into `status`:
  *   - db       → DB reachability ("ok" / "error").
- *   - cron     → freshness of the latest *successful* CronRun (name "snapshot").
- *                This is the E18 pull-based alarm: it goes stale when no cron has
- *                succeeded within the freshness window — even if old snapshot
- *                rows still exist. Free-plan compatible (no extra cron needed).
+ *   - cron     → outcome and freshness of the latest CronRun (name "snapshot").
+ *                This is the E18 pull-based alarm: a failed latest attempt is
+ *                degraded even when an older run succeeded recently.
  *   - snapshot → freshness of the most recent NetWorthSnapshot (the E17 signal).
  *   - priceCache → freshness of the newest cached market quote. Only aggregate
  *                   freshness metadata is exposed; no symbols, prices, or user
@@ -25,8 +24,8 @@ import { log } from "@/lib/logger";
  *
  * Overall `status` is the worst of the four:
  *   - "unhealthy" → DB unreachable. HTTP 503.
- *   - "degraded"  → DB reachable but the cron OR the latest snapshot is
- *                   stale/absent (> 36 h). HTTP 503.
+ *   - "degraded"  → DB reachable but the latest cron failed, or freshness data
+ *                   is stale/absent (> 36 h). HTTP 503.
  *   - "ok"        → all applicable signals healthy. HTTP 200.
  *
  * The 36 h freshness window is shared across snapshot, cron, and prices so
@@ -46,6 +45,9 @@ export async function GET(request: Request) {
   let dbOk = false;
   let latestSnapshotAt: string | null = null;
   let snapshotAgeMs: number | null = null;
+  let latestCronAt: string | null = null;
+  let latestCronAgeMs: number | null = null;
+  let latestCronOk: boolean | null = null;
   let lastCronSuccessAt: string | null = null;
   let cronAgeMs: number | null = null;
   let latestPriceAt: string | null = null;
@@ -54,14 +56,19 @@ export async function GET(request: Request) {
 
   try {
     // Lightweight liveness check + most-recent snapshot freshness + latest
-    // successful cron run, and newest PriceCache timestamp in one parallel
+    // cron attempt/success, and newest PriceCache timestamp in one parallel
     // round. PriceCache.updatedAt has its own index, so the aggregate stays a
     // lightweight freshness probe rather than loading any market data.
-    const [, latestSnapshot, latestCron, latestPrice] = await Promise.all([
+    const [, latestSnapshot, latestCron, latestCronSuccess, latestPrice] = await Promise.all([
       prisma.$queryRaw`SELECT 1`,
       prisma.netWorthSnapshot.findFirst({
         orderBy: { createdAt: "desc" },
         select: { createdAt: true },
+      }),
+      prisma.cronRun.findFirst({
+        where: { name: SNAPSHOT_CRON_NAME },
+        orderBy: { startedAt: "desc" },
+        select: { startedAt: true, ok: true },
       }),
       prisma.cronRun.findFirst({
         where: { name: SNAPSHOT_CRON_NAME, ok: true },
@@ -77,8 +84,13 @@ export async function GET(request: Request) {
       snapshotAgeMs = now - latestSnapshot.createdAt.getTime();
     }
     if (latestCron) {
-      lastCronSuccessAt = latestCron.startedAt.toISOString();
-      cronAgeMs = now - latestCron.startedAt.getTime();
+      latestCronAt = latestCron.startedAt.toISOString();
+      latestCronOk = latestCron.ok;
+      latestCronAgeMs = now - latestCron.startedAt.getTime();
+    }
+    if (latestCronSuccess) {
+      lastCronSuccessAt = latestCronSuccess.startedAt.toISOString();
+      cronAgeMs = now - latestCronSuccess.startedAt.getTime();
     }
     if (latestPrice._max.updatedAt) {
       latestPriceAt = latestPrice._max.updatedAt.toISOString();
@@ -105,7 +117,8 @@ export async function GET(request: Request) {
   }
 
   const snapshotFresh = snapshotAgeMs !== null && snapshotAgeMs <= FRESHNESS_MAX_AGE_MS;
-  const cronFresh = cronAgeMs !== null && cronAgeMs <= FRESHNESS_MAX_AGE_MS;
+  const cronFresh =
+    latestCronOk === true && latestCronAgeMs !== null && latestCronAgeMs <= FRESHNESS_MAX_AGE_MS;
   const priceFresh =
     priceAgeMs === null ? !emptyCacheHasPriceableAssets : priceAgeMs <= FRESHNESS_MAX_AGE_MS;
 
@@ -124,16 +137,19 @@ export async function GET(request: Request) {
   // Overall status is the worst of {db, cron, snapshot, priceCache}.
   const status = !dbOk ? "unhealthy" : snapshotFresh && cronFresh && priceFresh ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
+  const cron = !dbOk ? "unknown" : latestCronOk === false ? "error" : cronFresh ? "ok" : "stale";
 
   return Response.json(
     {
       status,
       db: dbOk ? "ok" : "error",
-      cron: !dbOk ? "unknown" : cronFresh ? "ok" : "stale",
+      cron,
       snapshot: !dbOk ? "unknown" : snapshotFresh ? "ok" : "stale",
       priceCache,
       latestSnapshotAt,
       snapshotAgeMs,
+      latestCronAt,
+      latestCronAgeMs,
       lastCronSuccessAt,
       cronAgeMs,
       latestPriceAt,

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -14,8 +14,8 @@ import { log } from "@/lib/logger";
  * Four independent signals are reported and rolled up into `status`:
  *   - db       → DB reachability ("ok" / "error").
  *   - cron     → outcome and freshness of the latest CronRun (name "snapshot").
- *                This is the E18 pull-based alarm: a failed latest attempt is
- *                degraded even when an older run succeeded recently.
+ *                A recent unfinished attempt is "running"; a completed failure
+ *                or overdue unfinished attempt is degraded.
  *   - snapshot → freshness of the most recent NetWorthSnapshot (the E17 signal).
  *   - priceCache → freshness of the newest cached market quote. Only aggregate
  *                   freshness metadata is exposed; no symbols, prices, or user
@@ -33,6 +33,13 @@ import { log } from "@/lib/logger";
  */
 const FRESHNESS_MAX_AGE_MS = 36 * 60 * 60 * 1000;
 
+/**
+ * Vercel terminates this cron at roughly 60 seconds. Five minutes avoids
+ * transient alerts while leaving only a small window before an unfinished
+ * audit row is treated as a likely crash.
+ */
+const CRON_RUNNING_GRACE_MS = 5 * 60 * 1000;
+
 /** CronRun.name written by /api/cron/snapshot. */
 const SNAPSHOT_CRON_NAME = "snapshot";
 
@@ -48,6 +55,7 @@ export async function GET(request: Request) {
   let latestCronAt: string | null = null;
   let latestCronAgeMs: number | null = null;
   let latestCronOk: boolean | null = null;
+  let latestCronRunning = false;
   let lastCronSuccessAt: string | null = null;
   let cronAgeMs: number | null = null;
   let latestPriceAt: string | null = null;
@@ -57,40 +65,53 @@ export async function GET(request: Request) {
   try {
     // Lightweight liveness check + most-recent snapshot freshness + latest
     // cron attempt/success, and newest PriceCache timestamp in one parallel
-    // round. PriceCache.updatedAt has its own index, so the aggregate stays a
-    // lightweight freshness probe rather than loading any market data.
-    const [, latestSnapshot, latestCron, latestCronSuccess, latestPrice] = await Promise.all([
-      prisma.$queryRaw`SELECT 1`,
-      prisma.netWorthSnapshot.findFirst({
-        orderBy: { createdAt: "desc" },
-        select: { createdAt: true },
-      }),
-      prisma.cronRun.findFirst({
-        where: { name: SNAPSHOT_CRON_NAME },
-        orderBy: { startedAt: "desc" },
-        select: { startedAt: true, ok: true },
-      }),
-      prisma.cronRun.findFirst({
-        where: { name: SNAPSHOT_CRON_NAME, ok: true },
-        orderBy: { startedAt: "desc" },
-        select: { startedAt: true },
-      }),
-      prisma.priceCache.aggregate({
-        _max: { updatedAt: true },
-      }),
-    ]);
+    // round. The two CronRun reads constrain `ok` so the existing
+    // [name, ok, startedAt] index can satisfy each ordering. PriceCache.updatedAt
+    // has its own index, keeping the aggregate a lightweight freshness probe.
+    const [, latestSnapshot, latestCronSuccess, latestCronFailure, latestPrice] = await Promise.all(
+      [
+        prisma.$queryRaw`SELECT 1`,
+        prisma.netWorthSnapshot.findFirst({
+          orderBy: { createdAt: "desc" },
+          select: { createdAt: true },
+        }),
+        prisma.cronRun.findFirst({
+          where: { name: SNAPSHOT_CRON_NAME, ok: true },
+          orderBy: { startedAt: "desc" },
+          select: { startedAt: true },
+        }),
+        prisma.cronRun.findFirst({
+          where: { name: SNAPSHOT_CRON_NAME, ok: false },
+          orderBy: { startedAt: "desc" },
+          select: { startedAt: true, finishedAt: true },
+        }),
+        prisma.priceCache.aggregate({
+          _max: { updatedAt: true },
+        }),
+      ],
+    );
     if (latestSnapshot) {
       latestSnapshotAt = latestSnapshot.createdAt.toISOString();
       snapshotAgeMs = now - latestSnapshot.createdAt.getTime();
     }
-    if (latestCron) {
-      latestCronAt = latestCron.startedAt.toISOString();
-      latestCronOk = latestCron.ok;
-      latestCronAgeMs = now - latestCron.startedAt.getTime();
-    }
     if (latestCronSuccess) {
       lastCronSuccessAt = latestCronSuccess.startedAt.toISOString();
       cronAgeMs = now - latestCronSuccess.startedAt.getTime();
+    }
+    const failureIsLatest =
+      latestCronFailure &&
+      (!latestCronSuccess ||
+        latestCronFailure.startedAt.getTime() >= latestCronSuccess.startedAt.getTime());
+    const latestCron = failureIsLatest ? latestCronFailure : latestCronSuccess;
+    if (latestCron) {
+      latestCronAt = latestCron.startedAt.toISOString();
+      latestCronAgeMs = now - latestCron.startedAt.getTime();
+      latestCronOk = !failureIsLatest;
+      latestCronRunning = Boolean(
+        failureIsLatest &&
+        latestCronFailure.finishedAt === null &&
+        latestCronAgeMs <= CRON_RUNNING_GRACE_MS,
+      );
     }
     if (latestPrice._max.updatedAt) {
       latestPriceAt = latestPrice._max.updatedAt.toISOString();
@@ -117,8 +138,10 @@ export async function GET(request: Request) {
   }
 
   const snapshotFresh = snapshotAgeMs !== null && snapshotAgeMs <= FRESHNESS_MAX_AGE_MS;
-  const cronFresh =
-    latestCronOk === true && latestCronAgeMs !== null && latestCronAgeMs <= FRESHNESS_MAX_AGE_MS;
+  const lastCronSuccessFresh = cronAgeMs !== null && cronAgeMs <= FRESHNESS_MAX_AGE_MS;
+  const cronFresh = latestCronRunning
+    ? lastCronSuccessFresh
+    : latestCronOk === true && latestCronAgeMs !== null && latestCronAgeMs <= FRESHNESS_MAX_AGE_MS;
   const priceFresh =
     priceAgeMs === null ? !emptyCacheHasPriceableAssets : priceAgeMs <= FRESHNESS_MAX_AGE_MS;
 
@@ -137,7 +160,15 @@ export async function GET(request: Request) {
   // Overall status is the worst of {db, cron, snapshot, priceCache}.
   const status = !dbOk ? "unhealthy" : snapshotFresh && cronFresh && priceFresh ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
-  const cron = !dbOk ? "unknown" : latestCronOk === false ? "error" : cronFresh ? "ok" : "stale";
+  const cron = !dbOk
+    ? "unknown"
+    : latestCronRunning
+      ? "running"
+      : latestCronOk === false
+        ? "error"
+        : cronFresh
+          ? "ok"
+          : "stale";
 
   return Response.json(
     {

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -194,7 +194,7 @@ describe("snapshot cron route", () => {
     expect(vi.mocked(prisma.holdingTransaction.createMany)).not.toHaveBeenCalled();
   });
 
-  it("returns 200 and records failed user ids when only some snapshots fail", async () => {
+  it("returns a retryable degraded result after preserving successful snapshots when one user fails", async () => {
     h.users = [
       { id: "user1", appSettings: { baseCurrency: "USD" } },
       { id: "user2", appSettings: { baseCurrency: "TWD" } },
@@ -211,10 +211,13 @@ describe("snapshot cron route", () => {
       }),
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: "Snapshot partially completed",
+      },
       data: {
-        success: true,
+        success: false,
         snapshotIds: ["snapshot-user1"],
         failedUserIds: ["user2"],
       },
@@ -230,11 +233,43 @@ describe("snapshot cron route", () => {
     expect(prisma.cronRun.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          ok: true,
+          ok: false,
           error: expect.stringContaining("user2"),
         }),
       }),
     );
+    expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "error");
+  });
+
+  it("records a clean success and invalidates every successful user's history", async () => {
+    h.users = [
+      { id: "user1", appSettings: { baseCurrency: "USD" } },
+      { id: "user2", appSettings: { baseCurrency: "TWD" } },
+    ];
+    const { GET } = await import("@/app/api/cron/snapshot/route");
+    const { prisma } = await import("@/lib/prisma");
+    const { finishSnapshotCronCheckIn } = await import("@/lib/sentry-cron");
+
+    const response = await GET(
+      new Request("http://unit.test/api/cron/snapshot", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        success: true,
+        snapshotIds: ["snapshot-user1", "snapshot-user2"],
+        failedUserIds: [],
+      },
+    });
+    expect(h.events).toContain("revalidate:snapshots");
+    expect(h.events).toContain("revalidate:history:user1");
+    expect(h.events).toContain("revalidate:history:user2");
+    const auditData = vi.mocked(prisma.cronRun.update).mock.calls[0][0].data;
+    expect(auditData).toMatchObject({ ok: true });
+    expect(auditData).not.toHaveProperty("error");
     expect(finishSnapshotCronCheckIn).toHaveBeenCalledWith("check-in", "ok");
   });
 
@@ -257,6 +292,7 @@ describe("snapshot cron route", () => {
 
     expect(response.status).toBe(500);
     expect(h.events).not.toContain("revalidate:snapshots");
+    expect(h.events.some((event) => event.startsWith("revalidate:history:"))).toBe(false);
     expect(log.error).toHaveBeenCalledWith("cron.snapshot.failed", {
       error: "Error: Snapshot failed for users: user1, user2",
     });

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({
   dbError: false,
   latestSnapshotAt: null as Date | null,
-  latestCronAt: null as Date | null,
+  cronRuns: [] as Array<{ startedAt: Date; ok: boolean }>,
   latestPriceAt: null as Date | null,
   hasPriceableHolding: false,
   hasPriceableWatch: false,
@@ -24,7 +24,25 @@ vi.mock("@/lib/prisma", () => ({
       findFirst: vi.fn(async () => (h.latestSnapshotAt ? { createdAt: h.latestSnapshotAt } : null)),
     },
     cronRun: {
-      findFirst: vi.fn(async () => (h.latestCronAt ? { startedAt: h.latestCronAt } : null)),
+      findFirst: vi.fn(
+        async (args?: {
+          where?: { ok?: boolean };
+          select?: { startedAt?: boolean; ok?: boolean };
+        }) => {
+          const matchingRuns =
+            args?.where?.ok === undefined
+              ? h.cronRuns
+              : h.cronRuns.filter((run) => run.ok === args.where?.ok);
+          const latest = [...matchingRuns].sort(
+            (left, right) => right.startedAt.getTime() - left.startedAt.getTime(),
+          )[0];
+          if (!latest) return null;
+          return {
+            startedAt: latest.startedAt,
+            ...(args?.select?.ok && { ok: latest.ok }),
+          };
+        },
+      ),
     },
     priceCache: {
       aggregate: vi.fn(async () => ({ _max: { updatedAt: h.latestPriceAt } })),
@@ -41,7 +59,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
-describe("health route price freshness", () => {
+describe("health route", () => {
   const now = new Date("2026-07-28T12:00:00.000Z");
 
   beforeEach(() => {
@@ -50,7 +68,7 @@ describe("health route price freshness", () => {
     vi.setSystemTime(now);
     h.dbError = false;
     h.latestSnapshotAt = now;
-    h.latestCronAt = now;
+    h.cronRuns = [{ startedAt: now, ok: true }];
     h.latestPriceAt = now;
     h.hasPriceableHolding = false;
     h.hasPriceableWatch = false;
@@ -87,6 +105,30 @@ describe("health route price freshness", () => {
       status: "degraded",
       priceCache: "stale",
     });
+  });
+
+  it("degrades for the latest failed snapshot attempt despite an older recent success", async () => {
+    const olderSuccess = new Date(now.getTime() - 60 * 60 * 1000);
+    h.cronRuns = [
+      { startedAt: olderSuccess, ok: true },
+      { startedAt: now, ok: false },
+    ];
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      status: "degraded",
+      cron: "error",
+      latestCronAt: now.toISOString(),
+      latestCronAgeMs: 0,
+      lastCronSuccessAt: olderSuccess.toISOString(),
+      cronAgeMs: 60 * 60 * 1000,
+    });
+    expect(body).not.toHaveProperty("users");
+    expect(body).not.toHaveProperty("userId");
+    expect(body).not.toHaveProperty("failedUserIds");
   });
 
   it("degrades an empty cache when a priceable holding exists", async () => {

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({
   dbError: false,
   latestSnapshotAt: null as Date | null,
-  cronRuns: [] as Array<{ startedAt: Date; ok: boolean }>,
+  cronRuns: [] as Array<{ startedAt: Date; finishedAt: Date | null; ok: boolean }>,
   latestPriceAt: null as Date | null,
   hasPriceableHolding: false,
   hasPriceableWatch: false,
@@ -26,8 +26,8 @@ vi.mock("@/lib/prisma", () => ({
     cronRun: {
       findFirst: vi.fn(
         async (args?: {
-          where?: { ok?: boolean };
-          select?: { startedAt?: boolean; ok?: boolean };
+          where?: { name?: string; ok?: boolean };
+          select?: { startedAt?: boolean; finishedAt?: boolean; ok?: boolean };
         }) => {
           const matchingRuns =
             args?.where?.ok === undefined
@@ -38,7 +38,8 @@ vi.mock("@/lib/prisma", () => ({
           )[0];
           if (!latest) return null;
           return {
-            startedAt: latest.startedAt,
+            ...(args?.select?.startedAt && { startedAt: latest.startedAt }),
+            ...(args?.select?.finishedAt && { finishedAt: latest.finishedAt }),
             ...(args?.select?.ok && { ok: latest.ok }),
           };
         },
@@ -68,7 +69,14 @@ describe("health route", () => {
     vi.setSystemTime(now);
     h.dbError = false;
     h.latestSnapshotAt = now;
-    h.cronRuns = [{ startedAt: now, ok: true }];
+    h.cronRuns = [
+      {
+        startedAt: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+        finishedAt: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+        ok: false,
+      },
+      { startedAt: now, finishedAt: now, ok: true },
+    ];
     h.latestPriceAt = now;
     h.hasPriceableHolding = false;
     h.hasPriceableWatch = false;
@@ -107,11 +115,11 @@ describe("health route", () => {
     });
   });
 
-  it("degrades for the latest failed snapshot attempt despite an older recent success", async () => {
+  it("degrades for the latest completed failed attempt despite an older recent success", async () => {
     const olderSuccess = new Date(now.getTime() - 60 * 60 * 1000);
     h.cronRuns = [
-      { startedAt: olderSuccess, ok: true },
-      { startedAt: now, ok: false },
+      { startedAt: olderSuccess, finishedAt: olderSuccess, ok: true },
+      { startedAt: now, finishedAt: now, ok: false },
     ];
     const { GET } = await import("@/app/api/health/route");
     const response = await GET(new Request("http://unit.test/api/health"));
@@ -129,6 +137,63 @@ describe("health route", () => {
     expect(body).not.toHaveProperty("users");
     expect(body).not.toHaveProperty("userId");
     expect(body).not.toHaveProperty("failedUserIds");
+  });
+
+  it("reports a recent unfinished attempt as running while a previous success keeps health fresh", async () => {
+    const previousSuccess = new Date(now.getTime() - 60 * 60 * 1000);
+    const activeStartedAt = new Date(now.getTime() - 60 * 1000);
+    h.cronRuns = [
+      { startedAt: previousSuccess, finishedAt: previousSuccess, ok: true },
+      { startedAt: activeStartedAt, finishedAt: null, ok: false },
+    ];
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ok",
+      cron: "running",
+      latestCronAt: activeStartedAt.toISOString(),
+      latestCronAgeMs: 60 * 1000,
+      lastCronSuccessAt: previousSuccess.toISOString(),
+      cronAgeMs: 60 * 60 * 1000,
+    });
+  });
+
+  it("keeps a first-ever unfinished attempt degraded while reporting it as running", async () => {
+    const activeStartedAt = new Date(now.getTime() - 60 * 1000);
+    h.cronRuns = [{ startedAt: activeStartedAt, finishedAt: null, ok: false }];
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      cron: "running",
+      latestCronAt: activeStartedAt.toISOString(),
+      lastCronSuccessAt: null,
+      cronAgeMs: null,
+    });
+  });
+
+  it("degrades an unfinished attempt that has exceeded the operational grace period", async () => {
+    const previousSuccess = new Date(now.getTime() - 60 * 60 * 1000);
+    const overdueStartedAt = new Date(now.getTime() - 5 * 60 * 1000 - 1);
+    h.cronRuns = [
+      { startedAt: previousSuccess, finishedAt: previousSuccess, ok: true },
+      { startedAt: overdueStartedAt, finishedAt: null, ok: false },
+    ];
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET(new Request("http://unit.test/api/health"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      cron: "error",
+      latestCronAt: overdueStartedAt.toISOString(),
+      latestCronAgeMs: 5 * 60 * 1000 + 1,
+      lastCronSuccessAt: previousSuccess.toISOString(),
+    });
   });
 
   it("degrades an empty cache when a priceable holding exists", async () => {


### PR DESCRIPTION
## Description

Fixes partial snapshot runs being reported as healthy when one or more users failed, while distinguishing an actively running cron from a completed or likely-crashed attempt.

### Root cause

The snapshot cron collected per-user failures but only threw when every user failed. Any one-of-many failure therefore still closed `CronRun` with `ok: true`, finished the Sentry monitor with `ok`, and returned HTTP 200. The health endpoint compounded this by querying only the latest successful run, so a newer degraded/failed attempt was skipped in favor of an older success while a single fresh global snapshot could mask per-user gaps.

The initial health fix also needed to account for the audit lifecycle: every run is inserted as `ok: false, finishedAt: null` before work starts. Treating the latest `ok: false` row as an immediate failure would make health report an active cron as failed. Its global latest-attempt query also could not fully use the existing `[name, ok, startedAt]` index for ordering.

### Outcome contract

- A partial run preserves successful snapshot writes and invalidates the global snapshot tag plus each successful user's history tag before responding.
- The authenticated cron response is HTTP 503 with `success: false`, successful snapshot IDs, and failed user IDs, making it retry/alert capable without discarding completed work.
- The audit row closes with `ok: false` and the Sentry check-in closes with `error`.
- `/api/health` queries the latest `ok: true` and `ok: false` rows separately so both reads use the existing compound index, then compares `startedAt` in application code.
- A latest unfinished attempt within a documented five-minute operational grace reports non-sensitive `cron: "running"`. Overall health remains OK only when a previous success, snapshot, and prices are fresh; a first-ever running attempt remains degraded.
- A completed failed attempt or an unfinished attempt older than five minutes reports `cron: "error"` and HTTP 503. A newer clean success supersedes an older failure.
- Health retains `lastCronSuccessAt`/`cronAgeMs` compatibility metadata and adds `latestCronAt`/`latestCronAgeMs`; no user identifiers or failure lists are exposed.
- Clean success, all-user failure, budget exhaustion, DB failure, price-cache health, and rate limiting retain their existing behavior.

The option-expiry section is intentionally untouched so the separate #661 change remains easy to merge.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## TDD evidence

Initial RED (`pnpm exec vitest run tests/unit/cron-snapshot-route.test.ts tests/unit/health-route.test.ts`):

- partial snapshot test expected HTTP 503 but received 200
- latest completed-failure health test expected HTTP 503 but received 200

Review follow-up RED:

- a one-minute unfinished attempt with an older recent success expected HTTP 200 / `cron: "running"` but received HTTP 503 / `cron: "error"`
- a first-ever unfinished attempt expected `cron: "running"` while remaining degraded but received `cron: "error"`
- after the active-run distinction, an unfinished attempt at five minutes plus one millisecond expected HTTP 503 / `cron: "error"` but received HTTP 200 / `cron: "running"`

GREEN:

- focused behavior tests: 2 files, 24 tests passed
- full unit suite: 65 files, 525 tests passed

Coverage includes one-of-many failure, all-user failure, clean success, cache invalidation, audit/check-in outcomes, completed partial failure, recent and overdue unfinished attempts, first-ever running behavior, and a newer success superseding an older failure.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests
- [x] All tests pass

Validation:

- `pnpm exec vitest run tests/unit/cron-snapshot-route.test.ts tests/unit/health-route.test.ts`
- `pnpm test:unit`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`
- production `pnpm build` with safe placeholder database/auth/cron environment values

## Screenshots (if applicable)

Not applicable; API and health behavior only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [x] I have updated documentation
- [x] No new warnings generated by this change

## Related Issues

Closes #662