### PR TITLE
fix: use warning tokens for demo banner actions

### DIFF
--- a/src/components/demo/demo-mode-banner.tsx
+++ b/src/components/demo/demo-mode-banner.tsx
@@ -140,7 +140,10 @@ export function DemoModeBanner({ expiresAt }: { expiresAt: string }) {
 
   return (
     <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
-      <section className="border-b border-warning/35 bg-warning/12 text-foreground shadow-sm md:sticky md:top-0 md:z-40">
+      <section
+        data-testid="demo-banner"
+        className="border-b border-warning/35 bg-warning/12 text-foreground shadow-sm md:sticky md:top-0 md:z-40"
+      >
         <form id="demo-reset-form" action={resetAction} />
         <p className="sr-only" aria-live="polite">
           {announcement}

--- a/src/components/demo/demo-mode-banner.tsx
+++ b/src/components/demo/demo-mode-banner.tsx
@@ -119,29 +119,18 @@ export function DemoModeBanner({ expiresAt }: { expiresAt: string }) {
     <>
       <AlertDialogTrigger
         render={
-          <Button
-            type="button"
-            variant="outline"
-            className="h-9 w-full bg-background/70 text-amber-950"
-          >
+          <Button type="button" variant="outline" className="h-11 w-full md:h-9">
             <RefreshCcw aria-hidden="true" />
             {t("banner.actions.reset")}
           </Button>
         }
       />
-      <Link
-        href="/login?from=demo"
-        className="inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-lg border border-amber-800/25 bg-background/70 px-2 text-sm font-medium text-amber-950 transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-amber-600/50 dark:text-amber-100"
-      >
-        <UserRound aria-hidden="true" className="size-4" />
+      <Button render={<Link href="/login?from=demo" />} className="h-11 w-full md:h-9">
+        <UserRound aria-hidden="true" />
         {t("banner.actions.signIn")}
-      </Link>
+      </Button>
       <form action={exitPublicDemoAction} className="w-full">
-        <Button
-          type="submit"
-          variant="outline"
-          className="h-9 w-full bg-background/70 text-amber-950"
-        >
+        <Button type="submit" variant="outline" className="h-11 w-full md:h-9">
           <LogOut aria-hidden="true" />
           {t("banner.actions.exit")}
         </Button>
@@ -151,7 +140,7 @@ export function DemoModeBanner({ expiresAt }: { expiresAt: string }) {
 
   return (
     <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
-      <section className="bg-amber-200 text-amber-950 shadow-sm dark:bg-amber-950 dark:text-amber-100 md:sticky md:top-0 md:z-40">
+      <section className="border-b border-warning/35 bg-warning/12 text-foreground shadow-sm md:sticky md:top-0 md:z-40">
         <form id="demo-reset-form" action={resetAction} />
         <p className="sr-only" aria-live="polite">
           {announcement}
@@ -163,10 +152,10 @@ export function DemoModeBanner({ expiresAt }: { expiresAt: string }) {
           <div className="grid min-w-[24rem] grid-cols-3 gap-2">{actions()}</div>
         </div>
         <div className="md:hidden">
-          <p className="px-3 py-2 text-center text-xs font-semibold">
+          <p className="px-3 py-2 text-center text-sm font-medium">
             {t("banner.title")} · {timeDetails}
           </p>
-          <div className="grid grid-cols-3 gap-2 border-t border-amber-900/15 px-3 py-2">
+          <div className="grid grid-cols-3 gap-2 border-t border-warning/25 px-3 py-2">
             {actions()}
           </div>
         </div>

--- a/tests/e2e/public-demo.spec.ts
+++ b/tests/e2e/public-demo.spec.ts
@@ -83,7 +83,7 @@ test("public Demo journey", async ({ browser, page }, testInfo) => {
   test.setTimeout(180_000);
   if (testInfo.project.name === "Public Demo Mobile zh-TW") {
     await startDemo(page);
-    const banner = page.locator("section.bg-amber-200");
+    const banner = page.getByTestId("demo-banner");
     await expect(banner).toBeVisible();
     await expect(page.getByText("Demo 模式").filter({ visible: true }).first()).toBeVisible();
     await expect(page.getByRole("button", { name: "重設資料" })).toBeVisible();
@@ -151,7 +151,7 @@ test("public Demo journey", async ({ browser, page }, testInfo) => {
   await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Exit Demo" })).toBeVisible();
 
-  const desktopActions = page.locator("section.bg-amber-200 div.hidden.md\\:flex > div");
+  const desktopActions = page.getByTestId("demo-banner").locator("div.hidden.md\\:flex > div");
   const desktopActionsBox = await desktopActions.boundingBox();
   expect(desktopActionsBox).not.toBeNull();
   const desktopActionBoxes = await Promise.all(


### PR DESCRIPTION
## Problem

In dark mode the demo banner's **重設資料** and **離開 Demo** buttons were nearly invisible: both hardcoded `text-amber-950` (near-black) with no dark variant, sitting on the banner's `dark:bg-amber-950` surface. Only the sign-in link was legible because it happened to carry `dark:text-amber-100`.

Root cause is design-system drift, not a one-off typo: the banner painted itself from the raw Tailwind `amber-*` palette while the project already has theme-aware `--warning` / `--warning-foreground` tokens (`globals.css:89`, with per-schema overrides so amber-schema users don't get a warning that collides with primary). The same hardcoding also meant the banner ignored the app's color-schema system entirely.

## Changes

- Banner surface uses the established caution pattern (`border-warning/35 bg-warning/12`), matching `freshness-badge.tsx:89` and `portfolio-heatmap.tsx:439`. Body copy is `text-foreground`, so contrast is AA in both themes and under every color schema.
- Action buttons drop all colour overrides and let the shared `Button` variants theme themselves. Against the tinted bar the `bg-background` outline chips now read as solid controls.
- Sign-in is promoted to the primary variant, so the three actions have a hierarchy instead of three identical chips — it's the action a demo user actually wants.
- Hand-rolled link styling (10 utility classes duplicating the button base) replaced with `Button render={<Link/>}`, the pattern used in `not-found.tsx`, `error.tsx`, and the settings demo CTAs.
- Mobile controls raised from `h-9` to `h-11 md:h-9`, and the mobile banner text from `text-xs` to `text-sm`, per the project's touch-target and mobile-legibility conventions.

Net: 8 insertions, 19 deletions; no new tokens, no new components.

## Verification

- `pnpm typecheck` and `pnpm lint` pass.
- **Not visually verified in a browser** — the local dev server was killed partway through by a disk-full condition on the machine, so light/dark screenshots of a live demo session are still outstanding. Worth an eyeball before merge.

## Follow-up (not in this PR)

Same hardcoded-amber drift exists in `demo/expired/page.tsx:24`, `login/page.tsx:204`, `fx-warning-banner.tsx:22`, `recurring-section.tsx:50`, and `accounts-list.tsx:92-94`. Those are legible today, so they're a separate cleanup.