### PR TITLE
feat: link login and changelog pages to the GitHub source repo

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1534,6 +1534,7 @@
     "title": "What's New",
     "subtitle": "Every release of astt, newest first.",
     "currentVersion": "You're on {version}",
+    "viewReleases": "View all releases on GitHub",
     "latest": "Latest",
     "empty": "No releases yet.",
     "types": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1534,6 +1534,7 @@
     "title": "更新內容",
     "subtitle": "astt 的每個版本，由新到舊。",
     "currentVersion": "目前版本 {version}",
+    "viewReleases": "在 GitHub 查看所有版本",
     "latest": "最新",
     "empty": "尚無版本。",
     "types": {

--- a/src/app/(main)/changelog/page.tsx
+++ b/src/app/(main)/changelog/page.tsx
@@ -3,6 +3,8 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { ChangelogTimeline } from "@/components/changelog/changelog-timeline";
 import { CHANGELOG, APP_VERSION } from "@/lib/changelog";
+import { REPO_URL } from "@/lib/repo";
+import { ArrowUpRightIcon } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -22,6 +24,15 @@ export default async function ChangelogPage() {
           <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary" />
           {t("currentVersion", { version: `v${APP_VERSION}` })}
         </span>
+        <a
+          href={`${REPO_URL}/releases`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          {t("viewReleases")}
+          <ArrowUpRightIcon className="h-3.5 w-3.5" />
+        </a>
       </header>
 
       <ChangelogTimeline releases={CHANGELOG} locale={locale as Locale} />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/env";
 import { getAuthContext } from "@/lib/auth-session";
 import { getTranslations } from "next-intl/server";
+import { REPO_URL } from "@/lib/repo";
+import { GitHubMark } from "@/components/layout/github-mark";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -39,6 +41,7 @@ async function exitDemoOriginBeforeFormalSignIn(): Promise<boolean> {
 
 async function LoginContent() {
   const t = await getTranslations("login");
+  const tNav = await getTranslations("nav");
 
   return (
     <div className="flex min-h-screen w-full items-center justify-center relative overflow-hidden bg-background">
@@ -216,6 +219,15 @@ async function LoginContent() {
             {t("footerLink")}
           </Link>
           .
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 flex items-center justify-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            <GitHubMark className="h-3.5 w-3.5" />
+            {tNav("sourceCode")}
+          </a>
         </div>
       </div>
     </div>

--- a/tests/unit/source-repo-contract.test.ts
+++ b/tests/unit/source-repo-contract.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const read = (p: string) => readFileSync(resolve(ROOT, p), "utf8");
+const readJson = (p: string) => JSON.parse(read(p)) as Record<string, unknown>;
+
+describe("source-repo link contract", () => {
+  it("login page links to the GitHub repository with safe external-link semantics", () => {
+    const source = read("src/app/login/page.tsx");
+    expect(source).toContain("REPO_URL");
+    expect(source).toContain('target="_blank"');
+    expect(source).toContain('rel="noopener noreferrer"');
+    expect(source).toContain("GitHubMark");
+    expect(source).toContain('getTranslations("nav")');
+  });
+
+  it("changelog page links to the GitHub releases page with safe external-link semantics", () => {
+    const source = read("src/app/(main)/changelog/page.tsx");
+    expect(source).toContain("REPO_URL");
+    expect(source).toContain("/releases");
+    expect(source).toContain('target="_blank"');
+    expect(source).toContain('rel="noopener noreferrer"');
+    expect(source).toContain("ArrowUpRightIcon");
+    expect(source).toContain('t("viewReleases")');
+  });
+
+  it("keeps changelog.viewReleases and nav.sourceCode bilingual with matching key sets", () => {
+    const en = readJson("messages/en-US.json") as {
+      changelog: Record<string, string>;
+      nav: Record<string, string>;
+    };
+    const zh = readJson("messages/zh-TW.json") as typeof en;
+
+    expect(en.changelog.viewReleases).toBeTypeOf("string");
+    expect(zh.changelog.viewReleases).toBeTypeOf("string");
+    expect(zh.changelog.viewReleases.length).toBeGreaterThan(0);
+    expect(zh.changelog.viewReleases).not.toBe(en.changelog.viewReleases);
+    expect(Object.keys(en.changelog).sort()).toEqual(Object.keys(zh.changelog).sort());
+    expect(en.nav.sourceCode).toBeTypeOf("string");
+    expect(zh.nav.sourceCode).toBeTypeOf("string");
+    expect(zh.nav.sourceCode).not.toBe(en.nav.sourceCode);
+  });
+});


### PR DESCRIPTION
## What

Direct users to the open-source repository from two more surfaces:

- **Login page** (`src/app/login/page.tsx`) — a "View source on GitHub" link (GitHubMark icon + reused bilingual `nav.sourceCode`) below the privacy-policy footer line, pointing to `REPO_URL`. This is the landing surface for public-demo visitors.
- **Changelog page** (`src/app/(main)/changelog/page.tsx`) — a "View all releases on GitHub" link (ArrowUpRightIcon, new bilingual `changelog.viewReleases`) below the version pill, pointing to `REPO_URL/releases`.

Both links open in a new tab with `target="_blank" rel="noopener noreferrer"`.

## Tests

- New contract test `tests/unit/source-repo-contract.test.ts` (mirrors the house `public-demo-ui-contract` pattern): source markers + external-link semantics on both pages, plus bilingual parity of `changelog.viewReleases` and `nav.sourceCode`.
- TDD: written first (RED), then made GREEN.
- Full unit suite (89 files / 791 tests), typecheck, lint, and production build all pass.

## Verification

Playwright real-browser QA (12/12 assertions): both links visible with correct text/icon, safe external-link attributes, and click-through opens the expected URL in a new tab. Screenshots captured during QA.

> Note: this branch was split out of `docs/ai-install-guide` per request — PR #686 now contains only the docs changes.