### PR TITLE
Add worktree include config

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,22 @@
+# Local environment
+.env
+.env.local
+.env.development.local
+.env.test.local
+
+# Local AI agent instructions
+AGENTS.md
+CLAUDE.md
+
+# Claude Code
+.claude/settings.local.json
+
+# Codex
+.codex/hooks.json
+.codex/hooks/
+
+# OMO / OpenCode local configuration
+.omo/
+
+# Vercel local project link
+.vercel/project.json


### PR DESCRIPTION
## What changed
- Add `.worktreeinclude` for local environment files used across worktrees.
- Include local AI agent configuration for Claude Code, Codex, and OMO/OpenCode.
- Include the local Vercel project link.

## Why
New git worktrees do not automatically inherit ignored local configuration. This keeps commonly needed local setup available when creating additional worktrees without copying build artifacts or dependencies.

## Validation
- Compared `agent/add-worktreeinclude` against `master`.
- Confirmed the branch is ahead by one commit and the only changed file is `.worktreeinclude`.