### PR TITLE
refactor(analysis): close payload follow-ups from #688

### DIFF
--- a/docs/superpowers/plans/2026-08-17-analysis-payload-followups.md
+++ b/docs/superpowers/plans/2026-08-17-analysis-payload-followups.md
@@ -1,0 +1,1004 @@
+# Analysis Payload Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the four analysis-payload follow-ups in issue #689 — a locale-independent cached payload with client-formatted month labels, two neutral `src/lib` modules, reduced payload metadata, and `messageKey`-carrying ranges with stale-persistence fallback — without changing any analysis calculation, range choice, chart presentation, or the mobile `#history` path.
+
+**Architecture:** Two neutral modules are created: `src/lib/analysis-range.ts` (the pure range module moved out of `src/components/analysis`, extended with `messageKey` and range-lookup helpers) and `src/lib/analysis-contract.ts` (the serializable `AnalysisRangeSeries` / `AnalysisPayload` / `AnalysisPayloadMeta` types). Server services (`analysis-payload-service`, `analysis-series-service`, `analysis-service`) keep all DB/cache/aggregation work but stop emitting localized labels and stop accepting `locale`; the three client charts (`cashflow-chart`, `cumulative-growth-chart`, `return-trend-chart`) format month keys with the active next-intl locale at render-data preparation time; `AnalysisView` derives `hasData` / `latestSnapshotAt` from the `snapshots` it already receives and resolves stale persisted ranges against `meta.defaultRange` before translating or selecting series.
+
+**Tech Stack:** Next.js 16.2.9+ (App Router, React 19, `next/cache` `unstable_cache`), next-intl v4, recharts v3.8, Vitest 4 (node env + `server-only` stub), Playwright 1.52 (chromium + Mobile Chrome projects). No new dependencies.
+
+## Global Constraints
+
+- **No commits.** This plan overrides the generic writing-plans "commit after each task" template: the executor makes file changes only and **does not commit, push, or modify git state** unless the user explicitly requests commits. Suggested atomic commit messages are listed per task for the explicit-request case.
+- No `unstable_cache` → `use cache` migration.
+- No change to analysis calculations, `resolveAnalysisRange` / `pickDefaultRange` Taiwan-calendar-day semantics, `ANALYSIS_RANGES` labels or month counts, chart styling/copy/formulas, or the mobile `#history` route.
+- No extraction of `NormalizedSnapshot`; no broader `src/lib/services` reorganization.
+- No change to `DrawdownPoint.label` or its consumers; no source-text-grep tests as behavior coverage.
+- No new dependencies.
+- Only two neutral modules may be created: `src/lib/analysis-range.ts` and `src/lib/analysis-contract.ts`.
+- No module under `src/lib/services` may import from `src/components` as part of this flow.
+- Server-computed series must expose stable `monthKey` values only (no preformatted `label`); clients format with `formatMonthLabel(monthKey, locale)`.
+- An unknown persisted range value must never call `t(undefined)` or crash the route; it falls back to `meta.defaultRange` before translation and series access.
+- All existing aggregation-parity assertions must stay green (`analysis-service.test.ts`, `analysis-series-service.test.ts`, `history-service.test.ts`, `first-day-recurring-cash-flow.test.ts`, `analysis-range.test.ts`).
+
+---
+
+## Context
+
+**Issue #689 (design spec `docs/superpowers/specs/2026-08-17-analysis-payload-followups-design.md`) asks for four changes:**
+
+1. **Locale-independent cached payload + client-formatted month labels.** `getCachedAnalysisPayload(userId, baseCurrency, locale)` currently keys the `unstable_cache` entry with `locale`, so the same heavy payload is computed twice (en-US and zh-TW). The locale also flows into `computeAllRangeSeries` → `computeAnalysisRangeSeries` → `buildCashFlowBuckets` / `computeInvestmentReturnSeries`, which pre-format `label` fields into every point. Fix: drop `locale` from the cache identity and from the server series; emit only `monthKey`; format labels in the three client charts via next-intl.
+2. **Two neutral `src/lib` modules.** `src/components/analysis/analysis-range.ts` moves to `src/lib/analysis-range.ts`; the serializable contract types move to `src/lib/analysis-contract.ts`. No `src/lib/services` module imports from `src/components` afterwards.
+3. **Reduced metadata.** `AnalysisPayloadMeta` currently ships `hasSnapshots` and `latestSnapshotAt` even though the client already receives `snapshots`. `AnalysisView` derives `hasData = snapshots.length > 0` and `latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null` — the exact expressions the server uses today. `meta` keeps only `defaultRange` (server-computed from one frozen clock reading, preserving Taiwan-day behavior).
+4. **Ranges carry `messageKey`; stale persisted values fall back.** `ANALYSIS_RANGES` entries gain `messageKey`; `AnalysisView` builds segmented options from the entries (no local `rangeLabelKey` record) and resolves the stored range against `defaultRange` before `t()` and series lookup.
+
+**Key current-state facts (verified):**
+
+- `getCachedAnalysisPayload` is called from exactly one place: `src/app/(main)/analysis/page.tsx:24`.
+- `ANALYSIS_RANGES` has five entries `{ label, months }`; `RangeLabel` is derived from it; `getMonthsForRange` uses `.find(...)!`. `src/lib/app-day.ts` is pure (no `server-only`), so the moved range module stays importable from both server and client.
+- `formatMonthLabel(monthKey, locale)` lives in `src/lib/services/analysis-service.ts` (no `server-only`) and is already imported at runtime by client components (`assets-liabilities-chart.tsx:15`, `kpi-tiles.tsx`). It stays put.
+- The three charts to modify use `XAxis dataKey="label"` and tooltips reading `payload[0].payload.label`; the data currently arrives pre-labeled from the server.
+- `tests/unit/analysis-range.test.ts`, `analysis-series-service.test.ts`, `analysis-service.test.ts`, `history-service.test.ts` (line 548), and `first-day-recurring-cash-flow.test.ts` (line 274) currently pass `"en-US"` as a locale argument to the functions being changed.
+- Vitest runs in a **node** environment with a `server-only` stub (`tests/stubs/server-only.ts`); there is no jsdom / React Testing Library, and adding one is forbidden. Client behavior is therefore covered by (a) pure-function unit tests on the neutral range module and (b) real-surface Playwright E2E scenarios.
+- Playwright has two projects: `chromium` (Desktop Chrome) and `Mobile Chrome` (Pixel 7). `analysis-populated.spec.ts` exists and seeds a shared DB fixture (`E2E_EMAIL = e2e-test@preview.local`); it requires `DATABASE_URL`.
+- Locale is resolved server-side from the `NEXT_LOCALE` cookie (`src/i18n/request.ts`), so E2E can switch locales by adding that cookie.
+- The analysis message keys `rangeYTD` / `range6M` / `range1Y` / `range2Y` / `rangeAll` exist in both `messages/en-US.json` and `messages/zh-TW.json`.
+- `Intl.DateTimeFormat` outputs verified: `formatMonthLabel("2026-08","en-US")` → `"Aug 2026"`, `formatMonthLabel("2025-03","zh-TW")` → `"2025年3月"`.
+
+---
+
+## Task Dependency Graph
+
+| Task                                                                | Depends On     | Reason                                                                                                                                                                                                             |
+| ------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Task 1: Neutralize range module + messageKey                        | None           | Starting point; creates `src/lib/analysis-range.ts` that every other task imports                                                                                                                                  |
+| Task 2: Locale-independent server series + contract type            | Task 1         | `analysis-series-service.ts` imports the moved range module and relocates `AnalysisRangeSeries` to `src/lib/analysis-contract.ts`                                                                                  |
+| Task 3: Client charts format month labels                           | Task 1         | Charts import `@/lib/analysis-range`-independent helpers but must wait for the module move wave; consumes the neutral module's naming and `formatMonthLabel` pattern. Run in parallel with Task 2 (disjoint files) |
+| Task 4: Locale-independent payload + reduced meta + view derivation | Task 1, Task 2 | `analysis-payload-service.ts` imports `pickDefaultRange` (Task 1) and calls the new `computeAllRangeSeries` signature (Task 2)                                                                                     |
+| Task 5: Stale-range fallback + messageKey options in view           | Task 1, Task 4 | Uses `resolveActiveRange` / `getMessageKeyForRange` (Task 1) and the reduced `meta` shape (Task 4)                                                                                                                 |
+| Task 6: E2E scenarios + full verification                           | Tasks 1–5      | Real-surface verification requires all production changes in place                                                                                                                                                 |
+
+## Parallel Execution Waves
+
+```
+Wave 1 (Start immediately):
+└── Task 1: Neutralize range module to src/lib + messageKey + lookup helpers
+
+Wave 2 (After Wave 1 completes — parallel, disjoint files):
+├── Task 2: Locale-independent server series (services + contract + unit tests)
+└── Task 3: Client charts format month labels (3 chart files)
+
+Wave 3 (After Wave 2 completes):
+└── Task 4: Locale-independent cached payload + reduced meta + view derivation
+
+Wave 4 (After Wave 3 completes):
+└── Task 5: Stale-range fallback + messageKey-driven segmented options in AnalysisView
+
+Wave 5 (After Wave 4 completes):
+└── Task 6: E2E scenarios + full verification suite
+
+Critical Path: Task 1 → Task 2 → Task 4 → Task 5 → Task 6
+```
+
+> Note: Wave 2's tasks edit disjoint files (`src/lib/services/*` + contract + service tests vs. the three chart components), so they run concurrently. The repo's typecheck is only guaranteed green once the whole wave lands; task-level QA is the targeted Vitest files, and the full `pnpm typecheck` gate runs in Task 6.
+
+---
+
+### Task 1: Neutralize the range module and make ranges carry `messageKey`
+
+**Files:**
+
+- Move: `src/components/analysis/analysis-range.ts` → `src/lib/analysis-range.ts`
+- Modify: `src/lib/services/analysis-series-service.ts:3-7` (import path), `src/lib/services/analysis-payload-service.ts:15` (import path), `src/components/analysis/analysis-view.tsx:19` (import path `./analysis-range` → `@/lib/analysis-range`)
+- Test: `tests/unit/analysis-range.test.ts` (import path + new expectations)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces:
+  - `export const ANALYSIS_RANGES = [...] as const` with each entry `{ label: "YTD"|"6M"|"1Y"|"2Y"|"All"; months: number; messageKey: string }`.
+  - `export type RangeLabel = (typeof ANALYSIS_RANGES)[number]["label"]` (unchanged).
+  - `export function getMonthsForRange(label: RangeLabel): number` (unchanged body).
+  - `export function getMessageKeyForRange(label: RangeLabel): string` (new).
+  - `export function resolveActiveRange(stored: string, fallback: RangeLabel): RangeLabel` (new).
+  - `resolveAnalysisRange`, `pickDefaultRange`, `AnalysisRange` (unchanged bodies — Taiwan-day semantics preserved).
+
+- [ ] **Step 1: Write the failing tests (RED)**
+
+Update the import in `tests/unit/analysis-range.test.ts:8`:
+
+```ts
+import {
+  ANALYSIS_RANGES,
+  getMonthsForRange,
+  getMessageKeyForRange,
+  pickDefaultRange,
+  resolveActiveRange,
+  resolveAnalysisRange,
+} from "@/lib/analysis-range";
+```
+
+Extend the `describe("ANALYSIS_RANGES")` block (after line 139) and append two new describes:
+
+```ts
+  it("carries the analysis translation messageKey for each range", () => {
+    expect(ANALYSIS_RANGES.map((r) => r.messageKey)).toEqual([
+      "rangeYTD",
+      "range6M",
+      "range1Y",
+      "range2Y",
+      "rangeAll",
+    ]);
+  });
+});
+
+describe("getMessageKeyForRange", () => {
+  it("maps each label to its analysis message key", () => {
+    expect(getMessageKeyForRange("YTD")).toBe("rangeYTD");
+    expect(getMessageKeyForRange("6M")).toBe("range6M");
+    expect(getMessageKeyForRange("1Y")).toBe("range1Y");
+    expect(getMessageKeyForRange("2Y")).toBe("range2Y");
+    expect(getMessageKeyForRange("All")).toBe("rangeAll");
+  });
+});
+
+describe("resolveActiveRange", () => {
+  it("returns the stored label when it names a known range", () => {
+    for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
+      expect(resolveActiveRange(label, "YTD")).toBe(label);
+    }
+  });
+
+  it("falls back to the default when the stored label is unknown", () => {
+    expect(resolveActiveRange("BOGUS_RANGE", "YTD")).toBe("YTD");
+    expect(resolveActiveRange("", "6M")).toBe("6M");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test:unit tests/unit/analysis-range.test.ts`
+Expected: FAIL — the module import `@/lib/analysis-range` cannot be resolved (module has not moved yet), so the whole file errors. This is the expected RED reason.
+
+- [ ] **Step 3: Move the module and add the new behavior (GREEN)**
+
+```bash
+git mv src/components/analysis/analysis-range.ts src/lib/analysis-range.ts
+```
+
+Update `src/lib/analysis-range.ts`:
+
+- Keep `AnalysisRange`, `resolveAnalysisRange`, and `pickDefaultRange` bodies byte-for-byte (Taiwan-day semantics must not change).
+- Replace the `ANALYSIS_RANGES` constant:
+
+```ts
+export const ANALYSIS_RANGES = [
+  { label: "YTD", months: 0, messageKey: "rangeYTD" },
+  { label: "6M", months: 6, messageKey: "range6M" },
+  { label: "1Y", months: 12, messageKey: "range1Y" },
+  { label: "2Y", months: 24, messageKey: "range2Y" },
+  { label: "All", months: Infinity, messageKey: "rangeAll" },
+] as const;
+```
+
+- Add after `getMonthsForRange`:
+
+```ts
+export function getMessageKeyForRange(label: RangeLabel): string {
+  return ANALYSIS_RANGES.find((r) => r.label === label)!.messageKey;
+}
+
+export function resolveActiveRange(stored: string, fallback: RangeLabel): RangeLabel {
+  return ANALYSIS_RANGES.find((r) => r.label === stored)?.label ?? fallback;
+}
+```
+
+Update the three importers:
+
+- `src/lib/services/analysis-series-service.ts:3-7`: `} from "@/lib/analysis-range";`
+- `src/lib/services/analysis-payload-service.ts:15`: `import { pickDefaultRange, type RangeLabel } from "@/lib/analysis-range";`
+- `src/components/analysis/analysis-view.tsx:19`: `import { ANALYSIS_RANGES, type RangeLabel } from "@/lib/analysis-range";`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test:unit tests/unit/analysis-range.test.ts`
+Expected: PASS — all existing range tests plus the new messageKey / getMessageKeyForRange / resolveActiveRange tests.
+
+- [ ] **Step 5: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add src/lib/analysis-range.ts src/lib/services/analysis-series-service.ts src/lib/services/analysis-payload-service.ts src/components/analysis/analysis-view.tsx tests/unit/analysis-range.test.ts
+git commit -m "refactor(analysis): move range module to src/lib and add messageKey to ranges"
+```
+
+**Acceptance Criteria:** `ANALYSIS_RANGES` entries each carry `messageKey`; `resolveActiveRange("BOGUS_RANGE","YTD") === "YTD"`; the old `src/components/analysis/analysis-range.ts` no longer exists; `pnpm test:unit tests/unit/analysis-range.test.ts` passes; no range-boundary or default-selection behavior changed (all existing `resolveAnalysisRange` / `pickDefaultRange` tests still pass untouched).
+
+---
+
+### Task 2: Make server series locale-independent and emit month keys only
+
+**Files:**
+
+- Create: `src/lib/analysis-contract.ts` (owns `AnalysisRangeSeries`)
+- Modify: `src/lib/services/analysis-service.ts` (`CashFlowBucket`, `buildCashFlowBuckets`, `CumulativeGrowthPoint`, `buildCumulativeGrowth`, `ReturnTrendPoint`, `computeInvestmentReturnSeries`)
+- Modify: `src/lib/services/analysis-series-service.ts` (drop local `AnalysisRangeSeries`; drop `locale` params; import contract type)
+- Test: `tests/unit/analysis-service.test.ts`, `tests/unit/analysis-series-service.test.ts`, `tests/unit/history-service.test.ts:548`, `tests/unit/first-day-recurring-cash-flow.test.ts:274`
+
+**Interfaces:**
+
+- Consumes: `ANALYSIS_RANGES`, `getMonthsForRange`, `resolveAnalysisRange`, `type RangeLabel` from `@/lib/analysis-range` (Task 1).
+- Produces:
+  - `export function buildCashFlowBuckets(buckets: MonthlyBucket[], contributions: MonthlyContribution[]): CashFlowBucket[]`
+  - `export function computeInvestmentReturnSeries(snapshots: SnapshotBreakdown[], accounts: AccountMeta[], accountCashFlows: AccountMonthlyContribution[], monthKeys: string[]): ReturnTrendPoint[]`
+  - `export function computeAnalysisRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, rangeLabel: RangeLabel, now = new Date()): AnalysisRangeSeries`
+  - `export function computeAllRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, now = new Date()): Record<RangeLabel, AnalysisRangeSeries>`
+  - `export interface AnalysisRangeSeries` now re-exported from `@/lib/analysis-contract`.
+  - `CashFlowBucket`, `CumulativeGrowthPoint`, `ReturnTrendPoint` no longer carry `label`.
+
+- [ ] **Step 1: Write/update the failing tests (RED)**
+
+In `tests/unit/analysis-service.test.ts`:
+
+- Update the three `buildCashFlowBuckets` calls (lines 183-187, 210, 228-232) to drop the `"en-US"` third argument.
+- Update the `bucket` helper in `describe("buildCumulativeGrowth")` (lines 238-250) to remove `label: monthKey,`.
+- Update every `computeInvestmentReturnSeries(..., "en-US")` call (lines 461-467, 494-500, 515-521, 542-548, 562-568, 576-583, 592-593) to drop the trailing `"en-US"` argument.
+- Add three behavior-locking tests:
+
+```ts
+it("exposes month keys without a preformatted label when locale is not passed", () => {
+  const buckets = [
+    {
+      monthKey: "2026-01",
+      endDate: "2026-01",
+      startNetWorth: 0,
+      endNetWorth: 100,
+      totalAssets: 100,
+      totalLiabilities: 0,
+      deltaNetWorth: 100,
+      deltaPct: null,
+      isEmpty: false,
+    },
+  ];
+  const result = buildCashFlowBuckets(buckets, [{ monthKey: "2026-01", contributions: 60 }]);
+  expect(result[0]).toMatchObject({ monthKey: "2026-01", contributions: 60 });
+  expect(result[0]).not.toHaveProperty("label");
+});
+```
+
+```ts
+it("does not copy a label onto cumulative points", () => {
+  const result = buildCumulativeGrowth([bucket("2026-01", 100, 20)]);
+  expect(result[0]).toMatchObject({ monthKey: "2026-01", cumulativeContributions: 100 });
+  expect(result[0]).not.toHaveProperty("label");
+});
+```
+
+```ts
+it("exposes return-trend month keys without a preformatted label", () => {
+  const snapshots: SnapshotBreakdown[] = [
+    { date: "2026-01-05", accountValues: { a1: 1000 } },
+    { date: "2026-01-31", accountValues: { a1: 1100 } },
+    { date: "2026-02-28", accountValues: { a1: 1265 } },
+  ];
+  const accounts: AccountMeta[] = [
+    { id: "a1", name: "Brokerage", category: "BROKERAGE", type: "ASSET" },
+  ];
+  const points = computeInvestmentReturnSeries(
+    snapshots,
+    accounts,
+    [],
+    ["2026-01", "2026-02", "2026-03"],
+  );
+  expect(points).toHaveLength(3);
+  expect(points[0].monthKey).toBe("2026-01");
+  expect(points[0]).not.toHaveProperty("label");
+});
+```
+
+(These rely on `SnapshotBreakdown` / `AccountMeta` being imported at the top of the file — they already are.)
+
+In `tests/unit/analysis-series-service.test.ts`:
+
+- Drop the `"en-US"` argument from every `computeAllRangeSeries` / `computeAnalysisRangeSeries` call (lines 61-68, 86-94, 193-201, 207-214, 222-230). The `NOW` argument moves into the previous position.
+- Add a behavior-locking test:
+
+```ts
+describe("locale-independent series", () => {
+  it("produces all five ranges from month keys without preformatted labels", () => {
+    const series = computeAllRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, NOW);
+    expect(Object.keys(series)).toEqual(["YTD", "6M", "1Y", "2Y", "All"]);
+    for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
+      const s = series[label];
+      expect(s.cashFlowBuckets[0].monthKey).toBeTypeOf("string");
+      expect(s.cashFlowBuckets[0]).not.toHaveProperty("label");
+      expect(s.cumulativeGrowth[0]).not.toHaveProperty("label");
+      expect(s.returnTrend.length).toBeGreaterThan(0);
+      expect(s.returnTrend[0]).not.toHaveProperty("label");
+    }
+  });
+});
+```
+
+In `tests/unit/history-service.test.ts:548`: `buildCashFlowBuckets(buckets, contributions, "en-US")` → `buildCashFlowBuckets(buckets, contributions)`.
+In `tests/unit/first-day-recurring-cash-flow.test.ts:274-278`: drop the `"en-US"` argument.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test:unit tests/unit/analysis-service.test.ts tests/unit/analysis-series-service.test.ts tests/unit/history-service.test.ts tests/unit/first-day-recurring-cash-flow.test.ts`
+Expected: FAIL — the new `not.toHaveProperty("label")` assertions fail because `buildCashFlowBuckets` / `buildCumulativeGrowth` / `computeInvestmentReturnSeries` still emit `label`, and `computeAllRangeSeries` still requires the locale argument (the five-range call returns labels). The existing aggregation-parity assertions fail only if the implementation regresses them.
+
+- [ ] **Step 3: Implement (GREEN)**
+
+Create `src/lib/analysis-contract.ts`:
+
+```ts
+import type {
+  MonthlyBucket,
+  AnalysisKpis,
+  CashFlowBucket,
+  CumulativeGrowthPoint,
+  CategoryDataPoint,
+  AttributionItem,
+  ReturnTrendPoint,
+} from "@/lib/services/analysis-service";
+import type { NormalizedSnapshot } from "@/lib/services/history-service";
+import type { InvestmentCostBasisSummary } from "@/lib/services/analysis-service";
+import type { RangeLabel } from "@/lib/analysis-range";
+
+export interface AnalysisRangeSeries {
+  buckets: MonthlyBucket[];
+  kpis: AnalysisKpis;
+  cashFlowBuckets: CashFlowBucket[];
+  cumulativeGrowth: CumulativeGrowthPoint[];
+  categoryHistory: CategoryDataPoint[];
+  attributionItems: AttributionItem[];
+  investmentReturnPct: number | null;
+  returnTrend: ReturnTrendPoint[];
+  rangeStartIso: string;
+}
+```
+
+(All imports are type-only; do NOT add `server-only` here — this module is imported by client components.)
+
+Edit `src/lib/services/analysis-service.ts`:
+
+- `CashFlowBucket` (lines 229-242): delete the `label` field and its doc comment.
+- `buildCashFlowBuckets` (lines 266-284): change signature to `(buckets: MonthlyBucket[], contributions: MonthlyContribution[])`, delete the `locale` param, delete `label: formatMonthLabel(b.monthKey, locale),` from the returned object, and delete the stale `@param locale` doc line.
+- `CumulativeGrowthPoint` (lines 287-299): delete the `label` field and its doc comment.
+- `buildCumulativeGrowth` (line 316): delete `label: b.label,`.
+- `ReturnTrendPoint` (lines 620-631): delete the `label` field and its doc comment.
+- `computeInvestmentReturnSeries` (lines 647-706): change signature to `(snapshots: SnapshotBreakdown[], accounts: AccountMeta[], accountCashFlows: AccountMonthlyContribution[], monthKeys: string[])`, delete `locale = "en-US"` and `const label = formatMonthLabel(monthKey, locale);` (line 687), and remove `label,` from all three returned objects (lines 691, 700, 704). Keep `formatMonthLabel` exported and unchanged (clients still use it).
+
+Edit `src/lib/services/analysis-series-service.ts`:
+
+- Delete the local `AnalysisRangeSeries` interface (lines 33-43) and import it instead:
+
+```ts
+import type { AnalysisRangeSeries } from "@/lib/analysis-contract";
+```
+
+- `computeAnalysisRangeSeries` (lines 56-123): drop the `locale: string` param and its JSDoc mention; drop the `locale,` argument from the `buildCashFlowBuckets` call (line 74-78) and from the `computeInvestmentReturnSeries` call (line 104-110).
+- `computeAllRangeSeries` (lines 125-146): drop the `locale: string` param; drop `locale,` from the `computeAnalysisRangeSeries` call.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test:unit tests/unit/analysis-service.test.ts tests/unit/analysis-series-service.test.ts tests/unit/history-service.test.ts tests/unit/first-day-recurring-cash-flow.test.ts`
+Expected: PASS — all aggregation parity assertions plus the new no-label assertions.
+
+- [ ] **Step 5: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add src/lib/analysis-contract.ts src/lib/services/analysis-service.ts src/lib/services/analysis-series-service.ts tests/unit/analysis-service.test.ts tests/unit/analysis-series-service.test.ts tests/unit/history-service.test.ts tests/unit/first-day-recurring-cash-flow.test.ts
+git commit -m "refactor(analysis): drop locale from server series and emit month keys without labels"
+```
+
+**Acceptance Criteria:** `buildCashFlowBuckets` / `computeInvestmentReturnSeries` no longer accept `locale`; `CashFlowBucket` / `CumulativeGrowthPoint` / `ReturnTrendPoint` have no `label` property; `computeAllRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, now)` compiles and produces all five ranges with month keys only; all listed unit-test files pass.
+
+---
+
+### Task 3: Client charts format month labels from the active locale
+
+**Files:**
+
+- Modify: `src/components/analysis/cashflow-chart.tsx`, `src/components/analysis/cumulative-growth-chart.tsx`, `src/components/analysis/return-trend-chart.tsx`
+
+**Interfaces:**
+
+- Consumes: `CashFlowBucket[]` / `CumulativeGrowthPoint[]` / `ReturnTrendPoint[]` (month keys only, from Task 2) and the existing `formatMonthLabel(monthKey, locale)` export from `@/lib/services/analysis-service`.
+- Produces: each chart renders `label` derived from `monthKey` with the active next-intl locale. No prop signature changes; no chart styling/copy/formula changes.
+
+- [ ] **Step 1: Write the failing test (RED) — real-surface only**
+
+There is no component-render unit harness and adding one is forbidden, so the failing check for this task is the _type_ contract: after Task 2 removes `label` from the three series types, these charts still reference `payload[0].payload.label` / `dataKey="label"` against `label`-less data.
+
+Run: `pnpm typecheck`
+Expected: FAIL — `Property 'label' does not exist on type 'CashFlowBucket'` (and `CumulativeGrowthPoint`, `ReturnTrendPoint`) in the three chart files. This is the expected RED: the charts must derive labels locally.
+
+- [ ] **Step 2: Implement (GREEN)**
+
+`src/components/analysis/cashflow-chart.tsx`:
+
+- Line 14: `import { useLocale, useTranslations } from "next-intl";`
+- Add after line 22: `import { formatMonthLabel } from "@/lib/services/analysis-service";`
+- After line 102 (`const t = useTranslations("analysis");`): `const locale = useLocale();`
+- Replace lines 113-116 (the `chartData` memo) with:
+
+```tsx
+const chartData = useMemo(
+  () =>
+    buckets.map((b) => ({
+      ...b,
+      label: formatMonthLabel(b.monthKey, locale),
+      deltaLine: b.isEmpty ? null : b.deltaNetWorth,
+    })),
+  [buckets, locale],
+);
+```
+
+`XAxis dataKey="label"` (line 180) and the tooltip's `b.label` (lines 57, 68) keep working because recharts now feeds them the mapped `chartData` (line 173 `<ComposedChart data={chartData}>`).
+
+`src/components/analysis/cumulative-growth-chart.tsx`:
+
+- Line 5: `import { useLocale, useTranslations } from "next-intl";`
+- Add after line 14: `import { formatMonthLabel } from "@/lib/services/analysis-service";`
+- After line 97 (`const t = useTranslations("analysis");`): `const locale = useLocale();`
+- Add before the `return (` (after line 105):
+
+```tsx
+const chartData = useMemo(
+  () => points.map((p) => ({ ...p, label: formatMonthLabel(p.monthKey, locale) })),
+  [points, locale],
+);
+```
+
+- Line 164: `<ComposedChart data={points}` → `<ComposedChart data={chartData}`. Tooltips (`p.label` at lines 45, 54) and `XAxis dataKey="label"` (line 182) now read the mapped payload.
+
+`src/components/analysis/return-trend-chart.tsx`:
+
+- Line 14: `import { useLocale, useTranslations } from "next-intl";`
+- Add after line 22: `import { formatMonthLabel } from "@/lib/services/analysis-service";`
+- After line 87 (`const t = useTranslations("analysis");`): `const locale = useLocale();`
+- Add before the `return (` (after line 97):
+
+```tsx
+const chartData = useMemo(
+  () => points.map((p) => ({ ...p, label: formatMonthLabel(p.monthKey, locale) })),
+  [points, locale],
+);
+```
+
+- Line 146: `<ComposedChart data={points}` → `<ComposedChart data={chartData}`. `XAxis dataKey="label"` (line 153) and the tooltip's `p.label` (lines 52, 66) read the mapped payload. The `Cell` mapping (line 177) may stay keyed on `points`.
+
+- [ ] **Step 3: Verify (GREEN)**
+
+Run: `pnpm typecheck`
+Expected: PASS — no `Property 'label' does not exist` errors; the three charts derive labels locally.
+
+- [ ] **Step 4: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add src/components/analysis/cashflow-chart.tsx src/components/analysis/cumulative-growth-chart.tsx src/components/analysis/return-trend-chart.tsx
+git commit -m "refactor(analysis): format month labels client-side in cash flow, growth, and return charts"
+```
+
+**Acceptance Criteria:** `pnpm typecheck` passes; the three charts import `formatMonthLabel` and `useLocale`; `XAxis`/tooltip labels are derived from `monthKey` at render-data preparation; no chart prop, class, or copy changed.
+
+---
+
+### Task 4: Locale-independent cached payload, reduced meta, derived metadata in the view
+
+**Files:**
+
+- Modify: `src/lib/analysis-contract.ts` (add `AnalysisPayloadMeta`, `AnalysisPayload`)
+- Modify: `src/lib/services/analysis-payload-service.ts` (import contract types; drop `locale` param + key part; `meta = { defaultRange }`)
+- Modify: `src/app/(main)/analysis/page.tsx:23-25` (drop the locale argument)
+- Modify: `src/components/analysis/analysis-view.tsx:101-102` (derive `hasData` / `latestSnapshotAt` from `snapshots`; update `AnalysisPayloadMeta` import to `@/lib/analysis-contract`)
+- Create test: `tests/unit/analysis-payload-service.test.ts`
+
+**Interfaces:**
+
+- Consumes: `computeAllRangeSeries` new signature (Task 2), `pickDefaultRange` from `@/lib/analysis-range` (Task 1).
+- Produces:
+  - `export interface AnalysisPayloadMeta { defaultRange: RangeLabel }`
+  - `export interface AnalysisPayload { seriesByRange: Record<RangeLabel, AnalysisRangeSeries>; investmentCostBasis: InvestmentCostBasisSummary; snapshots: NormalizedSnapshot[]; meta: AnalysisPayloadMeta }` (from `@/lib/analysis-contract`)
+  - `export async function getCachedAnalysisPayload(userId: string, baseCurrency: string): Promise<AnalysisPayload>` with `unstable_cache` key parts `["analysis-payload", userId, baseCurrency]`.
+
+- [ ] **Step 1: Write the failing cache-boundary test (RED)**
+
+Create `tests/unit/analysis-payload-service.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUnstableCache = vi.fn();
+
+vi.mock("next/cache", () => ({
+  unstable_cache: mockUnstableCache,
+}));
+
+vi.mock("@/lib/services/history-service", () => ({
+  getFullNormalizedHistory: vi.fn(async () => []),
+  getMonthlyCashFlow: vi.fn(async () => []),
+  getRawHistoryWithBreakdown: vi.fn(async () => ({ snapshots: [], accounts: [] })),
+  getAccountMonthlyCashFlow: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/services/investment-cost-basis-service", () => ({
+  getInvestmentCostBasisSummary: vi.fn(async () => ({
+    marketValue: 0,
+    costedMarketValue: 0,
+    costBasis: 0,
+    unrealizedGain: null,
+    unrealizedGainPct: null,
+    pricedHoldingCount: 0,
+    costedHoldingCount: 0,
+  })),
+}));
+
+import { getCachedAnalysisPayload } from "@/lib/services/analysis-payload-service";
+import { unstable_cache } from "next/cache";
+
+beforeEach(() => {
+  mockUnstableCache.mockReset();
+  mockUnstableCache.mockImplementation((fn: () => Promise<unknown>) => () => fn());
+});
+
+describe("getCachedAnalysisPayload", () => {
+  it("is keyed by user and base currency only — locale is not a key part and meta is reduced", async () => {
+    const payload = await getCachedAnalysisPayload("user-1", "USD");
+
+    expect(mockUnstableCache).toHaveBeenCalledTimes(1);
+    const keyParts = mockUnstableCache.mock.calls[0]?.[1];
+    expect(keyParts).toEqual(["analysis-payload", "user-1", "USD"]);
+
+    expect(payload.meta).toEqual({ defaultRange: "YTD" });
+    expect(payload.meta).not.toHaveProperty("hasSnapshots");
+    expect(payload.meta).not.toHaveProperty("latestSnapshotAt");
+  });
+});
+```
+
+Note: the signature is exercised by the two-argument call — passing a third `locale` argument here would be a typecheck error, which is the compile-time half of "locale is not accepted".
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit tests/unit/analysis-payload-service.test.ts`
+Expected: FAIL — the current key parts array is `["analysis-payload", "user-1", "USD", undefined]` (locale arg present, now `undefined`), so `toEqual(["analysis-payload", "user-1", "USD"])` fails; and `payload.meta` still contains `hasSnapshots` / `latestSnapshotAt`, so `toEqual({ defaultRange: "YTD" })` fails.
+
+- [ ] **Step 3: Implement (GREEN)**
+
+`src/lib/analysis-contract.ts` — append:
+
+```ts
+export interface AnalysisPayloadMeta {
+  defaultRange: RangeLabel;
+}
+
+export interface AnalysisPayload {
+  seriesByRange: Record<RangeLabel, AnalysisRangeSeries>;
+  investmentCostBasis: InvestmentCostBasisSummary;
+  /** Full normalized history — used by the mobile #history tab (HistoryView). */
+  snapshots: NormalizedSnapshot[];
+  meta: AnalysisPayloadMeta;
+}
+```
+
+`src/lib/services/analysis-payload-service.ts`:
+
+- Delete the local `AnalysisPayloadMeta` (lines 18-22) and `AnalysisPayload` (lines 24-30) interfaces; import them:
+
+```ts
+import type { AnalysisPayload, AnalysisPayloadMeta } from "@/lib/analysis-contract";
+```
+
+- `getCachedAnalysisPayload` (lines 32-85):
+  - Signature: `export async function getCachedAnalysisPayload(userId: string, baseCurrency: string): Promise<AnalysisPayload>` (drop `locale`).
+  - Remove `locale,` from the `computeAllRangeSeries(...)` call (line 53-60).
+  - Meta (lines 63-67) becomes:
+
+```ts
+        meta: {
+          defaultRange: pickDefaultRange(snapshots, now),
+        },
+```
+
+- Key parts (line 70) become: `["analysis-payload", userId, baseCurrency]`.
+
+`src/app/(main)/analysis/page.tsx:23-25`:
+
+```tsx
+const payloadP = Promise.all([settingsP, localeP]).then(([s]) =>
+  getCachedAnalysisPayload(userId, s.baseCurrency),
+);
+```
+
+`src/components/analysis/analysis-view.tsx`:
+
+- Line 18: `import type { AnalysisPayloadMeta } from "@/lib/services/analysis-payload-service";` → `import type { AnalysisPayloadMeta } from "@/lib/analysis-contract";`
+- Lines 101-102:
+
+```tsx
+const hasData = snapshots.length > 0;
+const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test:unit tests/unit/analysis-payload-service.test.ts tests/unit/analysis-range.test.ts tests/unit/analysis-series-service.test.ts`
+Expected: PASS — the cache-boundary test (empty snapshots make `pickDefaultRange` deterministically return `"YTD"`) and all prior suite updates.
+
+- [ ] **Step 5: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add src/lib/analysis-contract.ts src/lib/services/analysis-payload-service.ts "src/app/(main)/analysis/page.tsx" src/components/analysis/analysis-view.tsx tests/unit/analysis-payload-service.test.ts
+git commit -m "feat(analysis): locale-independent cached payload and meta reduced to defaultRange"
+```
+
+**Acceptance Criteria:** `getCachedAnalysisPayload(userId, baseCurrency)` no longer accepts `locale`; key parts are exactly `["analysis-payload", userId, baseCurrency]`; `AnalysisPayloadMeta` has only `defaultRange`; the view derives `hasData` / `latestSnapshotAt` from `snapshots` with the exact server-equivalent expressions; `meta.defaultRange` remains server-computed from one frozen clock reading; the cache-boundary test passes.
+
+---
+
+### Task 5: Resolve stale persisted ranges and build segmented options from `messageKey`
+
+**Files:**
+
+- Modify: `src/components/analysis/analysis-view.tsx` (lines 67, 73-91, 101-102 area, 151-160, 166-167)
+
+**Interfaces:**
+
+- Consumes: `resolveActiveRange` / `getMessageKeyForRange` / `ANALYSIS_RANGES` / `type RangeLabel` from `@/lib/analysis-range` (Task 1), reduced `meta` (Task 4).
+- Produces: `activeRange: RangeLabel` = `resolveActiveRange(range, meta.defaultRange)`; segmented options built from `ANALYSIS_RANGES` entries via `t(r.messageKey)`; `series = seriesByRange[activeRange]` (no runtime `??` fallback needed — resolution guarantees a valid label).
+
+- [ ] **Step 1: Write the failing test (RED)**
+
+The pure resolution logic already has unit coverage from Task 1 (`resolveActiveRange`). The view wiring is covered by the real-surface stale-range E2E scenario in Task 6; the failing check here is the type-level removal of the old path. Write the Task 6 stale-range E2E test first and confirm it fails against the current view because a stored `"BOGUS_RANGE"` leaves the `SegmentedControl` with no matching `value`, so no button is `aria-pressed`. If running tasks serially, you may instead use this type-level gate: after removing the `rangeLabelKey` record, `pnpm typecheck` must pass with `ANALYSIS_RANGES`-derived options — the "failing" state is the absence of `resolveActiveRange` (a typecheck error on the missing import), which is resolved by Step 2.
+
+Concretely, the RED check for this task (run after the Task 6 test file exists):
+Run: `pnpm test:e2e --project=chromium tests/e2e/analysis-populated.spec.ts --grep "unknown persisted range"`
+Expected: FAIL — the injected `BOGUS_RANGE` is passed straight into `t()`/`seriesByRange` and the control highlights nothing (or the route errors), so `getByRole("button", { pressed: true })` does not resolve to exactly one.
+
+- [ ] **Step 2: Implement (GREEN)**
+
+In `src/components/analysis/analysis-view.tsx`:
+
+- Line 19 import becomes:
+
+```tsx
+import {
+  ANALYSIS_RANGES,
+  getMessageKeyForRange,
+  resolveActiveRange,
+  type RangeLabel,
+} from "@/lib/analysis-range";
+```
+
+- Delete the `rangeLabelKey` record (lines 73-79).
+- Replace lines 81-91 with:
+
+```tsx
+const activeRange = resolveActiveRange(range, meta.defaultRange);
+const rangeOptions: SegmentedOption<RangeLabel>[] = ANALYSIS_RANGES.map((r) => ({
+  value: r.label,
+  label: t(r.messageKey),
+}));
+const activeRangeLabel = t(getMessageKeyForRange(activeRange));
+
+const series = seriesByRange[activeRange];
+```
+
+- Line 151-160 (`SegmentedControl`): change `value={range}` → `value={activeRange}` (so the control highlights the fallback when the persisted value is unknown). `onValueChange={setRange}` stays.
+- Line 166-167 (`motion.div key={range}`): change `key={range}` → `key={activeRange}`.
+- Lines 101-102 (`hasData` / `latestSnapshotAt`) are unchanged from Task 4.
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `pnpm test:unit tests/unit/analysis-range.test.ts`
+Expected: PASS — `resolveActiveRange` unit tests.
+Run: `pnpm test:e2e --project=chromium tests/e2e/analysis-populated.spec.ts --grep "unknown persisted range"`
+Expected: PASS — page renders, exactly one range button is `aria-pressed`.
+
+- [ ] **Step 4: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add src/components/analysis/analysis-view.tsx
+git commit -m "fix(analysis): fall back to defaultRange for stale persisted ranges"
+```
+
+**Acceptance Criteria:** `analysis-view.tsx` no longer declares `rangeLabelKey`; segmented options come from `ANALYSIS_RANGES` + `t(r.messageKey)`; an unknown persisted range resolves to `meta.defaultRange` before any `t()` call or series lookup; `SegmentedControl` reflects the resolved range; the stale-range E2E passes.
+
+---
+
+### Task 6: Real-surface E2E scenarios and full verification
+
+**Files:**
+
+- Modify: `tests/e2e/analysis-fixture.ts` (email parametrization + `seedAnalysisEmptyFixture`)
+- Modify: `tests/e2e/analysis-populated.spec.ts` (range-switch-back assertion; month-label tests; stale-range test)
+- Create: `tests/e2e/analysis-empty.spec.ts`
+- Create: `tests/e2e/analysis-history-mobile.spec.ts`
+
+**Scenario contract:**
+| Scenario | Surface | What it proves |
+|---|---|---|
+| Happy / populated | chromium | Charts render, range switching stays functional (existing + switch-back), en-US month label renders from month-key data |
+| Stale-range edge | chromium | Injected unknown persisted range falls back to server `defaultRange` without exception; exactly one range selected |
+| Locale independence | chromium | Same seeded payload renders both `en-US` and `zh-TW` month labels (via `NEXT_LOCALE` cookie) |
+| Empty-data edge | chromium | No snapshots → onboarding empty state; no freshness badge (derived `latestSnapshotAt` is `null`) |
+| Adjacent `#history` regression | Mobile Chrome | `/analysis#history` still renders `HistoryView` from the `snapshots` payload |
+
+- [ ] **Step 1: Write the failing tests (RED) — run against pre-Task-2/3/5 code**
+
+`tests/e2e/analysis-fixture.ts`:
+
+- Add email constants and parametrize the shared functions:
+
+```ts
+const E2E_EMAIL = "e2e-test@preview.local";
+const E2E_EMPTY_EMAIL = "e2e-empty@preview.local";
+const E2E_MOBILE_EMAIL = "e2e-mobile@preview.local";
+```
+
+- `getOrCreateE2eUser(pool: pg.Pool, email: string)` — take the email as a parameter; the two `INSERT ... $2` bindings for email/name stay identical, only the argument source changes.
+- `seedAnalysisFixture(email = E2E_EMAIL): Promise<AnalysisFixture>` — pass `email` to `getOrCreateE2eUser`.
+- `cleanupAnalysisFixture(fixture: AnalysisFixture, email = E2E_EMAIL)` — use `email` in the user lookup.
+- Append:
+
+```ts
+export async function seedAnalysisEmptyFixture(): Promise<AnalysisFixture> {
+  const pool = createDbPool();
+  try {
+    await getOrCreateE2eUser(pool, E2E_EMPTY_EMAIL);
+    return { snapshotDates: [] };
+  } finally {
+    await pool.end();
+  }
+}
+
+export async function cleanupAnalysisEmptyFixture() {
+  const pool = createDbPool();
+  try {
+    const user = await pool.query<{ id: string }>(`SELECT "id" FROM "User" WHERE "email" = $1`, [
+      E2E_EMPTY_EMAIL,
+    ]);
+    const userId = user.rows[0]?.id;
+    if (!userId) return;
+    await removeFixtureData(pool, userId, []);
+  } finally {
+    await pool.end();
+  }
+}
+```
+
+`tests/e2e/analysis-populated.spec.ts`:
+
+- Extend the existing test (after line 31) with a switch-back assertion:
+
+```ts
+await page.getByRole("button", { name: "YTD", exact: true }).click();
+await expect(page.getByRole("button", { name: "YTD", exact: true })).toHaveAttribute(
+  "aria-pressed",
+  "true",
+);
+```
+
+- Add a helper and three new tests:
+
+```ts
+function oldestMonthLabel(locale: string): string {
+  const oldest = new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() - 17, 1));
+  return new Intl.DateTimeFormat(locale, { month: "short", year: "numeric" }).format(oldest);
+}
+
+test("analysis falls back to the server default range for an unknown persisted range", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+  try {
+    await page
+      .context()
+      .addCookies([{ name: "NEXT_LOCALE", value: "en-US", url: "http://localhost:3000" }]);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "BOGUS_RANGE"),
+    );
+    await page.goto("/analysis");
+    await expect(page.getByRole("heading", { name: /^Movement/ })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("button", { pressed: true })).toHaveCount(1);
+    const pressedName = await page.getByRole("button", { pressed: true }).innerText();
+    expect(["YTD", "6M", "1Y", "2Y", "All"]).toContain(pressedName);
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+
+test("renders English month labels from the locale-independent payload", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+  try {
+    await page
+      .context()
+      .addCookies([{ name: "NEXT_LOCALE", value: "en-US", url: "http://localhost:3000" }]);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
+    );
+    await page.goto("/analysis");
+    await expect(page.getByText("Assets vs. Liabilities by Month")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page
+        .locator(".recharts-xAxis .recharts-cartesian-axis-tick-value")
+        .filter({ hasText: oldestMonthLabel("en-US") })
+        .first(),
+    ).toBeVisible();
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+
+test("renders Traditional Chinese month labels from the same locale-independent payload", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+  try {
+    await page
+      .context()
+      .addCookies([{ name: "NEXT_LOCALE", value: "zh-TW", url: "http://localhost:3000" }]);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
+    );
+    await page.goto("/analysis");
+    await expect(
+      page
+        .locator(".recharts-xAxis .recharts-cartesian-axis-tick-value")
+        .filter({ hasText: oldestMonthLabel("zh-TW") })
+        .first(),
+    ).toBeVisible({ timeout: 20_000 });
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+```
+
+Create `tests/e2e/analysis-empty.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+import {
+  cleanupAnalysisEmptyFixture,
+  hasAnalysisFixtureDatabase,
+  seedAnalysisEmptyFixture,
+} from "./analysis-fixture";
+
+test("analysis renders the onboarding empty state for a user with no snapshots", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Analysis empty-state QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Empty Analysis QA requires DATABASE_URL.");
+  await seedAnalysisEmptyFixture();
+  try {
+    await page
+      .context()
+      .addCookies([{ name: "NEXT_LOCALE", value: "en-US", url: "http://localhost:3000" }]);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/analysis");
+    await expect(page.getByText("Build the base for real analysis")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByRole("button", { name: "Add account" })).toBeVisible();
+    // Derived latestSnapshotAt is null when snapshots are empty → no freshness badge.
+    await expect(page.getByText(/Snapshot /)).toHaveCount(0);
+  } finally {
+    await cleanupAnalysisEmptyFixture();
+  }
+});
+```
+
+Create `tests/e2e/analysis-history-mobile.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+import {
+  cleanupAnalysisFixture,
+  hasAnalysisFixtureDatabase,
+  seedAnalysisFixture,
+} from "./analysis-fixture";
+
+const E2E_MOBILE_EMAIL = "e2e-mobile@preview.local";
+
+test("analysis #history deep link still renders HistoryView on mobile", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "Mobile Chrome", "Mobile-only #history tab.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture(E2E_MOBILE_EMAIL);
+  try {
+    await page.goto("/analysis#history");
+    await expect(page.getByText(/Tracking since/)).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("table")).toBeVisible();
+    await expect(page.getByText("Net Worth")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^Movement/ })).toHaveCount(0);
+  } finally {
+    await cleanupAnalysisFixture(fixture, E2E_MOBILE_EMAIL);
+  }
+});
+```
+
+- [ ] **Step 2: Run the E2E tests to verify they fail (RED) — before Tasks 1-5 land**
+
+Run: `pnpm test:e2e --project=chromium tests/e2e/analysis-populated.spec.ts tests/e2e/analysis-empty.spec.ts`
+Run: `pnpm test:e2e --project="Mobile Chrome" tests/e2e/analysis-history-mobile.spec.ts`
+Expected: FAIL — month-label tests fail (server still ships `label`, so ticks exist but the assertion depends on the injected-range path), the stale-range test fails (no `resolveActiveRange`), and/or the empty `#history` paths fail on the still-present `meta.hasSnapshots`. Any failure caused by the not-yet-implemented production behavior is the correct RED.
+
+- [ ] **Step 3: Implement (GREEN) — apply Tasks 1-5 if not already applied, then re-run**
+
+With Tasks 1-5 in place, re-run the E2E:
+Run: `pnpm test:e2e --project=chromium tests/e2e/analysis-populated.spec.ts tests/e2e/analysis-empty.spec.ts`
+Run: `pnpm test:e2e --project="Mobile Chrome" tests/e2e/analysis-history-mobile.spec.ts`
+Expected: PASS — all five scenarios green.
+
+- [ ] **Step 4: Full verification suite**
+
+```bash
+pnpm format:check          # if it reports changed files, run: pnpm format
+pnpm lint
+pnpm typecheck
+pnpm test:unit
+pnpm build
+pnpm test:e2e --project=chromium tests/e2e/analysis-populated.spec.ts tests/e2e/analysis-empty.spec.ts
+pnpm test:e2e --project="Mobile Chrome" tests/e2e/analysis-history-mobile.spec.ts
+```
+
+Expected: all green. `test:e2e` requires `DATABASE_URL`; the Playwright `webServer` builds and starts the app automatically when no `PLAYWRIGHT_TEST_BASE_URL` is set.
+
+- [ ] **Step 5: No commit (default).** If the user explicitly requested commits:
+
+```bash
+git add tests/e2e/analysis-fixture.ts tests/e2e/analysis-populated.spec.ts tests/e2e/analysis-empty.spec.ts tests/e2e/analysis-history-mobile.spec.ts
+git commit -m "test(analysis): real-surface E2E for locale-independent payload, stale range, empty data, and mobile history"
+```
+
+**Acceptance Criteria:** All five E2E scenarios pass in their projects; `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit`, and `pnpm build` all succeed; no commit is created unless explicitly requested.
+
+---
+
+## Commit Strategy
+
+**Default — no commits.** This overrides the generic writing-plans per-task "Commit" step. The executor edits the working tree only and hands the diff to the user for review. `git status` must never show a new commit from this work.
+
+**If the user explicitly requests commits**, create one atomic commit per task in the order the tasks completed, each containing exactly that task's files, with these messages:
+
+1. `refactor(analysis): move range module to src/lib and add messageKey to ranges`
+2. `refactor(analysis): drop locale from server series and emit month keys without labels`
+3. `refactor(analysis): format month labels client-side in cash flow, growth, and return charts`
+4. `feat(analysis): locale-independent cached payload and meta reduced to defaultRange`
+5. `fix(analysis): fall back to defaultRange for stale persisted ranges`
+6. `test(analysis): real-surface E2E for locale-independent payload, stale range, empty data, and mobile history`
+
+Commits 2 and 3 may be merged only if the user prefers a single commit, since they are wave-2 parallel tasks; all others stay separate.
+
+---
+
+## Success Criteria
+
+- [ ] `ANALYSIS_RANGES` carries `label` / `months` / `messageKey`; `AnalysisView` builds segmented options from it and no longer declares `rangeLabelKey`.
+- [ ] An unknown persisted range falls back to `meta.defaultRange` before `t()` and series access; the route never calls `t(undefined)`.
+- [ ] `getCachedAnalysisPayload(userId, baseCurrency)` is locale-independent; cache key parts are `["analysis-payload", userId, baseCurrency]`.
+- [ ] Server series (`cashFlowBuckets`, `cumulativeGrowth`, `returnTrend`) expose `monthKey` only; the three charts format labels with the active next-intl locale.
+- [ ] `AnalysisPayloadMeta` has only `defaultRange`; `AnalysisView` derives `hasData` and `latestSnapshotAt` from `snapshots` with the exact server-equivalent expressions.
+- [ ] `src/lib/analysis-range.ts` and `src/lib/analysis-contract.ts` exist; no `src/lib/services` module imports from `src/components`.
+- [ ] All existing aggregation-parity, range, series, history, and first-day tests pass unchanged in outcome.
+- [ ] All five E2E scenarios pass (happy/populated + range switching, stale-range fallback, en-US and zh-TW month labels, empty-data, mobile `#history`).
+- [ ] `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit`, `pnpm build` all pass.
+- [ ] No commits were made unless the user explicitly requested them; no `unstable_cache`→`use cache` migration, no chart/copy/formula changes, no new dependencies, no `NormalizedSnapshot` extraction, no `DrawdownPoint.label` changes.

--- a/docs/superpowers/specs/2026-08-17-analysis-payload-followups-design.md
+++ b/docs/superpowers/specs/2026-08-17-analysis-payload-followups-design.md
@@ -1,0 +1,117 @@
+# Analysis Payload Follow-ups Design
+
+## Goal
+
+Resolve the four follow-ups tracked in GitHub issue #689 without changing the analysis page's calculations, range choices, visual layout, or interaction model.
+
+## Scope
+
+This change covers:
+
+1. Make the cached analysis payload locale-independent and format month labels in client charts.
+2. Move shared analysis range definitions and payload contracts into neutral `src/lib` modules.
+3. Remove `hasSnapshots` and `latestSnapshotAt` from payload metadata because the client already receives `snapshots`.
+4. Make `ANALYSIS_RANGES` the single source of truth for range labels, durations, and translation keys.
+
+It does not migrate `unstable_cache` to Cache Components, change analysis calculations, remove the mobile `#history` route, alter chart presentation, or address the unrelated `DrawdownPoint.label` and source-grepping-test notes in #689.
+
+## Architecture
+
+Create two neutral modules:
+
+- `src/lib/analysis-range.ts` owns `ANALYSIS_RANGES`, `RangeLabel`, range resolution, default selection, and range lookup behavior. Move the current pure range module from `src/components/analysis` without changing date semantics.
+- `src/lib/analysis-contract.ts` owns the serializable `AnalysisRangeSeries`, `AnalysisPayload`, and `AnalysisPayloadMeta` types used by server services and the client view.
+
+Server-only services remain responsible for database reads, cache construction, and server aggregation. Client components import runtime range definitions and contract types only from neutral modules. No module under `src/lib/services` may import from `src/components` as part of this flow.
+
+`AnalysisPayloadMeta` retains only `defaultRange`. Keeping the existing `meta` wrapper minimizes payload and call-site churn while removing the two redundant fields.
+
+## Locale-independent Payload
+
+Remove `locale` from `getCachedAnalysisPayload`, `computeAllRangeSeries`, and `computeAnalysisRangeSeries`. The cache identity remains user and base-currency specific; locale no longer creates a second heavy payload entry.
+
+Server-computed series emit stable `monthKey` values only:
+
+- `CashFlowBucket` no longer carries a localized `label`.
+- `CumulativeGrowthPoint` no longer copies that label.
+- `ReturnTrendPoint` no longer carries a localized `label`.
+
+`buildCashFlowBuckets` and `computeInvestmentReturnSeries` therefore no longer accept `locale`. Their calculations and ordering remain unchanged.
+
+`cash-flow-chart.tsx`, `cumulative-growth-chart.tsx`, and `return-trend-chart.tsx` obtain the active locale from `next-intl` and call the existing `formatMonthLabel(monthKey, locale)` at render-data preparation time. This matches the existing client-side pattern in the assets/liabilities chart, category trend chart, and KPI tiles.
+
+## Range Definition
+
+Each `ANALYSIS_RANGES` entry carries:
+
+- `label`: persisted/internal range identity.
+- `months`: range calculation input.
+- `messageKey`: the `analysis` namespace translation key.
+
+`analysis-view.tsx` builds segmented options directly from these entries and no longer declares `rangeLabelKey`.
+
+A persisted range value can be stale at runtime despite the TypeScript generic. Range lookup must therefore fall back to the server-provided `defaultRange` descriptor before translating or selecting series. An unknown stored value must never call `t(undefined)` or crash the route.
+
+## Derived Metadata
+
+`analysis-view.tsx` derives:
+
+- `hasData` from `snapshots.length > 0`.
+- `latestSnapshotAt` from `snapshots.at(-1)?.createdAt ?? null`.
+
+These expressions match the current server computations exactly. `defaultRange` remains server-computed from one frozen clock reading so Taiwan calendar-day behavior and cache-fill consistency remain unchanged.
+
+## Data Flow
+
+1. The analysis Server Component resolves authentication, settings, locale, and accounts in parallel.
+2. It requests a locale-independent cached payload using only user ID and base currency.
+3. Server services precompute all range calculations with stable month keys.
+4. The Server Component passes the payload plus locale to `AnalysisView`.
+5. `AnalysisView` resolves a valid active range and passes locale-independent series to charts.
+6. Client charts format month keys using the active locale.
+
+## Testing
+
+Follow RED to GREEN for behavior changes.
+
+### Locale-independent cache and series
+
+- Add or update unit coverage proving analysis series are identical without a locale input and expose month keys without preformatted labels.
+- Add a cache-boundary test using a mocked `unstable_cache` that proves locale is not accepted by `getCachedAnalysisPayload` and is absent from explicit key parts.
+- Preserve all existing aggregation parity assertions.
+
+### Range definitions and stale persistence
+
+- Extend `analysis-range.test.ts` to prove each range includes the correct message key.
+- Add client behavior coverage proving an unknown persisted range falls back to `defaultRange` before translation and series access.
+
+### Derived metadata
+
+- Add client behavior coverage for empty snapshots and populated snapshots, including the latest snapshot timestamp.
+- Keep the existing empty-state and populated analysis E2E scenarios green.
+
+### Real-surface verification
+
+- Run the populated analysis Playwright scenario in Chromium.
+- Verify range switching remains functional.
+- Verify English and Traditional Chinese month labels render from the same locale-independent series shape.
+- Inject an unknown persisted range and verify the page falls back without an exception.
+
+## Verification Commands
+
+- Targeted Vitest files for analysis range, service, series, payload, and client behavior.
+- `pnpm test:unit`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm format:check`
+- `pnpm build`
+- The relevant Playwright analysis scenario.
+
+## Non-goals
+
+- No `unstable_cache` to `use cache` migration.
+- No chart redesign or copy change.
+- No new analysis ranges.
+- No analysis formula changes.
+- No extraction of `NormalizedSnapshot` or broader service-directory reorganization.
+- No cleanup of unrelated issue #689 observations.

--- a/src/app/(main)/analysis/page.tsx
+++ b/src/app/(main)/analysis/page.tsx
@@ -16,13 +16,11 @@ async function AnalysisContent() {
   const userId = session.user.id;
 
   // The payload is the slowest read on this page (five DB queries + the
-  // per-range aggregation), so it starts as soon as its two inputs resolve
-  // rather than after every other await.
+  // per-range aggregation), so it starts as soon as its settings/base-currency
+  // input resolves rather than after every other await.
   const settingsP = getOrCreateSettings(userId);
   const localeP = getLocale();
-  const payloadP = Promise.all([settingsP, localeP]).then(([s, l]) =>
-    getCachedAnalysisPayload(userId, s.baseCurrency, l),
-  );
+  const payloadP = settingsP.then((s) => getCachedAnalysisPayload(userId, s.baseCurrency));
 
   const [
     t,

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -14,9 +14,13 @@ import { Card } from "@/components/ui/card";
 import type { NormalizedSnapshot } from "@/lib/services/history-service";
 import { computeDrawdownSeries } from "@/lib/services/analysis-service";
 import type { InvestmentCostBasisSummary } from "@/lib/services/analysis-service";
-import type { AnalysisRangeSeries } from "@/lib/services/analysis-series-service";
-import type { AnalysisPayloadMeta } from "@/lib/services/analysis-payload-service";
-import { ANALYSIS_RANGES, type RangeLabel } from "./analysis-range";
+import type { AnalysisPayloadMeta, AnalysisRangeSeries } from "@/lib/analysis-contract";
+import {
+  ANALYSIS_RANGES,
+  getMessageKeyForRange,
+  resolveActiveRange,
+  type RangeLabel,
+} from "@/lib/analysis-range";
 import {
   LazyAssetsLiabilitiesChart,
   LazyCashFlowChart,
@@ -70,25 +74,16 @@ export function AnalysisView({
     ? { duration: 0 }
     : { duration: 0.22, ease: [0.16, 1, 0.3, 1] as const };
 
-  const rangeLabelKey: Record<RangeLabel, string> = {
-    YTD: "rangeYTD",
-    "6M": "range6M",
-    "1Y": "range1Y",
-    "2Y": "range2Y",
-    All: "rangeAll",
-  };
-
+  const activeRange = resolveActiveRange(range, meta.defaultRange);
   const rangeOptions: SegmentedOption<RangeLabel>[] = ANALYSIS_RANGES.map((r) => ({
     value: r.label,
-    label: t(rangeLabelKey[r.label] as Parameters<typeof t>[0]),
+    label: t(r.messageKey),
   }));
-  const activeRangeLabel = t(rangeLabelKey[range] as Parameters<typeof t>[0]);
+  const activeRangeLabel = t(getMessageKeyForRange(activeRange));
 
   // All series are precomputed on the server per range; switching ranges is an
-  // O(1) lookup into the payload (the fade below animates the swap). The
-  // fallback covers a stale sessionStorage value from an older range set —
-  // without it an unknown label takes the whole route down.
-  const series = seriesByRange[range] ?? seriesByRange[meta.defaultRange];
+  // O(1) lookup into the payload (the fade below animates the swap).
+  const series = seriesByRange[activeRange];
 
   // Not precomputed per range: this is one scan over `snapshots`, which is
   // shipped in full for HistoryView anyway. Five server-side copies would cost
@@ -98,8 +93,8 @@ export function AnalysisView({
     [snapshots, series.rangeStartIso],
   );
 
-  const hasData = meta.hasSnapshots;
-  const latestSnapshotAt = meta.latestSnapshotAt;
+  const hasData = snapshots.length > 0;
+  const latestSnapshotAt = snapshots.at(-1)?.createdAt ?? null;
 
   // Analysis no longer shows History as a peer tab; History has its own route and
   // the dashboard links there directly. The /analysis#history deep link still
@@ -152,7 +147,7 @@ export function AnalysisView({
             variant="pill"
             size="sm"
             options={rangeOptions}
-            value={range}
+            value={activeRange}
             onValueChange={setRange}
             aria-label={t("title")}
             className="flex-nowrap bg-background/80 dark:bg-card/70 ring-1 ring-border/50 backdrop-blur-md"
@@ -164,7 +159,7 @@ export function AnalysisView({
           <AnalysisEmptyState hasAccounts={hasAccounts} />
         ) : (
           <motion.div
-            key={range}
+            key={activeRange}
             initial={{ opacity: 0, y: 4 }}
             animate={{ opacity: 1, y: 0 }}
             transition={rangeFadeTransition}

--- a/src/components/analysis/analysis-view.tsx
+++ b/src/components/analysis/analysis-view.tsx
@@ -17,8 +17,8 @@ import type { InvestmentCostBasisSummary } from "@/lib/services/analysis-service
 import type { AnalysisPayloadMeta, AnalysisRangeSeries } from "@/lib/analysis-contract";
 import {
   ANALYSIS_RANGES,
+  ANALYSIS_RANGE_LABELS,
   getMessageKeyForRange,
-  resolveActiveRange,
   type RangeLabel,
 } from "@/lib/analysis-range";
 import {
@@ -68,22 +68,27 @@ export function AnalysisView({
   // lays them side-by-side, where the wider gap matches the column rhythm.
   const gridGapClass = isCompact ? "gap-3" : "gap-4 xl:gap-6";
   const stackGapClass = isCompact ? "space-y-3" : "space-y-6";
-  const [range, setRange] = usePersistedRange<RangeLabel>("analysis-view", meta.defaultRange);
+  const [range, setRange] = usePersistedRange<RangeLabel>(
+    "analysis-view",
+    meta.defaultRange,
+    ANALYSIS_RANGE_LABELS,
+  );
   const shouldReduceMotion = useReducedMotion();
   const rangeFadeTransition = shouldReduceMotion
     ? { duration: 0 }
     : { duration: 0.22, ease: [0.16, 1, 0.3, 1] as const };
 
-  const activeRange = resolveActiveRange(range, meta.defaultRange);
   const rangeOptions: SegmentedOption<RangeLabel>[] = ANALYSIS_RANGES.map((r) => ({
     value: r.label,
     label: t(r.messageKey),
   }));
-  const activeRangeLabel = t(getMessageKeyForRange(activeRange));
+  const activeRangeLabel = t(getMessageKeyForRange(range));
 
   // All series are precomputed on the server per range; switching ranges is an
-  // O(1) lookup into the payload (the fade below animates the swap).
-  const series = seriesByRange[activeRange];
+  // O(1) lookup into the payload (the fade below animates the swap). A stale
+  // sessionStorage label can never land here — usePersistedRange rejects
+  // anything outside ANALYSIS_RANGE_LABELS.
+  const series = seriesByRange[range];
 
   // Not precomputed per range: this is one scan over `snapshots`, which is
   // shipped in full for HistoryView anyway. Five server-side copies would cost
@@ -147,7 +152,7 @@ export function AnalysisView({
             variant="pill"
             size="sm"
             options={rangeOptions}
-            value={activeRange}
+            value={range}
             onValueChange={setRange}
             aria-label={t("title")}
             className="flex-nowrap bg-background/80 dark:bg-card/70 ring-1 ring-border/50 backdrop-blur-md"
@@ -159,7 +164,7 @@ export function AnalysisView({
           <AnalysisEmptyState hasAccounts={hasAccounts} />
         ) : (
           <motion.div
-            key={activeRange}
+            key={range}
             initial={{ opacity: 0, y: 4 }}
             animate={{ opacity: 1, y: 0 }}
             transition={rangeFadeTransition}

--- a/src/components/analysis/cashflow-chart.tsx
+++ b/src/components/analysis/cashflow-chart.tsx
@@ -11,12 +11,13 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartEmptyState } from "./chart-empty-state";
 import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick, getMonthTickInterval } from "@/lib/chart-formatters";
+import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import type { CashFlowBucket } from "@/lib/services/analysis-service";
@@ -30,7 +31,7 @@ interface Props {
 }
 
 interface TooltipPayload {
-  payload: CashFlowBucket;
+  payload: CashFlowBucket & { label: string; deltaLine: number | null };
   dataKey: string;
   value: number;
   color: string;
@@ -100,6 +101,7 @@ const cashflowConfig = {} satisfies ChartConfig;
 
 export const CashFlowChart = memo(function CashFlowChart({ buckets, baseCurrency }: Props) {
   const t = useTranslations("analysis");
+  const locale = useLocale();
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const chartHeight = density === "compact" ? 180 : 200;
@@ -111,8 +113,13 @@ export const CashFlowChart = memo(function CashFlowChart({ buckets, baseCurrency
 
   // Break the net-delta line on padded months instead of dragging it to zero.
   const chartData = useMemo(
-    () => buckets.map((b) => ({ ...b, deltaLine: b.isEmpty ? null : b.deltaNetWorth })),
-    [buckets],
+    () =>
+      buckets.map((b) => ({
+        ...b,
+        label: formatMonthLabel(b.monthKey, locale),
+        deltaLine: b.isEmpty ? null : b.deltaNetWorth,
+      })),
+    [buckets, locale],
   );
 
   return (

--- a/src/components/analysis/cumulative-growth-chart.tsx
+++ b/src/components/analysis/cumulative-growth-chart.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { memo, useEffect, useState, startTransition } from "react";
+import { memo, useEffect, useMemo, useState, startTransition } from "react";
 import { Area, CartesianGrid, ComposedChart, Line, ReferenceLine, XAxis, YAxis } from "recharts";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartEmptyState } from "./chart-empty-state";
 import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { formatCurrency } from "@/lib/currencies";
 import { formatChartTick, getMonthTickInterval } from "@/lib/chart-formatters";
+import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
@@ -21,7 +22,7 @@ interface Props {
 }
 
 interface TooltipPayload {
-  payload: CumulativeGrowthPoint;
+  payload: CumulativeGrowthPoint & { label: string };
 }
 
 function GrowthTooltip({
@@ -95,6 +96,7 @@ export const CumulativeGrowthChart = memo(function CumulativeGrowthChart({
   baseCurrency,
 }: Props) {
   const t = useTranslations("analysis");
+  const locale = useLocale();
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const chartHeight = density === "compact" ? 180 : 200;
@@ -103,6 +105,10 @@ export const CumulativeGrowthChart = memo(function CumulativeGrowthChart({
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
   useEffect(() => startTransition(() => setMounted(true)), []);
   const xAxisInterval = getMonthTickInterval(points.length, density === "compact" ? 5 : 6);
+  const chartData = useMemo(
+    () => points.map((p) => ({ ...p, label: formatMonthLabel(p.monthKey, locale) })),
+    [points, locale],
+  );
 
   return (
     <>
@@ -161,7 +167,7 @@ export const CumulativeGrowthChart = memo(function CumulativeGrowthChart({
                 initialDimension={{ width: 1, height: chartHeight }}
               >
                 <ComposedChart
-                  data={points}
+                  data={chartData}
                   stackOffset="sign"
                   margin={{ top: 8, right: 4, left: 0, bottom: 12 }}
                   {...crosshairHandlers}

--- a/src/components/analysis/return-trend-chart.tsx
+++ b/src/components/analysis/return-trend-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useEffect, useState, startTransition } from "react";
+import { memo, useEffect, useMemo, useState, startTransition } from "react";
 import {
   Bar,
   CartesianGrid,
@@ -11,11 +11,12 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartEmptyState } from "./chart-empty-state";
 import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/ui/chart";
 import { getMonthTickInterval } from "@/lib/chart-formatters";
+import { formatMonthLabel } from "@/lib/services/analysis-service";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
 import { useDensity } from "@/components/layout/density-context";
 import { useChartAnimation } from "@/hooks/use-chart-animation";
@@ -28,7 +29,7 @@ interface Props {
 }
 
 interface TooltipPayload {
-  payload: ReturnTrendPoint;
+  payload: ReturnTrendPoint & { label: string };
 }
 
 const formatPct = (v: number) => `${v >= 0 ? "+" : ""}${(v * 100).toFixed(1)}%`;
@@ -85,6 +86,7 @@ const returnConfig = {} satisfies ChartConfig;
 
 export const ReturnTrendChart = memo(function ReturnTrendChart({ points }: Props) {
   const t = useTranslations("analysis");
+  const locale = useLocale();
   const { privacyMode } = usePrivacyMode();
   const { density } = useDensity();
   const chartHeight = density === "compact" ? 180 : 200;
@@ -95,6 +97,10 @@ export const ReturnTrendChart = memo(function ReturnTrendChart({ points }: Props
   const xAxisInterval = getMonthTickInterval(points.length, density === "compact" ? 5 : 6);
 
   const hasData = points.some((p) => p.monthlyReturn !== null);
+  const chartData = useMemo(
+    () => points.map((p) => ({ ...p, label: formatMonthLabel(p.monthKey, locale) })),
+    [points, locale],
+  );
 
   return (
     <>
@@ -143,7 +149,7 @@ export const ReturnTrendChart = memo(function ReturnTrendChart({ points }: Props
                 initialDimension={{ width: 1, height: chartHeight }}
               >
                 <ComposedChart
-                  data={points}
+                  data={chartData}
                   margin={{ top: 8, right: 4, left: 0, bottom: 12 }}
                   {...crosshairHandlers}
                 >

--- a/src/components/dashboard/trend-chart-utils.ts
+++ b/src/components/dashboard/trend-chart-utils.ts
@@ -17,6 +17,9 @@ export const TREND_RANGES: TrendRange[] = [
  */
 export const DEFAULT_TREND_RANGE = "3M";
 
+/** Allow-list for the persisted range (see usePersistedRange). */
+export const TREND_RANGE_LABELS: readonly string[] = TREND_RANGES.map((r) => r.label);
+
 /**
  * Find the chart point matching an externally-driven active date (e.g. a
  * hovered heatmap cell). Returns undefined when there is no active date or no

--- a/src/components/dashboard/trend-chart.tsx
+++ b/src/components/dashboard/trend-chart.tsx
@@ -31,6 +31,7 @@ import { useActiveDate } from "@/components/history/active-day-context";
 import {
   DEFAULT_TREND_RANGE,
   TREND_RANGES,
+  TREND_RANGE_LABELS,
   findChartPoint,
 } from "@/components/dashboard/trend-chart-utils";
 
@@ -44,6 +45,9 @@ type SnapshotData = {
 };
 
 type ChartDataPoint = SnapshotData & { netWorthPct?: number };
+
+const PCT_MODES = ["off", "on"] as const;
+type PctMode = (typeof PCT_MODES)[number];
 
 function TrendTooltip({
   active,
@@ -166,8 +170,12 @@ export function TrendChart({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width: containerWidth, height: containerHeight } = useContainerSize(containerRef);
-  const [range, setRange] = usePersistedRange<string>("trend-chart", DEFAULT_TREND_RANGE);
-  const [pctMode, setPctMode] = usePersistedRange<string>("trend-pct-mode", "off");
+  const [range, setRange] = usePersistedRange<string>(
+    "trend-chart",
+    DEFAULT_TREND_RANGE,
+    TREND_RANGE_LABELS,
+  );
+  const [pctMode, setPctMode] = usePersistedRange<PctMode>("trend-pct-mode", "off", PCT_MODES);
   const t = useTranslations("trendChart");
   const { privacyMode } = usePrivacyMode();
   const { isAnimationActive, onAnimationEnd } = useChartAnimation();
@@ -177,6 +185,7 @@ export function TrendChart({
     ? { duration: 0 }
     : { duration: 0.18, ease: [0.16, 1, 0.3, 1] as const };
 
+  // Safe: usePersistedRange only ever returns a label from TREND_RANGE_LABELS.
   const selectedRange = TREND_RANGES.find((r) => r.label === range)!;
   const isPercentMode = pctMode === "on";
   const currencySymbol = getCurrencySymbol(baseCurrency);
@@ -342,7 +351,7 @@ export function TrendChart({
                 { value: "off", label: currencySymbol, title: t("absToggleTitle") },
                 { value: "on", label: "%", title: t("pctToggleTitle") },
               ]}
-              value={pctMode === "on" ? "on" : "off"}
+              value={pctMode}
               onValueChange={setPctMode}
               aria-label={t("valueModeLabel")}
               className="gap-0 bg-muted p-0.5"

--- a/src/hooks/use-persisted-range.ts
+++ b/src/hooks/use-persisted-range.ts
@@ -2,7 +2,25 @@
 
 import { useState, useEffect, startTransition } from "react";
 
-export function usePersistedRange<T extends string>(key: string, initialValue: T) {
+/**
+ * sessionStorage survives a deploy, so a stored value can name an option that
+ * the current build no longer offers. Validate here rather than at each call
+ * site: a consumer that forgets (`OPTIONS.find(...)!`) takes its whole route
+ * down on an unknown label.
+ */
+export function resolvePersistedRange<T extends string>(
+  stored: string | null,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return stored !== null && allowed.includes(stored as T) ? (stored as T) : fallback;
+}
+
+export function usePersistedRange<T extends string>(
+  key: string,
+  initialValue: T,
+  allowed: readonly T[],
+) {
   const [range, setRange] = useState<T>(initialValue);
   const [mounted, setMounted] = useState(false);
 
@@ -10,10 +28,11 @@ export function usePersistedRange<T extends string>(key: string, initialValue: T
     startTransition(() => {
       setMounted(true);
       const stored = sessionStorage.getItem(`asset-tracker:range:${key}`);
-      if (stored) {
-        setRange(stored as T);
-      }
+      setRange(resolvePersistedRange(stored, allowed, initialValue));
     });
+    // `allowed`/`initialValue` are read once on mount; re-running on a new
+    // array identity would clobber a range the user just picked.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 
   const setPersistedRange = (newRange: T) => {

--- a/src/lib/analysis-contract.ts
+++ b/src/lib/analysis-contract.ts
@@ -1,0 +1,36 @@
+import type {
+  MonthlyBucket,
+  AnalysisKpis,
+  CashFlowBucket,
+  CumulativeGrowthPoint,
+  CategoryDataPoint,
+  AttributionItem,
+  ReturnTrendPoint,
+} from "@/lib/services/analysis-service";
+import type { NormalizedSnapshot } from "@/lib/services/history-service";
+import type { InvestmentCostBasisSummary } from "@/lib/services/analysis-service";
+import type { RangeLabel } from "@/lib/analysis-range";
+
+export interface AnalysisRangeSeries {
+  buckets: MonthlyBucket[];
+  kpis: AnalysisKpis;
+  cashFlowBuckets: CashFlowBucket[];
+  cumulativeGrowth: CumulativeGrowthPoint[];
+  categoryHistory: CategoryDataPoint[];
+  attributionItems: AttributionItem[];
+  investmentReturnPct: number | null;
+  returnTrend: ReturnTrendPoint[];
+  rangeStartIso: string;
+}
+
+export interface AnalysisPayloadMeta {
+  defaultRange: RangeLabel;
+}
+
+export interface AnalysisPayload {
+  seriesByRange: Record<RangeLabel, AnalysisRangeSeries>;
+  investmentCostBasis: InvestmentCostBasisSummary;
+  /** Full normalized history — used by the mobile #history tab (HistoryView). */
+  snapshots: NormalizedSnapshot[];
+  meta: AnalysisPayloadMeta;
+}

--- a/src/lib/analysis-range.ts
+++ b/src/lib/analysis-range.ts
@@ -62,17 +62,27 @@ export function resolveAnalysisRange<T extends { date: string }>(
 }
 
 export const ANALYSIS_RANGES = [
-  { label: "YTD", months: 0 },
-  { label: "6M", months: 6 },
-  { label: "1Y", months: 12 },
-  { label: "2Y", months: 24 },
-  { label: "All", months: Infinity },
+  { label: "YTD", months: 0, messageKey: "rangeYTD" },
+  { label: "6M", months: 6, messageKey: "range6M" },
+  { label: "1Y", months: 12, messageKey: "range1Y" },
+  { label: "2Y", months: 24, messageKey: "range2Y" },
+  { label: "All", months: Infinity, messageKey: "rangeAll" },
 ] as const;
 
 export type RangeLabel = (typeof ANALYSIS_RANGES)[number]["label"];
 
 export function getMonthsForRange(label: RangeLabel): number {
   return ANALYSIS_RANGES.find((r) => r.label === label)!.months;
+}
+
+export function getMessageKeyForRange(label: RangeLabel): string {
+  return (
+    ANALYSIS_RANGES.find((r) => r.label === label)?.messageKey ?? ANALYSIS_RANGES[0].messageKey
+  );
+}
+
+export function resolveActiveRange(stored: string, fallback: RangeLabel): RangeLabel {
+  return ANALYSIS_RANGES.find((r) => r.label === stored)?.label ?? fallback;
 }
 
 /**

--- a/src/lib/analysis-range.ts
+++ b/src/lib/analysis-range.ts
@@ -71,6 +71,9 @@ export const ANALYSIS_RANGES = [
 
 export type RangeLabel = (typeof ANALYSIS_RANGES)[number]["label"];
 
+/** Allow-list for the persisted range (see usePersistedRange). */
+export const ANALYSIS_RANGE_LABELS: readonly RangeLabel[] = ANALYSIS_RANGES.map((r) => r.label);
+
 export function getMonthsForRange(label: RangeLabel): number {
   return ANALYSIS_RANGES.find((r) => r.label === label)!.months;
 }
@@ -79,10 +82,6 @@ export function getMessageKeyForRange(label: RangeLabel): string {
   return (
     ANALYSIS_RANGES.find((r) => r.label === label)?.messageKey ?? ANALYSIS_RANGES[0].messageKey
   );
-}
-
-export function resolveActiveRange(stored: string, fallback: RangeLabel): RangeLabel {
-  return ANALYSIS_RANGES.find((r) => r.label === stored)?.label ?? fallback;
 }
 
 /**

--- a/src/lib/services/analysis-payload-service.ts
+++ b/src/lib/services/analysis-payload-service.ts
@@ -5,34 +5,15 @@ import {
   getFullNormalizedHistory,
   getMonthlyCashFlow,
   getRawHistoryWithBreakdown,
-  type NormalizedSnapshot,
 } from "@/lib/services/history-service";
 import { getInvestmentCostBasisSummary } from "@/lib/services/investment-cost-basis-service";
-import {
-  computeAllRangeSeries,
-  type AnalysisRangeSeries,
-} from "@/lib/services/analysis-series-service";
-import { pickDefaultRange, type RangeLabel } from "@/components/analysis/analysis-range";
-import type { InvestmentCostBasisSummary } from "@/lib/services/analysis-service";
-
-export interface AnalysisPayloadMeta {
-  hasSnapshots: boolean;
-  latestSnapshotAt: string | null;
-  defaultRange: RangeLabel;
-}
-
-export interface AnalysisPayload {
-  seriesByRange: Record<RangeLabel, AnalysisRangeSeries>;
-  investmentCostBasis: InvestmentCostBasisSummary;
-  /** Full normalized history — used by the mobile #history tab (HistoryView). */
-  snapshots: NormalizedSnapshot[];
-  meta: AnalysisPayloadMeta;
-}
+import { computeAllRangeSeries } from "@/lib/services/analysis-series-service";
+import { pickDefaultRange } from "@/lib/analysis-range";
+import type { AnalysisPayload, AnalysisPayloadMeta } from "@/lib/analysis-contract";
 
 export async function getCachedAnalysisPayload(
   userId: string,
   baseCurrency: string,
-  locale: string,
 ): Promise<AnalysisPayload> {
   return unstable_cache(
     async () => {
@@ -55,19 +36,16 @@ export async function getCachedAnalysisPayload(
           rawHistory,
           cashFlowData,
           accountCashFlow,
-          locale,
           now,
         ),
         investmentCostBasis,
         snapshots,
         meta: {
-          hasSnapshots: snapshots.length > 0,
-          latestSnapshotAt: snapshots.at(-1)?.createdAt ?? null,
           defaultRange: pickDefaultRange(snapshots, now),
-        },
+        } satisfies AnalysisPayloadMeta,
       };
     },
-    ["analysis-payload", userId, baseCurrency, locale],
+    ["analysis-payload", userId, baseCurrency],
     {
       revalidate: 300,
       // All bundled reads convert at current FX (getAllExchangeRates +

--- a/src/lib/services/analysis-series-service.ts
+++ b/src/lib/services/analysis-series-service.ts
@@ -4,7 +4,7 @@ import {
   getMonthsForRange,
   resolveAnalysisRange,
   type RangeLabel,
-} from "@/components/analysis/analysis-range";
+} from "@/lib/analysis-range";
 import {
   aggregateMonthlyChange,
   fillMonthRange,
@@ -15,13 +15,7 @@ import {
   computePerformanceAttribution,
   computeInvestmentReturn,
   computeInvestmentReturnSeries,
-  type MonthlyBucket,
-  type AnalysisKpis,
-  type CashFlowBucket,
-  type CumulativeGrowthPoint,
   type CategoryDataPoint,
-  type AttributionItem,
-  type ReturnTrendPoint,
   type MonthlyContribution,
 } from "@/lib/services/analysis-service";
 import type {
@@ -29,18 +23,7 @@ import type {
   RawHistoryData,
   AccountMonthlyContribution,
 } from "@/lib/services/history-service";
-
-export interface AnalysisRangeSeries {
-  buckets: MonthlyBucket[];
-  kpis: AnalysisKpis;
-  cashFlowBuckets: CashFlowBucket[];
-  cumulativeGrowth: CumulativeGrowthPoint[];
-  categoryHistory: CategoryDataPoint[];
-  attributionItems: AttributionItem[];
-  investmentReturnPct: number | null;
-  returnTrend: ReturnTrendPoint[];
-  rangeStartIso: string;
-}
+import type { AnalysisRangeSeries } from "@/lib/analysis-contract";
 
 /**
  * Replicates the former client-side AnalysisView useMemo chain exactly, per
@@ -59,7 +42,6 @@ export function computeAnalysisRangeSeries(
   cashFlowData: MonthlyContribution[],
   accountCashFlow: AccountMonthlyContribution[],
   rangeLabel: RangeLabel,
-  locale: string,
   now = new Date(),
 ): AnalysisRangeSeries {
   const { filteredSnapshots, rangeStart, rangeEnd, rangeStartIso } = resolveAnalysisRange(
@@ -74,7 +56,6 @@ export function computeAnalysisRangeSeries(
   const cashFlowBuckets = buildCashFlowBuckets(
     buckets,
     cashFlowData.filter((c) => c.monthKey >= rangeStartIso.slice(0, 7)),
-    locale,
   );
   const cumulativeGrowth = buildCumulativeGrowth(cashFlowBuckets);
 
@@ -106,7 +87,6 @@ export function computeAnalysisRangeSeries(
     rawHistory.accounts,
     accountCashFlow,
     buckets.map((b) => b.monthKey),
-    locale,
   );
 
   return {
@@ -127,7 +107,6 @@ export function computeAllRangeSeries(
   rawHistory: RawHistoryData,
   cashFlowData: MonthlyContribution[],
   accountCashFlow: AccountMonthlyContribution[],
-  locale: string,
   now = new Date(),
 ): Record<RangeLabel, AnalysisRangeSeries> {
   const result = {} as Record<RangeLabel, AnalysisRangeSeries>;
@@ -138,7 +117,6 @@ export function computeAllRangeSeries(
       cashFlowData,
       accountCashFlow,
       label,
-      locale,
       now,
     );
   }

--- a/src/lib/services/analysis-service.ts
+++ b/src/lib/services/analysis-service.ts
@@ -229,8 +229,6 @@ export interface MonthlyContribution {
 export interface CashFlowBucket {
   /** "YYYY-MM" */
   monthKey: string;
-  /** Human-readable label (set by the caller via formatMonthLabel). */
-  label: string;
   /** Net cash deposits/withdrawals in baseCurrency. */
   contributions: number;
   /** deltaNetWorth − contributions: value created/destroyed by market movement. */
@@ -261,12 +259,10 @@ export interface CategoryDataPoint {
  *
  * @param buckets  Output of fillMonthRange() (padded, sorted asc).
  * @param contributions  Output of getMonthlyCashFlow() from history-service.ts.
- * @param locale   For formatMonthLabel.
  */
 export function buildCashFlowBuckets(
   buckets: MonthlyBucket[],
   contributions: MonthlyContribution[],
-  locale: string,
 ): CashFlowBucket[] {
   const contribMap = new Map(contributions.map((c) => [c.monthKey, c.contributions]));
 
@@ -274,7 +270,6 @@ export function buildCashFlowBuckets(
     const contrib = b.isEmpty ? 0 : (contribMap.get(b.monthKey) ?? 0);
     return {
       monthKey: b.monthKey,
-      label: formatMonthLabel(b.monthKey, locale),
       contributions: contrib,
       marketPerformance: b.deltaNetWorth - contrib,
       deltaNetWorth: b.deltaNetWorth,
@@ -287,8 +282,6 @@ export function buildCashFlowBuckets(
 export interface CumulativeGrowthPoint {
   /** "YYYY-MM" */
   monthKey: string;
-  /** Human-readable label (carried from the source CashFlowBucket). */
-  label: string;
   /** Running total of net cash deposited/withdrawn since the range start. */
   cumulativeContributions: number;
   /** Running total of market gains/losses since the range start. */
@@ -313,7 +306,6 @@ export function buildCumulativeGrowth(buckets: CashFlowBucket[]): CumulativeGrow
     market += b.marketPerformance;
     return {
       monthKey: b.monthKey,
-      label: b.label,
       cumulativeContributions: contrib,
       cumulativeMarket: market,
       cumulativeTotal: contrib + market,
@@ -620,8 +612,6 @@ export function computeInvestmentReturn(
 export interface ReturnTrendPoint {
   /** YYYY-MM. */
   monthKey: string;
-  /** Locale-formatted month label for the X axis. */
-  label: string;
   /** Half-weight Dietz return for the month as a fraction; null when the month is empty or its base ≤ 0. */
   monthlyReturn: number | null;
   /** Π(1 + rᵢ) − 1 over non-null months so far; null until the first computable month, carried forward through gaps. */
@@ -649,7 +639,6 @@ export function computeInvestmentReturnSeries(
   accounts: AccountMeta[],
   accountCashFlows: AccountMonthlyContribution[],
   monthKeys: string[],
-  locale = "en-US",
 ): ReturnTrendPoint[] {
   if (snapshots.length < 2) return [];
 
@@ -684,11 +673,10 @@ export function computeInvestmentReturnSeries(
   let index: number | null = null;
   let pendingCash = 0;
   return monthKeys.map((monthKey) => {
-    const label = formatMonthLabel(monthKey, locale);
     const endSnap = monthLast.get(monthKey);
     if (!endSnap) {
       if (prevEnd !== null) pendingCash += cashByMonth.get(monthKey) ?? 0;
-      return { monthKey, label, monthlyReturn: null, cumulativeReturn: index, isEmpty: true };
+      return { monthKey, monthlyReturn: null, cumulativeReturn: index, isEmpty: true };
     }
     const start = prevEnd ?? investmentValue(monthFirst.get(monthKey)!);
     const end = investmentValue(endSnap);
@@ -697,11 +685,11 @@ export function computeInvestmentReturnSeries(
     prevEnd = end;
     const base = start + cash / 2;
     if (base <= 0) {
-      return { monthKey, label, monthlyReturn: null, cumulativeReturn: index };
+      return { monthKey, monthlyReturn: null, cumulativeReturn: index };
     }
     const r = (end - start - cash) / base;
     index = index === null ? r : (1 + index) * (1 + r) - 1;
-    return { monthKey, label, monthlyReturn: r, cumulativeReturn: index };
+    return { monthKey, monthlyReturn: r, cumulativeReturn: index };
   });
 }
 

--- a/tests/e2e/analysis-empty.spec.ts
+++ b/tests/e2e/analysis-empty.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import {
+  authenticateAnalysisFixture,
+  cleanupAnalysisEmptyFixture,
+  hasAnalysisFixtureDatabase,
+  seedAnalysisEmptyFixture,
+  setAnalysisFixtureLocale,
+} from "./analysis-fixture";
+
+test("analysis renders the onboarding empty state for a user with no snapshots", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Analysis empty-state QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Empty Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisEmptyFixture();
+
+  try {
+    await authenticateAnalysisFixture(page.context(), fixture);
+    await setAnalysisFixtureLocale(page.context(), "en-US");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/analysis");
+    const emptyStateHeading = page.locator("h2:visible").filter({
+      hasText: /^Build the base for real analysis$/,
+    });
+    await expect(emptyStateHeading).toHaveCount(1, {
+      timeout: 20_000,
+    });
+    await expect(page.getByRole("link", { name: "Add account" }).first()).toBeVisible();
+    await expect(page.getByText(/Snapshot /)).toHaveCount(0);
+  } finally {
+    await cleanupAnalysisEmptyFixture(fixture);
+  }
+});

--- a/tests/e2e/analysis-fixture-auth.ts
+++ b/tests/e2e/analysis-fixture-auth.ts
@@ -1,0 +1,59 @@
+import type { BrowserContext } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+import type { AnalysisFixture } from "./analysis-fixture";
+
+export function resolveAnalysisFixtureBaseUrl(baseUrl: string, trustedOrigin?: string): string {
+  const target = new URL(baseUrl);
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    throw new Error("Analysis fixture targets must use HTTP or HTTPS.");
+  }
+
+  const normalizedTarget = target.origin;
+  const isLoopback = target.hostname === "localhost" || target.hostname === "127.0.0.1";
+  if (!isLoopback && target.protocol !== "https:") {
+    throw new Error("Remote Analysis fixture targets must use HTTPS.");
+  }
+
+  if (trustedOrigin !== undefined && new URL(trustedOrigin).origin !== normalizedTarget) {
+    throw new Error("Analysis fixture target must match the configured application origin.");
+  }
+
+  if (!isLoopback && trustedOrigin === undefined) {
+    throw new Error("Remote Analysis fixture targets require a configured application origin.");
+  }
+
+  return normalizedTarget;
+}
+
+function analysisFixtureBaseUrl(): string {
+  const targetUrl = process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3000";
+  const trustedOrigin =
+    process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL;
+  return resolveAnalysisFixtureBaseUrl(targetUrl, trustedOrigin);
+}
+
+export async function setAnalysisFixtureLocale(
+  context: BrowserContext,
+  locale: string,
+): Promise<void> {
+  await context.addCookies([{ name: "NEXT_LOCALE", value: locale, url: analysisFixtureBaseUrl() }]);
+}
+
+export async function authenticateAnalysisFixture(
+  context: BrowserContext,
+  fixture: AnalysisFixture,
+): Promise<void> {
+  const baseUrl = analysisFixtureBaseUrl();
+  const secureCookie = baseUrl.startsWith("https://");
+  const cookieName = secureCookie ? "__Secure-authjs.session-token" : "authjs.session-token";
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) throw new Error("AUTH_SECRET is required to authenticate the E2E fixture user.");
+
+  const sessionToken = await encode({
+    token: { sub: fixture.userId, email: fixture.email, name: "E2E Test User" },
+    secret,
+    salt: cookieName,
+  });
+
+  await context.addCookies([{ name: cookieName, value: sessionToken, url: baseUrl }]);
+}

--- a/tests/e2e/analysis-fixture.ts
+++ b/tests/e2e/analysis-fixture.ts
@@ -1,8 +1,16 @@
 import { loadEnvConfig } from "@next/env";
 import pg from "pg";
 import { randomUUID } from "node:crypto";
+import { taiwanCalendarDay } from "@/lib/app-day";
+export {
+  authenticateAnalysisFixture,
+  resolveAnalysisFixtureBaseUrl,
+  setAnalysisFixtureLocale,
+} from "./analysis-fixture-auth";
 
-const E2E_EMAIL = "e2e-test@preview.local";
+const E2E_EMAIL = "e2e-analysis-populated@preview.local";
+const E2E_EMPTY_EMAIL = "e2e-empty@preview.local";
+export const E2E_MOBILE_EMAIL = "e2e-mobile@preview.local";
 const FIXTURE_PREFIX = "E2E Analysis QA";
 const BASE_CURRENCY = "USD";
 const MONTH_COUNT = 18;
@@ -39,15 +47,25 @@ function fixtureMonths() {
   return Array.from({ length: MONTH_COUNT }, (_, index) => addMonths(firstMonth, index));
 }
 
-interface AnalysisFixture {
-  snapshotDates: string[];
+export interface AnalysisFixture {
+  readonly email: string;
+  readonly expectedDefaultRange: "6M" | "YTD";
+  readonly userId: string;
+  readonly snapshotDates: readonly string[];
 }
 
 function toDateKey(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-async function getOrCreateE2eUser(pool: pg.Pool) {
+function expectedDefaultRange(snapshotDates: readonly string[]): "6M" | "YTD" {
+  if (snapshotDates.length <= 6) {
+    throw new Error("Analysis fixture must contain more than six monthly snapshots.");
+  }
+  return taiwanCalendarDay(new Date()).getUTCMonth() < 3 ? "6M" : "YTD";
+}
+
+async function getOrCreateE2eUser(pool: pg.Pool, email: string) {
   const userId = randomUUID();
   const user = await pool.query<{ id: string }>(
     `
@@ -56,7 +74,7 @@ async function getOrCreateE2eUser(pool: pg.Pool) {
       ON CONFLICT ("email") DO UPDATE SET "name" = COALESCE("User"."name", EXCLUDED."name")
       RETURNING "id"
     `,
-    [userId, E2E_EMAIL, "E2E Test User"],
+    [userId, email, "E2E Test User"],
   );
   const id = user.rows[0].id;
 
@@ -75,7 +93,7 @@ async function getOrCreateE2eUser(pool: pg.Pool) {
   return { id };
 }
 
-async function removeFixtureData(pool: pg.Pool, userId: string, snapshotDates: string[]) {
+async function removeFixtureData(pool: pg.Pool, userId: string, snapshotDates: readonly string[]) {
   await pool.query(`DELETE FROM "Account" WHERE "userId" = $1 AND "name" LIKE $2`, [
     userId,
     `${FIXTURE_PREFIX}%`,
@@ -86,12 +104,19 @@ async function removeFixtureData(pool: pg.Pool, userId: string, snapshotDates: s
   );
 }
 
-export async function seedAnalysisFixture(): Promise<AnalysisFixture> {
+async function deleteFixtureUser(pool: pg.Pool, fixture: AnalysisFixture): Promise<void> {
+  await pool.query(`DELETE FROM "User" WHERE "id" = $1 AND "email" = $2`, [
+    fixture.userId,
+    fixture.email,
+  ]);
+}
+
+export async function seedAnalysisFixture(email = E2E_EMAIL): Promise<AnalysisFixture> {
   const pool = createDbPool();
   const snapshotDates = fixtureMonths().map(toDateKey);
 
   try {
-    const user = await getOrCreateE2eUser(pool);
+    const user = await getOrCreateE2eUser(pool, email);
     await removeFixtureData(pool, user.id, snapshotDates);
 
     const accountInputs = [
@@ -196,7 +221,12 @@ export async function seedAnalysisFixture(): Promise<AnalysisFixture> {
       );
     }
 
-    return { snapshotDates };
+    return {
+      email,
+      expectedDefaultRange: expectedDefaultRange(snapshotDates),
+      userId: user.id,
+      snapshotDates,
+    };
   } finally {
     await pool.end();
   }
@@ -205,12 +235,32 @@ export async function seedAnalysisFixture(): Promise<AnalysisFixture> {
 export async function cleanupAnalysisFixture(fixture: AnalysisFixture) {
   const pool = createDbPool();
   try {
-    const user = await pool.query<{ id: string }>(`SELECT "id" FROM "User" WHERE "email" = $1`, [
-      E2E_EMAIL,
-    ]);
-    const userId = user.rows[0]?.id;
-    if (!userId) return;
-    await removeFixtureData(pool, userId, fixture.snapshotDates);
+    await deleteFixtureUser(pool, fixture);
+  } finally {
+    await pool.end();
+  }
+}
+
+export async function seedAnalysisEmptyFixture(): Promise<AnalysisFixture> {
+  const pool = createDbPool();
+  try {
+    const user = await getOrCreateE2eUser(pool, E2E_EMPTY_EMAIL);
+    await removeFixtureData(pool, user.id, []);
+    return {
+      email: E2E_EMPTY_EMAIL,
+      expectedDefaultRange: "YTD",
+      userId: user.id,
+      snapshotDates: [],
+    };
+  } finally {
+    await pool.end();
+  }
+}
+
+export async function cleanupAnalysisEmptyFixture(fixture: AnalysisFixture) {
+  const pool = createDbPool();
+  try {
+    await deleteFixtureUser(pool, fixture);
   } finally {
     await pool.end();
   }

--- a/tests/e2e/analysis-history-mobile.spec.ts
+++ b/tests/e2e/analysis-history-mobile.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import {
+  authenticateAnalysisFixture,
+  cleanupAnalysisFixture,
+  E2E_MOBILE_EMAIL,
+  hasAnalysisFixtureDatabase,
+  seedAnalysisFixture,
+} from "./analysis-fixture";
+
+test("analysis #history deep link still renders HistoryView on mobile", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "Mobile Chrome", "Mobile-only #history tab.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture(E2E_MOBILE_EMAIL);
+
+  try {
+    await authenticateAnalysisFixture(page.context(), fixture);
+    await page.goto("/analysis#history");
+    await expect(page.getByText("All Snapshots")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("table")).toBeVisible();
+    await expect(page.getByText("Net Worth Trend")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^Movement/ })).toHaveCount(0);
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});

--- a/tests/e2e/analysis-populated.spec.ts
+++ b/tests/e2e/analysis-populated.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "@playwright/test";
 import {
   cleanupAnalysisFixture,
+  authenticateAnalysisFixture,
   hasAnalysisFixtureDatabase,
   seedAnalysisFixture,
+  setAnalysisFixtureLocale,
 } from "./analysis-fixture";
+
+test.describe.configure({ mode: "serial" });
 
 test("analysis renders populated desktop charts without layout overflow", async ({
   page,
@@ -14,6 +18,7 @@ test("analysis renders populated desktop charts without layout overflow", async 
   const fixture = await seedAnalysisFixture();
 
   try {
+    await authenticateAnalysisFixture(page.context(), fixture);
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto("/analysis");
 
@@ -29,6 +34,11 @@ test("analysis renders populated desktop charts without layout overflow", async 
 
     await page.getByRole("button", { name: "All", exact: true }).click();
     await expect(page.getByText("Showing top 5 of 7 categories by latest value.")).toBeVisible();
+    await page.getByRole("button", { name: "YTD", exact: true }).click();
+    await expect(page.getByRole("button", { name: "YTD", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
     const layout = await page.evaluate(() => {
       const documentElement = document.documentElement;
@@ -68,6 +78,105 @@ test("analysis renders populated desktop charts without layout overflow", async 
       body: await page.screenshot({ fullPage: true }),
       contentType: "image/png",
     });
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+
+function oldestMonthLabel(snapshotDates: readonly string[], locale: string): string {
+  const oldestDate = snapshotDates[0];
+  if (!oldestDate) throw new Error("Analysis fixture must contain at least one snapshot date.");
+  return new Intl.DateTimeFormat(locale, { month: "short", year: "numeric" }).format(
+    new Date(`${oldestDate}T00:00:00.000Z`),
+  );
+}
+
+test("analysis falls back to the server default range for an unknown persisted range", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+
+  try {
+    await authenticateAnalysisFixture(page.context(), fixture);
+    await setAnalysisFixtureLocale(page.context(), "en-US");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "BOGUS_RANGE"),
+    );
+    await page.goto("/analysis");
+    await expect(page.getByRole("heading", { name: /^Movement/ })).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByRole("button", { pressed: true })).toHaveCount(1);
+    const pressedName = await page.getByRole("button", { pressed: true }).innerText();
+    expect(pressedName).toBe(fixture.expectedDefaultRange);
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+
+test("renders English month labels from the locale-independent payload", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+
+  try {
+    await authenticateAnalysisFixture(page.context(), fixture);
+    await setAnalysisFixtureLocale(page.context(), "en-US");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
+    );
+    await page.goto("/analysis");
+    const cashFlowCard = page
+      .locator('[data-slot="card"]')
+      .filter({
+        has: page.getByRole("heading", { name: "Cash Flow Decomposition", exact: true }),
+      })
+      .first();
+    await expect(
+      cashFlowCard.getByRole("heading", { name: "Cash Flow Decomposition", exact: true }),
+    ).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      cashFlowCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "en-US"), {
+        exact: true,
+      }),
+    ).toBeVisible();
+  } finally {
+    await cleanupAnalysisFixture(fixture);
+  }
+});
+
+test("renders Traditional Chinese month labels from the same locale-independent payload", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
+  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  const fixture = await seedAnalysisFixture();
+
+  try {
+    await authenticateAnalysisFixture(page.context(), fixture);
+    await setAnalysisFixtureLocale(page.context(), "zh-TW");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() =>
+      sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
+    );
+    await page.goto("/analysis");
+    const cashFlowCard = page
+      .locator('[data-slot="card"]')
+      .filter({ has: page.getByRole("heading", { name: "現金流分解", exact: true }) })
+      .first();
+    await expect(
+      cashFlowCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "zh-TW"), {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: 20_000 });
   } finally {
     await cleanupAnalysisFixture(fixture);
   }

--- a/tests/e2e/analysis-populated.spec.ts
+++ b/tests/e2e/analysis-populated.spec.ts
@@ -117,66 +117,56 @@ test("analysis falls back to the server default range for an unknown persisted r
   }
 });
 
-test("renders English month labels from the locale-independent payload", async ({
-  page,
-}, testInfo) => {
+test("renders both locales' month labels from one cached payload", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
   test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
+  // Both loads run as the same user inside the payload's 300s revalidate
+  // window, so the zh-TW render is served from the entry the en-US render
+  // filled. That shared entry is the point: if any locale-formatted value
+  // creeps back into the payload, the second assertion sees English labels.
+  // Seeding per locale would give each load its own cache key and prove nothing.
   const fixture = await seedAnalysisFixture();
 
   try {
     await authenticateAnalysisFixture(page.context(), fixture);
-    await setAnalysisFixtureLocale(page.context(), "en-US");
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.addInitScript(() =>
       sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
     );
+
+    await setAnalysisFixtureLocale(page.context(), "en-US");
     await page.goto("/analysis");
-    const cashFlowCard = page
+    const englishCard = page
       .locator('[data-slot="card"]')
       .filter({
         has: page.getByRole("heading", { name: "Cash Flow Decomposition", exact: true }),
       })
       .first();
     await expect(
-      cashFlowCard.getByRole("heading", { name: "Cash Flow Decomposition", exact: true }),
-    ).toBeVisible({
-      timeout: 20_000,
-    });
+      englishCard.getByRole("heading", { name: "Cash Flow Decomposition", exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
     await expect(
-      cashFlowCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "en-US"), {
+      englishCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "en-US"), {
         exact: true,
       }),
     ).toBeVisible();
-  } finally {
-    await cleanupAnalysisFixture(fixture);
-  }
-});
 
-test("renders Traditional Chinese month labels from the same locale-independent payload", async ({
-  page,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== "chromium", "Populated Analysis QA is desktop-only.");
-  test.skip(!hasAnalysisFixtureDatabase(), "Populated Analysis QA requires DATABASE_URL.");
-  const fixture = await seedAnalysisFixture();
-
-  try {
-    await authenticateAnalysisFixture(page.context(), fixture);
     await setAnalysisFixtureLocale(page.context(), "zh-TW");
-    await page.setViewportSize({ width: 1440, height: 900 });
-    await page.addInitScript(() =>
-      sessionStorage.setItem("asset-tracker:range:analysis-view", "All"),
-    );
-    await page.goto("/analysis");
-    const cashFlowCard = page
+    await page.reload();
+    const chineseCard = page
       .locator('[data-slot="card"]')
       .filter({ has: page.getByRole("heading", { name: "現金流分解", exact: true }) })
       .first();
     await expect(
-      cashFlowCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "zh-TW"), {
+      chineseCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "zh-TW"), {
         exact: true,
       }),
     ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      chineseCard.locator("svg").getByText(oldestMonthLabel(fixture.snapshotDates, "en-US"), {
+        exact: true,
+      }),
+    ).toHaveCount(0);
   } finally {
     await cleanupAnalysisFixture(fixture);
   }

--- a/tests/unit/analysis-fixture-url-policy.test.ts
+++ b/tests/unit/analysis-fixture-url-policy.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveAnalysisFixtureBaseUrl } from "../e2e/analysis-fixture-auth";
+
+describe("resolveAnalysisFixtureBaseUrl", () => {
+  it("accepts localhost HTTP and returns its normalized origin", () => {
+    // Given a local fixture target with a path
+    const targetUrl = "http://localhost:3000/analysis";
+
+    // When the fixture URL is resolved without a configured remote origin
+    const resolvedUrl = resolveAnalysisFixtureBaseUrl(targetUrl);
+
+    // Then the cookie target is the origin only
+    expect(resolvedUrl).toBe("http://localhost:3000");
+  });
+
+  it("accepts 127.0.0.1 HTTP and returns its normalized origin", () => {
+    // Given a loopback fixture target with a trailing slash
+    const targetUrl = "http://127.0.0.1:3000/";
+
+    // When the fixture URL is resolved without a configured remote origin
+    const resolvedUrl = resolveAnalysisFixtureBaseUrl(targetUrl);
+
+    // Then the cookie target is the origin only
+    expect(resolvedUrl).toBe("http://127.0.0.1:3000");
+  });
+
+  it("accepts matching remote HTTPS and returns its normalized origin", () => {
+    // Given a remote HTTPS target and the matching configured application origin
+    const targetUrl = "https://preview.example.com/analysis?fixture=1";
+    const trustedOrigin = "https://preview.example.com/";
+
+    // When the fixture URL is resolved
+    const resolvedUrl = resolveAnalysisFixtureBaseUrl(targetUrl, trustedOrigin);
+
+    // Then the cookie target is the matching origin only
+    expect(resolvedUrl).toBe("https://preview.example.com");
+  });
+
+  it("rejects remote HTTP targets", () => {
+    // Given a remote plaintext target
+    const targetUrl = "http://preview.example.com/analysis";
+
+    // When the fixture URL is resolved
+    const resolve = () => resolveAnalysisFixtureBaseUrl(targetUrl, targetUrl);
+
+    // Then the fixture refuses to create cookies for it
+    expect(resolve).toThrow("Remote Analysis fixture targets must use HTTPS.");
+  });
+
+  it("rejects a mismatched configured origin", () => {
+    // Given a remote HTTPS target and a different configured application origin
+    const targetUrl = "https://preview.example.com/analysis";
+    const trustedOrigin = "https://other.example.com";
+
+    // When the fixture URL is resolved
+    const resolve = () => resolveAnalysisFixtureBaseUrl(targetUrl, trustedOrigin);
+
+    // Then the fixture refuses to create cookies for the mismatched target
+    expect(resolve).toThrow(
+      "Analysis fixture target must match the configured application origin.",
+    );
+  });
+
+  it("rejects an explicitly mismatched loopback origin", () => {
+    // Given a loopback target and a configured origin for a different loopback host
+    const targetUrl = "http://127.0.0.1:3000/analysis";
+    const trustedOrigin = "http://localhost:3000";
+
+    // When the fixture URL is resolved
+    const resolve = () => resolveAnalysisFixtureBaseUrl(targetUrl, trustedOrigin);
+
+    // Then the fixture refuses to create cookies for the mismatched target
+    expect(resolve).toThrow(
+      "Analysis fixture target must match the configured application origin.",
+    );
+  });
+});

--- a/tests/unit/analysis-payload-service.test.ts
+++ b/tests/unit/analysis-payload-service.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUnstableCache = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  unstable_cache: mockUnstableCache,
+}));
+
+vi.mock("@/lib/services/history-service", () => ({
+  getFullNormalizedHistory: vi.fn(async () => []),
+  getMonthlyCashFlow: vi.fn(async () => []),
+  getRawHistoryWithBreakdown: vi.fn(async () => ({ snapshots: [], accounts: [] })),
+  getAccountMonthlyCashFlow: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/services/investment-cost-basis-service", () => ({
+  getInvestmentCostBasisSummary: vi.fn(async () => ({
+    marketValue: 0,
+    costedMarketValue: 0,
+    costBasis: 0,
+    unrealizedGain: null,
+    unrealizedGainPct: null,
+    pricedHoldingCount: 0,
+    costedHoldingCount: 0,
+  })),
+}));
+
+import { getCachedAnalysisPayload } from "@/lib/services/analysis-payload-service";
+
+beforeEach(() => {
+  mockUnstableCache.mockReset();
+  mockUnstableCache.mockImplementation((fn: () => Promise<unknown>) => () => fn());
+});
+
+describe("getCachedAnalysisPayload", () => {
+  it("is keyed by user and base currency only — locale is not a key part and meta is reduced", async () => {
+    const payload = await getCachedAnalysisPayload("user-1", "USD");
+
+    expect(mockUnstableCache).toHaveBeenCalledTimes(1);
+    const keyParts = mockUnstableCache.mock.calls[0]?.[1];
+    expect(keyParts).toEqual(["analysis-payload", "user-1", "USD"]);
+
+    expect(payload.meta).toEqual({ defaultRange: "YTD" });
+    expect(payload.meta).not.toHaveProperty("hasSnapshots");
+    expect(payload.meta).not.toHaveProperty("latestSnapshotAt");
+  });
+});

--- a/tests/unit/analysis-range.test.ts
+++ b/tests/unit/analysis-range.test.ts
@@ -3,9 +3,11 @@ import { computePerformanceAttribution } from "@/lib/services/analysis-service";
 import {
   ANALYSIS_RANGES,
   getMonthsForRange,
+  getMessageKeyForRange,
   pickDefaultRange,
+  resolveActiveRange,
   resolveAnalysisRange,
-} from "@/components/analysis/analysis-range";
+} from "@/lib/analysis-range";
 import type { AccountMonthlyContribution, SnapshotBreakdown } from "@/lib/services/history-service";
 
 const originalTimezone = process.env.TZ;
@@ -136,6 +138,39 @@ describe("ANALYSIS_RANGES", () => {
   it("defines the five ranges in selector order with their month counts", () => {
     expect(ANALYSIS_RANGES.map((r) => r.label)).toEqual(["YTD", "6M", "1Y", "2Y", "All"]);
     expect(ANALYSIS_RANGES.map((r) => r.months)).toEqual([0, 6, 12, 24, Infinity]);
+  });
+
+  it("carries the analysis translation messageKey for each range", () => {
+    expect(ANALYSIS_RANGES.map((r) => r.messageKey)).toEqual([
+      "rangeYTD",
+      "range6M",
+      "range1Y",
+      "range2Y",
+      "rangeAll",
+    ]);
+  });
+});
+
+describe("getMessageKeyForRange", () => {
+  it("maps each label to its analysis message key", () => {
+    expect(getMessageKeyForRange("YTD")).toBe("rangeYTD");
+    expect(getMessageKeyForRange("6M")).toBe("range6M");
+    expect(getMessageKeyForRange("1Y")).toBe("range1Y");
+    expect(getMessageKeyForRange("2Y")).toBe("range2Y");
+    expect(getMessageKeyForRange("All")).toBe("rangeAll");
+  });
+});
+
+describe("resolveActiveRange", () => {
+  it("returns the stored label when it names a known range", () => {
+    for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
+      expect(resolveActiveRange(label, "YTD")).toBe(label);
+    }
+  });
+
+  it("falls back to the default when the stored label is unknown", () => {
+    expect(resolveActiveRange("BOGUS_RANGE", "YTD")).toBe("YTD");
+    expect(resolveActiveRange("", "6M")).toBe("6M");
   });
 });
 

--- a/tests/unit/analysis-range.test.ts
+++ b/tests/unit/analysis-range.test.ts
@@ -2,10 +2,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { computePerformanceAttribution } from "@/lib/services/analysis-service";
 import {
   ANALYSIS_RANGES,
+  ANALYSIS_RANGE_LABELS,
   getMonthsForRange,
   getMessageKeyForRange,
   pickDefaultRange,
-  resolveActiveRange,
   resolveAnalysisRange,
 } from "@/lib/analysis-range";
 import type { AccountMonthlyContribution, SnapshotBreakdown } from "@/lib/services/history-service";
@@ -161,16 +161,9 @@ describe("getMessageKeyForRange", () => {
   });
 });
 
-describe("resolveActiveRange", () => {
-  it("returns the stored label when it names a known range", () => {
-    for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
-      expect(resolveActiveRange(label, "YTD")).toBe(label);
-    }
-  });
-
-  it("falls back to the default when the stored label is unknown", () => {
-    expect(resolveActiveRange("BOGUS_RANGE", "YTD")).toBe("YTD");
-    expect(resolveActiveRange("", "6M")).toBe("6M");
+describe("ANALYSIS_RANGE_LABELS", () => {
+  it("is the persisted-range allow-list for every declared range", () => {
+    expect(ANALYSIS_RANGE_LABELS).toEqual(ANALYSIS_RANGES.map((r) => r.label));
   });
 });
 

--- a/tests/unit/analysis-series-service.test.ts
+++ b/tests/unit/analysis-series-service.test.ts
@@ -58,14 +58,7 @@ const NOW = new Date(2026, 6, 28, 12);
 
 describe("computeAllRangeSeries", () => {
   it("produces every one of the five ranges with the full series shape", () => {
-    const series = computeAllRangeSeries(
-      snapshots,
-      rawHistory,
-      cashFlowData,
-      accountCashFlow,
-      "en-US",
-      NOW,
-    );
+    const series = computeAllRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, NOW);
     expect(Object.keys(series)).toEqual(["YTD", "6M", "1Y", "2Y", "All"]);
     for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
       expect(series[label]).toMatchObject({
@@ -81,17 +74,24 @@ describe("computeAllRangeSeries", () => {
   });
 });
 
+describe("locale-independent series", () => {
+  it("produces all five ranges from month keys without preformatted labels", () => {
+    const series = computeAllRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, NOW);
+    expect(Object.keys(series)).toEqual(["YTD", "6M", "1Y", "2Y", "All"]);
+    for (const label of ["YTD", "6M", "1Y", "2Y", "All"] as const) {
+      const s = series[label];
+      expect(s.cashFlowBuckets[0].monthKey).toBeTypeOf("string");
+      expect(s.cashFlowBuckets[0]).not.toHaveProperty("label");
+      expect(s.cumulativeGrowth[0]).not.toHaveProperty("label");
+      expect(s.returnTrend.length).toBeGreaterThan(0);
+      expect(s.returnTrend[0]).not.toHaveProperty("label");
+    }
+  });
+});
+
 describe("computeAnalysisRangeSeries — 1Y (now = Jul 2026)", () => {
   const s = () =>
-    computeAnalysisRangeSeries(
-      snapshots,
-      rawHistory,
-      cashFlowData,
-      accountCashFlow,
-      "1Y",
-      "en-US",
-      NOW,
-    );
+    computeAnalysisRangeSeries(snapshots, rawHistory, cashFlowData, accountCashFlow, "1Y", NOW);
 
   it("aligns buckets to the 1Y month window", () => {
     const series = s();
@@ -196,7 +196,6 @@ describe("computeAnalysisRangeSeries — Taiwan-day month boundary", () => {
       cashFlowData,
       accountCashFlow,
       "6M",
-      "en-US",
       JUST_AFTER_CRON,
     );
     expect(series.buckets.at(-1)?.monthKey).toBe("2026-09");
@@ -209,7 +208,6 @@ describe("computeAnalysisRangeSeries — Taiwan-day month boundary", () => {
       withSeptember,
       cashFlowData,
       accountCashFlow,
-      "en-US",
       JUST_AFTER_CRON,
     );
     const lastMonths = Object.values(all).map((s) => s.buckets.at(-1)?.monthKey);
@@ -219,15 +217,7 @@ describe("computeAnalysisRangeSeries — Taiwan-day month boundary", () => {
 
 describe("computeAnalysisRangeSeries — empty history", () => {
   it("returns empty/zeroed series without throwing", () => {
-    const s = computeAnalysisRangeSeries(
-      [],
-      { snapshots: [], accounts },
-      [],
-      [],
-      "YTD",
-      "en-US",
-      NOW,
-    );
+    const s = computeAnalysisRangeSeries([], { snapshots: [], accounts }, [], [], "YTD", NOW);
     expect(s.buckets).toHaveLength(7);
     expect(s.buckets.every((b) => b.isEmpty)).toBe(true);
     expect(s.kpis).toEqual({

--- a/tests/unit/analysis-service.test.ts
+++ b/tests/unit/analysis-service.test.ts
@@ -180,17 +180,32 @@ describe("buildCashFlowBuckets", () => {
         isEmpty: false,
       },
     ];
-    const result = buildCashFlowBuckets(
-      buckets,
-      [{ monthKey: "2026-01", contributions: 60 }],
-      "en-US",
-    );
+    const result = buildCashFlowBuckets(buckets, [{ monthKey: "2026-01", contributions: 60 }]);
     expect(result[0]).toMatchObject({
       monthKey: "2026-01",
       contributions: 60,
       marketPerformance: 40,
       deltaNetWorth: 100,
     });
+  });
+
+  it("exposes month keys without a preformatted label when locale is not passed", () => {
+    const buckets = [
+      {
+        monthKey: "2026-01",
+        endDate: "2026-01",
+        startNetWorth: 0,
+        endNetWorth: 100,
+        totalAssets: 100,
+        totalLiabilities: 0,
+        deltaNetWorth: 100,
+        deltaPct: null,
+        isEmpty: false,
+      },
+    ];
+    const result = buildCashFlowBuckets(buckets, [{ monthKey: "2026-01", contributions: 60 }]);
+    expect(result[0]).toMatchObject({ monthKey: "2026-01", contributions: 60 });
+    expect(result[0]).not.toHaveProperty("label");
   });
 
   it("treats months with no contribution data as zero contribution", () => {
@@ -207,7 +222,7 @@ describe("buildCashFlowBuckets", () => {
         isEmpty: false,
       },
     ];
-    const result = buildCashFlowBuckets(buckets, [], "en-US");
+    const result = buildCashFlowBuckets(buckets, []);
     expect(result[0]).toMatchObject({ contributions: 0, marketPerformance: -10 });
   });
 
@@ -225,11 +240,7 @@ describe("buildCashFlowBuckets", () => {
         isEmpty: true,
       },
     ];
-    const result = buildCashFlowBuckets(
-      buckets,
-      [{ monthKey: "2026-03", contributions: 500 }],
-      "en-US",
-    );
+    const result = buildCashFlowBuckets(buckets, [{ monthKey: "2026-03", contributions: 500 }]);
     expect(result[0]).toMatchObject({ contributions: 0, marketPerformance: 0 });
   });
 });
@@ -242,7 +253,6 @@ describe("buildCumulativeGrowth", () => {
     isEmpty = false,
   ) => ({
     monthKey,
-    label: monthKey,
     contributions,
     marketPerformance,
     deltaNetWorth: contributions + marketPerformance,
@@ -258,6 +268,12 @@ describe("buildCumulativeGrowth", () => {
     expect(result.map((p) => p.cumulativeContributions)).toEqual([100, 150, 150]);
     expect(result.map((p) => p.cumulativeMarket)).toEqual([20, 10, 40]);
     expect(result.map((p) => p.cumulativeTotal)).toEqual([120, 160, 190]);
+  });
+
+  it("does not copy a label onto cumulative points", () => {
+    const result = buildCumulativeGrowth([bucket("2026-01", 100, 20)]);
+    expect(result[0]).toMatchObject({ monthKey: "2026-01", cumulativeContributions: 100 });
+    expect(result[0]).not.toHaveProperty("label");
   });
 
   it("keeps the running total flat across empty padded months", () => {
@@ -463,7 +479,6 @@ describe("computeInvestmentReturnSeries", () => {
       accounts,
       [],
       ["2026-01", "2026-02", "2026-03"],
-      "en-US",
     );
     expect(points).toHaveLength(3);
     // Jan: first-month baseline = first snapshot within the month (1000), end 1100
@@ -482,6 +497,23 @@ describe("computeInvestmentReturnSeries", () => {
     // BANK account movement (a2: 500 → 9999) must not affect any return
   });
 
+  it("exposes return-trend month keys without a preformatted label", () => {
+    const snapshots: SnapshotBreakdown[] = [
+      { date: "2026-01-05", accountValues: { a1: 1000 } },
+      { date: "2026-01-31", accountValues: { a1: 1100 } },
+      { date: "2026-02-28", accountValues: { a1: 1265 } },
+    ];
+    const points = computeInvestmentReturnSeries(
+      snapshots,
+      accounts,
+      [],
+      ["2026-01", "2026-02", "2026-03"],
+    );
+    expect(points).toHaveLength(3);
+    expect(points[0].monthKey).toBe("2026-01");
+    expect(points[0]).not.toHaveProperty("label");
+  });
+
   it("applies half-weight cash flows in the month they occur", () => {
     const snapshots: SnapshotBreakdown[] = [
       { date: "2026-01-31", accountValues: { a1: 1000 } },
@@ -491,13 +523,10 @@ describe("computeInvestmentReturnSeries", () => {
       { accountId: "a1", monthKey: "2026-02", contributions: 200 },
       { accountId: "a2", monthKey: "2026-02", contributions: 4000 }, // BANK — excluded
     ];
-    const points = computeInvestmentReturnSeries(
-      snapshots,
-      accounts,
-      cashFlows,
-      ["2026-01", "2026-02"],
-      "en-US",
-    );
+    const points = computeInvestmentReturnSeries(snapshots, accounts, cashFlows, [
+      "2026-01",
+      "2026-02",
+    ]);
     // Feb: gain = 1500 − 1000 − 200 = 300; base = 1000 + 100 = 1100
     expect(points[1].monthlyReturn).toBeCloseTo(300 / 1100, 10);
   });
@@ -512,13 +541,11 @@ describe("computeInvestmentReturnSeries", () => {
     const cashFlows: AccountMonthlyContribution[] = [
       { accountId: "a1", monthKey: "2026-02", contributions: 1000 },
     ];
-    const points = computeInvestmentReturnSeries(
-      snapshots,
-      accounts,
-      cashFlows,
-      ["2026-01", "2026-02", "2026-03"],
-      "en-US",
-    );
+    const points = computeInvestmentReturnSeries(snapshots, accounts, cashFlows, [
+      "2026-01",
+      "2026-02",
+      "2026-03",
+    ]);
     // Jan: base = 0 → null return, index still null
     expect(points[0].monthlyReturn).toBeNull();
     expect(points[0].cumulativeReturn).toBeNull();
@@ -539,13 +566,11 @@ describe("computeInvestmentReturnSeries", () => {
     const cashFlows: AccountMonthlyContribution[] = [
       { accountId: "a1", monthKey: "2026-02", contributions: 10000 }, // deposited during the gap
     ];
-    const points = computeInvestmentReturnSeries(
-      snapshots,
-      accounts,
-      cashFlows,
-      ["2026-01", "2026-02", "2026-03"],
-      "en-US",
-    );
+    const points = computeInvestmentReturnSeries(snapshots, accounts, cashFlows, [
+      "2026-01",
+      "2026-02",
+      "2026-03",
+    ]);
     expect(points[1].isEmpty).toBe(true);
     // Mar: gain = 11100 − 1000 − 10000 = 100; base = 1000 + 10000/2 = 6000
     expect(points[2].monthlyReturn).toBeCloseTo(100 / 6000, 10);
@@ -559,13 +584,10 @@ describe("computeInvestmentReturnSeries", () => {
     const cashFlows: AccountMonthlyContribution[] = [
       { accountId: "a1", monthKey: "2026-01", contributions: 10000 }, // predates the baseline
     ];
-    const points = computeInvestmentReturnSeries(
-      snapshots,
-      accounts,
-      cashFlows,
-      ["2026-01", "2026-02"],
-      "en-US",
-    );
+    const points = computeInvestmentReturnSeries(snapshots, accounts, cashFlows, [
+      "2026-01",
+      "2026-02",
+    ]);
     expect(points[0].isEmpty).toBe(true);
     // Feb baseline is the first snapshot within Feb (10000), which already contains the Jan deposit
     expect(points[1].monthlyReturn).toBeCloseTo(500 / 10000, 10);
@@ -578,7 +600,6 @@ describe("computeInvestmentReturnSeries", () => {
         accounts,
         [],
         ["2026-01"],
-        "en-US",
       ),
     ).toEqual([]);
     const bankOnly: AccountMeta[] = [
@@ -588,9 +609,7 @@ describe("computeInvestmentReturnSeries", () => {
       { date: "2026-01-31", accountValues: { a2: 500 } },
       { date: "2026-02-28", accountValues: { a2: 600 } },
     ];
-    expect(
-      computeInvestmentReturnSeries(snaps, bankOnly, [], ["2026-01", "2026-02"], "en-US"),
-    ).toEqual([]);
+    expect(computeInvestmentReturnSeries(snaps, bankOnly, [], ["2026-01", "2026-02"])).toEqual([]);
   });
 });
 

--- a/tests/unit/first-day-recurring-cash-flow.test.ts
+++ b/tests/unit/first-day-recurring-cash-flow.test.ts
@@ -271,11 +271,7 @@ describe("first-day recurring cash flow (#658)", () => {
       getAccountMonthlyCashFlow("u1", "USD"),
       getRawHistoryWithBreakdown("u1", "USD"),
     ]);
-    const cashFlow = buildCashFlowBuckets(
-      aggregateMonthlyChange(snapshots),
-      monthlyCashFlow,
-      "en-US",
-    );
+    const cashFlow = buildCashFlowBuckets(aggregateMonthlyChange(snapshots), monthlyCashFlow);
     const cumulative = buildCumulativeGrowth(cashFlow);
     const attribution = computePerformanceAttribution(
       rawHistory.snapshots,

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -545,7 +545,7 @@ describe("getAccountMonthlyCashFlow (occurrence-date bucketing — locks #498)",
       new Date(Date.UTC(2026, 2, 1)),
       new Date(Date.UTC(2026, 3, 1)),
     );
-    const cashFlow = buildCashFlowBuckets(buckets, contributions, "en-US");
+    const cashFlow = buildCashFlowBuckets(buckets, contributions);
     const cumulative = buildCumulativeGrowth(cashFlow);
 
     // First bucket: no fake market loss.

--- a/tests/unit/use-persisted-range.test.ts
+++ b/tests/unit/use-persisted-range.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { resolvePersistedRange } from "@/hooks/use-persisted-range";
+import { ANALYSIS_RANGE_LABELS } from "@/lib/analysis-range";
+import { TREND_RANGE_LABELS, DEFAULT_TREND_RANGE } from "@/components/dashboard/trend-chart-utils";
+
+describe("resolvePersistedRange", () => {
+  it("keeps a stored value that is still on the allow-list", () => {
+    // Given a persisted value the current build still offers
+    const stored = "1Y";
+
+    // When it is resolved against the analysis ranges
+    const resolved = resolvePersistedRange(stored, ANALYSIS_RANGE_LABELS, "YTD");
+
+    // Then the user's choice survives
+    expect(resolved).toBe("1Y");
+  });
+
+  it("falls back when nothing is stored yet", () => {
+    // Given a first visit with an empty sessionStorage
+    const stored = null;
+
+    // When the value is resolved
+    const resolved = resolvePersistedRange(stored, ANALYSIS_RANGE_LABELS, "6M");
+
+    // Then the caller's default is used
+    expect(resolved).toBe("6M");
+  });
+
+  it("falls back on a value written by an older build", () => {
+    // Given a label this build no longer offers (the #689 crash)
+    const stored = "BOGUS_RANGE";
+
+    // When the value is resolved
+    const resolved = resolvePersistedRange(stored, ANALYSIS_RANGE_LABELS, "YTD");
+
+    // Then it never reaches the caller's `seriesByRange[range]` lookup
+    expect(resolved).toBe("YTD");
+    expect(ANALYSIS_RANGE_LABELS).not.toContain(stored);
+  });
+
+  it("falls back on an empty string", () => {
+    // Given a blank sessionStorage entry
+    // When the value is resolved
+    // Then the default wins over the empty label
+    expect(resolvePersistedRange("", ANALYSIS_RANGE_LABELS, "All")).toBe("All");
+  });
+
+  it("guards the dashboard trend range against the same stale value", () => {
+    // Given a trend range written before the option set changed
+    const stored = "7D";
+
+    // When it is resolved against the dashboard allow-list
+    const resolved = resolvePersistedRange(stored, TREND_RANGE_LABELS, DEFAULT_TREND_RANGE);
+
+    // Then TREND_RANGES.find() downstream always matches
+    expect(TREND_RANGE_LABELS).toContain(resolved);
+  });
+
+  it("accepts every label the analysis and trend range sets declare", () => {
+    // Given each shipped label in turn
+    for (const label of ANALYSIS_RANGE_LABELS) {
+      // When resolved against its own allow-list, it is returned unchanged
+      expect(resolvePersistedRange(label, ANALYSIS_RANGE_LABELS, "YTD")).toBe(label);
+    }
+    for (const label of TREND_RANGE_LABELS) {
+      expect(resolvePersistedRange(label, TREND_RANGE_LABELS, DEFAULT_TREND_RANGE)).toBe(label);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Closes the `/analysis` payload follow-ups identified after #688:

- remove locale from the heavy payload cache identity and emit locale-neutral month keys
- format affected chart labels on the client using the active locale
- move range definitions and serializable payload contracts into neutral `src/lib` modules
- derive snapshot metadata from the snapshots already shipped to the client
- make range translation keys part of the shared range definition and safely recover stale persisted values
- add isolated desktop/mobile/locale/empty-state browser coverage with secure fixture authentication and complete teardown

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests
- [x] All tests pass

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` — 92 files, 834 tests
- `pnpm build` — 39/39 pages generated
- Chromium Analysis E2E — 5/5 passed
- Mobile Chrome Analysis E2E — 1 passed, 5 expected desktop-only skips
- en-US and zh-TW client label rendering, stale persisted range fallback, empty state, and mobile `/analysis#history` verified
- dual independent visual QA and five-lane final review passed

## Screenshots (if applicable)

Not applicable. This is a non-visual payload and layering refactor; rendered desktop, mobile, and Traditional Chinese surfaces were regression-tested.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [x] I have updated documentation
- [x] No new warnings generated

## Related Issues

Closes #689