### PR TITLE
Fix first-day recurring cash flow baseline

### DIFF
--- a/prisma/migrations/20260728010000_add_cash_materialization_provenance/migration.sql
+++ b/prisma/migrations/20260728010000_add_cash_materialization_provenance/migration.sql
@@ -1,0 +1,29 @@
+-- Keep recurring-cash provenance after its source rule is deleted, and record
+-- the real posting instant for all rows created after this migration.
+ALTER TABLE "CashTransaction"
+  ADD COLUMN "materializedAt" TIMESTAMPTZ(3),
+  ADD COLUMN "materializedAtEstimated" BOOLEAN NOT NULL DEFAULT false;
+
+-- Legacy materialization overwrote CashTransaction.createdAt with the
+-- occurrence-day midnight. For still-linked rows, the later of that value and
+-- the rule's creation time is the best recoverable lower bound:
+--   * a rule created after its first occurrence identifies an immediate
+--     backfill that could not have posted before the rule existed;
+--   * older scheduled/catch-up rows retain the occurrence-day estimate.
+--
+-- Mark every recovered timestamp as estimated so analysis never presents it
+-- as an exact posting instant. Rows whose rule was already deleted have
+-- recurringId = NULL (ON DELETE SET NULL) and are indistinguishable from
+-- manual occurrence-dated rows, so this migration intentionally leaves them
+-- unclassified rather than guessing.
+UPDATE "CashTransaction" AS cash
+SET
+  "materializedAt" =
+    GREATEST(cash."createdAt", rule."createdAt") AT TIME ZONE 'UTC',
+  "materializedAtEstimated" = true
+FROM "RecurringCashTransaction" AS rule
+WHERE cash."recurringId" = rule."id";
+
+-- Analysis floors exact generated rows by account and posting instant.
+CREATE INDEX "CashTransaction_accountId_materializedAt_idx"
+  ON "CashTransaction"("accountId", "materializedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,12 +140,17 @@ model CashTransaction {
   // materialization idempotent (a re-run can't double-post the same occurrence).
   // Both NULL for manually-entered transactions (Postgres treats NULLs as
   // distinct, so manual rows never collide on this constraint).
-  recurringId    String?
-  recurring      RecurringCashTransaction? @relation(fields: [recurringId], references: [id], onDelete: SetNull)
-  occurrenceDate DateTime?                 @db.Date
+  recurringId             String?
+  recurring               RecurringCashTransaction? @relation(fields: [recurringId], references: [id], onDelete: SetNull)
+  occurrenceDate          DateTime?                 @db.Date
+  // Durable recurring-generation provenance. Unlike recurringId this survives
+  // rule deletion; occurrenceDate remains the reporting bucket.
+  materializedAt          DateTime?                 @db.Timestamptz(3)
+  materializedAtEstimated Boolean                   @default(false)
 
   @@unique([recurringId, occurrenceDate])
   @@index([accountId, createdAt(sort: Desc)])
+  @@index([accountId, materializedAt])
 }
 
 enum RecurringFrequency {

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -444,6 +444,15 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                 // createdAt only when occurrenceDate is null.
                 occurrenceDate: t.occurrenceDate ?? null,
                 recurringId: t.recurringId ? (recurringCashIdMap.get(t.recurringId) ?? null) : null,
+                // v1.4+ backups preserve durable provenance directly. For an
+                // older backup, a surviving recurringId proves generation but
+                // its exported createdAt is only an estimated posting bound.
+                materializedAt:
+                  t.materializedAt ?? (t.recurringId && t.createdAt ? t.createdAt : null),
+                materializedAtEstimated:
+                  t.materializedAt != null
+                    ? t.materializedAtEstimated
+                    : Boolean(t.recurringId && t.createdAt),
               })),
             });
           }

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -93,6 +93,12 @@ function remapGoalScopeRefId(goal: ImportGoal, accountIdMap: Map<string, string>
   return remapped;
 }
 
