### PR TITLE
Fix option expiry sweep business day

### DIFF
--- a/src/app/api/cron/snapshot/route.ts
+++ b/src/app/api/cron/snapshot/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: Request) {
   }
 
   const startedAt = new Date();
+  const businessDay = taiwanCalendarDay(startedAt);
   const checkIn = startSnapshotCronCheckIn();
   let cronRun: { id: string } | null = null;
 
@@ -56,14 +57,14 @@ export async function GET(request: Request) {
       select: { id: true },
     });
 
-    // 0. Sweep expired option contracts so the snapshot doesn't include them
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
+    // 0. Sweep contracts that expired before this run's Taiwan business day so
+    // the snapshot does not carry yesterday's options into today's valuation.
+    // A contract expiring on businessDay remains active through that day.
     let expiredOptionsChanged = false;
     const expiredOptions = await prisma.holding.findMany({
       where: {
         assetType: "OPTION",
-        expiration: { lt: today },
+        expiration: { lt: businessDay },
         quantity: { gt: 0 },
       },
     });
@@ -154,7 +155,6 @@ export async function GET(request: Request) {
     // Materialize against the TAIWAN business day so a rule due "today"
     // (Taipei) posts in the same run whose snapshot is stamped with that day —
     // at 21:30 UTC the raw UTC day is still yesterday in Taipei.
-    const businessDay = taiwanCalendarDay(new Date());
     const recurring = await materializeDueRecurringTransactions(businessDay);
     if (recurring.rulesProcessed > 0) {
       log.info("cron.recurring.summary", recurring);
@@ -235,6 +235,7 @@ export async function GET(request: Request) {
           const snapshot = await createSnapshot(user.id, baseCurrency, {
             fresh: true,
             preloaded: inputs.get(user.id),
+            businessDay,
           });
           return { userId: user.id, snapshot };
         });

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -21,11 +21,14 @@ import { taiwanCalendarDay } from "@/lib/app-day";
  * `preloaded` carries inputs the caller already bulk-loaded, so a multi-user
  * sweep costs a fixed number of queries instead of three per user (#641). It
  * only changes where the data comes from, never the arithmetic.
+ *
+ * `businessDay` lets a batch caller keep every snapshot on the calendar day
+ * captured when the run began, even if later work crosses a day boundary.
  */
 export async function createSnapshot(
   userId: string,
   baseCurrency: string,
-  opts: { fresh?: boolean; preloaded?: NetWorthInputs } = {},
+  opts: { fresh?: boolean; preloaded?: NetWorthInputs; businessDay?: Date } = {},
 ) {
   const summary =
     opts.fresh || opts.preloaded
@@ -42,7 +45,7 @@ export async function createSnapshot(
   // bucketing elsewhere in the app (history table, heatmap, projections) that a
   // Taipei user actually sees. The result is still a fixed UTC-midnight Date, so
   // the `userId_date_baseCurrency` upsert key stays timezone-independent.
-  const today = taiwanCalendarDay(snapshotTakenAt);
+  const today = opts.businessDay ?? taiwanCalendarDay(snapshotTakenAt);
 
   const breakdown = Object.fromEntries(
     summary.accounts.map((a) => [a.id, { value: a.totalValue, currency: a.currency }]),

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -218,99 +218,6 @@ describe("snapshot cron route", () => {
     expect(vi.mocked(prisma.holdingTransaction.createMany)).not.toHaveBeenCalled();
   });
 
-  it("uses the captured Taiwan business day for option expiry, recurring work, and snapshots", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-05T21:30:00.000Z")); // Jul 6 05:30 Taipei
-    h.expiredOptions = [
-      { id: "expired-before-day", quantity: 2, expiration: new Date("2026-07-05T00:00:00Z") },
-      { id: "active-on-day", quantity: 3, expiration: new Date("2026-07-06T00:00:00Z") },
-      { id: "active-after-day", quantity: 4, expiration: new Date("2026-07-07T00:00:00Z") },
-    ];
-    try {
-      const { GET } = await import("@/app/api/cron/snapshot/route");
-      const { prisma } = await import("@/lib/prisma");
-      const { materializeDueRecurringTransactions } =
-        await import("@/lib/services/recurring-cash-service");
-      const { materializeDueInvestments } =
-        await import("@/lib/services/recurring-investment-service");
-
-      const response = await GET(
-        new Request("http://unit.test/api/cron/snapshot", {
-          headers: { authorization: "Bearer test-secret" },
-        }),
-      );
-
-      expect(response.status).toBe(200);
-      const businessDay = new Date("2026-07-06T00:00:00.000Z");
-      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
-        where: {
-          assetType: "OPTION",
-          expiration: { lt: businessDay },
-          quantity: { gt: 0 },
-        },
-      });
-      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledWith({
-        where: { id: "expired-before-day", quantity: 2 },
-        data: { quantity: 0 },
-      });
-      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledWith({
-        data: {
-          holdingId: "expired-before-day",
-          type: "SELL",
-          quantity: 2,
-          note: "Expired",
-        },
-      });
-      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
-      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
-      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
-      expect(h.events.indexOf("option:expired-before-day:zeroed")).toBeLessThan(
-        h.events.indexOf("option:expired-before-day:sell-recorded"),
-      );
-      expect(h.events.indexOf("option:expired-before-day:sell-recorded")).toBeLessThan(
-        h.events.indexOf("snapshot-inputs:loaded"),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("preserves the UTC cutoff when UTC and Taiwan share the calendar day", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-05T12:00:00.000Z")); // Jul 5 in UTC and Taipei
-    try {
-      const { GET } = await import("@/app/api/cron/snapshot/route");
-      const { prisma } = await import("@/lib/prisma");
-      const { materializeDueRecurringTransactions } =
-        await import("@/lib/services/recurring-cash-service");
-      const { materializeDueInvestments } =
-        await import("@/lib/services/recurring-investment-service");
-
-      const response = await GET(
-        new Request("http://unit.test/api/cron/snapshot", {
-          headers: { authorization: "Bearer test-secret" },
-        }),
-      );
-
-      expect(response.status).toBe(200);
-      const businessDay = new Date("2026-07-05T00:00:00.000Z");
-      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
-        where: {
-          assetType: "OPTION",
-          expiration: { lt: businessDay },
-          quantity: { gt: 0 },
-        },
-      });
-      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
-      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
-      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("returns 200 and records failed user ids when only some snapshots fail", async () => {
     h.users = [
       { id: "user1", appSettings: { baseCurrency: "USD" } },
@@ -610,6 +517,99 @@ describe("snapshot cron route", () => {
       const expected = new Date("2026-07-06T00:00:00.000Z");
       expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(expected);
       expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(expected);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the captured Taiwan business day for option expiry, recurring work, and snapshots", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T21:30:00.000Z")); // Jul 6 05:30 Taipei
+    h.expiredOptions = [
+      { id: "expired-before-day", quantity: 2, expiration: new Date("2026-07-05T00:00:00Z") },
+      { id: "active-on-day", quantity: 3, expiration: new Date("2026-07-06T00:00:00Z") },
+      { id: "active-after-day", quantity: 4, expiration: new Date("2026-07-07T00:00:00Z") },
+    ];
+    try {
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { prisma } = await import("@/lib/prisma");
+      const { materializeDueRecurringTransactions } =
+        await import("@/lib/services/recurring-cash-service");
+      const { materializeDueInvestments } =
+        await import("@/lib/services/recurring-investment-service");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const businessDay = new Date("2026-07-06T00:00:00.000Z");
+      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
+        where: {
+          assetType: "OPTION",
+          expiration: { lt: businessDay },
+          quantity: { gt: 0 },
+        },
+      });
+      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledWith({
+        where: { id: "expired-before-day", quantity: 2 },
+        data: { quantity: 0 },
+      });
+      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledWith({
+        data: {
+          holdingId: "expired-before-day",
+          type: "SELL",
+          quantity: 2,
+          note: "Expired",
+        },
+      });
+      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
+      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
+      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
+      expect(h.events.indexOf("option:expired-before-day:zeroed")).toBeLessThan(
+        h.events.indexOf("option:expired-before-day:sell-recorded"),
+      );
+      expect(h.events.indexOf("option:expired-before-day:sell-recorded")).toBeLessThan(
+        h.events.indexOf("snapshot-inputs:loaded"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves the UTC cutoff when UTC and Taiwan share the calendar day", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00.000Z")); // Jul 5 in UTC and Taipei
+    try {
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { prisma } = await import("@/lib/prisma");
+      const { materializeDueRecurringTransactions } =
+        await import("@/lib/services/recurring-cash-service");
+      const { materializeDueInvestments } =
+        await import("@/lib/services/recurring-investment-service");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const businessDay = new Date("2026-07-05T00:00:00.000Z");
+      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
+        where: {
+          assetType: "OPTION",
+          expiration: { lt: businessDay },
+          quantity: { gt: 0 },
+        },
+      });
+      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
+      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
+      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/cron-snapshot-route.test.ts
+++ b/tests/unit/cron-snapshot-route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
   events: [] as string[],
-  expiredOptions: [] as Array<{ id: string; quantity: number }>,
+  expiredOptions: [] as Array<{ id: string; quantity: number; expiration?: Date }>,
   optionSweepGuardFails: false,
   users: [{ id: "user1", appSettings: { baseCurrency: "USD" } }],
   snapshotFailures: new Set<string>(),
@@ -52,6 +52,7 @@ vi.mock("@/lib/services/exchange-rate-service", () => ({
 
 vi.mock("@/lib/services/net-worth-service", () => ({
   loadNetWorthInputsForUsers: vi.fn(async (userIds: string[]) => {
+    h.events.push("snapshot-inputs:loaded");
     h.inputLoads.push(userIds);
     return new Map(userIds.map((id) => [id, { accounts: [], ratesMap: new Map(), priceMap: {} }]));
   }),
@@ -88,13 +89,36 @@ vi.mock("@/lib/prisma", () => {
       update: vi.fn(async () => ({})),
     },
     holding: {
-      findMany: vi.fn(async () => h.expiredOptions),
+      findMany: vi.fn(
+        async (args?: {
+          where?: {
+            assetType?: string;
+            expiration?: { lt: Date };
+            quantity?: { gt: number };
+          };
+        }) => {
+          if (args?.where?.assetType !== "OPTION") return h.expiredOptions;
+          h.events.push("options:queried");
+          const cutoff = args.where.expiration?.lt;
+          return h.expiredOptions.filter(
+            (holding) =>
+              holding.quantity > (args.where?.quantity?.gt ?? 0) &&
+              (!holding.expiration || !cutoff || holding.expiration < cutoff),
+          );
+        },
+      ),
       // Per-holding guarded zeroing: count 0 simulates a concurrent writer
       // moving the quantity between the sweep's read and its write.
-      updateMany: vi.fn(async () => ({ count: h.optionSweepGuardFails ? 0 : 1 })),
+      updateMany: vi.fn(async (args: { where: { id: string } }) => {
+        h.events.push(`option:${args.where.id}:zeroed`);
+        return { count: h.optionSweepGuardFails ? 0 : 1 };
+      }),
     },
     holdingTransaction: {
-      create: vi.fn(async () => ({})),
+      create: vi.fn(async (args: { data: { holdingId: string } }) => {
+        h.events.push(`option:${args.data.holdingId}:sell-recorded`);
+        return {};
+      }),
       createMany: vi.fn(async () => ({ count: h.expiredOptions.length })),
     },
     account: {
@@ -192,6 +216,99 @@ describe("snapshot cron route", () => {
     expect(response.status).toBe(200);
     expect(vi.mocked(prisma.holdingTransaction.create)).not.toHaveBeenCalled();
     expect(vi.mocked(prisma.holdingTransaction.createMany)).not.toHaveBeenCalled();
+  });
+
+  it("uses the captured Taiwan business day for option expiry, recurring work, and snapshots", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T21:30:00.000Z")); // Jul 6 05:30 Taipei
+    h.expiredOptions = [
+      { id: "expired-before-day", quantity: 2, expiration: new Date("2026-07-05T00:00:00Z") },
+      { id: "active-on-day", quantity: 3, expiration: new Date("2026-07-06T00:00:00Z") },
+      { id: "active-after-day", quantity: 4, expiration: new Date("2026-07-07T00:00:00Z") },
+    ];
+    try {
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { prisma } = await import("@/lib/prisma");
+      const { materializeDueRecurringTransactions } =
+        await import("@/lib/services/recurring-cash-service");
+      const { materializeDueInvestments } =
+        await import("@/lib/services/recurring-investment-service");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const businessDay = new Date("2026-07-06T00:00:00.000Z");
+      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
+        where: {
+          assetType: "OPTION",
+          expiration: { lt: businessDay },
+          quantity: { gt: 0 },
+        },
+      });
+      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.holding.updateMany)).toHaveBeenCalledWith({
+        where: { id: "expired-before-day", quantity: 2 },
+        data: { quantity: 0 },
+      });
+      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.holdingTransaction.create)).toHaveBeenCalledWith({
+        data: {
+          holdingId: "expired-before-day",
+          type: "SELL",
+          quantity: 2,
+          note: "Expired",
+        },
+      });
+      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
+      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
+      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
+      expect(h.events.indexOf("option:expired-before-day:zeroed")).toBeLessThan(
+        h.events.indexOf("option:expired-before-day:sell-recorded"),
+      );
+      expect(h.events.indexOf("option:expired-before-day:sell-recorded")).toBeLessThan(
+        h.events.indexOf("snapshot-inputs:loaded"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves the UTC cutoff when UTC and Taiwan share the calendar day", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00.000Z")); // Jul 5 in UTC and Taipei
+    try {
+      const { GET } = await import("@/app/api/cron/snapshot/route");
+      const { prisma } = await import("@/lib/prisma");
+      const { materializeDueRecurringTransactions } =
+        await import("@/lib/services/recurring-cash-service");
+      const { materializeDueInvestments } =
+        await import("@/lib/services/recurring-investment-service");
+
+      const response = await GET(
+        new Request("http://unit.test/api/cron/snapshot", {
+          headers: { authorization: "Bearer test-secret" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const businessDay = new Date("2026-07-05T00:00:00.000Z");
+      expect(vi.mocked(prisma.holding.findMany)).toHaveBeenCalledWith({
+        where: {
+          assetType: "OPTION",
+          expiration: { lt: businessDay },
+          quantity: { gt: 0 },
+        },
+      });
+      expect(vi.mocked(materializeDueRecurringTransactions)).toHaveBeenCalledWith(businessDay);
+      expect(vi.mocked(materializeDueInvestments)).toHaveBeenCalledWith(businessDay);
+      expect(h.snapshotOpts).toEqual([expect.objectContaining({ fresh: true, businessDay })]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns 200 and records failed user ids when only some snapshots fail", async () => {

--- a/tests/unit/snapshot-service.test.ts
+++ b/tests/unit/snapshot-service.test.ts
@@ -55,6 +55,22 @@ describe("createSnapshot date bucketing", () => {
     const args = h.upsertArgs[0] as { create: { date: Date } };
     expect(args.create.date.toISOString().split("T")[0]).toBe("2026-07-06");
   });
+
+  it("uses the caller's captured business day when snapshot execution crosses a day boundary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T16:30:00.000Z")); // Jul 7 00:30 Taipei
+
+    await createSnapshot("u1", "USD", {
+      businessDay: new Date("2026-07-06T00:00:00.000Z"),
+    });
+
+    const args = h.upsertArgs[0] as {
+      where: { userId_date_baseCurrency: { date: Date } };
+      create: { date: Date };
+    };
+    expect(args.where.userId_date_baseCurrency.date).toEqual(new Date("2026-07-06T00:00:00.000Z"));
+    expect(args.create.date).toEqual(new Date("2026-07-06T00:00:00.000Z"));
+  });
 });
 
 // Regression #640: the cron refreshes prices/FX and materializes recurring rows,


### PR DESCRIPTION
## Description

Fix the daily snapshot cron so option expiry, recurring cash materialization, recurring investments (DCA), and snapshot bucketing all use one Taiwan business day derived from the run's captured start instant.

The root cause was that the option sweep independently floored `new Date()` to UTC midnight, while recurring jobs and snapshot persistence used the Taiwan calendar day. At the scheduled 21:30 UTC run, those dates differ.

Boundary semantics at `2026-07-05T21:30:00Z` (Taiwan Jul 6):

- expiration before Jul 6 is zeroed and records the guarded `SELL` before snapshot inputs load
- expiration equal to Jul 6 remains active for Jul 6
- expiration after Jul 6 remains active

The existing quantity compare-and-swap guard and cache invalidation behavior are preserved. When UTC and Taiwan have the same calendar day, the cutoff remains unchanged.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Strict RED → GREEN:

- RED: focused run failed 3 tests because the route queried Jul 5 instead of Jul 6, snapshots did not receive the captured business day, and delayed snapshot persistence stamped Jul 7 instead of the captured Jul 6.
- GREEN: focused route and snapshot-service tests pass (19/19).

Validation:

- untouched baseline: 65 files, 520 tests passed
- post-change full unit suite: 65 files, 523 tests passed
- Prettier check passed
- ESLint passed
- TypeScript `tsc --noEmit` passed
- `git diff --check` passed
- production `next build` passed with safe CI placeholder environment values

- [x] I have tested these changes locally
- [x] I have added/updated tests
- [x] All tests pass

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [ ] I have updated documentation
- [x] No new warnings generated

## Related Issues

Closes #661