### PR TITLE
feat: add Safari PWA install hint for iOS users

### DIFF
--- a/docs/superpowers/plans/2026-08-10-pwa-safari-install-toast.md
+++ b/docs/superpowers/plans/2026-08-10-pwa-safari-install-toast.md
@@ -1,0 +1,240 @@
+# Safari PWA Install Toast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a one-time localized Sonner toast to iPhone/iPad users in non-Safari browsers, suggesting Safari → Share → Add to Home Screen for an app-like experience.
+
+**Architecture:** Keep browser eligibility logic in a pure helper so it is easy to unit test in the existing Node-based Vitest setup. A small client component reads real browser state, checks localStorage, calls the helper, shows the existing Sonner toast, and persists the shown flag; the root layout mounts this component inside the existing NextIntl provider while the shared toaster remains unchanged.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, next-intl, Sonner, Vitest.
+
+## Global Constraints
+
+- Show only on iOS/iPadOS when the current browser is not Safari.
+- Never show in standalone / installed PWA mode.
+- Never show after `assets-tracker:pwa-safari-hint-shown` has been persisted.
+- Browser/storage detection failures must fail silently and must not affect application rendering.
+- Safari detection must exclude `CriOS`, `FxiOS`, `EdgiOS`, and `OPiOS`.
+- Do not change service-worker registration, manifest behavior, Android install behavior, or the shared Sonner component.
+- Add both English and Traditional Chinese UI copy.
+
+---
+
+### Task 1: Add and test pure PWA hint eligibility logic
+
+**Files:**
+- Create: `src/lib/pwa-install-hint.ts`
+- Create: `tests/unit/pwa-install-hint.test.ts`
+
+**Interfaces:**
+- Produces: `shouldShowSafariPwaHint(input: SafariPwaHintEnvironment): boolean`
+- `SafariPwaHintEnvironment` contains `userAgent: string`, `platform: string`, `maxTouchPoints: number`, `isStandalone: boolean`, and `hasBeenShown: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/pwa-install-hint.test.ts` with focused cases for iPhone Chrome, iPhone Firefox, iPhone Safari, Android Chrome, desktop Chrome, iPadOS desktop-style user agent, standalone mode, and already-shown state.
+
+```ts
+import { describe, expect, it } from "vitest";
+import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+
+const iphoneSafari =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
+
+const base = {
+  userAgent: iphoneSafari,
+  platform: "iPhone",
+  maxTouchPoints: 5,
+  isStandalone: false,
+  hasBeenShown: false,
+};
+
+describe("shouldShowSafariPwaHint", () => {
+  it("shows on iPhone Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 CriOS/140.0.0.0 Mobile/15E148 Safari/604.1",
+      }),
+    ).toBe(true);
+  });
+
+  it("shows on iPhone Firefox", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 FxiOS/142.0 Mobile/15E148 Safari/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not show on iPhone Safari", () => {
+    expect(shouldShowSafariPwaHint(base)).toBe(false);
+  });
+
+  it("does not show on Android Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "Linux armv8l",
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36 Chrome/140.0.0.0 Mobile Safari/537.36",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not show on desktop Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows for iPadOS desktop-style user agent in a non-Safari browser", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 CriOS/140.0.0.0 Version/18.0 Safari/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not show in standalone mode", () => {
+    expect(shouldShowSafariPwaHint({ ...base, isStandalone: true })).toBe(false);
+  });
+
+  it("does not show after the hint has already been shown", () => {
+    expect(shouldShowSafariPwaHint({ ...base, hasBeenShown: true })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test:unit tests/unit/pwa-install-hint.test.ts`
+
+Expected: FAIL because `@/lib/pwa-install-hint` does not exist yet.
+
+- [ ] **Step 3: Implement the minimal pure helper**
+
+Create `src/lib/pwa-install-hint.ts` with explicit iOS/iPadOS and Safari classification. Treat `MacIntel` + `maxTouchPoints > 1` as iPadOS. Treat a browser as Safari only when its user agent contains `Safari` and does not contain `CriOS`, `FxiOS`, `EdgiOS`, or `OPiOS`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm test:unit tests/unit/pwa-install-hint.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/pwa-install-hint.ts tests/unit/pwa-install-hint.test.ts
+git commit -m "feat: add Safari PWA hint eligibility logic"
+```
+
+### Task 2: Add localized client toast and mount it in the root layout
+
+**Files:**
+- Create: `src/components/layout/pwa-install-hint.tsx`
+- Modify: `src/app/layout.tsx`
+- Modify: `messages/en-US.json`
+- Modify: `messages/zh-TW.json`
+
+**Interfaces:**
+- Consumes: `shouldShowSafariPwaHint(...)` from Task 1.
+- Produces: `PwaInstallHint` client component with no props.
+
+- [ ] **Step 1: Add localized strings**
+
+Add a top-level `pwaInstallHint` namespace to both locale files.
+
+English:
+
+```json
+"pwaInstallHint": {
+  "title": "Use Assets Tracker like an app",
+  "description": "Open this site in Safari, then tap Share → Add to Home Screen for a more app-like experience."
+}
+```
+
+Traditional Chinese:
+
+```json
+"pwaInstallHint": {
+  "title": "像 App 一樣使用 Assets Tracker",
+  "description": "使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。"
+}
+```
+
+- [ ] **Step 2: Implement the client component**
+
+Create `src/components/layout/pwa-install-hint.tsx` as a `"use client"` component. In a single `useEffect`:
+
+1. Read `navigator.userAgent`, `navigator.platform`, and `navigator.maxTouchPoints`.
+2. Determine standalone mode using both `window.matchMedia("(display-mode: standalone)").matches` and legacy `(navigator as Navigator & { standalone?: boolean }).standalone === true`.
+3. Read `assets-tracker:pwa-safari-hint-shown` from localStorage in a guarded `try/catch`.
+4. Call `shouldShowSafariPwaHint`.
+5. When eligible, call `toast.info(t("title"), { description: t("description") })`.
+6. Persist the key to `"1"` after the toast is triggered, also in guarded storage handling.
+7. Return `null`.
+
+Use `useTranslations("pwaInstallHint")`; do not hard-code localized copy in the component.
+
+- [ ] **Step 3: Mount inside the locale provider**
+
+In `src/app/layout.tsx`:
+
+1. Import `PwaInstallHint`.
+2. Add `"pwaInstallHint"` to the `pickMessages` namespace list.
+3. Render `<PwaInstallHint />` inside `LocaleProviders`, after `<HtmlLangSync />`, so it has access to localized messages.
+4. Leave `<LazyToaster />` in its current root position and do not modify `src/components/ui/sonner.tsx`.
+
+- [ ] **Step 4: Run static verification**
+
+Run:
+
+```bash
+pnpm format:check
+pnpm lint
+pnpm typecheck
+pnpm test:unit tests/unit/pwa-install-hint.test.ts
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/pwa-install-hint.tsx src/app/layout.tsx messages/en-US.json messages/zh-TW.json
+git commit -m "feat: suggest Safari PWA install on iOS"
+```
+
+### Task 3: Final verification
+
+**Files:** No new files.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm test:unit`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run project checks**
+
+Run: `pnpm lint && pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the branch diff**
+
+Confirm the branch changes are limited to the spec/plan, the pure helper + tests, the small client component, root-layout wiring, and two locale files. Confirm no service-worker, manifest, Android install, or shared Sonner changes are present.

--- a/docs/superpowers/plans/2026-08-10-pwa-safari-install-toast.md
+++ b/docs/superpowers/plans/2026-08-10-pwa-safari-install-toast.md
@@ -23,10 +23,12 @@
 ### Task 1: Add and test pure PWA hint eligibility logic
 
 **Files:**
+
 - Create: `src/lib/pwa-install-hint.ts`
 - Create: `tests/unit/pwa-install-hint.test.ts`
 
 **Interfaces:**
+
 - Produces: `shouldShowSafariPwaHint(input: SafariPwaHintEnvironment): boolean`
 - `SafariPwaHintEnvironment` contains `userAgent: string`, `platform: string`, `maxTouchPoints: number`, `isStandalone: boolean`, and `hasBeenShown: boolean`.
 
@@ -145,12 +147,14 @@ git commit -m "feat: add Safari PWA hint eligibility logic"
 ### Task 2: Add localized client toast and mount it in the root layout
 
 **Files:**
+
 - Create: `src/components/layout/pwa-install-hint.tsx`
 - Modify: `src/app/layout.tsx`
 - Modify: `messages/en-US.json`
 - Modify: `messages/zh-TW.json`
 
 **Interfaces:**
+
 - Consumes: `shouldShowSafariPwaHint(...)` from Task 1.
 - Produces: `PwaInstallHint` client component with no props.
 

--- a/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
+++ b/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
@@ -21,10 +21,12 @@
 ### Task 1: Clipboard helper and regression tests
 
 **Files:**
+
 - Modify: `src/lib/pwa-install-hint.ts`
 - Modify: `tests/unit/pwa-install-hint.test.ts`
 
 **Interfaces:**
+
 - Produces: `copyPageUrl(writeText: ((text: string) => Promise<void>) | undefined, href: string): Promise<boolean>`
 - Returns `true` only when the clipboard write resolves; returns `false` when the API is missing or rejects.
 
@@ -65,10 +67,12 @@ Expected: PASS.
 ### Task 2: Localized persistent Copy link action
 
 **Files:**
+
 - Modify: `src/components/layout/pwa-install-hint.tsx`
 - Modify: `tests/unit/pwa-install-hint.test.ts`
 
 **Interfaces:**
+
 - Consumes: `copyPageUrl(...)`
 - Uses a stable toast id such as `pwa-safari-install-hint` so success updates the same toast.
 
@@ -109,7 +113,7 @@ Expected: PASS.
 
 ### Task 3: Repository verification
 
-**Files:** no new files.
+**Files:** No new files.
 
 - [ ] **Step 1: Run repository checks**
 

--- a/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
+++ b/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
@@ -1,0 +1,120 @@
+# PWA Copy-Link Toast Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a localized Copy link action to the persistent iOS Safari guidance toast so users can copy the exact current page URL before switching browsers.
+
+**Architecture:** Keep browser eligibility in `src/lib/pwa-install-hint.ts` and add a small injected clipboard helper there so success and failure can be unit tested without browser mocks. Keep toast rendering in `src/components/layout/pwa-install-hint.tsx`; use a stable Sonner toast id so a successful copy updates the existing toast action label to `Copied` / `已複製` without creating or dismissing another toast.
+
+**Tech Stack:** TypeScript, React 19, next-intl locale selection, Sonner 2.0.7, Vitest.
+
+## Global Constraints
+
+- Copy `window.location.href` exactly, including path, query string, and hash.
+- The toast remains visible with `duration: Number.POSITIVE_INFINITY` until the user explicitly closes it.
+- Copying must never dismiss the toast.
+- Clipboard failure must be silent and leave the Copy link action usable.
+- No redirect, Safari deep link, Android changes, service-worker changes, or manifest changes.
+
+---
+
+### Task 1: Clipboard helper and regression tests
+
+**Files:**
+- Modify: `src/lib/pwa-install-hint.ts`
+- Modify: `tests/unit/pwa-install-hint.test.ts`
+
+**Interfaces:**
+- Produces: `copyPageUrl(writeText: ((text: string) => Promise<void>) | undefined, href: string): Promise<boolean>`
+- Returns `true` only when the clipboard write resolves; returns `false` when the API is missing or rejects.
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that verify the helper passes the exact supplied URL to the clipboard writer, returns `true` on success, returns `false` when no writer is available, and returns `false` when the writer rejects.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: FAIL because `copyPageUrl` does not exist yet.
+
+- [ ] **Step 3: Implement the minimal helper**
+
+```ts
+export async function copyPageUrl(
+  writeText: ((text: string) => Promise<void>) | undefined,
+  href: string,
+): Promise<boolean> {
+  if (!writeText) return false;
+
+  try {
+    await writeText(href);
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: PASS.
+
+### Task 2: Localized persistent Copy link action
+
+**Files:**
+- Modify: `src/components/layout/pwa-install-hint.tsx`
+- Modify: `tests/unit/pwa-install-hint.test.ts`
+
+**Interfaces:**
+- Consumes: `copyPageUrl(...)`
+- Uses a stable toast id such as `pwa-safari-install-hint` so success updates the same toast.
+
+- [ ] **Step 1: Write failing toast-contract tests**
+
+Assert the component source includes localized `Copy link` / `複製連結` and `Copied` / `已複製` copy, an `action` object, `window.location.href`, the stable toast id, and does not call `toast.dismiss` from the copy path.
+
+- [ ] **Step 2: Run focused tests to verify RED**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: FAIL because the action is not implemented yet.
+
+- [ ] **Step 3: Implement the minimal action**
+
+Add `copyLink` and `copied` strings to both locales. Render the toast through a small local `showToast(actionLabel)` function with the existing infinite duration and close button plus:
+
+```ts
+action: {
+  label: actionLabel,
+  onClick: async () => {
+    const copied = await copyPageUrl(
+      navigator.clipboard?.writeText.bind(navigator.clipboard),
+      window.location.href,
+    );
+    if (copied) showToast(copy.copied);
+  },
+},
+```
+
+Use the same `id` on every `toast.info` call so the success label updates the existing toast rather than creating a new one.
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: PASS.
+
+### Task 3: Repository verification
+
+**Files:** no new files.
+
+- [ ] **Step 1: Run repository checks**
+
+Run the PR CI-equivalent checks: format, lint, typecheck, unit tests, PostgreSQL integration tests, production build / bundle-size, and Playwright smoke tests.
+
+- [ ] **Step 2: Verify PR status**
+
+Confirm PR #680 remains open and mergeable on the final head SHA with all required workflows successful.

--- a/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
+++ b/docs/superpowers/plans/2026-08-11-pwa-copy-link-action.md
@@ -30,17 +30,17 @@
 - Produces: `copyPageUrl(writeText: ((text: string) => Promise<void>) | undefined, href: string): Promise<boolean>`
 - Returns `true` only when the clipboard write resolves; returns `false` when the API is missing or rejects.
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add tests that verify the helper passes the exact supplied URL to the clipboard writer, returns `true` on success, returns `false` when no writer is available, and returns `false` when the writer rejects.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
 
-Expected: FAIL because `copyPageUrl` does not exist yet.
+Observed: FAIL because `copyPageUrl` did not exist yet.
 
-- [ ] **Step 3: Implement the minimal helper**
+- [x] **Step 3: Implement the minimal helper**
 
 ```ts
 export async function copyPageUrl(
@@ -58,11 +58,11 @@ export async function copyPageUrl(
 }
 ```
 
-- [ ] **Step 4: Run focused tests to verify GREEN**
+- [x] **Step 4: Run focused tests to verify GREEN**
 
 Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
 
-Expected: PASS.
+Observed: Clipboard helper cases PASS after implementation.
 
 ### Task 2: Localized persistent Copy link action
 
@@ -74,51 +74,36 @@ Expected: PASS.
 **Interfaces:**
 
 - Consumes: `copyPageUrl(...)`
-- Uses a stable toast id such as `pwa-safari-install-hint` so success updates the same toast.
+- Uses a stable toast id `pwa-safari-install-hint` so success updates the same toast.
 
-- [ ] **Step 1: Write failing toast-contract tests**
+- [x] **Step 1: Write failing toast-contract tests**
 
-Assert the component source includes localized `Copy link` / `複製連結` and `Copied` / `已複製` copy, an `action` object, `window.location.href`, the stable toast id, and does not call `toast.dismiss` from the copy path.
+Assert the component source includes localized `Copy link` / `複製連結` and `Copied` / `已複製` copy, an `action` object, `window.location.href`, the stable toast id, synchronous `event.preventDefault()` to suppress Sonner's default action dismissal, and no `toast.dismiss` call from the copy path.
 
-- [ ] **Step 2: Run focused tests to verify RED**
-
-Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
-
-Expected: FAIL because the action is not implemented yet.
-
-- [ ] **Step 3: Implement the minimal action**
-
-Add `copyLink` and `copied` strings to both locales. Render the toast through a small local `showToast(actionLabel)` function with the existing infinite duration and close button plus:
-
-```ts
-action: {
-  label: actionLabel,
-  onClick: async () => {
-    const copied = await copyPageUrl(
-      navigator.clipboard?.writeText.bind(navigator.clipboard),
-      window.location.href,
-    );
-    if (copied) showToast(copy.copied);
-  },
-},
-```
-
-Use the same `id` on every `toast.info` call so the success label updates the existing toast rather than creating a new one.
-
-- [ ] **Step 4: Run focused tests to verify GREEN**
+- [x] **Step 2: Run focused tests to verify RED**
 
 Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
 
-Expected: PASS.
+Observed: FAIL only on the missing Copy link toast action after the clipboard helper tests were green.
+
+- [x] **Step 3: Implement the minimal action**
+
+Add `copyLink` and `copied` strings to both locales. Render the toast through a local `showToast(actionLabel)` function with the existing infinite duration and close button. The action synchronously calls `event.preventDefault()`, copies the current `window.location.href`, updates the same toast to `Copied` / `已複製` on success, and resets the label after two seconds without dismissing the toast.
+
+- [x] **Step 4: Run focused tests to verify GREEN**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Observed: PASS as part of the full unit suite on the final implementation head.
 
 ### Task 3: Repository verification
 
 **Files:** No new files.
 
-- [ ] **Step 1: Run repository checks**
+- [x] **Step 1: Run repository checks**
 
-Run the PR CI-equivalent checks: format, lint, typecheck, unit tests, PostgreSQL integration tests, production build / bundle-size, and Playwright smoke tests.
+The PR CI-equivalent checks completed successfully on implementation head `9030907bea723931f3f203510ed9ce01d40ceebd`: format, lint, typecheck, unit tests, PostgreSQL integration tests, production build / bundle-size, and Playwright authenticated/public Demo smoke tests.
 
-- [ ] **Step 2: Verify PR status**
+- [x] **Step 2: Verify PR status**
 
-Confirm PR #680 remains open and mergeable on the final head SHA with all required workflows successful.
+PR #680 remained open and mergeable on implementation head `9030907bea723931f3f203510ed9ce01d40ceebd` with both CI and E2E workflows successful.

--- a/docs/superpowers/plans/2026-08-12-pwa-copy-link-button-height.md
+++ b/docs/superpowers/plans/2026-08-12-pwa-copy-link-button-height.md
@@ -1,0 +1,85 @@
+# PWA Copy-Link Button Height Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Increase only the Safari PWA hint Copy link / Copied action button height from Sonner's 24px default to exactly 36px without changing the toast size or other Sonner buttons.
+
+**Architecture:** Keep the change local to `PwaInstallHint` by using Sonner's per-toast `actionButtonStyle` option. Lock the contract with the existing source-based toast behavior unit tests so a future refactor cannot accidentally remove the 36px height or move it into the shared toaster.
+
+**Tech Stack:** React 19, TypeScript, Sonner 2.0.7, Vitest.
+
+## Global Constraints
+
+- The PWA hint action button height must be exactly 36px.
+- Do not change the shared `src/components/ui/sonner.tsx` component.
+- Do not change global Sonner CSS or default button sizing.
+- Keep existing action width behavior, horizontal padding, color, border radius, toast dimensions, Copy/Copied behavior, and persistent-toast behavior unchanged.
+
+---
+
+### Task 1: Add a PWA-specific 36px action-button contract
+
+**Files:**
+
+- Modify: `tests/unit/pwa-install-hint.test.ts`
+- Modify: `src/components/layout/pwa-install-hint.tsx`
+
+**Interfaces:**
+
+- Consumes: Sonner per-toast `actionButtonStyle` option.
+- Produces: the existing PWA hint action rendered with `height: 36` only for this toast.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Extend the `PwaInstallHint toast behavior` suite:
+
+```ts
+it("uses a 36px action button without changing the shared toaster", () => {
+  const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
+  const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
+
+  expect(source).toContain("actionButtonStyle: { height: 36 }");
+  expect(sharedToaster).not.toContain("actionButtonStyle");
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: FAIL because `PwaInstallHint` does not yet set `actionButtonStyle: { height: 36 }`.
+
+- [ ] **Step 3: Implement the minimal local style override**
+
+Inside the existing `toast.info(copy.title, { ... })` options in `showToast`, add:
+
+```ts
+actionButtonStyle: { height: 36 },
+```
+
+Place it next to the existing `action` configuration. Do not modify `src/components/ui/sonner.tsx`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm vitest run tests/unit/pwa-install-hint.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/pwa-install-hint.test.ts src/components/layout/pwa-install-hint.tsx
+git commit -m "style: increase PWA copy-link button height"
+```
+
+### Task 2: Repository verification
+
+**Files:** no new production files.
+
+- [ ] **Step 1: Run the PR CI-equivalent checks**
+
+Verify format, lint, typecheck, unit tests, PostgreSQL integration, production build / bundle-size, and Playwright smoke tests on the final head SHA.
+
+- [ ] **Step 2: Verify PR status**
+
+Confirm PR #680 remains open and mergeable and that the final head SHA is the SHA whose CI and E2E workflows succeeded.

--- a/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
+++ b/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
@@ -58,6 +58,12 @@ Add a Sonner action button to the toast. When the user clicks it:
 
 The close button remains the only explicit control that dismisses the toast.
 
+### Action Button Sizing
+
+The Copy link / Copied action must be **36px high** so it uses more of the toast's available vertical space than Sonner's 24px default action button. Keep the existing button width behavior, horizontal padding, color, border radius, and toast dimensions unchanged.
+
+Apply the 36px height only to this PWA hint toast action. Do not change the shared Sonner component or the default action-button height used by other toasts.
+
 ## Architecture
 
 Keep the focused client component at `src/components/layout/pwa-install-hint.tsx`, responsible for:
@@ -66,9 +72,10 @@ Keep the focused client component at `src/components/layout/pwa-install-hint.tsx
 - checking/writing the local persistence flag,
 - triggering the existing Sonner toast,
 - copying the current URL when the action is clicked,
-- maintaining the transient `Copied` action-label state.
+- maintaining the transient `Copied` action-label state,
+- applying PWA-toast-specific action-button sizing.
 
-Keep browser classification in the pure helper `src/lib/pwa-install-hint.ts` so it remains independently testable. Do not place browser-detection or clipboard behavior inside the shared `src/components/ui/sonner.tsx` component.
+Keep browser classification in the pure helper `src/lib/pwa-install-hint.ts` so it remains independently testable. Do not place browser-detection, clipboard behavior, or PWA-specific button sizing inside the shared `src/components/ui/sonner.tsx` component.
 
 ## Browser Detection
 
@@ -110,6 +117,8 @@ Cover at least:
 - Copy link uses the current `window.location.href`
 - successful copy does not dismiss the toast
 - clipboard failure leaves the toast usable
+- PWA hint action button height is exactly 36px
+- shared Sonner defaults are not changed to achieve the PWA-specific button height
 
 ## Non-Goals
 
@@ -118,3 +127,4 @@ Cover at least:
 - No Android install prompt changes.
 - No changes to service-worker registration or web-app manifest behavior.
 - No fixed homepage URL for the copy action; always copy the current page URL.
+- No global action-button height change for other Sonner toasts.

--- a/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
+++ b/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
@@ -15,9 +15,11 @@ Show the toast only when all of the following are true:
 1. The client is running on iOS or iPadOS.
 2. The current browser is not Safari.
 3. The app is not already running in standalone / installed PWA mode.
-4. The user has not previously dismissed or seen this hint on the current device/browser profile.
+4. The user has not previously seen this hint on the current device/browser profile.
 
 Do not show the toast on desktop browsers, Android, Safari, or installed standalone mode.
+
+The toast must remain visible indefinitely and must not auto-dismiss. It must expose a close button so the user explicitly dismisses it.
 
 Persist a local flag with `localStorage` after the toast is shown so it does not appear on every visit.
 
@@ -31,29 +33,52 @@ Description:
 
 > 使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。
 
-The copy should use the application's existing localization infrastructure if this component is rendered inside the locale provider. English should be added alongside Traditional Chinese if the project conventions require both locales for new UI strings.
+Action label:
+
+> 複製連結
+
+English equivalents:
+
+- Title: `Use Assets Tracker like an app`
+- Description: `Open this site in Safari, then tap Share → Add to Home Screen for a more app-like experience.`
+- Action label: `Copy link`
+- Success label: `Copied`
+
+The copy should follow the active application locale.
+
+## Copy-Link Action
+
+Add a Sonner action button to the toast. When the user clicks it:
+
+1. Copy `window.location.href`, preserving the exact current page URL including path, query string, and hash.
+2. Keep the PWA hint toast open; copying must never dismiss it.
+3. Temporarily change the action label to `Copied` / `已複製` after a successful clipboard write.
+4. If the Clipboard API is unavailable or `navigator.clipboard.writeText` rejects, fail silently and keep the action available for another attempt.
+5. Do not navigate, open Safari automatically, or replace the current page.
+
+The close button remains the only explicit control that dismisses the toast.
 
 ## Architecture
 
-Create a focused client component, for example `src/components/layout/pwa-install-hint.tsx`, responsible only for:
+Keep the focused client component at `src/components/layout/pwa-install-hint.tsx`, responsible for:
 
-- detecting iOS/iPadOS,
-- detecting Safari vs. other browsers,
-- detecting standalone mode,
+- collecting client browser state,
 - checking/writing the local persistence flag,
-- triggering the existing Sonner toast.
+- triggering the existing Sonner toast,
+- copying the current URL when the action is clicked,
+- maintaining the transient `Copied` action-label state.
 
-Mount the component near `LazyToaster` in the root layout so the toast infrastructure is already available. Do not place browser-detection logic inside the shared `src/components/ui/sonner.tsx` component.
+Keep browser classification in the pure helper `src/lib/pwa-install-hint.ts` so it remains independently testable. Do not place browser-detection or clipboard behavior inside the shared `src/components/ui/sonner.tsx` component.
 
 ## Browser Detection
 
-Use conservative client-side detection because this feature is only a non-critical UX hint. Account for iPadOS devices that can report a desktop-like user agent when possible. Safari detection must exclude common iOS browser tokens such as Chrome (`CriOS`), Firefox (`FxiOS`), Edge (`EdgiOS`), and Opera (`OPiOS`).
+Use conservative client-side detection because this feature is only a non-critical UX hint. Account for iPadOS devices that can report a desktop-like user agent when possible. Safari detection must exclude common iOS browser tokens such as Chrome (`CriOS`), Firefox (`FxiOS`), Edge (`EdgiOS`), Opera (`OPiOS`), and Brave (`Brave`).
 
 Standalone mode should consider both `window.matchMedia('(display-mode: standalone)').matches` and the legacy iOS `navigator.standalone` value.
 
 ## Persistence
 
-Use a stable namespaced key such as:
+Use the stable namespaced key:
 
 `assets-tracker:pwa-safari-hint-shown`
 
@@ -61,25 +86,35 @@ If storage is unavailable or throws, fail silently. The hint is optional and mus
 
 ## Error Handling
 
-All browser APIs must be accessed client-side only. Any feature-detection or storage failure should result in no crash and no impact to the rest of the application.
+All browser APIs must be accessed client-side only. Any feature-detection, storage, or clipboard failure must not crash or affect the rest of the application.
+
+Clipboard failure does not dismiss the toast and does not mark the copy action as successful.
 
 ## Testing
 
-Add focused tests for the decision logic, preferably by keeping browser-state classification in pure helper functions that can be tested without mounting the full application.
+Keep focused tests around both eligibility and toast behavior.
 
 Cover at least:
 
 - iPhone Chrome → show
 - iPhone Firefox → show
+- iPhone Brave → show
 - iPhone Safari → do not show
 - Android Chrome → do not show
 - desktop Chrome → do not show
 - installed standalone PWA → do not show
 - already-shown localStorage flag → do not show
+- toast duration is infinite
+- toast exposes a close button
+- toast exposes a localized Copy link action
+- Copy link uses the current `window.location.href`
+- successful copy does not dismiss the toast
+- clipboard failure leaves the toast usable
 
 ## Non-Goals
 
 - No automatic redirect or deep link to Safari.
-- No persistent banner or modal.
+- No separate persistent banner or modal.
 - No Android install prompt changes.
 - No changes to service-worker registration or web-app manifest behavior.
+- No fixed homepage URL for the copy action; always copy the current page URL.

--- a/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
+++ b/docs/superpowers/specs/2026-08-10-pwa-safari-install-toast-design.md
@@ -1,0 +1,85 @@
+# Safari PWA Install Toast Design
+
+## Goal
+
+Help iPhone and iPad users who open Assets Tracker in a non-Safari browser discover that opening the site in Safari and using **Add to Home Screen** provides a more app-like experience.
+
+## Scope
+
+This change adds a lightweight, one-time Sonner toast. It does not redesign the existing PWA setup, add a custom install banner, or attempt to force-open Safari.
+
+## Behavior
+
+Show the toast only when all of the following are true:
+
+1. The client is running on iOS or iPadOS.
+2. The current browser is not Safari.
+3. The app is not already running in standalone / installed PWA mode.
+4. The user has not previously dismissed or seen this hint on the current device/browser profile.
+
+Do not show the toast on desktop browsers, Android, Safari, or installed standalone mode.
+
+Persist a local flag with `localStorage` after the toast is shown so it does not appear on every visit.
+
+## Copy
+
+Title:
+
+> 像 App 一樣使用 Assets Tracker
+
+Description:
+
+> 使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。
+
+The copy should use the application's existing localization infrastructure if this component is rendered inside the locale provider. English should be added alongside Traditional Chinese if the project conventions require both locales for new UI strings.
+
+## Architecture
+
+Create a focused client component, for example `src/components/layout/pwa-install-hint.tsx`, responsible only for:
+
+- detecting iOS/iPadOS,
+- detecting Safari vs. other browsers,
+- detecting standalone mode,
+- checking/writing the local persistence flag,
+- triggering the existing Sonner toast.
+
+Mount the component near `LazyToaster` in the root layout so the toast infrastructure is already available. Do not place browser-detection logic inside the shared `src/components/ui/sonner.tsx` component.
+
+## Browser Detection
+
+Use conservative client-side detection because this feature is only a non-critical UX hint. Account for iPadOS devices that can report a desktop-like user agent when possible. Safari detection must exclude common iOS browser tokens such as Chrome (`CriOS`), Firefox (`FxiOS`), Edge (`EdgiOS`), and Opera (`OPiOS`).
+
+Standalone mode should consider both `window.matchMedia('(display-mode: standalone)').matches` and the legacy iOS `navigator.standalone` value.
+
+## Persistence
+
+Use a stable namespaced key such as:
+
+`assets-tracker:pwa-safari-hint-shown`
+
+If storage is unavailable or throws, fail silently. The hint is optional and must never block rendering.
+
+## Error Handling
+
+All browser APIs must be accessed client-side only. Any feature-detection or storage failure should result in no crash and no impact to the rest of the application.
+
+## Testing
+
+Add focused tests for the decision logic, preferably by keeping browser-state classification in pure helper functions that can be tested without mounting the full application.
+
+Cover at least:
+
+- iPhone Chrome → show
+- iPhone Firefox → show
+- iPhone Safari → do not show
+- Android Chrome → do not show
+- desktop Chrome → do not show
+- installed standalone PWA → do not show
+- already-shown localStorage flag → do not show
+
+## Non-Goals
+
+- No automatic redirect or deep link to Safari.
+- No persistent banner or modal.
+- No Android install prompt changes.
+- No changes to service-worker registration or web-app manifest behavior.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -935,6 +935,24 @@ html[data-vt-theme]::view-transition-new(root) {
   color: var(--accent-foreground) !important;
 }
 
+/* PWA install hint — Copy link is the toast's primary CTA, so it fills the full
+   toast height (no dead space beside the 3-line description) and uses --primary.
+   Scoped: every other toast keeps the muted 30px outline style above. */
+[data-sonner-toast][data-styled="true"].pwa-install-hint [data-action] {
+  align-self: stretch !important;
+  height: auto !important;
+  min-height: 44px !important;
+  background: var(--primary) !important;
+  color: var(--primary-foreground) !important;
+  border-color: transparent !important;
+  font-weight: 600 !important;
+}
+
+[data-sonner-toast][data-styled="true"].pwa-install-hint [data-action]:hover {
+  background: color-mix(in oklch, var(--primary) 88%, black) !important;
+  color: var(--primary-foreground) !important;
+}
+
 /* Slide in from right, slide out to right for top-right toaster.
    Sonner animates via --y which is applied as transform: var(--y). */
 [data-sonner-toaster][data-x-position="right"]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { ColorSchemaProvider } from "@/components/layout/color-schema-context";
 import { LazyToaster } from "@/components/layout/lazy-toaster";
+import { PwaInstallHint } from "@/components/layout/pwa-install-hint";
 import { CustomSpeedInsights } from "@/components/layout/speed-insights";
 import { HtmlLangSync } from "@/components/layout/html-lang-sync";
 import { Analytics } from "@vercel/analytics/next";
@@ -88,6 +89,7 @@ async function LocaleProviders({ children }: { children: React.ReactNode }) {
       ])}
     >
       <HtmlLangSync />
+      <PwaInstallHint />
       {children}
     </NextIntlClientProvider>
   );

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -72,11 +72,12 @@ export function PwaInstallHint() {
         description: copy.description,
         duration: Number.POSITIVE_INFINITY,
         closeButton: true,
+        style: { paddingTop: 8, paddingBottom: 8 },
         onDismiss: () => {
           dismissed = true;
           clearCopiedResetTimer();
         },
-        actionButtonStyle: { height: 36 },
+        actionButtonStyle: { alignSelf: "stretch", height: "auto" },
         action: {
           label: actionLabel,
           onClick: (event) => {

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -51,7 +51,11 @@ export function PwaInstallHint() {
     if (!shouldShow) return;
 
     const copy = locale === "zh-TW" ? COPY["zh-TW"] : COPY["en-US"];
-    toast.info(copy.title, { description: copy.description });
+    toast.info(copy.title, {
+      description: copy.description,
+      duration: Number.POSITIVE_INFINITY,
+      closeButton: true,
+    });
 
     try {
       window.localStorage.setItem(STORAGE_KEY, "1");

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -3,19 +3,25 @@
 import { useEffect } from "react";
 import { useLocale } from "next-intl";
 import { toast } from "sonner";
-import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+import { copyPageUrl, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
 
 const STORAGE_KEY = "assets-tracker:pwa-safari-hint-shown";
+const TOAST_ID = "pwa-safari-install-hint";
+const COPY_SUCCESS_DURATION_MS = 2_000;
 
 const COPY = {
   "en-US": {
     title: "Use Assets Tracker like an app",
     description:
       "Open this site in Safari, then tap Share → Add to Home Screen for a more app-like experience.",
+    copyLink: "Copy link",
+    copied: "Copied",
   },
   "zh-TW": {
     title: "像 App 一樣使用 Assets Tracker",
     description: "使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。",
+    copyLink: "複製連結",
+    copied: "已複製",
   },
 } as const;
 
@@ -51,17 +57,62 @@ export function PwaInstallHint() {
     if (!shouldShow) return;
 
     const copy = locale === "zh-TW" ? COPY["zh-TW"] : COPY["en-US"];
-    toast.info(copy.title, {
-      description: copy.description,
-      duration: Number.POSITIVE_INFINITY,
-      closeButton: true,
-    });
+    let copiedResetTimer: number | undefined;
+    let dismissed = false;
+
+    const clearCopiedResetTimer = () => {
+      if (copiedResetTimer === undefined) return;
+      window.clearTimeout(copiedResetTimer);
+      copiedResetTimer = undefined;
+    };
+
+    const showToast = (actionLabel: string) => {
+      toast.info(copy.title, {
+        id: TOAST_ID,
+        description: copy.description,
+        duration: Number.POSITIVE_INFINITY,
+        closeButton: true,
+        onDismiss: () => {
+          dismissed = true;
+          clearCopiedResetTimer();
+        },
+        action: {
+          label: actionLabel,
+          onClick: (event) => {
+            event.preventDefault();
+
+            void (async () => {
+              const copied = await copyPageUrl(
+                navigator.clipboard?.writeText?.bind(navigator.clipboard),
+                window.location.href,
+              );
+
+              if (!copied || dismissed) return;
+
+              showToast(copy.copied);
+              clearCopiedResetTimer();
+              copiedResetTimer = window.setTimeout(() => {
+                if (!dismissed) showToast(copy.copyLink);
+                copiedResetTimer = undefined;
+              }, COPY_SUCCESS_DURATION_MS);
+            })();
+          },
+        },
+      });
+    };
+
+    showToast(copy.copyLink);
 
     try {
       window.localStorage.setItem(STORAGE_KEY, "1");
     } catch {
       // The hint is optional; storage failures must not affect app rendering.
     }
+
+    return () => {
+      dismissed = true;
+      clearCopiedResetTimer();
+    };
   }, [locale]);
 
   return null;

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLocale } from "next-intl";
+import { toast } from "sonner";
+import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+
+const STORAGE_KEY = "assets-tracker:pwa-safari-hint-shown";
+
+const COPY = {
+  "en-US": {
+    title: "Use Assets Tracker like an app",
+    description:
+      "Open this site in Safari, then tap Share → Add to Home Screen for a more app-like experience.",
+  },
+  "zh-TW": {
+    title: "像 App 一樣使用 Assets Tracker",
+    description: "使用 Safari 開啟後，點選分享 → 加入主畫面，即可獲得更接近原生 App 的體驗。",
+  },
+} as const;
+
+type NavigatorWithStandalone = Navigator & {
+  standalone?: boolean;
+};
+
+export function PwaInstallHint() {
+  const locale = useLocale();
+
+  useEffect(() => {
+    let hasBeenShown: boolean;
+
+    try {
+      hasBeenShown = window.localStorage.getItem(STORAGE_KEY) === "1";
+    } catch {
+      return;
+    }
+
+    const navigatorWithStandalone = navigator as NavigatorWithStandalone;
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      navigatorWithStandalone.standalone === true;
+
+    const shouldShow = shouldShowSafariPwaHint({
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+      maxTouchPoints: navigator.maxTouchPoints,
+      isStandalone,
+      hasBeenShown,
+    });
+
+    if (!shouldShow) return;
+
+    const copy = locale === "zh-TW" ? COPY["zh-TW"] : COPY["en-US"];
+    toast.info(copy.title, { description: copy.description });
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // The hint is optional; storage failures must not affect app rendering.
+    }
+  }, [locale]);
+
+  return null;
+}

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -76,6 +76,7 @@ export function PwaInstallHint() {
           dismissed = true;
           clearCopiedResetTimer();
         },
+        actionButtonStyle: { height: 36 },
         action: {
           label: actionLabel,
           onClick: (event) => {

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -3,10 +3,12 @@
 import { useEffect } from "react";
 import { useLocale } from "next-intl";
 import { toast } from "sonner";
-import { copyPageUrl, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+import { copyPageUrl, publishUntilRendered, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
 
 const STORAGE_KEY = "assets-tracker:pwa-safari-hint-shown";
 const TOAST_ID = "pwa-safari-install-hint";
+// Also the CSS hook for the full-height Copy link button in globals.css.
+const TOAST_CLASS = "pwa-install-hint";
 const COPY_SUCCESS_DURATION_MS = 2_000;
 
 const COPY = {
@@ -66,18 +68,28 @@ export function PwaInstallHint() {
       copiedResetTimer = undefined;
     };
 
+    const markShown = () => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, "1");
+      } catch {
+        // The hint is optional; storage failures must not affect app rendering.
+      }
+    };
+
     const showToast = (actionLabel: string) => {
       toast.info(copy.title, {
         id: TOAST_ID,
         description: copy.description,
         duration: Number.POSITIVE_INFINITY,
         closeButton: true,
+        className: TOAST_CLASS,
         style: { paddingTop: 8, paddingBottom: 8 },
         onDismiss: () => {
           dismissed = true;
           clearCopiedResetTimer();
+          // Dismissing counts as shown, even if it beat the render check.
+          markShown();
         },
-        actionButtonStyle: { height: 48 },
         action: {
           label: actionLabel,
           onClick: (event) => {
@@ -103,13 +115,12 @@ export function PwaInstallHint() {
       });
     };
 
-    showToast(copy.copyLink);
-
-    try {
-      window.localStorage.setItem(STORAGE_KEY, "1");
-    } catch {
-      // The hint is optional; storage failures must not affect app rendering.
-    }
+    publishUntilRendered({
+      publish: () => showToast(copy.copyLink),
+      hasRendered: () => document.querySelector(`[data-sonner-toast].${TOAST_CLASS}`) !== null,
+      onRendered: markShown,
+      isCancelled: () => dismissed,
+    });
 
     return () => {
       dismissed = true;

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -77,7 +77,7 @@ export function PwaInstallHint() {
           dismissed = true;
           clearCopiedResetTimer();
         },
-        actionButtonStyle: { alignSelf: "stretch", height: "auto" },
+        actionButtonStyle: { height: 48 },
         action: {
           label: actionLabel,
           onClick: (event) => {

--- a/src/lib/pwa-install-hint.ts
+++ b/src/lib/pwa-install-hint.ts
@@ -6,7 +6,7 @@ export type SafariPwaHintEnvironment = {
   hasBeenShown: boolean;
 };
 
-const IOS_BROWSER_TOKENS = ["CriOS", "FxiOS", "EdgiOS", "OPiOS"] as const;
+const IOS_BROWSER_TOKENS = ["CriOS", "FxiOS", "EdgiOS", "OPiOS", "Brave"] as const;
 
 export function shouldShowSafariPwaHint({
   userAgent,

--- a/src/lib/pwa-install-hint.ts
+++ b/src/lib/pwa-install-hint.ts
@@ -8,6 +8,20 @@ export type SafariPwaHintEnvironment = {
 
 const IOS_BROWSER_TOKENS = ["CriOS", "FxiOS", "EdgiOS", "OPiOS", "Brave"] as const;
 
+export async function copyPageUrl(
+  writeText: ((text: string) => Promise<void>) | undefined,
+  href: string,
+): Promise<boolean> {
+  if (!writeText) return false;
+
+  try {
+    await writeText(href);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function shouldShowSafariPwaHint({
   userAgent,
   platform,

--- a/src/lib/pwa-install-hint.ts
+++ b/src/lib/pwa-install-hint.ts
@@ -22,6 +22,46 @@ export async function copyPageUrl(
   }
 }
 
+export type PublishUntilRenderedOptions = {
+  publish: () => void;
+  hasRendered: () => boolean;
+  onRendered: () => void;
+  isCancelled: () => boolean;
+  maxAttempts?: number;
+  delayMs?: number;
+};
+
+/**
+ * Sonner publishes a toast only to the subscribers mounted at that instant and
+ * never replays it, while the app's <Toaster> is a dynamic() import that can
+ * subscribe after this hint's mount effect runs — so the toast is silently
+ * dropped. Re-publishing under the same toast id is idempotent, so republish
+ * until the toast is really in the DOM, and let the caller persist its
+ * "already shown" flag only once that is confirmed.
+ */
+export function publishUntilRendered({
+  publish,
+  hasRendered,
+  onRendered,
+  isCancelled,
+  maxAttempts = 20,
+  delayMs = 100,
+}: PublishUntilRenderedOptions): void {
+  const attempt = (remaining: number) => {
+    if (isCancelled()) return;
+    publish();
+
+    // The toast lands on React's next render, not synchronously, so check later.
+    setTimeout(() => {
+      if (isCancelled()) return;
+      if (hasRendered()) onRendered();
+      else if (remaining > 0) attempt(remaining - 1);
+    }, delayMs);
+  };
+
+  attempt(maxAttempts);
+}
+
 export function shouldShowSafariPwaHint({
   userAgent,
   platform,

--- a/src/lib/pwa-install-hint.ts
+++ b/src/lib/pwa-install-hint.ts
@@ -1,0 +1,28 @@
+export type SafariPwaHintEnvironment = {
+  userAgent: string;
+  platform: string;
+  maxTouchPoints: number;
+  isStandalone: boolean;
+  hasBeenShown: boolean;
+};
+
+const IOS_BROWSER_TOKENS = ["CriOS", "FxiOS", "EdgiOS", "OPiOS"] as const;
+
+export function shouldShowSafariPwaHint({
+  userAgent,
+  platform,
+  maxTouchPoints,
+  isStandalone,
+  hasBeenShown,
+}: SafariPwaHintEnvironment): boolean {
+  if (isStandalone || hasBeenShown) return false;
+
+  const isIOSDevice = /iPhone|iPad|iPod/.test(userAgent);
+  const isIPadOSDesktopMode = platform === "MacIntel" && maxTouchPoints > 1;
+  if (!isIOSDevice && !isIPadOSDesktopMode) return false;
+
+  const isAlternativeIOSBrowser = IOS_BROWSER_TOKENS.some((token) => userAgent.includes(token));
+  const isSafari = userAgent.includes("Safari") && !isAlternativeIOSBrowser;
+
+  return !isSafari;
+}

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -33,6 +33,16 @@ describe("shouldShowSafariPwaHint", () => {
     ).toBe(true);
   });
 
+  it("shows on iPhone Brave", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1 Brave/1.90",
+      }),
+    ).toBe(true);
+  });
+
   it("does not show on iPhone Safari", () => {
     expect(shouldShowSafariPwaHint(base)).toBe(false);
   });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -125,4 +125,19 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).toContain("duration: Number.POSITIVE_INFINITY");
     expect(source).toContain("closeButton: true");
   });
+
+  it("offers a localized Copy link action without dismissing the toast", () => {
+    const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
+
+    expect(source).toContain('copyLink: "Copy link"');
+    expect(source).toContain('copyLink: "複製連結"');
+    expect(source).toContain('copied: "Copied"');
+    expect(source).toContain('copied: "已複製"');
+    expect(source).toContain('const TOAST_ID = "pwa-safari-install-hint"');
+    expect(source).toContain("action: {");
+    expect(source).toContain("label: actionLabel");
+    expect(source).toContain("window.location.href");
+    expect(source).toContain("if (copied) showToast(copy.copied)");
+    expect(source).not.toContain("toast.dismiss");
+  });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -136,8 +136,11 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).toContain('const TOAST_ID = "pwa-safari-install-hint"');
     expect(source).toContain("action: {");
     expect(source).toContain("label: actionLabel");
+    expect(source).toContain("event.preventDefault()");
     expect(source).toContain("window.location.href");
-    expect(source).toContain("if (copied) showToast(copy.copied)");
+    expect(source).toContain("showToast(copy.copied)");
+    expect(source).toContain("window.setTimeout");
+    expect(source).toContain("showToast(copy.copyLink)");
     expect(source).not.toContain("toast.dismiss");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
-import { copyPageUrl, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyPageUrl, publishUntilRendered, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
 
 const iphoneSafari =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
@@ -118,6 +118,81 @@ describe("copyPageUrl", () => {
   });
 });
 
+describe("publishUntilRendered", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const run = (
+    rendersAfterAttempt: number,
+    overrides: Partial<Parameters<typeof publishUntilRendered>[0]> = {},
+  ) => {
+    const publish = vi.fn();
+    const onRendered = vi.fn();
+    publishUntilRendered({
+      publish,
+      hasRendered: () => publish.mock.calls.length >= rendersAfterAttempt,
+      onRendered,
+      isCancelled: () => false,
+      ...overrides,
+    });
+    return { publish, onRendered };
+  };
+
+  it("publishes immediately, without waiting for a timer", () => {
+    const { publish } = run(1);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops and reports once the toast is in the DOM", () => {
+    const { publish, onRendered } = run(1);
+    vi.advanceTimersByTime(1_000);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(onRendered).toHaveBeenCalledTimes(1);
+  });
+
+  it("republishes until a late-mounting Toaster picks the toast up", () => {
+    const { publish, onRendered } = run(3);
+    vi.advanceTimersByTime(1_000);
+
+    expect(publish).toHaveBeenCalledTimes(3);
+    expect(onRendered).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after maxAttempts without reporting it as shown", () => {
+    const { publish, onRendered } = run(Number.POSITIVE_INFINITY, { maxAttempts: 4 });
+    vi.advanceTimersByTime(10_000);
+
+    expect(publish).toHaveBeenCalledTimes(5); // first attempt + 4 retries
+    expect(onRendered).not.toHaveBeenCalled();
+  });
+
+  it("never publishes when cancelled before it starts", () => {
+    const { publish, onRendered } = run(1, { isCancelled: () => true });
+    vi.advanceTimersByTime(1_000);
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(onRendered).not.toHaveBeenCalled();
+  });
+
+  it("stops republishing once the user dismisses mid-retry", () => {
+    let dismissed = false;
+    const { publish, onRendered } = run(Number.POSITIVE_INFINITY, {
+      isCancelled: () => dismissed,
+    });
+
+    vi.advanceTimersByTime(250);
+    const publishedBeforeDismiss = publish.mock.calls.length;
+    dismissed = true;
+    vi.advanceTimersByTime(5_000);
+
+    expect(publishedBeforeDismiss).toBeGreaterThan(1);
+    expect(publish).toHaveBeenCalledTimes(publishedBeforeDismiss);
+    expect(onRendered).not.toHaveBeenCalled();
+  });
+});
+
 describe("PwaInstallHint toast behavior", () => {
   it("stays visible until the user closes it", () => {
     const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
@@ -144,12 +219,35 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).not.toContain("toast.dismiss");
   });
 
-  it("uses a large 48px action button with only 8px toast padding", () => {
+  it("only records the hint as shown once the toast actually rendered", () => {
     const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
-    const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
+
+    expect(source).toContain("publishUntilRendered({");
+    expect(source).toContain("onRendered: markShown");
+    expect(source).toContain("isCancelled: () => dismissed");
+    // The flag must not be set unconditionally right after publishing.
+    expect(source).not.toMatch(/showToast\(copy\.copyLink\);\s*\n\s*try \{/);
+  });
+
+  it("scopes its action-button styling with a class, since globals.css wins on !important", () => {
+    const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
+    const css = readFileSync("src/app/globals.css", "utf8");
 
     expect(source).toContain("style: { paddingTop: 8, paddingBottom: 8 }");
-    expect(source).toContain("actionButtonStyle: { height: 48 }");
-    expect(sharedToaster).not.toContain("actionButtonStyle");
+    // The class is both the toast's CSS hook and how the render check finds it.
+    expect(source).toContain('const TOAST_CLASS = "pwa-install-hint"');
+    expect(source).toContain("className: TOAST_CLASS");
+    expect(source).toContain("`[data-sonner-toast].${TOAST_CLASS}`");
+    // Inline actionButtonStyle can never beat the !important shared rule.
+    expect(source).not.toContain("actionButtonStyle");
+
+    const scoped = css.slice(
+      css.indexOf('[data-sonner-toast][data-styled="true"].pwa-install-hint [data-action] {'),
+    );
+    expect(scoped).toContain("align-self: stretch !important");
+    expect(scoped).toContain("height: auto !important");
+    expect(scoped).toContain("min-height: 44px !important");
+    expect(scoped).toContain("background: var(--primary) !important");
+    expect(scoped).toContain("color: var(--primary-foreground) !important");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -148,8 +148,10 @@ describe("PwaInstallHint toast behavior", () => {
     const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
     const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
 
-    expect(source).toContain('style: { paddingTop: 8, paddingBottom: 8 }');
-    expect(source).toContain('actionButtonStyle: { alignSelf: "stretch", height: "auto" }');
+    expect(source).toContain("style: { paddingTop: 8, paddingBottom: 8 }");
+    expect(source).toContain(
+      'actionButtonStyle: { alignSelf: "stretch", height: "auto" }',
+    );
     expect(sharedToaster).not.toContain("actionButtonStyle");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -143,4 +143,12 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).toContain("showToast(copy.copyLink)");
     expect(source).not.toContain("toast.dismiss");
   });
+
+  it("uses a 36px action button without changing the shared toaster", () => {
+    const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
+    const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
+
+    expect(source).toContain("actionButtonStyle: { height: 36 }");
+    expect(sharedToaster).not.toContain("actionButtonStyle");
+  });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
 
@@ -88,5 +89,14 @@ describe("shouldShowSafariPwaHint", () => {
 
   it("does not show after the hint has already been shown", () => {
     expect(shouldShowSafariPwaHint({ ...base, hasBeenShown: true })).toBe(false);
+  });
+});
+
+describe("PwaInstallHint toast behavior", () => {
+  it("stays visible until the user closes it", () => {
+    const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
+
+    expect(source).toContain("duration: Number.POSITIVE_INFINITY");
+    expect(source).toContain("closeButton: true");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -149,9 +149,7 @@ describe("PwaInstallHint toast behavior", () => {
     const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
 
     expect(source).toContain("style: { paddingTop: 8, paddingBottom: 8 }");
-    expect(source).toContain(
-      'actionButtonStyle: { alignSelf: "stretch", height: "auto" }',
-    );
+    expect(source).toContain('actionButtonStyle: { alignSelf: "stretch", height: "auto" }');
     expect(sharedToaster).not.toContain("actionButtonStyle");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -144,12 +144,12 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).not.toContain("toast.dismiss");
   });
 
-  it("stretches the action button vertically with only 8px toast padding", () => {
+  it("uses a large 48px action button with only 8px toast padding", () => {
     const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
     const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
 
     expect(source).toContain("style: { paddingTop: 8, paddingBottom: 8 }");
-    expect(source).toContain('actionButtonStyle: { alignSelf: "stretch", height: "auto" }');
+    expect(source).toContain("actionButtonStyle: { height: 48 }");
     expect(sharedToaster).not.toContain("actionButtonStyle");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -144,11 +144,12 @@ describe("PwaInstallHint toast behavior", () => {
     expect(source).not.toContain("toast.dismiss");
   });
 
-  it("uses a 36px action button without changing the shared toaster", () => {
+  it("stretches the action button vertically with only 8px toast padding", () => {
     const source = readFileSync("src/components/layout/pwa-install-hint.tsx", "utf8");
     const sharedToaster = readFileSync("src/components/ui/sonner.tsx", "utf8");
 
-    expect(source).toContain("actionButtonStyle: { height: 36 }");
+    expect(source).toContain('style: { paddingTop: 8, paddingBottom: 8 }');
+    expect(source).toContain('actionButtonStyle: { alignSelf: "stretch", height: "auto" }');
     expect(sharedToaster).not.toContain("actionButtonStyle");
   });
 });

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+import { copyPageUrl, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
 
 const iphoneSafari =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
@@ -89,6 +89,32 @@ describe("shouldShowSafariPwaHint", () => {
 
   it("does not show after the hint has already been shown", () => {
     expect(shouldShowSafariPwaHint({ ...base, hasBeenShown: true })).toBe(false);
+  });
+});
+
+describe("copyPageUrl", () => {
+  it("copies the exact current page URL", async () => {
+    const href = "https://astt.app/accounts/abc?tab=holdings#latest";
+    let written = "";
+
+    const copied = await copyPageUrl(async (text) => {
+      written = text;
+    }, href);
+
+    expect(copied).toBe(true);
+    expect(written).toBe(href);
+  });
+
+  it("returns false when the Clipboard API is unavailable", async () => {
+    await expect(copyPageUrl(undefined, "https://astt.app/")).resolves.toBe(false);
+  });
+
+  it("returns false when the clipboard write rejects", async () => {
+    const copied = await copyPageUrl(async () => {
+      throw new Error("clipboard denied");
+    }, "https://astt.app/");
+
+    expect(copied).toBe(false);
   });
 });
 

--- a/tests/unit/pwa-install-hint.test.ts
+++ b/tests/unit/pwa-install-hint.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+
+const iphoneSafari =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
+
+const base = {
+  userAgent: iphoneSafari,
+  platform: "iPhone",
+  maxTouchPoints: 5,
+  isStandalone: false,
+  hasBeenShown: false,
+};
+
+describe("shouldShowSafariPwaHint", () => {
+  it("shows on iPhone Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 CriOS/140.0.0.0 Mobile/15E148 Safari/604.1",
+      }),
+    ).toBe(true);
+  });
+
+  it("shows on iPhone Firefox", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 FxiOS/142.0 Mobile/15E148 Safari/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not show on iPhone Safari", () => {
+    expect(shouldShowSafariPwaHint(base)).toBe(false);
+  });
+
+  it("does not show on Android Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "Linux armv8l",
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36 Chrome/140.0.0.0 Mobile Safari/537.36",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not show on desktop Chrome", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows for iPadOS desktop-style user agent in a non-Safari browser", () => {
+    expect(
+      shouldShowSafariPwaHint({
+        ...base,
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 CriOS/140.0.0.0 Version/18.0 Safari/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not show in standalone mode", () => {
+    expect(shouldShowSafariPwaHint({ ...base, isStandalone: true })).toBe(false);
+  });
+
+  it("does not show after the hint has already been shown", () => {
+    expect(shouldShowSafariPwaHint({ ...base, hasBeenShown: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add a one-time persistent Sonner toast for iPhone/iPad users in non-Safari browsers, guiding them to continue in Safari and use Add to Home Screen for an app-like experience.

## Changes

- Detect iOS/iPadOS non-Safari browsers, including Chrome, Firefox, Edge, Opera, and Brave
- Hide the hint in Safari and standalone / installed PWA mode
- Keep the toast visible until the user explicitly closes it
- Persist the shown state in localStorage to avoid repeated prompts
- Add localized English / Traditional Chinese copy
- Add a Copy link / 複製連結 action that copies the exact current page URL
- Keep the toast open after copying; show Copied / 已複製 briefly, then restore the action label
- Fail silently if clipboard or storage APIs are unavailable

## Validation

- TDD regression coverage for browser eligibility, Brave iOS, persistent toast behavior, and clipboard success/failure
- Format, lint, typecheck, full unit suite, PostgreSQL integration, production build / bundle-size, authenticated E2E, and public Demo E2E all pass on the latest head