+function latestImportTimestamp(first: string | undefined, second: string | undefined) {
+  if (!first) return second ?? null;
+  if (!second) return first;
+  return Date.parse(first) >= Date.parse(second) ? first : second;
+}
+
 function dedupeSnapshots(snapshots: ImportSnapshot[] | undefined, targetBaseCurrency: string) {
   // Same tie-break as normalizeSnapshots: prefer a baseCurrency match with the
   // target, then the greatest createdAt. The export's snapshot order is not
@@ -341,6 +347,7 @@ export const POST = withAuth(async (request, _ctx, userId) => {
           // Recurring rules — created before holdings/cashTransactions so their
           // new ids are available to remap HoldingTransaction/CashTransaction.recurringId.
           const recurringCashIdMap = new Map<string, string>();
+          const recurringCashCreatedAtMap = new Map<string, string>();
           if (Array.isArray(acc.recurringCashTransactions)) {
             for (const rule of acc.recurringCashTransactions) {
               const created = await tx.recurringCashTransaction.create({
@@ -358,7 +365,10 @@ export const POST = withAuth(async (request, _ctx, userId) => {
                   updatedAt: rule.updatedAt,
                 },
               });
-              if (rule.id) recurringCashIdMap.set(rule.id, created.id);
+              if (rule.id) {
+                recurringCashIdMap.set(rule.id, created.id);
+                if (rule.createdAt) recurringCashCreatedAtMap.set(rule.id, rule.createdAt);
+              }
             }
           }
 
@@ -434,26 +444,33 @@ export const POST = withAuth(async (request, _ctx, userId) => {
           if (Array.isArray(acc.cashTransactions) && acc.cashTransactions.length > 0) {
             await tx.cashTransaction.createMany({
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              data: acc.cashTransactions.map((t: any) => ({
-                accountId: newAccount.id,
-                type: t.type,
-                amount: t.amount,
-                note: t.note,
-                createdAt: t.createdAt,
-                // Preserve null as null — analysis bucketing falls back to
-                // createdAt only when occurrenceDate is null.
-                occurrenceDate: t.occurrenceDate ?? null,
-                recurringId: t.recurringId ? (recurringCashIdMap.get(t.recurringId) ?? null) : null,
-                // v1.4+ backups preserve durable provenance directly. For an
-                // older backup, a surviving recurringId proves generation but
-                // its exported createdAt is only an estimated posting bound.
-                materializedAt:
-                  t.materializedAt ?? (t.recurringId && t.createdAt ? t.createdAt : null),
-                materializedAtEstimated:
-                  t.materializedAt != null
-                    ? t.materializedAtEstimated
-                    : Boolean(t.recurringId && t.createdAt),
-              })),
+              data: acc.cashTransactions.map((t: any) => {
+                const estimatedMaterializedAt = t.recurringId
+                  ? latestImportTimestamp(t.createdAt, recurringCashCreatedAtMap.get(t.recurringId))
+                  : null;
+
+                return {
+                  accountId: newAccount.id,
+                  type: t.type,
+                  amount: t.amount,
+                  note: t.note,
+                  createdAt: t.createdAt,
+                  // Preserve null as null — analysis bucketing falls back to
+                  // createdAt only when occurrenceDate is null.
+                  occurrenceDate: t.occurrenceDate ?? null,
+                  recurringId: t.recurringId
+                    ? (recurringCashIdMap.get(t.recurringId) ?? null)
+                    : null,
+                  // v1.4+ backups preserve durable provenance directly. For an
+                  // older backup, the best recoverable posting bound is the
+                  // later of the transaction and linked rule creation times.
+                  materializedAt: t.materializedAt ?? estimatedMaterializedAt,
+                  materializedAtEstimated:
+                    t.materializedAt != null
+                      ? t.materializedAtEstimated
+                      : estimatedMaterializedAt != null,
+                };
+              }),
             });
           }
         }

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -493,9 +493,11 @@ export async function getAccountMonthlyCashFlow(
   // aligns the contribution window with that baseline, so only flows that
   // occurred AFTER the starting snapshot are attributed to the first bucket.
   // (Months before the first snapshot are unreachable by the analysis UI, so
-  // this also preserves PE29's scan-narrowing intent.) The floor compares
-  // against the effective date (occurrenceDate ?? createdAt) to match the
-  // month-key bucketing below.
+  // this also preserves PE29's scan-narrowing intent.) Manual rows retain the
+  // effective-date boundary (occurrenceDate ?? createdAt) from #509/#551.
+  // Recurring rows instead use createdAt for inclusion because occurrenceDate
+  // is a business-day bucket that can be later than the wall-clock snapshot;
+  // bucketing below still uses occurrenceDate.
   const floor = firstSnapshot ? (firstSnapshot.createdAt ?? firstSnapshot.date) : null;
 
   const transactions = await prisma.cashTransaction.findMany({
@@ -505,19 +507,50 @@ export async function getAccountMonthlyCashFlow(
       ...(floor
         ? {
             OR: [
-              { occurrenceDate: { gt: floor } },
-              { occurrenceDate: null, createdAt: { gt: floor } },
+              // Recurring rows use occurrenceDate only for reporting. Their
+              // creation instant says whether the balance changed after the
+              // baseline and keeps late catch-up postings in scope.
+              { recurringId: { not: null }, createdAt: { gt: floor } },
+              // Manual/backdated flows preserve the #509/#551 effective-date
+              // boundary.
+              { recurringId: null, occurrenceDate: { gt: floor } },
+              { recurringId: null, occurrenceDate: null, createdAt: { gt: floor } },
             ],
           }
         : {}),
     },
-    select: { amount: true, type: true, createdAt: true, occurrenceDate: true, accountId: true },
+    select: {
+      amount: true,
+      type: true,
+      createdAt: true,
+      occurrenceDate: true,
+      recurringId: true,
+      accountId: true,
+    },
     orderBy: { createdAt: "asc" },
   });
 
   const byKey = new Map<string, number>();
 
   for (const tx of transactions) {
+    // A recurring row's occurrenceDate is a business-day bucket, not the
+    // instant its balance changed. New rows keep their real createdAt, so that
+    // timestamp says whether the balance changed after the baseline.
+    //
+    // Before #658 the materializer set createdAt === occurrenceDate. For those
+    // legacy rows the actual posting instant is irretrievable, but the daily
+    // cron's order is deterministic: occurrences on/before the first
+    // snapshot's business day were materialized into that snapshot. Comparing
+    // like-for-like business days repairs those stored rows without changing
+    // manual/backdated transaction semantics.
+    if (floor && firstSnapshot && tx.recurringId) {
+      const isLegacyBackdated = tx.occurrenceDate?.getTime() === tx.createdAt.getTime();
+      const isAfterBaseline = isLegacyBackdated
+        ? tx.occurrenceDate!.getTime() > firstSnapshot.date.getTime()
+        : tx.createdAt.getTime() > floor.getTime();
+      if (!isAfterBaseline) continue;
+    }
+
     // Bucket by when the cash flow actually happened (occurrenceDate), falling
     // back to createdAt for legacy rows that never recorded one (#498).
     const monthKey = (tx.occurrenceDate ?? tx.createdAt).toISOString().slice(0, 7);

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -495,9 +495,9 @@ export async function getAccountMonthlyCashFlow(
   // (Months before the first snapshot are unreachable by the analysis UI, so
   // this also preserves PE29's scan-narrowing intent.) Manual rows retain the
   // effective-date boundary (occurrenceDate ?? createdAt) from #509/#551.
-  // Recurring rows instead use createdAt for inclusion because occurrenceDate
-  // is a business-day bucket that can be later than the wall-clock snapshot;
-  // bucketing below still uses occurrenceDate.
+  // Recurring rows instead use their durable materializedAt posting instant
+  // because occurrenceDate is a business-day bucket that can be later than the
+  // wall-clock snapshot; bucketing below still uses occurrenceDate.
   const floor = firstSnapshot ? (firstSnapshot.createdAt ?? firstSnapshot.date) : null;
 
   const transactions = await prisma.cashTransaction.findMany({
@@ -507,14 +507,31 @@ export async function getAccountMonthlyCashFlow(
       ...(floor
         ? {
             OR: [
-              // Recurring rows use occurrenceDate only for reporting. Their
-              // creation instant says whether the balance changed after the
-              // baseline and keeps late catch-up postings in scope.
-              { recurringId: { not: null }, createdAt: { gt: floor } },
+              // Exact generated rows can be narrowed in SQL. Durable
+              // provenance survives ON DELETE SET NULL.
+              {
+                materializedAtEstimated: false,
+                materializedAt: { gt: floor },
+              },
+              // Estimated legacy rows need application-level handling because
+              // their exact posting instant was never stored.
+              {
+                materializedAtEstimated: true,
+                materializedAt: { not: null },
+              },
+              // Compatibility for a stale/pre-migration row. A deployed
+              // migration backfills all still-linked rows into the branch
+              // above; keeping this branch makes partial restores safe.
+              { materializedAt: null, recurringId: { not: null } },
               // Manual/backdated flows preserve the #509/#551 effective-date
               // boundary.
-              { recurringId: null, occurrenceDate: { gt: floor } },
-              { recurringId: null, occurrenceDate: null, createdAt: { gt: floor } },
+              { materializedAt: null, recurringId: null, occurrenceDate: { gt: floor } },
+              {
+                materializedAt: null,
+                recurringId: null,
+                occurrenceDate: null,
+                createdAt: { gt: floor },
+              },
             ],
           }
         : {}),
@@ -525,6 +542,8 @@ export async function getAccountMonthlyCashFlow(
       createdAt: true,
       occurrenceDate: true,
       recurringId: true,
+      materializedAt: true,
+      materializedAtEstimated: true,
       accountId: true,
     },
     orderBy: { createdAt: "asc" },
@@ -533,21 +552,26 @@ export async function getAccountMonthlyCashFlow(
   const byKey = new Map<string, number>();
 
   for (const tx of transactions) {
-    // A recurring row's occurrenceDate is a business-day bucket, not the
-    // instant its balance changed. New rows keep their real createdAt, so that
-    // timestamp says whether the balance changed after the baseline.
+    // materializedAt is both the durable generated-row marker and, for new
+    // rows, the exact balance-change instant. It remains populated when rule
+    // deletion nulls recurringId.
     //
-    // Before #658 the materializer set createdAt === occurrenceDate. For those
-    // legacy rows the actual posting instant is irretrievable, but the daily
-    // cron's order is deterministic: occurrences on/before the first
-    // snapshot's business day were materialized into that snapshot. Comparing
-    // like-for-like business days repairs those stored rows without changing
-    // manual/backdated transaction semantics.
-    if (floor && firstSnapshot && tx.recurringId) {
-      const isLegacyBackdated = tx.occurrenceDate?.getTime() === tx.createdAt.getTime();
-      const isAfterBaseline = isLegacyBackdated
-        ? tx.occurrenceDate!.getTime() > firstSnapshot.date.getTime()
-        : tx.createdAt.getTime() > floor.getTime();
+    // Linked rows predating the migration carry an explicitly estimated
+    // timestamp. When the estimate differs from occurrenceDate, it came from
+    // the later rule-creation bound and can still prove an immediate backfill
+    // happened after the baseline. Otherwise the exact failed-run/catch-up
+    // instant is irretrievable, so retain the like-for-like business-day
+    // fallback rather than pretending the estimate is exact.
+    const isGenerated = tx.materializedAt !== null || tx.recurringId !== null;
+    if (floor && firstSnapshot && isGenerated) {
+      const hasUsefulPostingBound =
+        tx.materializedAt !== null &&
+        (!tx.materializedAtEstimated ||
+          tx.occurrenceDate === null ||
+          tx.materializedAt.getTime() !== tx.occurrenceDate.getTime());
+      const isAfterBaseline = hasUsefulPostingBound
+        ? tx.materializedAt!.getTime() > floor.getTime()
+        : (tx.occurrenceDate ?? tx.createdAt).getTime() > firstSnapshot.date.getTime();
       if (!isAfterBaseline) continue;
     }
 

--- a/src/lib/services/recurring-cash-service.ts
+++ b/src/lib/services/recurring-cash-service.ts
@@ -16,9 +16,8 @@ import type { RecurringFrequency } from "@/generated/prisma/client";
  * successful run, so a skipped/failed cron day self-heals on the next run.
  *
  * All date math is in UTC and operates on calendar days only — `@db.Date`
- * columns come back as UTC-midnight `Date`s, and occurrences post at the cron's
- * run time (the `createdAt` is backdated to the occurrence day so history
- * groups them on the correct calendar date).
+ * columns come back as UTC-midnight `Date`s. `occurrenceDate` preserves that
+ * reporting day while `createdAt` records when the balance actually changed.
  */
 
 /** Floors a Date to UTC midnight (calendar-day granularity). */
@@ -200,8 +199,6 @@ export async function materializeDueRecurringTransactions(
             note: rule.note,
             recurringId: rule.id,
             occurrenceDate: d,
-            // Backdate so the row groups under its occurrence day in history.
-            createdAt: d,
           })),
           skipDuplicates: true,
         });

--- a/src/lib/services/recurring-cash-service.ts
+++ b/src/lib/services/recurring-cash-service.ts
@@ -191,6 +191,7 @@ export async function materializeDueRecurringTransactions(
         });
         if (reservation.count === 0) return 0;
 
+        const materializedAt = new Date();
         const res = await tx.cashTransaction.createMany({
           data: occurrences.map((d) => ({
             accountId: rule.accountId,
@@ -199,6 +200,8 @@ export async function materializeDueRecurringTransactions(
             note: rule.note,
             recurringId: rule.id,
             occurrenceDate: d,
+            materializedAt,
+            materializedAtEstimated: false,
           })),
           skipDuplicates: true,
         });

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -436,6 +436,7 @@ const importTimestamp = z.iso.datetime().optional();
 // to; manual rows export it as null. Preserve null as null — never default it,
 // since analysis bucketing falls back to createdAt only when it is null.
 const importOccurrenceDate = z.iso.datetime().optional().nullable();
+const importMaterializedAt = z.iso.datetime().optional().nullable();
 const importHoldingTransactionUnitPrice = decimalSchema
   .optional()
   .nullable()
@@ -508,6 +509,8 @@ export const dataImportSchema = z.object({
               createdAt: importTimestamp,
               occurrenceDate: importOccurrenceDate,
               recurringId: z.string().optional().nullable(),
+              materializedAt: importMaterializedAt,
+              materializedAtEstimated: z.boolean().default(false),
             }),
           )
           .max(MAX_IMPORT_CASH_TRANSACTIONS_PER_ACCOUNT)

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => {
   const makeTx = () => ({
     account: { deleteMany: vi.fn(), create: vi.fn(async () => ({ id: "new_account_1" })) },
+    cashTransaction: { createMany: vi.fn() },
+    recurringCashTransaction: { create: vi.fn(async () => ({ id: "new_cash_rule_1" })) },
+    recurringInvestment: { create: vi.fn() },
     netWorthSnapshot: { deleteMany: vi.fn(), createMany: vi.fn() },
     goal: { deleteMany: vi.fn(), createMany: vi.fn() },
     stockWatchItem: { deleteMany: vi.fn(), createMany: vi.fn() },
@@ -171,6 +174,90 @@ describe("Calendar whole-app backup", () => {
     expect(response.status).toBe(200);
     expect(h.tx.calendarEntry.deleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
     expect(h.tx.calendarEntry.createMany).not.toHaveBeenCalled();
+  });
+
+  it("preserves durable recurring cash provenance during backup import", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          cashTransactions: [
+            {
+              type: "DEPOSIT",
+              amount: 100,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              occurrenceDate: "2026-01-01T00:00:00.000Z",
+              materializedAt: "2025-12-31T21:30:00.000Z",
+              materializedAtEstimated: false,
+              recurringId: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          accountId: "new_account_1",
+          materializedAt: "2025-12-31T21:30:00.000Z",
+          materializedAtEstimated: false,
+          recurringId: null,
+        }),
+      ],
+    });
+  });
+
+  it("recovers estimated provenance when importing an older linked recurring row", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          recurringCashTransactions: [
+            {
+              id: "old_cash_rule_1",
+              type: "DEPOSIT",
+              amount: 100,
+              frequency: "MONTHLY",
+              startDate: "2026-01-01T00:00:00.000Z",
+              nextRunDate: "2026-02-01T00:00:00.000Z",
+              isActive: true,
+            },
+          ],
+          cashTransactions: [
+            {
+              type: "DEPOSIT",
+              amount: 100,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              occurrenceDate: "2026-01-01T00:00:00.000Z",
+              recurringId: "old_cash_rule_1",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          materializedAt: "2026-01-01T00:00:00.000Z",
+          materializedAtEstimated: true,
+          recurringId: "new_cash_rule_1",
+        }),
+      ],
+    });
   });
 
   it("preserves remapped mixed-currency snapshot breakdown entries for later FX revaluation", async () => {

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -186,6 +186,18 @@ describe("Calendar whole-app backup", () => {
           category: "BROKERAGE",
           currency: "USD",
           cashBalance: 100,
+          recurringCashTransactions: [
+            {
+              id: "old_cash_rule_1",
+              type: "DEPOSIT",
+              amount: 100,
+              frequency: "MONTHLY",
+              startDate: "2026-01-01T00:00:00.000Z",
+              nextRunDate: "2026-02-01T00:00:00.000Z",
+              isActive: true,
+              createdAt: "2026-01-02T00:00:00.000Z",
+            },
+          ],
           cashTransactions: [
             {
               type: "DEPOSIT",
@@ -194,7 +206,7 @@ describe("Calendar whole-app backup", () => {
               occurrenceDate: "2026-01-01T00:00:00.000Z",
               materializedAt: "2025-12-31T21:30:00.000Z",
               materializedAtEstimated: false,
-              recurringId: null,
+              recurringId: "old_cash_rule_1",
             },
           ],
         },
@@ -208,13 +220,13 @@ describe("Calendar whole-app backup", () => {
           accountId: "new_account_1",
           materializedAt: "2025-12-31T21:30:00.000Z",
           materializedAtEstimated: false,
-          recurringId: null,
+          recurringId: "new_cash_rule_1",
         }),
       ],
     });
   });
 
-  it("recovers estimated provenance when importing an older linked recurring row", async () => {
+  it("uses the linked rule creation bound for an older backfill imported after a snapshot", async () => {
     const response = await importBackup({
       version: "1.4",
       accounts: [
@@ -233,14 +245,71 @@ describe("Calendar whole-app backup", () => {
               startDate: "2026-01-01T00:00:00.000Z",
               nextRunDate: "2026-02-01T00:00:00.000Z",
               isActive: true,
+              createdAt: "2026-03-06T12:00:00.000Z",
             },
           ],
           cashTransactions: [
             {
               type: "DEPOSIT",
               amount: 100,
-              createdAt: "2026-01-01T00:00:00.000Z",
-              occurrenceDate: "2026-01-01T00:00:00.000Z",
+              createdAt: "2026-03-01T00:00:00.000Z",
+              occurrenceDate: "2026-03-01T00:00:00.000Z",
+              recurringId: "old_cash_rule_1",
+            },
+          ],
+        },
+      ],
+      snapshots: [
+        {
+          date: "2026-03-05T00:00:00.000Z",
+          totalAssets: 100,
+          totalLiabilities: 0,
+          netWorth: 100,
+          baseCurrency: "USD",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          materializedAt: "2026-03-06T12:00:00.000Z",
+          materializedAtEstimated: true,
+          recurringId: "new_cash_rule_1",
+        }),
+      ],
+    });
+  });
+
+  it("keeps the transaction creation bound when it is later than the linked rule", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          recurringCashTransactions: [
+            {
+              id: "old_cash_rule_1",
+              type: "DEPOSIT",
+              amount: 100,
+              frequency: "MONTHLY",
+              startDate: "2026-01-01T00:00:00.000Z",
+              nextRunDate: "2026-02-01T00:00:00.000Z",
+              isActive: true,
+              createdAt: "2026-03-01T00:00:00.000Z",
+            },
+          ],
+          cashTransactions: [
+            {
+              type: "DEPOSIT",
+              amount: 100,
+              createdAt: "2026-03-07T00:00:00.000Z",
+              occurrenceDate: "2026-03-01T00:00:00.000Z",
               recurringId: "old_cash_rule_1",
             },
           ],
@@ -252,9 +321,44 @@ describe("Calendar whole-app backup", () => {
     expect(h.tx.cashTransaction.createMany).toHaveBeenCalledWith({
       data: [
         expect.objectContaining({
-          materializedAt: "2026-01-01T00:00:00.000Z",
+          materializedAt: "2026-03-07T00:00:00.000Z",
           materializedAtEstimated: true,
           recurringId: "new_cash_rule_1",
+        }),
+      ],
+    });
+  });
+
+  it("keeps the transaction creation bound when the linked rule is missing", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          cashTransactions: [
+            {
+              type: "DEPOSIT",
+              amount: 100,
+              createdAt: "2026-03-07T00:00:00.000Z",
+              occurrenceDate: "2026-03-01T00:00:00.000Z",
+              recurringId: "missing_cash_rule",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.cashTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          materializedAt: "2026-03-07T00:00:00.000Z",
+          materializedAtEstimated: true,
+          recurringId: null,
         }),
       ],
     });

--- a/tests/unit/first-day-recurring-cash-flow.test.ts
+++ b/tests/unit/first-day-recurring-cash-flow.test.ts
@@ -7,6 +7,8 @@ interface CashRow {
   recurringId: string | null;
   occurrenceDate: Date | null;
   createdAt: Date;
+  materializedAt: Date | null;
+  materializedAtEstimated: boolean;
 }
 
 interface SnapshotRow {
@@ -71,6 +73,25 @@ function matchesCashWhere(row: CashRow, where: Record<string, unknown>): boolean
         return false;
       }
       continue;
+    }
+    if (field === "materializedAt") {
+      if (condition === null && row.materializedAt !== null) return false;
+      if (condition !== null) {
+        if ((condition as { not?: null }).not === null && row.materializedAt === null) {
+          return false;
+        }
+        if (
+          "gt" in (condition as object) &&
+          (row.materializedAt === null ||
+            row.materializedAt.getTime() <= ((condition as { gt: Date }).gt as Date).getTime())
+        ) {
+          return false;
+        }
+      }
+      continue;
+    }
+    if (field === "materializedAtEstimated" && row.materializedAtEstimated !== condition) {
+      return false;
     }
     if (field === "occurrenceDate") {
       if (condition === null) {
@@ -140,6 +161,12 @@ vi.mock("@/lib/prisma", () => {
             ...args.data.map((row) => ({
               ...row,
               createdAt: row.createdAt ?? new Date(),
+              materializedAt:
+                "materializedAt" in row && row.materializedAt instanceof Date
+                  ? row.materializedAt
+                  : null,
+              materializedAtEstimated:
+                "materializedAtEstimated" in row && row.materializedAtEstimated === true,
             })),
           );
           return { count: args.data.length };
@@ -228,6 +255,9 @@ describe("first-day recurring cash flow (#658)", () => {
     const businessDay = taiwanCalendarDay(new Date());
     expect(businessDay.toISOString()).toBe("2026-01-01T00:00:00.000Z");
     await materializeDueRecurringTransactions(businessDay);
+    // Deleting the rule sets the foreign key to null. Durable materialization
+    // provenance must still keep this generated row out of the baseline.
+    h.cashRows[0].recurringId = null;
 
     // Snapshotting happens after the balance-changing materialization.
     vi.setSystemTime(new Date("2025-12-31T21:30:01.000Z"));

--- a/tests/unit/first-day-recurring-cash-flow.test.ts
+++ b/tests/unit/first-day-recurring-cash-flow.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface CashRow {
+  accountId: string;
+  amount: number;
+  type: "DEPOSIT" | "WITHDRAWAL";
+  recurringId: string | null;
+  occurrenceDate: Date | null;
+  createdAt: Date;
+}
+
+interface SnapshotRow {
+  id: string;
+  userId: string;
+  date: Date;
+  createdAt: Date;
+  netWorth: number;
+  totalAssets: number;
+  totalLiabilities: number;
+  baseCurrency: string;
+  breakdown: Record<string, { value: number; currency: string }>;
+  label: null;
+  note: null;
+}
+
+const h = vi.hoisted(() => ({
+  balance: 0,
+  cashRows: [] as CashRow[],
+  snapshotRows: [] as SnapshotRow[],
+  dueRules: [] as Array<Record<string, unknown>>,
+  accounts: [
+    {
+      id: "brokerage",
+      userId: "u1",
+      name: "Brokerage",
+      type: "ASSET",
+      category: "BROKERAGE",
+      currency: "USD",
+    },
+  ],
+}));
+
+function matchesDate(value: Date, condition: Record<string, Date>): boolean {
+  if (condition.gt) return value.getTime() > condition.gt.getTime();
+  if (condition.gte) return value.getTime() >= condition.gte.getTime();
+  return true;
+}
+
+function matchesCashWhere(row: CashRow, where: Record<string, unknown>): boolean {
+  if (Array.isArray(where.OR) && !where.OR.some((branch) => matchesCashWhere(row, branch))) {
+    return false;
+  }
+  if (Array.isArray(where.AND) && !where.AND.every((branch) => matchesCashWhere(row, branch))) {
+    return false;
+  }
+
+  for (const [field, condition] of Object.entries(where)) {
+    if (field === "OR" || field === "AND") continue;
+    if (field === "accountId" || field === "type") {
+      const values = (condition as { in?: string[] }).in;
+      if (values && !values.includes(String(row[field]))) return false;
+      continue;
+    }
+    if (field === "recurringId") {
+      if (condition === null && row.recurringId !== null) return false;
+      if (
+        condition !== null &&
+        (condition as { not?: null }).not === null &&
+        row.recurringId === null
+      ) {
+        return false;
+      }
+      continue;
+    }
+    if (field === "occurrenceDate") {
+      if (condition === null) {
+        if (row.occurrenceDate !== null) return false;
+      } else if (
+        row.occurrenceDate === null ||
+        !matchesDate(row.occurrenceDate, condition as Record<string, Date>)
+      ) {
+        return false;
+      }
+      continue;
+    }
+    if (field === "createdAt" && !matchesDate(row.createdAt, condition as Record<string, Date>)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+vi.mock("next/cache", () => ({ cacheTag: () => {}, cacheLife: () => {} }));
+vi.mock("@/lib/logger", () => ({
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getAllExchangeRates: vi.fn(async () => new Map<string, number>()) };
+});
+vi.mock("@/lib/services/net-worth-service", () => ({
+  computeNetWorthSummary: vi.fn(async () => ({
+    totalAssets: h.balance,
+    totalLiabilities: 0,
+    netWorth: h.balance,
+    accounts: [
+      {
+        id: "brokerage",
+        totalValue: h.balance,
+        currency: "USD",
+      },
+    ],
+  })),
+  getCachedNetWorthSummary: vi.fn(),
+}));
+vi.mock("@/lib/prisma", () => {
+  const prisma = {
+    account: {
+      findMany: vi.fn(async () => h.accounts),
+      update: vi.fn(async (args: { data: { cashBalance: { increment: unknown } } }) => {
+        h.balance += Number(args.data.cashBalance.increment);
+        return {};
+      }),
+    },
+    recurringCashTransaction: {
+      findMany: vi.fn(async () => h.dueRules),
+      update: vi.fn(async () => ({})),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+    cashTransaction: {
+      createMany: vi.fn(
+        async (args: {
+          data: Array<
+            Omit<CashRow, "createdAt"> & {
+              createdAt?: Date;
+            }
+          >;
+        }) => {
+          h.cashRows.push(
+            ...args.data.map((row) => ({
+              ...row,
+              createdAt: row.createdAt ?? new Date(),
+            })),
+          );
+          return { count: args.data.length };
+        },
+      ),
+      findMany: vi.fn(async (args: { where: Record<string, unknown> }) =>
+        h.cashRows.filter((row) => matchesCashWhere(row, args.where)),
+      ),
+    },
+    netWorthSnapshot: {
+      upsert: vi.fn(
+        async (args: {
+          create: Omit<SnapshotRow, "id" | "label" | "note">;
+          update: Partial<SnapshotRow>;
+        }) => {
+          const row: SnapshotRow = {
+            id: `snapshot-${h.snapshotRows.length + 1}`,
+            label: null,
+            note: null,
+            ...args.create,
+          };
+          h.snapshotRows.push(row);
+          return row;
+        },
+      ),
+      findFirst: vi.fn(async () =>
+        [...h.snapshotRows].sort((a, b) => a.date.getTime() - b.date.getTime()).at(0),
+      ),
+      findMany: vi.fn(async () =>
+        [...h.snapshotRows].sort((a, b) => a.date.getTime() - b.date.getTime()),
+      ),
+    },
+    $transaction: vi.fn(async (fn: (tx: typeof prisma) => Promise<unknown>) => fn(prisma)),
+  };
+  return { prisma };
+});
+
+const { taiwanCalendarDay } = await import("@/lib/app-day");
+const { materializeDueRecurringTransactions } =
+  await import("@/lib/services/recurring-cash-service");
+const { createSnapshot } = await import("@/lib/services/snapshot-service");
+const {
+  getAccountMonthlyCashFlow,
+  getFullNormalizedHistory,
+  getMonthlyCashFlow,
+  getRawHistoryWithBreakdown,
+} = await import("@/lib/services/history-service");
+const {
+  aggregateMonthlyChange,
+  buildCashFlowBuckets,
+  buildCumulativeGrowth,
+  computeInvestmentReturn,
+  computePerformanceAttribution,
+} = await import("@/lib/services/analysis-service");
+
+describe("first-day recurring cash flow (#658)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.balance = 0;
+    h.cashRows = [];
+    h.snapshotRows = [];
+    h.dueRules = [
+      {
+        id: "monthly-deposit",
+        accountId: "brokerage",
+        type: "DEPOSIT",
+        amount: 100,
+        note: "Monthly savings",
+        frequency: "MONTHLY",
+        startDate: new Date("2026-01-01T00:00:00.000Z"),
+        endDate: null,
+        nextRunDate: new Date("2026-01-01T00:00:00.000Z"),
+        isActive: true,
+        updatedAt: new Date("2025-12-01T00:00:00.000Z"),
+      },
+    ];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not subtract a Taiwan Jan 1 deposit already represented in the first snapshot", async () => {
+    // The real cron interleaving: 21:30 UTC is already Jan 1 in Taiwan.
+    vi.setSystemTime(new Date("2025-12-31T21:30:00.000Z"));
+    const businessDay = taiwanCalendarDay(new Date());
+    expect(businessDay.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    await materializeDueRecurringTransactions(businessDay);
+
+    // Snapshotting happens after the balance-changing materialization.
+    vi.setSystemTime(new Date("2025-12-31T21:30:01.000Z"));
+    await createSnapshot("u1", "USD", { fresh: true });
+    vi.setSystemTime(new Date("2026-01-30T21:30:00.000Z"));
+    await createSnapshot("u1", "USD", { fresh: true });
+
+    const [snapshots, monthlyCashFlow, accountCashFlow, rawHistory] = await Promise.all([
+      getFullNormalizedHistory("u1", "USD"),
+      getMonthlyCashFlow("u1", "USD"),
+      getAccountMonthlyCashFlow("u1", "USD"),
+      getRawHistoryWithBreakdown("u1", "USD"),
+    ]);
+    const cashFlow = buildCashFlowBuckets(
+      aggregateMonthlyChange(snapshots),
+      monthlyCashFlow,
+      "en-US",
+    );
+    const cumulative = buildCumulativeGrowth(cashFlow);
+    const attribution = computePerformanceAttribution(
+      rawHistory.snapshots,
+      rawHistory.accounts,
+      accountCashFlow,
+      "2026-01",
+    );
+    const investmentReturn = computeInvestmentReturn(
+      rawHistory.snapshots,
+      rawHistory.accounts,
+      accountCashFlow,
+      "2026-01",
+    );
+
+    expect(monthlyCashFlow).toEqual([]);
+    expect(cashFlow[0]).toMatchObject({ contributions: 0, marketPerformance: 0 });
+    expect(cumulative[0]).toMatchObject({
+      cumulativeContributions: 0,
+      cumulativeMarket: 0,
+    });
+    expect(attribution.reduce((sum, item) => sum + item.marketPerformance, 0)).toBe(0);
+    expect(investmentReturn).toBe(0);
+  });
+});

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -20,6 +20,8 @@ interface CashTransactionFixture {
   createdAt: Date;
   occurrenceDate: Date | null;
   recurringId: string | null;
+  materializedAt: Date | null;
+  materializedAtEstimated: boolean;
   accountId: string;
 }
 const h = vi.hoisted(() => ({
@@ -66,6 +68,24 @@ vi.mock("@/lib/prisma", () => ({
             if (recurring === null && tx.recurringId !== null) return false;
             if (recurring && tx.recurringId === null) return false;
 
+            const materialized = branch.materializedAt as { not?: null } | null | undefined;
+            if (materialized === null && tx.materializedAt !== null) return false;
+            if (materialized) {
+              if (tx.materializedAt === null) return false;
+              if (
+                "gt" in materialized &&
+                tx.materializedAt.getTime() <= (materialized.gt as Date).getTime()
+              ) {
+                return false;
+              }
+            }
+            if (
+              typeof branch.materializedAtEstimated === "boolean" &&
+              tx.materializedAtEstimated !== branch.materializedAtEstimated
+            ) {
+              return false;
+            }
+
             const occ = branch.occurrenceDate as Record<string, Date> | null | undefined;
             if (occ && typeof occ === "object") {
               if (tx.occurrenceDate == null) return false;
@@ -79,7 +99,7 @@ vi.mock("@/lib/prisma", () => ({
               return cmp(op, tx.createdAt, floor);
             }
             const created = branch.createdAt as Record<string, Date> | undefined;
-            if (!created) return false;
+            if (!created) return materialized !== undefined || recurring !== undefined;
             const [op, floor] = Object.entries(created)[0];
             return cmp(op, tx.createdAt, floor);
           }),
@@ -366,6 +386,8 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
       createdAt: new Date("2026-07-01T10:00:00.000Z"),
       occurrenceDate: null,
       recurringId: null,
+      materializedAt: null,
+      materializedAtEstimated: false,
       accountId: "acc",
       ...over,
     };
@@ -420,9 +442,16 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     // counting them as contributions double-counts the opening deposit (#509).
     const floor = new Date("2026-03-05T21:30:00.000Z");
     expect(args.where.OR).toEqual([
-      { recurringId: { not: null }, createdAt: { gt: floor } },
-      { recurringId: null, occurrenceDate: { gt: floor } },
-      { recurringId: null, occurrenceDate: null, createdAt: { gt: floor } },
+      { materializedAtEstimated: false, materializedAt: { gt: floor } },
+      { materializedAtEstimated: true, materializedAt: { not: null } },
+      { materializedAt: null, recurringId: { not: null } },
+      { materializedAt: null, recurringId: null, occurrenceDate: { gt: floor } },
+      {
+        materializedAt: null,
+        recurringId: null,
+        occurrenceDate: null,
+        createdAt: { gt: floor },
+      },
     ]);
     // The accountId/type conditions stay ANDed alongside the floor OR.
     expect(args.where.accountId).toEqual({ in: ["acc"] });
@@ -513,7 +542,7 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     expect(args.where.OR).toBeUndefined();
   });
 
-  it("includes a catch-up recurring flow created after the first snapshot in its occurrence month", async () => {
+  it("includes a generated catch-up posted after the first snapshot after its rule is deleted", async () => {
     h.accounts = [account()];
     h.latestSnapshot = row({
       id: "first",
@@ -523,15 +552,39 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     h.cashTransactions = [
       cashTx({
         amount: 75,
-        recurringId: "weekly-deposit",
+        recurringId: null,
         occurrenceDate: new Date("2026-03-01T00:00:00.000Z"),
-        createdAt: new Date("2026-03-06T21:30:00.000Z"),
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        materializedAt: new Date("2026-03-06T21:30:00.000Z"),
       }),
     ];
 
     const result = await getAccountMonthlyCashFlow("u1", "USD");
 
     expect(result).toEqual([{ accountId: "acc", monthKey: "2026-03", contributions: 75 }]);
+  });
+
+  it("uses an estimated rule-creation posting bound for a legacy immediate backfill", async () => {
+    h.accounts = [account()];
+    h.latestSnapshot = row({
+      id: "first",
+      date: new Date("2026-03-05T00:00:00.000Z"),
+      createdAt: new Date("2026-03-05T21:30:00.000Z"),
+    });
+    h.cashTransactions = [
+      cashTx({
+        amount: 80,
+        recurringId: null,
+        occurrenceDate: new Date("2026-03-01T00:00:00.000Z"),
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        materializedAt: new Date("2026-03-06T12:00:00.000Z"),
+        materializedAtEstimated: true,
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([{ accountId: "acc", monthKey: "2026-03", contributions: 80 }]);
   });
 
   it("excludes a legacy backdated recurring flow already represented in the first snapshot", async () => {

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -19,6 +19,7 @@ interface CashTransactionFixture {
   type: "DEPOSIT" | "WITHDRAWAL";
   createdAt: Date;
   occurrenceDate: Date | null;
+  recurringId: string | null;
   accountId: string;
 }
 const h = vi.hoisted(() => ({
@@ -61,6 +62,10 @@ vi.mock("@/lib/prisma", () => ({
           op === "gt" ? a.getTime() > b.getTime() : a.getTime() >= b.getTime();
         return h.cashTransactions.filter((tx) =>
           or.some((branch) => {
+            const recurring = branch.recurringId as { not?: null } | null | undefined;
+            if (recurring === null && tx.recurringId !== null) return false;
+            if (recurring && tx.recurringId === null) return false;
+
             const occ = branch.occurrenceDate as Record<string, Date> | null | undefined;
             if (occ && typeof occ === "object") {
               if (tx.occurrenceDate == null) return false;
@@ -73,7 +78,10 @@ vi.mock("@/lib/prisma", () => ({
               const [op, floor] = Object.entries(created)[0];
               return cmp(op, tx.createdAt, floor);
             }
-            return false;
+            const created = branch.createdAt as Record<string, Date> | undefined;
+            if (!created) return false;
+            const [op, floor] = Object.entries(created)[0];
+            return cmp(op, tx.createdAt, floor);
           }),
         );
       }),
@@ -357,6 +365,7 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
       type: "DEPOSIT",
       createdAt: new Date("2026-07-01T10:00:00.000Z"),
       occurrenceDate: null,
+      recurringId: null,
       accountId: "acc",
       ...over,
     };
@@ -411,8 +420,9 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
     // counting them as contributions double-counts the opening deposit (#509).
     const floor = new Date("2026-03-05T21:30:00.000Z");
     expect(args.where.OR).toEqual([
-      { occurrenceDate: { gt: floor } },
-      { occurrenceDate: null, createdAt: { gt: floor } },
+      { recurringId: { not: null }, createdAt: { gt: floor } },
+      { recurringId: null, occurrenceDate: { gt: floor } },
+      { recurringId: null, occurrenceDate: null, createdAt: { gt: floor } },
     ]);
     // The accountId/type conditions stay ANDed alongside the floor OR.
     expect(args.where.accountId).toEqual({ in: ["acc"] });
@@ -501,6 +511,50 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
       where: Record<string, unknown>;
     };
     expect(args.where.OR).toBeUndefined();
+  });
+
+  it("includes a catch-up recurring flow created after the first snapshot in its occurrence month", async () => {
+    h.accounts = [account()];
+    h.latestSnapshot = row({
+      id: "first",
+      date: new Date("2026-03-05T00:00:00.000Z"),
+      createdAt: new Date("2026-03-05T21:30:00.000Z"),
+    });
+    h.cashTransactions = [
+      cashTx({
+        amount: 75,
+        recurringId: "weekly-deposit",
+        occurrenceDate: new Date("2026-03-01T00:00:00.000Z"),
+        createdAt: new Date("2026-03-06T21:30:00.000Z"),
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([{ accountId: "acc", monthKey: "2026-03", contributions: 75 }]);
+  });
+
+  it("excludes a legacy backdated recurring flow already represented in the first snapshot", async () => {
+    h.accounts = [account()];
+    h.latestSnapshot = row({
+      id: "first",
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2025-12-31T21:30:01.000Z"),
+    });
+    h.cashTransactions = [
+      cashTx({
+        amount: 100,
+        recurringId: "monthly-deposit",
+        occurrenceDate: new Date("2026-01-01T00:00:00.000Z"),
+        // Rows created before #658 backdated both timestamps to the business
+        // day, even though cron had posted the balance before this snapshot.
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      }),
+    ];
+
+    const result = await getAccountMonthlyCashFlow("u1", "USD");
+
+    expect(result).toEqual([]);
   });
 });
 

--- a/tests/unit/recurring-cash-service.test.ts
+++ b/tests/unit/recurring-cash-service.test.ts
@@ -216,6 +216,8 @@ describe("materializeDueRecurringTransactions", () => {
   });
 
   it("posts due occurrences and increments balance by the signed total", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-14T21:30:00.000Z"));
     h.dueRules = [
       {
         id: "rule1",
@@ -231,16 +233,24 @@ describe("materializeDueRecurringTransactions", () => {
     ];
     const result = await materializeDueRecurringTransactions(d("2026-06-14"));
 
-    // 2026-06-01, 06-08 are <= 06-14 (06-15 is the next run).
-    expect(result).toEqual({ created: 2, rulesProcessed: 1 });
-    expect(h.createManyCalls[0].data).toHaveLength(2);
-    expect(h.createManyCalls[0].skipDuplicates).toBe(true);
-    // +100 * 2 inserted rows.
-    const inc = (h.accountUpdates[0].data as { cashBalance: { increment: unknown } }).cashBalance
-      .increment;
-    expect(Number(inc)).toBe(200);
-    expect(iso(h.ruleUpdates[0].data.nextRunDate as Date)).toBe("2026-06-15");
-    expect(h.ruleUpdates[0].data.isActive).toBe(true);
+    try {
+      // 2026-06-01, 06-08 are <= 06-14 (06-15 is the next run).
+      expect(result).toEqual({ created: 2, rulesProcessed: 1 });
+      expect(h.createManyCalls[0].data).toHaveLength(2);
+      expect(h.createManyCalls[0].skipDuplicates).toBe(true);
+      expect(h.createManyCalls[0].data[0]).toMatchObject({
+        materializedAt: new Date("2026-06-14T21:30:00.000Z"),
+        materializedAtEstimated: false,
+      });
+      // +100 * 2 inserted rows.
+      const inc = (h.accountUpdates[0].data as { cashBalance: { increment: unknown } }).cashBalance
+        .increment;
+      expect(Number(inc)).toBe(200);
+      expect(iso(h.ruleUpdates[0].data.nextRunDate as Date)).toBe("2026-06-15");
+      expect(h.ruleUpdates[0].data.isActive).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("negates the balance delta for withdrawals", async () => {

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -451,7 +451,7 @@ describe("dataImportSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("preserves transaction occurrenceDate through parsing, keeping null as null", () => {
+  it("preserves transaction occurrenceDate and recurring materialization provenance", () => {
     const result = dataImportSchema.safeParse({
       version: "1.2",
       accounts: [
@@ -475,7 +475,13 @@ describe("dataImportSchema", () => {
             },
           ],
           cashTransactions: [
-            { type: "DEPOSIT", amount: "50", occurrenceDate: "2026-06-15T00:00:00.000Z" },
+            {
+              type: "DEPOSIT",
+              amount: "50",
+              occurrenceDate: "2026-06-15T00:00:00.000Z",
+              materializedAt: "2026-06-15T21:30:00.000Z",
+              materializedAtEstimated: false,
+            },
             { type: "WITHDRAWAL", amount: "10", occurrenceDate: null },
             { type: "DEPOSIT", amount: "5" },
           ],
@@ -495,6 +501,16 @@ describe("dataImportSchema", () => {
       "2026-06-15T00:00:00.000Z",
       null,
       undefined,
+    ]);
+    expect(account.cashTransactions?.map((t) => t.materializedAt)).toEqual([
+      "2026-06-15T21:30:00.000Z",
+      undefined,
+      undefined,
+    ]);
+    expect(account.cashTransactions?.map((t) => t.materializedAtEstimated)).toEqual([
+      false,
+      false,
+      false,
     ]);
   });
 


### PR DESCRIPTION
## Description

Fix first-day recurring cash contributions being counted after they were already absorbed into the starting net-worth snapshot, with durable posting provenance that survives recurring-rule deletion.

The daily cron materializes recurring cash before it creates snapshots. At 21:30 UTC, the Taiwan business day is the next UTC date-only day. The materializer originally backdated both `occurrenceDate` and `createdAt` to that future midnight, so the cash-flow floor compared a business-day timestamp later than the snapshot's wall-clock `createdAt` and counted the already-represented deposit again.

The initial fix separated reporting from posting time, but review identified two remaining gaps: historical catch-up timing was irretrievable, and deleting a rule nulls `recurringId`, erasing provenance. This revision makes the distinction durable:

- `occurrenceDate` remains the reporting/month bucket, preserving catch-up bucketing.
- `materializedAt` records the actual recurring posting instant for new rows and remains populated after `recurringId` is set to null.
- `materializedAtEstimated` explicitly distinguishes migrated legacy bounds from exact new posting instants.
- Exact generated rows are floored by `materializedAt`; estimated immediate backfills can use the later rule-creation bound; older estimated rows retain the business-day compatibility fallback.
- Manual and backdated non-recurring rows retain the #509/#551 effective-date boundary.
- Backup validation/import preserves both fields. For older linked backups, import recovers the estimated bound as `max(transaction.createdAt, original linked rule.createdAt)` before remapping IDs; a missing rule mapping retains the transaction bound, while explicit modern provenance remains authoritative.

## Migration safety

The migration adds the nullable posting timestamp, the non-null estimated flag with a safe `false` default, and an `(accountId, materializedAt)` analysis index. Still-linked legacy rows are backfilled with `GREATEST(cash.createdAt, rule.createdAt)` interpreted as UTC and marked estimated. This recovers a useful lower bound for immediate backfills without presenting it as an exact posting time.

Historical limits remain explicit: a scheduled/failed-run legacy row whose recovered bound equals its occurrence day has no reconstructable exact posting instant, so it uses the prior business-day fallback. Rows whose rule was already deleted before migration are indistinguishable from manual occurrence-dated rows and cannot be safely backfilled; they remain unclassified rather than guessed.

## Regression coverage

The service-level cron-order regression freezes 2025-12-31 21:30 UTC, materializes the Jan 1 Taiwan-day deposit, simulates rule deletion, snapshots the resulting balance, and verifies cash flow, cumulative growth, attribution, and investment return contain no phantom loss.

Additional behavior coverage verifies:

- a generated catch-up posted after the first snapshot survives in its older occurrence month after rule deletion;
- a first-day generated row posted before the snapshot remains excluded after rule deletion;
- estimated rule-creation bounds preserve legacy immediate backfills;
- manual/backdated #509/#551 behavior is unchanged;
- current backups preserve explicit provenance even when a linked rule provides a later inferred bound;
- older linked backups use the later transaction/rule creation bound, retain a later transaction bound, and retain the transaction bound when the rule mapping is missing.

## TDD evidence

- Original untouched baseline: 65 files / 520 unit tests passed.
- PR-head durable-provenance baseline: 66 files / 523 unit tests passed.
- Main durable-provenance RED: 5 expected failures / 111 passes (orphan first-day double-count, orphan catch-up omission, estimated immediate-backfill omission, missing materializer timestamp, validator stripping provenance).
- Older-backup provenance RED: imported linked rows received null/false provenance instead of an estimated bound.
- Final import-bound baseline: 66 files / 526 unit tests passed.
- Final import-bound RED: expected linked rule bound `2026-03-06T12:00:00.000Z`, received the older transaction bound `2026-03-01T00:00:00.000Z` (1 failed, 8 skipped).
- GREEN: all #658-focused suites passed 175/175 tests; the final route suite passed 9/9.

## Validation

- [x] Full unit suite: 528 passed (66 files)
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `prisma validate`
- [x] `git diff --check`
- [x] Full 22-migration deploy against isolated PostgreSQL 15
- [x] Recurring CAS integration: 6/6 passed
- [x] Legacy backfill + post-rule-delete durability probe against PostgreSQL 15
- [x] Production `pnpm build` with the repository's non-sensitive CI placeholder environment values (38/38 static pages generated)

## Scope

This PR remains based on `master@95daf18976c0977e98e65ca29b9d02d3d7c710c0` and contains only the #658 fix; it does not incorporate #659 / PR #667.

Closes #658