### PR TITLE
ci: pin container image names instead of deriving them from the repo slug

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -26,6 +26,14 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # Image names are spelled out rather than derived from ${{ github.repository }}:
+  # the published image name is a contract with every self-hoster's compose file,
+  # while the repo slug is an internal identifier that can change. Deriving one
+  # from the other means renaming the repo silently starts publishing to a new
+  # package while existing `docker compose pull` keeps succeeding against the old
+  # one — frozen forever with no error. GitHub Actions cannot expand `env` inside
+  # a `strategy` block, so the literal is repeated instead of shared.
+  #
   # Each architecture builds natively on its own runner and pushes an untagged
   # image by digest; the merge job assembles the tagged manifest lists. Building
   # linux/arm64 under QEMU on an x86 runner took ~18 minutes for the app image.
@@ -40,10 +48,10 @@ jobs:
         include:
           - name: app
             target: runner
-            image: ghcr.io/${{ github.repository }}
+            image: ghcr.io/mike840609/assets_tracker
           - name: migrations
             target: migrate
-            image: ghcr.io/${{ github.repository }}-migrate
+            image: ghcr.io/mike840609/assets_tracker-migrate
           - arch: amd64
             runner: ubuntu-latest
             platform: linux/amd64
@@ -116,9 +124,9 @@ jobs:
       matrix:
         include:
           - name: app
-            image: ghcr.io/${{ github.repository }}
+            image: ghcr.io/mike840609/assets_tracker
           - name: migrations
-            image: ghcr.io/${{ github.repository }}-migrate
+            image: ghcr.io/mike840609/assets_tracker-migrate
 
     steps:
       - name: Download digests


### PR DESCRIPTION
Prerequisite for any future repo rename. Worth doing on its own regardless.

## Problem

`publish-container.yml` built its image names from `${{ github.repository }}` in four places (two matrices × app/migrations). That couples a **published contract** — the image name in every self-hoster's `docker-compose.yml` — to an **internal identifier** that is free to change.

Renaming `assets_tracker` → `astt` would therefore start publishing to a brand-new GHCR package. The old package is not renamed along with it; it just stops receiving pushes. Existing deployments pulling `ghcr.io/mike840609/assets_tracker:latest` would get **no 404 and no error** — they would silently freeze at whatever version shipped last, and nobody finds out until someone asks why they never got a new feature.

## Change

Spell the names out:

```
ghcr.io/mike840609/assets_tracker
ghcr.io/mike840609/assets_tracker-migrate
```

Actions cannot expand `env` inside a `strategy` block, so the literal is repeated rather than shared through the existing `REGISTRY` env. A comment above `jobs:` records why it is written out longhand, so nobody "tidies" it back into the variable.

## Verification

- Values match the packages that are live now — both `:1.3.0` manifests return HTTP 200 from the GHCR API.
- Prettier parses the workflow, and no `github.repository` reference remains outside the explanatory comment.
- Nothing here runs on a PR; `publish-container` fires on push to master and on release tags, so the merge itself is the first exercise.

https://claude.ai/code/session_01JfoMqpNRzQUdsXFTffpz4h