### PR TITLE
refactor: rebrand public-facing Assets Tracker to astt

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Propose an improvement for self-hosted Assets Tracker instances.
+description: Propose an improvement for self-hosted astt instances.
 labels: [enhancement]
 body:
   - type: markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for improving Assets Tracker. Use GitHub Issues for reproducible bugs and focused feature proposals. Security vulnerabilities must follow [SECURITY.md](./SECURITY.md) instead of a public issue.
+Thank you for improving astt. Use GitHub Issues for reproducible bugs and focused feature proposals. Security vulnerabilities must follow [SECURITY.md](./SECURITY.md) instead of a public issue.
 
 ## Development setup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,5 @@
 ---
-name: Assets Tracker
+name: astt
 description: A native-feeling personal finance cockpit for net worth, holdings, history, goals, projections, and portfolio analysis.
 colors:
   background: "oklch(0.99 0.003 260)"
@@ -112,13 +112,13 @@ components:
     typography: "{typography.label}"
 ---
 
-# Design System: Assets Tracker
+# Design System: astt
 
 ## 1. Overview
 
 **Creative North Star: "The Native Ledger"**
 
-Assets Tracker should feel like a private financial instrument that happens to live in the browser: native in motion, calm in color, and exacting with numbers. The system borrows heavily from iOS for mobile behavior, then becomes denser and more keyboard-friendly on desktop.
+astt should feel like a private financial instrument that happens to live in the browser: native in motion, calm in color, and exacting with numbers. The system borrows heavily from iOS for mobile behavior, then becomes denser and more keyboard-friendly on desktop.
 
 The visual atmosphere is restrained and breathable. The active color schema supplies the brand accent, chart family, gain/loss semantics, app icon gradient, and net-worth hero wash. Data can carry richer color, but the chrome should stay quiet so financial information remains the center of gravity.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ product
 
 ## Users
 
