### PR TITLE
fix: match demo CTA to the Google button style

### DIFF
--- a/src/components/demo/demo-login-button.tsx
+++ b/src/components/demo/demo-login-button.tsx
@@ -13,13 +13,11 @@ export function DemoLoginButton({ variant = "start" }: { variant?: "start" | "re
   const [state, action, pending] = useActionState(startPublicDemoAction, INITIAL_DEMO_ACTION_STATE);
   return (
     <form action={action} className="space-y-2">
-      {/* ponytail: border carries the visibility, not the fill — the neutral fill steps
-          are ~1.1:1 against the glass card in both themes, the border clears 3:1 */}
+      {/* ponytail: same class list as the Google button in login/page.tsx, minus the logo */}
       <Button
         type="submit"
-        variant="secondary"
         disabled={pending}
-        className="h-12 w-full rounded-xl border border-muted-foreground/90"
+        className="flex h-12 w-full items-center justify-center gap-3 rounded-xl border border-border bg-background text-sm font-medium tracking-wide text-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:bg-secondary hover:shadow-md"
       >
         {pending ? <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" /> : null}
         {pending ? t("preparing") : t(variant === "restart" ? "restartButton" : "button")}

--- a/src/components/demo/demo-login-button.tsx
+++ b/src/components/demo/demo-login-button.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState } from "react";
 import { useTranslations } from "next-intl";
-import { Loader2 } from "lucide-react";
+import { CirclePlay, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { startPublicDemoAction, type DemoActionState } from "@/app/demo/actions";
 
@@ -13,13 +13,17 @@ export function DemoLoginButton({ variant = "start" }: { variant?: "start" | "re
   const [state, action, pending] = useActionState(startPublicDemoAction, INITIAL_DEMO_ACTION_STATE);
   return (
     <form action={action} className="space-y-2">
-      {/* ponytail: same class list as the Google button in login/page.tsx, minus the logo */}
+      {/* ponytail: same class list and icon slot as the Google button in login/page.tsx */}
       <Button
         type="submit"
         disabled={pending}
         className="flex h-12 w-full items-center justify-center gap-3 rounded-xl border border-border bg-background text-sm font-medium tracking-wide text-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:bg-secondary hover:shadow-md"
       >
-        {pending ? <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" /> : null}
+        {pending ? (
+          <Loader2 className="size-5 shrink-0 animate-spin" aria-hidden="true" />
+        ) : (
+          <CirclePlay className="size-5 shrink-0" aria-hidden="true" />
+        )}
         {pending ? t("preparing") : t(variant === "restart" ? "restartButton" : "button")}
       </Button>
       <p className="text-center text-xs text-muted-foreground">{t("description")}</p>

--- a/src/components/demo/demo-login-button.tsx
+++ b/src/components/demo/demo-login-button.tsx
@@ -13,7 +13,14 @@ export function DemoLoginButton({ variant = "start" }: { variant?: "start" | "re
   const [state, action, pending] = useActionState(startPublicDemoAction, INITIAL_DEMO_ACTION_STATE);
   return (
     <form action={action} className="space-y-2">
-      <Button type="submit" variant="outline" disabled={pending} className="h-12 w-full rounded-xl">
+      {/* ponytail: border carries the visibility, not the fill — the neutral fill steps
+          are ~1.1:1 against the glass card in both themes, the border clears 3:1 */}
+      <Button
+        type="submit"
+        variant="secondary"
+        disabled={pending}
+        className="h-12 w-full rounded-xl border border-muted-foreground/90"
+      >
         {pending ? <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" /> : null}
         {pending ? t("preparing") : t(variant === "restart" ? "restartButton" : "button")}
       </Button>


### PR DESCRIPTION
## Problem

The demo CTA used `variant="outline"`, which is *almost* the Google button — `bg-background` + `border-border` — but without `shadow-sm`, `hover:shadow-md` or `hover:-translate-y-0.5`. That missing elevation is the whole reason it read as a footnote rather than a sibling of the Google button.

## Change

The button now carries the Google button's own class list from `login/page.tsx:82`, minus the logo:

```
flex h-12 w-full items-center justify-center gap-3 rounded-xl border border-border
bg-background text-sm font-medium tracking-wide text-foreground shadow-sm
transition-all hover:-translate-y-0.5 hover:bg-secondary hover:shadow-md
```

No new tokens, no new variants — the two sign-in paths are now literally the same control.

## Verification

Computed styles compared in a real browser, both themes:

```
light: identical on all 10 properties
dark:  identical on all 10 properties
```

(`backgroundColor`, `borderColor`, `borderWidth`, `borderRadius`, `boxShadow`, `color`, `height`, `fontSize`, `fontWeight`, `letterSpacing`.)

Screenshotted at `/login` and `/demo/expired` in light and dark.

## Note

`/demo/expired` shares this component (`variant="restart"`) and has no Google button to sit beside. There the CTA is now `bg-background`, which in dark mode is slightly darker than the card it sits on — still clearly delineated by its border and shadow, but the gap between it and the "Sign in" outline button below is subtler than before. Say the word if that page should keep a stronger primary action.

Unrelated and untouched: `/demo/expired` renders its card off-centre with a seam at 480px. Confirmed identical on `master`.