### PR TITLE
fix(calendar): respond to date selection instantly + hover feedback

### DIFF
--- a/src/components/calendar/calendar-month-grid.tsx
+++ b/src/components/calendar/calendar-month-grid.tsx
@@ -214,9 +214,14 @@ export function CalendarMonthGrid({
                       onKeyDown={(event) => handleKeyDown(event, date, index)}
                       className={cn(
                         "flex min-h-16 w-full flex-col items-center gap-1 px-1.5 py-2 text-center outline-none motion-fast sm:min-h-20 sm:items-start sm:text-left",
-                        "hover:bg-muted/60 focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                        "transition-colors duration-150 ease-[var(--ease-micro)]",
+                        "motion-reduce:transition-none",
+                        "hover:bg-foreground/8",
+                        "active:bg-foreground/12",
+                        "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                         !isCurrentMonth && "text-muted-foreground",
-                        isSelected && "relative z-10 bg-primary/8 ring-2 ring-inset ring-primary",
+                        isSelected &&
+                          "relative z-10 bg-primary/8 ring-2 ring-inset ring-primary hover:bg-primary/15",
                       )}
                     >
                       <span className="flex min-h-7 flex-col items-center sm:items-start">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useMemo, useRef, useState } from "react";
+import { useMemo, useOptimistic, useRef, useState, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
@@ -26,7 +26,6 @@ type CalendarViewProps = {
 
 export function CalendarView({
   initialEntries,
-  month,
   selectedDate,
   today,
   locale,
@@ -39,17 +38,24 @@ export function CalendarView({
   const agendaRef = useRef<HTMLDivElement>(null);
   const [formOpen, setFormOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<SerializedCalendarEntry | null>(null);
+  const [, startTransition] = useTransition();
+  const [optimisticDate, setOptimisticDate] = useOptimistic(selectedDate);
+  const effectiveDate = optimisticDate;
+  const effectiveMonth = effectiveDate.slice(0, 7);
 
   function navigate(date: string) {
-    router.replace(
-      buildCalendarNavigationHref({
-        pathname,
-        search: window.location.search,
-        hash: window.location.hash,
-        date,
-      }),
-      { scroll: false },
-    );
+    startTransition(() => {
+      setOptimisticDate(date);
+      router.replace(
+        buildCalendarNavigationHref({
+          pathname,
+          search: window.location.search,
+          hash: window.location.hash,
+          date,
+        }),
+        { scroll: false },
+      );
+    });
   }
 
   function selectDate(date: string, source: "pointer" | "keyboard") {
@@ -98,7 +104,7 @@ export function CalendarView({
             mobileTouch
             aria-label={t("previousMonth")}
             title={t("previousMonth")}
-            onClick={() => navigate(moveCalendarMonth(selectedDate, -1))}
+            onClick={() => navigate(moveCalendarMonth(effectiveDate, -1))}
           >
             <ChevronLeft />
           </Button>
@@ -112,7 +118,7 @@ export function CalendarView({
             mobileTouch
             aria-label={t("nextMonth")}
             title={t("nextMonth")}
-            onClick={() => navigate(moveCalendarMonth(selectedDate, 1))}
+            onClick={() => navigate(moveCalendarMonth(effectiveDate, 1))}
           >
             <ChevronRight />
           </Button>
@@ -126,8 +132,8 @@ export function CalendarView({
 
       <div className="gap-4 md:grid md:grid-cols-[minmax(0,1fr)_minmax(20rem,0.42fr)] md:items-start">
         <CalendarMonthGrid
-          month={month}
-          selectedDate={selectedDate}
+          month={effectiveMonth}
+          selectedDate={effectiveDate}
           today={today}
           entriesByDate={entriesByDate}
           locale={locale}
@@ -135,8 +141,8 @@ export function CalendarView({
         />
         <div ref={agendaRef} className="mt-4 scroll-mt-4 md:sticky md:top-4 md:mt-0">
           <CalendarDayAgenda
-            date={selectedDate}
-            entries={entriesByDate.get(selectedDate) ?? []}
+            date={effectiveDate}
+            entries={entriesByDate.get(effectiveDate) ?? []}
             locale={locale}
             onAdd={addEntry}
             onEdit={editEntry}


### PR DESCRIPTION
## Summary

Two calendar UX improvements:

1. **Instant date selection** — Date navigation is now wrapped in a React transition with an optimistic selection applied immediately, so the month grid highlight and day agenda update the moment you click instead of waiting for the server round-trip. This removes the perceived click lag.

2. **Hover / pressed feedback on day cells** — Added an adaptive foreground overlay (`hover:bg-foreground/8`, `active:bg-foreground/12`) so cells visibly react on mouse hover and press in both light and dark themes, while respecting the reduced-motion preference. Previously the dark-mode hover was nearly invisible.

## Commits

- `fix(calendar): respond to date selection immediately`
- `feat(calendar): add hover and active feedback to day cells`

## Verification

- `pnpm exec tsc --noEmit` ✅
- `pnpm exec eslint` ✅
- Calendar unit tests (8 files / 52 tests) ✅
- Pre-push hook (prettier + eslint + tsc) ✅