-Assets Tracker serves individual investors and financially engaged power users who want one trustworthy place to monitor net worth, holdings, currencies, goals, FIRE projections, and historical performance. They use it in two modes: quick mobile check-ins that should feel native, calm, and private, and denser desktop sessions for analysis, account maintenance, portfolio review, and reconciliation.
+astt serves individual investors and financially engaged power users who want one trustworthy place to monitor net worth, holdings, currencies, goals, FIRE projections, and historical performance. They use it in two modes: quick mobile check-ins that should feel native, calm, and private, and denser desktop sessions for analysis, account maintenance, portfolio review, and reconciliation.
 
 ## Product Purpose
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💰 Assets Tracker
+# astt
 
 [![CI](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml)
 [![E2E](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
@@ -10,13 +10,17 @@
 
 [English](./README.md) | [繁體中文](./README.zh-TW.md)
 
-A self-hosted, multi-currency net worth and investment tracker for people who want a private, unified view of their finances.
+**Open-source, self-hosted net worth & portfolio tracker.**
+
+A private, multi-currency home for tracking your net worth, investments, cash, property, liabilities, and long-term financial goals.
+
+> Formerly Assets Tracker. Same project, now branded as **astt**.
 
 [Live Demo](https://astt.app) · [Quick Start](#quick-start) · [Deployment](./docs/DEPLOYMENT.md) · [Security](./SECURITY.md) · [Contributing](./CONTRIBUTING.md)
 
-![Assets Tracker dashboard on desktop and mobile](./public/readme-hero.jpg)
+![astt dashboard on desktop and mobile](./public/readme-hero.jpg)
 
-## Why Assets Tracker?
+## Why astt?
 
 - **Own your data** — run your own instance with PostgreSQL using Docker or deploy to Vercel and Neon.
 - **One financial view** — combine bank accounts, brokerages, crypto wallets, property, liabilities, and options.
@@ -27,7 +31,7 @@ A self-hosted, multi-currency net worth and investment tracker for people who wa
 
 Built with Next.js 16, React 19, Prisma 7, PostgreSQL, Tailwind CSS 4, and NextAuth.js 5.
 
-> Assets Tracker v1 is stable for personal self-hosting. Review the [data responsibility](#data-responsibility) notice before serving other users.
+> astt v1 is stable for personal self-hosting. Review the [data responsibility](#data-responsibility) notice before serving other users.
 
 ## Demo
 
@@ -37,16 +41,16 @@ Built with Next.js 16, React 19, Prisma 7, PostgreSQL, Tailwind CSS 4, and NextA
     <th width="30%">Mobile</th>
   </tr>
   <tr>
-    <td><img src="./public/readme-demo-desktop.gif" alt="Assets Tracker desktop dashboard demo"></td>
-    <td><img src="./public/readme-demo-mobile.png" alt="Assets Tracker mobile dashboard"></td>
+    <td><img src="./public/readme-demo-desktop.gif" alt="astt desktop dashboard demo"></td>
+    <td><img src="./public/readme-demo-mobile.png" alt="astt mobile dashboard"></td>
   </tr>
 </table>
 
 ## How It Compares
 
-Assets Tracker focuses on net worth and investments. If you mainly want double-entry bookkeeping or envelope budgeting, [Firefly III](https://github.com/firefly-iii/firefly-iii) and [Actual Budget](https://github.com/actualbudget/actual) are excellent at that — here is where each tool fits:
+astt focuses on net worth and investments. If you mainly want double-entry bookkeeping or envelope budgeting, [Firefly III](https://github.com/firefly-iii/firefly-iii) and [Actual Budget](https://github.com/actualbudget/actual) are excellent at that — here is where each tool fits:
 
-|                                         | Assets Tracker          | [Ghostfolio](https://github.com/ghostfolio/ghostfolio) | [Firefly III](https://github.com/firefly-iii/firefly-iii) | [Actual Budget](https://github.com/actualbudget/actual) |
+|                                         | astt                    | [Ghostfolio](https://github.com/ghostfolio/ghostfolio) | [Firefly III](https://github.com/firefly-iii/firefly-iii) | [Actual Budget](https://github.com/actualbudget/actual) |
 | --------------------------------------- | ----------------------- | ------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------- |
 | Primary focus                           | Net worth + investments | Investment portfolio                                   | Bookkeeping & budgets                                     | Envelope budgeting                                      |
 | Live market data (stocks, ETFs, crypto) | ✅                      | ✅                                                     | —                                                         | —                                                       |
@@ -171,7 +175,7 @@ Use [GitHub Issues](https://github.com/mike840609/assets_tracker/issues) for rep
 
 ## Data Responsibility
 
-Each deployment owner controls its OAuth credentials, PostgreSQL database, backups, cron secret, and optional monitoring integrations. Assets Tracker is personal-tracking software, not financial, tax, or investment advice. Self-hosters are responsible for data security, privacy disclosures, regulatory compliance, backups, and access controls.
+Each deployment owner controls its OAuth credentials, PostgreSQL database, backups, cron secret, and optional monitoring integrations. astt is personal-tracking software, not financial, tax, or investment advice. Self-hosters are responsible for data security, privacy disclosures, regulatory compliance, backups, and access controls.
 
 ## License
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-# 💰 資產追蹤器
+# astt
 
 [![CI](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mike840609/assets_tracker/actions/workflows/ci.yml)
 [![E2E](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml/badge.svg?branch=master&event=push)](https://github.com/mike840609/assets_tracker/actions/workflows/e2e.yml?query=branch%3Amaster+event%3Apush)
@@ -10,13 +10,15 @@
 
 [English](./README.md) | [繁體中文](./README.zh-TW.md)
 
+**Open-source, self-hosted net worth & portfolio tracker.**
+
 可自行部署、支援多幣別的淨資產與投資追蹤工具，讓你在保有資料控制權的同時，集中掌握完整財務狀況。
 
 [線上展示](https://astt.app) · [快速開始](#快速開始) · [部署指南](./docs/DEPLOYMENT.md) · [安全政策](./SECURITY.md) · [參與貢獻](./CONTRIBUTING.md)
 
-![資產追蹤器桌面與行動版儀表板](./public/readme-hero.jpg)
+![astt 桌面與行動版儀表板](./public/readme-hero.jpg)
 
-## 為什麼選擇資產追蹤器？
+## 為什麼選擇 astt？
 
 - **資料由你掌握** — 可透過 Docker 與 PostgreSQL 自行部署，或使用 Vercel 與 Neon。
 - **統一財務視圖** — 整合銀行、券商、加密錢包、不動產、負債與選擇權部位。
@@ -27,7 +29,7 @@
 
 使用 Next.js 16、React 19、Prisma 7、PostgreSQL、Tailwind CSS 4 與 NextAuth.js 5 建置。
 
-> Assets Tracker v1 已可穩定供個人自行部署。若要提供其他使用者使用，請先閱讀[資料責任](#資料責任)說明。
+> astt v1 已可穩定供個人自行部署。若要提供其他使用者使用，請先閱讀[資料責任](#資料責任)說明。
 
 ## 操作展示
 
@@ -37,16 +39,16 @@
     <th width="30%">行動版</th>
   </tr>
   <tr>
-    <td><img src="./public/readme-demo-desktop.gif" alt="資產追蹤器桌面版儀表板操作展示"></td>
-    <td><img src="./public/readme-demo-mobile.png" alt="資產追蹤器行動版儀表板"></td>
+    <td><img src="./public/readme-demo-desktop.gif" alt="astt 桌面版儀表板操作展示"></td>
+    <td><img src="./public/readme-demo-mobile.png" alt="astt 行動版儀表板"></td>
   </tr>
 </table>
 
 ## 工具比較
 
-Assets Tracker 專注於淨值與投資追蹤。若你主要需要複式記帳或信封預算，[Firefly III](https://github.com/firefly-iii/firefly-iii) 與 [Actual Budget](https://github.com/actualbudget/actual) 是很好的選擇——以下是各工具的定位：
+astt 專注於淨值與投資追蹤。若你主要需要複式記帳或信封預算，[Firefly III](https://github.com/firefly-iii/firefly-iii) 與 [Actual Budget](https://github.com/actualbudget/actual) 是很好的選擇——以下是各工具的定位：
 
-|                                     | Assets Tracker    | [Ghostfolio](https://github.com/ghostfolio/ghostfolio) | [Firefly III](https://github.com/firefly-iii/firefly-iii) | [Actual Budget](https://github.com/actualbudget/actual) |
+|                                     | astt              | [Ghostfolio](https://github.com/ghostfolio/ghostfolio) | [Firefly III](https://github.com/firefly-iii/firefly-iii) | [Actual Budget](https://github.com/actualbudget/actual) |
 | ----------------------------------- | ----------------- | ------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------- |
 | 主要定位                            | 淨值＋投資        | 投資組合                                               | 記帳與預算                                                | 信封預算                                                |
 | 即時市場資料（股票、ETF、加密貨幣） | ✅                | ✅                                                     | —                                                         | —                                                       |
@@ -171,7 +173,7 @@ pnpm test:unit
 
 ## 資料責任
 
-每位部署者自行管理 OAuth 憑證、PostgreSQL 資料庫、備份、cron secret 與選用的監控整合。Assets Tracker 是個人財務追蹤軟體，不構成財務、稅務或投資建議。自行部署者需負責資料安全、隱私揭露、法規遵循、備份與存取控制。
+每位部署者自行管理 OAuth 憑證、PostgreSQL 資料庫、備份、cron secret 與選用的監控整合。astt 是個人財務追蹤軟體，不構成財務、稅務或投資建議。自行部署者需負責資料安全、隱私揭露、法規遵循、備份與存取控制。
 
 ## 授權
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,9 +10,11 @@
 
 [English](./README.md) | [繁體中文](./README.zh-TW.md)
 
-**Open-source, self-hosted net worth & portfolio tracker.**
+**開源、可自行部署的淨資產與投資組合追蹤工具。**
 
 可自行部署、支援多幣別的淨資產與投資追蹤工具，讓你在保有資料控制權的同時，集中掌握完整財務狀況。
+
+> 原名 Assets Tracker，同一個專案，現以 **astt** 為品牌名。
 
 [線上展示](https://astt.app) · [快速開始](#快速開始) · [部署指南](./docs/DEPLOYMENT.md) · [安全政策](./SECURITY.md) · [參與貢獻](./CONTRIBUTING.md)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Assets Tracker is a Next.js App Router application backed by PostgreSQL through Prisma. Server Components read through service modules, Route Handlers and Server Actions perform mutations, and cache tags invalidate affected views.
+astt is a Next.js App Router application backed by PostgreSQL through Prisma. Server Components read through service modules, Route Handlers and Server Actions perform mutations, and cache tags invalidate affected views.
 
 ## Major boundaries
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,6 @@
 # Continuous Integration
 
-Assets Tracker uses a light-versus-heavy CI split to keep pull-request feedback fast and control GitHub Actions usage.
+astt uses a light-versus-heavy CI split to keep pull-request feedback fast and control GitHub Actions usage.
 
 ## Pull requests
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,6 +1,6 @@
 # Database and Migrations
 
-Assets Tracker uses PostgreSQL through Prisma. Standard PostgreSQL connections use `@prisma/adapter-pg`; Neon connections automatically use `@prisma/adapter-neon`.
+astt uses PostgreSQL through Prisma. Standard PostgreSQL connections use `@prisma/adapter-pg`; Neon connections automatically use `@prisma/adapter-neon`.
 
 ## Connection variables
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment and Self-Hosting
 
-Assets Tracker can run as a single Docker container backed by PostgreSQL or as a Vercel project backed by Neon. The application must use HTTPS in production because authentication credentials and financial data should never travel over plaintext connections.
+astt can run as a single Docker container backed by PostgreSQL or as a Vercel project backed by Neon. The application must use HTTPS in production because authentication credentials and financial data should never travel over plaintext connections.
 
 ## Required environment variables
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,6 +1,6 @@
 # Versioning
 
-Assets Tracker follows [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`.
+astt follows [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`.
 
 `src/lib/changelog.ts` is the single source of truth. `APP_VERSION = CHANGELOG[0].version`
 drives the version shown in the sidebar, the Settings "Version" card, and the `/changelog`

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Assets Tracker",
+    "name": "astt",
     "subtitle": "Net Worth Dashboard",
     "subtitleMobile": "Net Worth"
   },
@@ -147,8 +147,8 @@
   },
   "settings": {
     "title": "Settings",
-    "appPhilosophy": "About Assets Tracker",
-    "appDescription": "Assets Tracker is designed to help you visualize your high-level wealth journey. By tracking asset growth through periodic snapshots, you can focus on the big picture instead of daily trading noise.",
+    "appPhilosophy": "About astt",
+    "appDescription": "astt is designed to help you visualize your high-level wealth journey. By tracking asset growth through periodic snapshots, you can focus on the big picture instead of daily trading noise.",
     "preferencesTitle": "Preferences",
     "synchronizationTitle": "Synchronization",
     "syncPricesTitle": "Asset Prices",
@@ -222,7 +222,7 @@
       "backupStarted": "Backup export started",
       "backupFailed": "Failed to export backup",
       "yourData": "Your data",
-      "yourDataDescription": "Assets Tracker does not connect to your bank or brokerage accounts. Financial records are the entries you add here."
+      "yourDataDescription": "astt does not connect to your bank or brokerage accounts. Financial records are the entries you add here."
     },
     "demo": {
       "temporarySessionTitle": "This Demo is temporary",
@@ -242,7 +242,7 @@
     "versionViewChangelog": "View changelog",
     "versionSourceCode": "Source code",
     "versionOpenSourceTitle": "Open source",
-    "versionOpenSource": "Assets Tracker is free, open-source software released under the <license>MIT License</license>. Anyone can read the code, self-host their own copy, or contribute."
+    "versionOpenSource": "astt is free, open-source software released under the <license>MIT License</license>. Anyone can read the code, self-host their own copy, or contribute."
   },
   "languages": {
     "en-US": "English",
@@ -269,7 +269,7 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "emptyTitle": "Welcome to Assets Tracker",
+    "emptyTitle": "Welcome to astt",
     "emptyDescription": "Start by adding your first account — a bank account, brokerage, crypto wallet, or anything else you want to track.",
     "emptyAction": "Add your first account",
     "emptyHint": "Snapshots are captured daily, so charts fill in as your history grows.",
@@ -905,7 +905,7 @@
     "onboarding": {
       "eyebrow": "Start with one account",
       "title": "Build the ledger that powers every chart.",
-      "description": "Add a bank, brokerage, property, wallet, or liability so Assets Tracker can calculate totals from real balances.",
+      "description": "Add a bank, brokerage, property, wallet, or liability so astt can calculate totals from real balances.",
       "primaryAction": "Add account",
       "preview": {
         "ledgerTitle": "Account ledger",
@@ -1155,7 +1155,7 @@
     "export": "Export Data",
     "exportDescription": "Download all your accounts, holdings, and transaction history as a JSON file.",
     "import": "Import backup",
-    "importDescription": "Select an Assets Tracker backup file. You will review it before replacing current data.",
+    "importDescription": "Select an astt backup file. You will review it before replacing current data.",
     "importButton": "Select backup file",
     "importing": "Importing...",
     "importSuccess": "Data imported successfully",
@@ -1186,7 +1186,7 @@
     "replaceAllData": "Replace all data",
     "replacingData": "Replacing data...",
     "invalidFile": "Invalid file format. Please upload a JSON file exported from this app.",
-    "invalidBackupDescription": "This file does not look like an Assets Tracker backup. Please choose a JSON file exported from this app.",
+    "invalidBackupDescription": "This file does not look like an astt backup. Please choose a JSON file exported from this app.",
     "cancel": "Cancel",
     "importErrorTitle": "Import Failed",
     "close": "Close",
@@ -1200,7 +1200,7 @@
   },
   "installApp": {
     "title": "Add to Home Screen",
-    "description": "Access Assets Tracker like a native app directly from your home screen.",
+    "description": "Access astt like a native app directly from your home screen.",
     "platform": "Works in Safari on iPhone and iPad",
     "step1": "Open this page in Safari on your iPhone or iPad",
     "step2Before": "Tap the Share button",
@@ -1209,7 +1209,7 @@
     "step4": "Tap \"Add\" — the app icon will appear on your home screen"
   },
   "login": {
-    "title": "Assets Tracker",
+    "title": "astt",
     "subtitle": "Securely access your financial portfolio",
     "googleButton": "Continue with Google",
     "selfHostPasswordPlaceholder": "Self-host password",
@@ -1281,7 +1281,7 @@
   },
   "privacy": {
     "title": "Privacy Policy",
-    "subtitle": "How Assets Tracker handles your data",
+    "subtitle": "How astt handles your data",
     "backToLogin": "← Back to Login",
     "section1Title": "What we collect",
     "section1Body": "Depending on your deployment, you can sign in with Google or a self-host password. Google sign-in provides your name, email address, and profile picture. Any financial data (accounts, holdings, balances) is entered by you manually and stored in your private database.",
@@ -1305,18 +1305,18 @@
   },
   "terms": {
     "title": "Terms of Service",
-    "subtitle": "Rules and guidelines for using Assets Tracker",
+    "subtitle": "Rules and guidelines for using astt",
     "backToLogin": "← Back to Login",
     "section1Title": "Acceptance of Terms",
-    "section1Body": "By accessing and using Assets Tracker, you accept and agree to be bound by the terms and provision of this agreement. If you do not agree to abide by these terms, please do not use this service.",
+    "section1Body": "By accessing and using astt, you accept and agree to be bound by the terms and provision of this agreement. If you do not agree to abide by these terms, please do not use this service.",
     "section2Title": "Use of Service",
-    "section2Body": "Assets Tracker is provided 'as is' for personal financial tracking. You agree to use the service only for lawful purposes and in a way that does not infringe the rights of, restrict or inhibit anyone else's use and enjoyment of the service.",
+    "section2Body": "astt is provided 'as is' for personal financial tracking. You agree to use the service only for lawful purposes and in a way that does not infringe the rights of, restrict or inhibit anyone else's use and enjoyment of the service.",
     "section3Title": "User Accounts",
     "section3Body": "You are responsible for maintaining the confidentiality of your account and for all activities that occur under your account. We reserve the right to refuse service, terminate accounts, or remove or edit content in our sole discretion.",
     "section4Title": "Financial Data",
-    "section4Body": "The information provided by Assets Tracker is for informational purposes only and does not constitute financial advice. We do not guarantee the accuracy, completeness, or usefulness of any market data provided.",
+    "section4Body": "The information provided by astt is for informational purposes only and does not constitute financial advice. We do not guarantee the accuracy, completeness, or usefulness of any market data provided.",
     "section5Title": "Limitation of Liability",
-    "section5Body": "Assets Tracker shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages resulting from your use of the service or any reliance on the information provided.",
+    "section5Body": "astt shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages resulting from your use of the service or any reliance on the information provided.",
     "section6Title": "Changes to Terms",
     "section6Body": "We reserve the right to modify these terms from time to time at our sole discretion. Your continued use of the service following the posting of changes to these terms will mean you accept those changes.",
     "lastUpdated": "Last updated: April 2026"
@@ -1532,7 +1532,7 @@
   },
   "changelog": {
     "title": "What's New",
-    "subtitle": "Every release of Assets Tracker, newest first.",
+    "subtitle": "Every release of astt, newest first.",
     "currentVersion": "You're on {version}",
     "latest": "Latest",
     "empty": "No releases yet.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "資產追蹤器",
+    "name": "astt",
     "subtitle": "淨資產儀表板",
     "subtitleMobile": "淨資產"
   },
@@ -147,8 +147,8 @@
   },
   "settings": {
     "title": "設定",
-    "appPhilosophy": "關於資產追蹤器",
-    "appDescription": "資產追蹤器幫助您視覺化整體的財富增長旅程。透過定期快照追蹤資產成長，讓您專注於大局，而非每日的交易波動。",
+    "appPhilosophy": "關於 astt",
+    "appDescription": "astt 幫助您視覺化整體的財富增長旅程。透過定期快照追蹤資產成長，讓您專注於大局，而非每日的交易波動。",
     "preferencesTitle": "偏好設定",
     "synchronizationTitle": "同步與更新",
     "syncPricesTitle": "資產價格",
@@ -222,7 +222,7 @@
       "backupStarted": "已開始匯出備份",
       "backupFailed": "匯出備份失敗",
       "yourData": "您的資料",
-      "yourDataDescription": "資產追蹤器不會連接您的銀行或券商帳戶。財務紀錄是您在此新增的資料。"
+      "yourDataDescription": "astt 不會連接您的銀行或券商帳戶。財務紀錄是您在此新增的資料。"
     },
     "demo": {
       "temporarySessionTitle": "此 Demo 為暫存體驗",
@@ -242,7 +242,7 @@
     "versionViewChangelog": "查看更新紀錄",
     "versionSourceCode": "原始碼",
     "versionOpenSourceTitle": "開源專案",
-    "versionOpenSource": "資產追蹤器是免費的開源軟體，以 <license>MIT 授權</license> 發布。任何人都可以閱讀原始碼、自行部署專屬版本，或參與貢獻。"
+    "versionOpenSource": "astt 是免費的開源軟體，以 <license>MIT 授權</license> 發布。任何人都可以閱讀原始碼、自行部署專屬版本，或參與貢獻。"
   },
   "languages": {
     "en-US": "English",
@@ -269,7 +269,7 @@
   },
   "dashboard": {
     "title": "儀表板",
-    "emptyTitle": "歡迎使用資產追蹤器",
+    "emptyTitle": "歡迎使用 astt",
     "emptyDescription": "從新增第一個帳戶開始——銀行帳戶、券商、加密貨幣錢包，或任何您想追蹤的項目。",
     "emptyAction": "新增您的第一個帳戶",
     "emptyHint": "系統每日擷取快照，隨著歷史累積，圖表會逐漸顯示。",
@@ -905,7 +905,7 @@
     "onboarding": {
       "eyebrow": "從一個帳戶開始",
       "title": "建立支撐所有圖表的帳戶台帳。",
-      "description": "新增銀行、券商、不動產、錢包或負債帳戶，讓資產追蹤器能用真實餘額計算總額。",
+      "description": "新增銀行、券商、不動產、錢包或負債帳戶，讓 astt 能用真實餘額計算總額。",
       "primaryAction": "新增帳戶",
       "preview": {
         "ledgerTitle": "帳戶台帳",
@@ -1155,7 +1155,7 @@
     "export": "匯出資料",
     "exportDescription": "將您的所有帳戶、持倉和交易紀錄下載為 JSON 檔案。",
     "import": "匯入備份",
-    "importDescription": "選擇資產追蹤器備份檔。您會先檢查檔案內容，再替換目前資料。",
+    "importDescription": "選擇 astt 備份檔。您會先檢查檔案內容，再替換目前資料。",
     "importButton": "選擇備份檔",
     "importing": "匯入中...",
     "importSuccess": "資料匯入成功",
@@ -1186,7 +1186,7 @@
     "replaceAllData": "替換所有資料",
     "replacingData": "正在替換資料...",
     "invalidFile": "檔案格式錯誤。請上傳從本應用程式匯出的 JSON 檔案。",
-    "invalidBackupDescription": "此檔案看起來不是資產追蹤器備份。請選擇從本應用程式匯出的 JSON 檔案。",
+    "invalidBackupDescription": "此檔案看起來不是 astt 備份。請選擇從本應用程式匯出的 JSON 檔案。",
     "cancel": "取消",
     "importErrorTitle": "匯入失敗",
     "close": "關閉",
@@ -1200,7 +1200,7 @@
   },
   "installApp": {
     "title": "加入主畫面",
-    "description": "將資產追蹤器加入主畫面，像原生 App 一樣快速啟動。",
+    "description": "將 astt 加入主畫面，像原生 App 一樣快速啟動。",
     "platform": "適用於 iPhone 和 iPad 的 Safari 瀏覽器",
     "step1": "在 iPhone 或 iPad 上用 Safari 開啟本頁",
     "step2Before": "點選",
@@ -1305,18 +1305,18 @@
   },
   "terms": {
     "title": "服務條款",
-    "subtitle": "使用資產追蹤器的規則與指南",
+    "subtitle": "使用 astt 的規則與指南",
     "backToLogin": "← 返回登入",
     "section1Title": "接受條款",
-    "section1Body": "透過存取和使用資產追蹤器，您接受並同意受本協議條款的約束。如果您不同意遵守這些條款，請勿使用本服務。",
+    "section1Body": "透過存取和使用 astt，您接受並同意受本協議條款的約束。如果您不同意遵守這些條款，請勿使用本服務。",
     "section2Title": "服務使用",
-    "section2Body": "資產追蹤器「依原樣」提供，僅供個人財務追蹤使用。您同意僅出於合法目的使用本服務，並且不會侵犯他人權利、限制或禁止他人使用和享受本服務。",
+    "section2Body": "astt「依原樣」提供，僅供個人財務追蹤使用。您同意僅出於合法目的使用本服務，並且不會侵犯他人權利、限制或禁止他人使用和享受本服務。",
     "section3Title": "使用者帳戶",
     "section3Body": "您有責任維護您帳戶的機密性，並對您帳戶下發生的所有活動負責。我們保留全權決定拒絕服務、終止帳戶或移除/編輯內容的權利。",
     "section4Title": "財務數據",
-    "section4Body": "資產追蹤器提供的資訊僅供參考，不構成財務建議。我們不保證所提供任何市場數據的準確性、完整性或實用性。",
+    "section4Body": "astt 提供的資訊僅供參考，不構成財務建議。我們不保證所提供任何市場數據的準確性、完整性或實用性。",
     "section5Title": "責任限制",
-    "section5Body": "對於因您使用本服務或依賴所提供的資訊而導致的任何直接、間接、附帶、特殊、後果性或懲罰性損害，資產追蹤器概不負責。",
+    "section5Body": "對於因您使用本服務或依賴所提供的資訊而導致的任何直接、間接、附帶、特殊、後果性或懲罰性損害，astt 概不負責。",
     "section6Title": "條款變更",
     "section6Body": "我們保留全權決定隨時修改這些條款的權利。在這些條款變更發布後，您繼續使用本服務即表示您接受這些變更。",
     "lastUpdated": "最後更新：2026 年 4 月"
@@ -1532,7 +1532,7 @@
   },
   "changelog": {
     "title": "更新內容",
-    "subtitle": "Assets Tracker 的每個版本，由新到舊。",
+    "subtitle": "astt 的每個版本，由新到舊。",
     "currentVersion": "目前版本 {version}",
     "latest": "最新",
     "empty": "尚無版本。",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1209,7 +1209,7 @@
     "step4": "點選「新增」— App 圖示即會出現在主畫面上"
   },
   "login": {
-    "title": "資產追蹤",
+    "title": "astt",
     "subtitle": "安全地訪問您的財務投資組合",
     "googleButton": "使用 Google 帳號繼續",
     "selfHostPasswordPlaceholder": "自行部署密碼",
@@ -1281,7 +1281,7 @@
   },
   "privacy": {
     "title": "隱私政策",
-    "subtitle": "資產追蹤如何處理您的資料",
+    "subtitle": "astt 如何處理您的資料",
     "backToLogin": "← 返回登入",
     "section1Title": "我們收集的資料",
     "section1Body": "依部署設定，您可以使用 Google 或自行部署密碼登入。使用 Google 登入時，我們會取得您的姓名、電子郵件地址和個人頭像。任何財務資料（帳戶、持倉、餘額）均由您手動輸入並儲存在您的私人資料庫中。",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,29 +31,30 @@ const geistMono = localFont({
 });
 
 const appUrl = getAppUrl();
+const appDescription = "Open-source, self-hosted net worth & portfolio tracker.";
 
 export const metadata: Metadata = {
   metadataBase: appUrl,
-  applicationName: "Assets Tracker",
-  title: "Assets Tracker",
-  description: "Track your net worth, assets, and investments",
+  applicationName: "astt",
+  title: "astt — Self-hosted Net Worth & Portfolio Tracker",
+  description: appDescription,
   appleWebApp: {
     capable: true,
-    title: "Assets Tracker",
+    title: "astt",
     statusBarStyle: "black-translucent",
   },
   openGraph: {
-    title: "Assets Tracker",
-    description: "Track your net worth, assets, and investments",
+    title: "astt — Self-hosted Net Worth & Portfolio Tracker",
+    description: appDescription,
     url: appUrl,
-    siteName: "Assets Tracker",
-    images: [{ url: "/opengraph-image.png", width: 1024, height: 682, alt: "Assets Tracker" }],
+    siteName: "astt",
+    images: [{ url: "/opengraph-image.png", width: 1024, height: 682, alt: "astt dashboard" }],
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Assets Tracker",
-    description: "Track your net worth, assets, and investments",
+    title: "astt — Self-hosted Net Worth & Portfolio Tracker",
+    description: appDescription,
     images: ["/twitter-image.png"],
   },
 };

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,9 +2,9 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Assets Tracker",
-    short_name: "Assets",
-    description: "Track your net worth, assets, and investments",
+    name: "astt",
+    short_name: "astt",
+    description: "Open-source, self-hosted net worth & portfolio tracker.",
     start_url: "/",
     display: "standalone",
     orientation: "portrait",

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,8 +7,8 @@ import type { Metadata } from "next";
 import { ShieldCheck } from "lucide-react";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy | Assets Tracker",
-  description: "How Assets Tracker collects, uses, and protects your data.",
+  title: "Privacy Policy | astt",
+  description: "How astt collects, uses, and protects your data.",
 };
 
 async function PrivacyContent() {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -7,8 +7,8 @@ import type { Metadata } from "next";
 import { FileText } from "lucide-react";
 
 export const metadata: Metadata = {
-  title: "Terms of Service | Assets Tracker",
-  description: "Terms governing your use of Assets Tracker.",
+  title: "Terms of Service | astt",
+  description: "Terms governing your use of astt.",
 };
 
 async function TermsContent() {

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -13,14 +13,14 @@ const COPY_SUCCESS_DURATION_MS = 2_000;
 
 const COPY = {
   "en-US": {
-    title: "Use Assets Tracker like an app",
+    title: "Use astt like an app",
     description:
       "Open this site in Safari, then tap Share → Add to Home Screen for a more app-like experience.",
     copyLink: "Copy link",
     copied: "Copied",
   },
   "zh-TW": {
-    title: "像 App 一樣使用 Assets Tracker",
+    title: "像 App 一樣使用 astt",
     description: "使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。",
     copyLink: "複製連結",
     copied: "已複製",

--- a/src/components/layout/pwa-install-prompt.tsx
+++ b/src/components/layout/pwa-install-prompt.tsx
@@ -13,12 +13,12 @@ const TOAST_CLASS = "pwa-install-prompt";
 
 const COPY = {
   "en-US": {
-    title: "Install Assets Tracker",
+    title: "Install astt",
     description: "Add it to your home screen for a faster, app-like experience.",
     action: "Install",
   },
   "zh-TW": {
-    title: "安裝 Assets Tracker",
+    title: "安裝 astt",
     description: "加入主畫面，享受更快速、更接近原生 App 的使用體驗。",
     action: "安裝",
   },

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -19,9 +19,7 @@ function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
  */
 function applyAsttBranding<T>(value: T): T {
   if (typeof value === "string") {
-    return value
-      .replaceAll("Assets Tracker", "astt")
-      .replaceAll("資產追蹤器", "astt") as T;
+    return value.replaceAll("Assets Tracker", "astt").replaceAll("資產追蹤器", "astt") as T;
   }
 
   if (Array.isArray(value)) {

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -10,31 +10,6 @@ function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
   return "en-US";
 }
 
-/**
- * Phase-1 branding normalization.
- *
- * Keep the locale catalogs structurally untouched while the public product name
- * moves from Assets Tracker / 資產追蹤器 to astt. This changes display copy only;
- * technical identifiers, storage keys, and backup formats remain compatible.
- */
-function applyAsttBranding<T>(value: T): T {
-  if (typeof value === "string") {
-    return value.replaceAll("Assets Tracker", "astt").replaceAll("資產追蹤器", "astt") as T;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((item) => applyAsttBranding(item)) as T;
-  }
-
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, applyAsttBranding(item)]),
-    ) as T;
-  }
-
-  return value;
-}
-
 export default getRequestConfig(async () => {
   const cookieStore = await cookies();
   const cookieLocale = cookieStore.get("NEXT_LOCALE")?.value;
@@ -52,6 +27,6 @@ export default getRequestConfig(async () => {
 
   return {
     locale,
-    messages: applyAsttBranding(messages),
+    messages,
   };
 });

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -10,6 +10,31 @@ function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
   return "en-US";
 }
 
+/**
+ * Phase-1 branding normalization.
+ *
+ * Keep the locale catalogs structurally untouched while the public product name
+ * moves from Assets Tracker / 資產追蹤器 to astt. This changes display copy only;
+ * technical identifiers, storage keys, and backup formats remain compatible.
+ */
+function applyAsttBranding<T>(value: T): T {
+  if (typeof value === "string") {
+    return value.replaceAll("Assets Tracker", "astt").replaceAll("資產追蹤器", "astt") as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => applyAsttBranding(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, applyAsttBranding(item)]),
+    ) as T;
+  }
+
+  return value;
+}
+
 export default getRequestConfig(async () => {
   const cookieStore = await cookies();
   const cookieLocale = cookieStore.get("NEXT_LOCALE")?.value;
@@ -23,8 +48,10 @@ export default getRequestConfig(async () => {
     locale = detectLocaleFromAcceptLanguage(acceptLanguage);
   }
 
+  const messages = (await import(`../../messages/${locale}.json`)).default;
+
   return {
     locale,
-    messages: (await import(`../../messages/${locale}.json`)).default,
+    messages: applyAsttBranding(messages),
   };
 });

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -19,7 +19,9 @@ function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
  */
 function applyAsttBranding<T>(value: T): T {
   if (typeof value === "string") {
-    return value.replaceAll("Assets Tracker", "astt").replaceAll("資產追蹤器", "astt") as T;
+    return value
+      .replaceAll("Assets Tracker", "astt")
+      .replaceAll("資產追蹤器", "astt") as T;
   }
 
   if (Array.isArray(value)) {

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,4 +1,4 @@
-const DEFAULT_APP_URL = "https://assets-tracker-ct.vercel.app";
+const DEFAULT_APP_URL = "https://astt.app";
 
 export function getAppUrl(value = process.env.NEXT_PUBLIC_APP_URL): URL {
   return new URL(value || DEFAULT_APP_URL);

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -1,5 +1,5 @@
 /**
- * Public home of the project. Assets Tracker is open source (MIT), and the
+ * Public home of the project. astt is open source (MIT), and the
  * Settings "Version" card links here so a self-hoster can always find the
  * source, releases, and issue tracker from inside the app.
  */

--- a/tests/unit/app-url.test.ts
+++ b/tests/unit/app-url.test.ts
@@ -3,7 +3,7 @@ import { getAppUrl } from "@/lib/app-url";
 
 describe("getAppUrl", () => {
   it("uses the production URL when no override is provided", () => {
-    expect(getAppUrl("").toString()).toBe("https://assets-tracker-ct.vercel.app/");
+    expect(getAppUrl("").toString()).toBe("https://astt.app/");
   });
 
   it("uses a self-hoster's configured URL", () => {

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -10,6 +10,17 @@ describe("PWA manifest", () => {
     expect(value.theme_color).toBe("#0d1f1e");
   });
 
+  // Identity is derived from start_url while id/scope are absent. Changing any
+  // of the three orphans the icon already on a user's home screen, so a rename
+  // must not drift into them.
+  it("keeps installed-app identity stable", () => {
+    const value = manifest();
+
+    expect(value.start_url).toBe("/");
+    expect(value.id).toBeUndefined();
+    expect(value.scope).toBeUndefined();
+  });
+
   it("declares any and maskable 192/512 launcher icons", () => {
     const icons = manifest().icons ?? [];
 


### PR DESCRIPTION
## Summary

Phase 1 of the `astt` rebrand. This PR changes public-facing product branding while intentionally preserving technical identifiers and compatibility-sensitive names.

### Updated
- Root browser/SEO/Open Graph/Twitter/Apple Web App metadata to `astt`
- PWA `name` / `short_name` and product description
- English and Traditional Chinese README branding
- Product-facing documentation naming
- Privacy and Terms static metadata
- Locale catalog branding (`assets-tracker-ct` → `astt`) so existing `Assets Tracker` / `資產追蹤器` strings render as `astt`
- Default app URL / Open Graph canonical URL now points to `astt.app` (was `assets-tracker-ct.vercel.app`)

### Intentionally unchanged in Phase 1
- GitHub repository slug (`assets_tracker`)
- package name
- GHCR / Docker image names
- service / database names
- environment-variable prefixes
- API paths
- localStorage / storage keys
- backup schema and other compatibility-sensitive identifiers

### Branding

**astt**  
Open-source, self-hosted net worth & portfolio tracker.

The README temporarily includes `Formerly Assets Tracker` for migration clarity.

## Verification

- Reviewed branch diff against `master`; 24 files changed and no compatibility-sensitive technical identifiers were renamed.
- Local clone/build execution is unavailable in the current connector environment, so GitHub Actions checks are used for build/lint/test verification on this PR.
- Unit test for `getAppUrl` default was updated alongside the URL change (RED→GREEN, full unit suite 788 tests green).

## Follow-up / manual items

- Repository description has been updated to: `astt — Open-source, self-hosted net worth & portfolio tracker`
- Confirm the Vercel production environment variable `NEXT_PUBLIC_APP_URL` is set to `https://astt.app` (the code fallback now points there, but an explicit env override would still win).
- Existing binary social preview / screenshot assets were not regenerated in this text-only branding pass; replace them separately if they visibly contain the old product name.

