### PR TITLE
fix: optimize mobile responsive panel mounting

### DIFF
--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -10,8 +10,10 @@ import {
 } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { Reorder, useDragControls } from "framer-motion";
 import { toast } from "sonner";
+import { useIsMobile, useIsViewportReady } from "@/hooks/use-is-mobile";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ArrowUpDown, CheckCircle2, GripVertical, Plus, Save, Target, X } from "lucide-react";
@@ -19,9 +21,6 @@ import type { GoalWithProgress, SerializedAccount, SerializedCalendarEntry } fro
 import type { ProjectionData } from "@/lib/services/projection-service";
 import type { CalendarEarningsItem } from "@/lib/services/calendar-earnings-data";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
-import { ProjectionView } from "@/components/projections/projection-view";
-import { StockTrackerView } from "@/components/stocks/stock-tracker-view";
-import { CalendarView } from "@/components/calendar/calendar-view";
 import { GoalCard } from "./goal-card";
 import { GoalFormDialog } from "./goal-form-dialog";
 import { GoalsOnboarding } from "./goals-onboarding";
@@ -30,8 +29,24 @@ import {
   getMobilePlanPanelId,
   getMobilePlanTabId,
   handleMobilePlanTabKey,
+  renderActiveMobilePlanPanel,
+  shouldRenderMobilePlanContent,
+  shouldRenderGoalsPanel,
   type MobilePlanTab,
 } from "./mobile-plan-tabs";
+
+const StockTrackerView = dynamic(
+  () => import("@/components/stocks/stock-tracker-view").then((module) => module.StockTrackerView),
+  { ssr: false },
+);
+const ProjectionView = dynamic(
+  () => import("@/components/projections/projection-view").then((module) => module.ProjectionView),
+  { ssr: false },
+);
+const CalendarView = dynamic(
+  () => import("@/components/calendar/calendar-view").then((module) => module.CalendarView),
+  { ssr: false },
+);
 
 interface GoalsViewProps {
   goalsWithProgress: GoalWithProgress[];
@@ -132,6 +147,8 @@ export function GoalsView({
   const tNav = useTranslations("nav");
   const common = useTranslations("common");
   const router = useRouter();
+  const isMobile = useIsMobile();
+  const isViewportReady = useIsViewportReady();
   const [createOpen, setCreateOpen] = useState(false);
   const [manageMode, setManageMode] = useState(false);
   const [savingOrder, setSavingOrder] = useState(false);
@@ -192,15 +209,39 @@ export function GoalsView({
           : "watchlist";
   const activeTab: MobilePlanTab = override ?? hashTab;
 
+  // Keep the structural tabpanels in the DOM so every tab retains its
+  // aria-controls target, but only create the heavy mobile child for the active
+  // mobile tab. The hydration-safe viewport hook keeps even the default Watchlist
+  // child out of the desktop render.
+  const mobileContentEnabled = shouldRenderMobilePlanContent(isViewportReady, isMobile);
+  const activeMobilePanelContent = renderActiveMobilePlanPanel(mobileContentEnabled, activeTab, {
+    watchlist: () => <StockTrackerView stocks={stocks} />,
+    projections: () => (
+      <ProjectionView projectionData={projectionData} baseCurrency={baseCurrency} />
+    ),
+    calendar: () => (
+      <CalendarView
+        initialEntries={calendarEntries}
+        month={calendarMonth}
+        selectedDate={calendarSelectedDate}
+        today={calendarToday}
+        locale={locale}
+        showHeader={false}
+        earningsByDate={earningsByDate}
+      />
+    ),
+  });
+  const renderGoalsContent = shouldRenderGoalsPanel(isViewportReady, isMobile, activeTab);
+
   useEffect(() => {
-    if (!window.matchMedia("(max-width: 767px)").matches) return;
+    if (!isMobile) return;
 
     tabRefs.current[activeTab]?.scrollIntoView({
       block: "nearest",
       inline: "center",
       behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
     });
-  }, [activeTab]);
+  }, [activeTab, isMobile]);
 
   const handleTabChange = (tab: MobilePlanTab) => {
     setOverride(tab);
@@ -260,7 +301,7 @@ export function GoalsView({
         hidden={activeTab !== "watchlist"}
         className="md:hidden"
       >
-        <StockTrackerView stocks={stocks} />
+        {activeTab === "watchlist" ? activeMobilePanelContent : null}
       </div>
 
       {/* Goals tab — always visible on desktop, conditional on mobile */}
@@ -270,73 +311,75 @@ export function GoalsView({
         aria-labelledby={getMobilePlanTabId("goals")}
         className={activeTab === "goals" ? "block" : "hidden md:block"}
       >
-        <div className="space-y-6">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
-            {manageMode ? (
-              <div className="grid grid-cols-2 gap-2 sm:flex">
-                <Button
-                  variant="outline"
-                  onClick={cancelManageMode}
-                  disabled={savingOrder}
-                  className="w-full sm:w-auto"
-                >
-                  <X className="h-4 w-4" />
-                  {common("cancel")}
-                </Button>
-                <Button onClick={saveOrder} disabled={savingOrder} className="w-full sm:w-auto">
-                  <Save className="h-4 w-4" />
-                  {savingOrder ? common("saving") : common("save")}
-                </Button>
-              </div>
-            ) : (
-              <div className="flex flex-wrap gap-2 sm:flex-nowrap">
-                {goalsWithProgress.length > 1 && (
+        {renderGoalsContent ? (
+          <div className="space-y-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+              {manageMode ? (
+                <div className="grid grid-cols-2 gap-2 sm:flex">
                   <Button
                     variant="outline"
-                    onClick={enterManageMode}
-                    className="flex-1 sm:flex-none"
+                    onClick={cancelManageMode}
+                    disabled={savingOrder}
+                    className="w-full sm:w-auto"
                   >
-                    <ArrowUpDown className="h-4 w-4" />
-                    {t("manageOrder")}
+                    <X className="h-4 w-4" />
+                    {common("cancel")}
                   </Button>
-                )}
-                <Button
-                  onClick={() => setCreateOpen(true)}
-                  className="order-last w-full sm:order-none sm:w-auto sm:flex-none"
-                >
-                  <Plus className="h-4 w-4" />
-                  {t("addGoal")}
-                </Button>
+                  <Button onClick={saveOrder} disabled={savingOrder} className="w-full sm:w-auto">
+                    <Save className="h-4 w-4" />
+                    {savingOrder ? common("saving") : common("save")}
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex flex-wrap gap-2 sm:flex-nowrap">
+                  {goalsWithProgress.length > 1 && (
+                    <Button
+                      variant="outline"
+                      onClick={enterManageMode}
+                      className="flex-1 sm:flex-none"
+                    >
+                      <ArrowUpDown className="h-4 w-4" />
+                      {t("manageOrder")}
+                    </Button>
+                  )}
+                  <Button
+                    onClick={() => setCreateOpen(true)}
+                    className="order-last w-full sm:order-none sm:w-auto sm:flex-none"
+                  >
+                    <Plus className="h-4 w-4" />
+                    {t("addGoal")}
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            {goalsWithProgress.length === 0 ? (
+              <GoalsOnboarding onAdd={() => setCreateOpen(true)} />
+            ) : manageMode ? (
+              <ManageGoalsList draft={draft} onReorder={setDraft} />
+            ) : (
+              <div className="grid gap-4">
+                {goalsWithProgress.map((data) => (
+                  <GoalCard
+                    key={data.goal.id}
+                    data={data}
+                    baseCurrency={baseCurrency}
+                    accounts={accounts}
+                    defaultCurrency={baseCurrency}
+                  />
+                ))}
               </div>
             )}
+
+            <GoalFormDialog
+              open={createOpen}
+              onOpenChange={setCreateOpen}
+              accounts={accounts}
+              defaultCurrency={baseCurrency}
+            />
           </div>
-
-          {goalsWithProgress.length === 0 ? (
-            <GoalsOnboarding onAdd={() => setCreateOpen(true)} />
-          ) : manageMode ? (
-            <ManageGoalsList draft={draft} onReorder={setDraft} />
-          ) : (
-            <div className="grid gap-4">
-              {goalsWithProgress.map((data) => (
-                <GoalCard
-                  key={data.goal.id}
-                  data={data}
-                  baseCurrency={baseCurrency}
-                  accounts={accounts}
-                  defaultCurrency={baseCurrency}
-                />
-              ))}
-            </div>
-          )}
-
-          <GoalFormDialog
-            open={createOpen}
-            onOpenChange={setCreateOpen}
-            accounts={accounts}
-            defaultCurrency={baseCurrency}
-          />
-        </div>
+        ) : null}
       </div>
 
       {/* Projections tab — mobile only */}
@@ -347,7 +390,7 @@ export function GoalsView({
         hidden={activeTab !== "projections"}
         className="md:hidden"
       >
-        <ProjectionView projectionData={projectionData} baseCurrency={baseCurrency} />
+        {activeTab === "projections" ? activeMobilePanelContent : null}
       </div>
 
       {/* Calendar tab — mobile only */}
@@ -358,15 +401,7 @@ export function GoalsView({
         hidden={activeTab !== "calendar"}
         className="pb-20 md:hidden"
       >
-        <CalendarView
-          initialEntries={calendarEntries}
-          month={calendarMonth}
-          selectedDate={calendarSelectedDate}
-          today={calendarToday}
-          locale={locale}
-          showHeader={false}
-          earningsByDate={earningsByDate}
-        />
+        {activeTab === "calendar" ? activeMobilePanelContent : null}
       </div>
     </div>
   );

--- a/src/components/goals/mobile-plan-tabs.ts
+++ b/src/components/goals/mobile-plan-tabs.ts
@@ -1,6 +1,10 @@
+import type { ReactNode } from "react";
+
 export const MOBILE_PLAN_TABS = ["watchlist", "goals", "projections", "calendar"] as const;
 
 export type MobilePlanTab = (typeof MOBILE_PLAN_TABS)[number];
+export type MobileOnlyPlanTab = Exclude<MobilePlanTab, "goals">;
+export type MobilePlanPanelRenderers = Record<MobileOnlyPlanTab, () => ReactNode>;
 
 export function getMobilePlanTabId(tab: MobilePlanTab): string {
   return `mobile-plan-tab-${tab}`;
@@ -8,6 +12,30 @@ export function getMobilePlanTabId(tab: MobilePlanTab): string {
 
 export function getMobilePlanPanelId(tab: MobilePlanTab): string {
   return `mobile-plan-panel-${tab}`;
+}
+
+export function renderActiveMobilePlanPanel(
+  isMobile: boolean,
+  activeTab: MobilePlanTab,
+  renderers: MobilePlanPanelRenderers,
+): ReactNode {
+  if (!isMobile || activeTab === "goals") return null;
+  return renderers[activeTab]();
+}
+
+export function shouldRenderMobilePlanContent(
+  isViewportReady: boolean,
+  isMobile: boolean,
+): boolean {
+  return isViewportReady && isMobile;
+}
+
+export function shouldRenderGoalsPanel(
+  isViewportReady: boolean,
+  isMobile: boolean,
+  activeTab: MobilePlanTab,
+): boolean {
+  return isViewportReady && (!isMobile || activeTab === "goals");
 }
 
 type MobilePlanTabKeyHandlerOptions = {

--- a/src/components/layout/mobile-hub-redirect.tsx
+++ b/src/components/layout/mobile-hub-redirect.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { getMobileHubClientRedirectUrl } from "@/lib/mobile-hub-route";
 
 /**
  * Standalone /stocks, /projections, and /calendar are desktop surfaces (sidebar entries).
@@ -10,9 +11,9 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
  * a standalone route (in-app link, command palette, bookmark) is bounced into the hub
  * to keep one consistent mobile home.
  *
- * ponytail: a brief standalone render flashes before the post-hydration redirect on
- * direct mobile navigation (useIsMobile returns false on the server snapshot). That
- * path is rare; swap to a middleware UA check if it ever needs to be flash-free.
+ * The proxy redirects normal mobile user agents before the page reaches the server
+ * component. This client fallback still handles a desktop browser resized below the
+ * breakpoint, where the server cannot know the viewport width from the request.
  */
 export function MobileHubRedirect({ hash, search = "" }: { hash: `#${string}`; search?: string }) {
   const isMobile = useIsMobile();
@@ -20,7 +21,13 @@ export function MobileHubRedirect({ hash, search = "" }: { hash: `#${string}`; s
 
   useEffect(() => {
     if (!isMobile) return;
-    router.replace(`/goals${search}${hash}`);
+    router.replace(
+      getMobileHubClientRedirectUrl({
+        currentSearch: window.location.search,
+        fallbackSearch: search,
+        hash,
+      }),
+    );
   }, [isMobile, hash, search, router]);
 
   return null;

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -384,6 +384,7 @@ function StockRow({
   const t = useTranslations("stocks");
   const common = useTranslations("common");
   const format = useFormatters();
+  const isMobile = useIsMobile();
   const currency = stock.latestPriceCurrency ?? stock.currency;
   const isGain = (stock.change ?? 0) >= 0;
   const hasDirection = stock.changePercent !== null;
@@ -490,103 +491,64 @@ function StockRow({
       )}
     >
       <CardContent className="space-y-3 md:px-3">
-        <div className="hidden items-center gap-5 md:grid md:grid-cols-[minmax(180px,1.5fr)_minmax(280px,1.3fr)_minmax(116px,auto)_1.75rem]">
-          {renderIdentity(true)}
+        {isMobile ? null : (
+          <div className="hidden items-center gap-5 md:grid md:grid-cols-[minmax(180px,1.5fr)_minmax(280px,1.3fr)_minmax(116px,auto)_1.75rem]">
+            {renderIdentity(true)}
 
-          {/* Price journey: the recorded reference price, then the live quote it's measured against. */}
-          <div className="min-w-0">
-            <p className="text-[11px] font-medium text-muted-foreground">
-              {t("recorded")}
-              <ArrowRight className="mx-1.5 inline h-3 w-3 -translate-y-px text-muted-foreground/40" />
-              {t("latestPrice")}
-            </p>
-            {/* flex-wrap (not truncate): a long price must never be clipped mid-number. */}
-            <p className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5 font-mono tabular-nums">
-              <span className="text-sm font-medium text-muted-foreground">{recordPrice}</span>
-              <ArrowRight
-                className={cn(
-                  "h-3.5 w-3.5 shrink-0 translate-y-0.5",
-                  directionInk ?? "text-muted-foreground/40",
-                )}
-              />
-              <span className="text-base font-semibold text-foreground">
-                {latestPrice ?? t("unavailable")}
-              </span>
-            </p>
-            <p className="mt-1 truncate text-[11px] leading-4 text-muted-foreground/80">
-              {format.date(stock.recordDate)}
-              {recordPeriodLabel && ` · ${recordPeriodLabel}`}
-            </p>
-            {!stock.latestPriceUpdatedAt && (
-              <p className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground">
-                {t("noLatestPrice")}
+            {/* Price journey: the recorded reference price, then the live quote it's measured against. */}
+            <div className="min-w-0">
+              <p className="text-[11px] font-medium text-muted-foreground">
+                {t("recorded")}
+                <ArrowRight className="mx-1.5 inline h-3 w-3 -translate-y-px text-muted-foreground/40" />
+                {t("latestPrice")}
               </p>
-            )}
-          </div>
-
-          {/* Change: the payoff, anchored to the row's right edge so pills line up down the list. */}
-          <div className="flex flex-col items-end gap-1 justify-self-end">
-            {stock.changePercent !== null ? (
-              <span
-                className={cn(
-                  "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
-                  isGain
-                    ? "bg-[var(--gain)]/15 text-[var(--gain-ink)] ring-[var(--gain)]/25"
-                    : "bg-[var(--loss)]/15 text-[var(--loss-ink)] ring-[var(--loss)]/25",
-                )}
-              >
-                <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
-                {percent}
-              </span>
-            ) : (
-              <p className="font-mono text-sm font-semibold tabular-nums text-muted-foreground">
-                {t("unavailable")}
+              {/* flex-wrap (not truncate): a long price must never be clipped mid-number. */}
+              <p className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5 font-mono tabular-nums">
+                <span className="text-sm font-medium text-muted-foreground">{recordPrice}</span>
+                <ArrowRight
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0 translate-y-0.5",
+                    directionInk ?? "text-muted-foreground/40",
+                  )}
+                />
+                <span className="text-base font-semibold text-foreground">
+                  {latestPrice ?? t("unavailable")}
+                </span>
               </p>
-            )}
-            {stock.change !== null && (
-              <p
-                className={cn(
-                  "font-mono text-[11px] font-medium tabular-nums",
-                  directionInk ?? "text-muted-foreground",
-                )}
-              >
-                {change}
+              <p className="mt-1 truncate text-[11px] leading-4 text-muted-foreground/80">
+                {format.date(stock.recordDate)}
+                {recordPeriodLabel && ` · ${recordPeriodLabel}`}
               </p>
-            )}
-          </div>
+              {!stock.latestPriceUpdatedAt && (
+                <p className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground">
+                  {t("noLatestPrice")}
+                </p>
+              )}
+            </div>
 
-          <div className="justify-self-end">{renderActions()}</div>
-        </div>
-
-        <div className="flex flex-col gap-3.5 md:hidden">
-          <div className="flex items-start justify-between gap-4">
-            {renderIdentity()}
-
-            <div className="flex min-w-0 shrink-0 flex-col items-end">
+            {/* Change: the payoff, anchored to the row's right edge so pills line up down the list. */}
+            <div className="flex flex-col items-end gap-1 justify-self-end">
               {stock.changePercent !== null ? (
                 <span
                   className={cn(
-                    "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
+                    "inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-mono text-sm font-semibold tabular-nums leading-none ring-1 ring-inset",
                     isGain
                       ? "bg-[var(--gain)]/15 text-[var(--gain-ink)] ring-[var(--gain)]/25"
                       : "bg-[var(--loss)]/15 text-[var(--loss-ink)] ring-[var(--loss)]/25",
                   )}
                 >
-                  <DirectionIcon className="h-4 w-4 shrink-0" />
+                  <DirectionIcon className="h-3.5 w-3.5 shrink-0" />
                   {percent}
                 </span>
               ) : (
-                <p className="font-mono text-base font-bold tabular-nums text-muted-foreground">
+                <p className="font-mono text-sm font-semibold tabular-nums text-muted-foreground">
                   {t("unavailable")}
                 </p>
               )}
-              <p className="mt-2 font-mono text-base font-semibold tabular-nums text-foreground">
-                {latestPrice ?? t("unavailable")}
-              </p>
-              {change && (
+              {stock.change !== null && (
                 <p
                   className={cn(
-                    "mt-0.5 font-mono text-[11px] font-medium tabular-nums",
+                    "font-mono text-[11px] font-medium tabular-nums",
                     directionInk ?? "text-muted-foreground",
                   )}
                 >
@@ -594,26 +556,69 @@ function StockRow({
                 </p>
               )}
             </div>
-          </div>
 
-          <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/30 px-3 py-2.5">
-            <div className="min-w-0">
-              <p className="text-xs text-muted-foreground">
-                <span className="font-medium text-foreground/80">{t("recorded")}:</span>{" "}
-                <span className="font-mono font-medium text-foreground/90">{recordPrice}</span>
-              </p>
-              <p className="mt-0.5 truncate text-[11px] text-muted-foreground/70">
-                {format.date(stock.recordDate)}
-                {recordPeriodLabel && ` • ${recordPeriodLabel}`}
-              </p>
+            <div className="justify-self-end">{renderActions()}</div>
+          </div>
+        )}
+
+        {isMobile ? (
+          <div className="flex flex-col gap-3.5">
+            <div className="flex items-start justify-between gap-4">
+              {renderIdentity()}
+
+              <div className="flex min-w-0 shrink-0 flex-col items-end">
+                {stock.changePercent !== null ? (
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-full px-3 py-1.5 font-mono text-base font-bold tabular-nums leading-none ring-1 ring-inset",
+                      isGain
+                        ? "bg-[var(--gain)]/15 text-[var(--gain-ink)] ring-[var(--gain)]/25"
+                        : "bg-[var(--loss)]/15 text-[var(--loss-ink)] ring-[var(--loss)]/25",
+                    )}
+                  >
+                    <DirectionIcon className="h-4 w-4 shrink-0" />
+                    {percent}
+                  </span>
+                ) : (
+                  <p className="font-mono text-base font-bold tabular-nums text-muted-foreground">
+                    {t("unavailable")}
+                  </p>
+                )}
+                <p className="mt-2 font-mono text-base font-semibold tabular-nums text-foreground">
+                  {latestPrice ?? t("unavailable")}
+                </p>
+                {change && (
+                  <p
+                    className={cn(
+                      "mt-0.5 font-mono text-[11px] font-medium tabular-nums",
+                      directionInk ?? "text-muted-foreground",
+                    )}
+                  >
+                    {change}
+                  </p>
+                )}
+              </div>
             </div>
-            <div className="shrink-0">{renderActions()}</div>
-          </div>
 
-          {!stock.latestPriceUpdatedAt && (
-            <p className="text-[11px] text-muted-foreground">{t("noLatestPrice")}</p>
-          )}
-        </div>
+            <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/30 px-3 py-2.5">
+              <div className="min-w-0">
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground/80">{t("recorded")}:</span>{" "}
+                  <span className="font-mono font-medium text-foreground/90">{recordPrice}</span>
+                </p>
+                <p className="mt-0.5 truncate text-[11px] text-muted-foreground/70">
+                  {format.date(stock.recordDate)}
+                  {recordPeriodLabel && ` • ${recordPeriodLabel}`}
+                </p>
+              </div>
+              <div className="shrink-0">{renderActions()}</div>
+            </div>
+
+            {!stock.latestPriceUpdatedAt && (
+              <p className="text-[11px] text-muted-foreground">{t("noLatestPrice")}</p>
+            )}
+          </div>
+        ) : null}
 
         {noteText && (
           <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2.5">

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -2,6 +2,30 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 
+function subscribeToViewportReady() {
+  return () => {};
+}
+
+function getViewportReadySnapshot() {
+  return true;
+}
+
+function getServerViewportReadySnapshot() {
+  return false;
+}
+
+/**
+ * Returns false for the server render and the initial hydrated render, then true
+ * once a client viewport is available for responsive mount decisions.
+ */
+export function useIsViewportReady() {
+  return useSyncExternalStore(
+    subscribeToViewportReady,
+    getViewportReadySnapshot,
+    getServerViewportReadySnapshot,
+  );
+}
+
 /**
  * Hydration-safe viewport media-query hook.
  *

--- a/src/lib/mobile-hub-route.ts
+++ b/src/lib/mobile-hub-route.ts
@@ -1,0 +1,38 @@
+const MOBILE_HUB_HASHES: Record<string, `#${string}`> = {
+  "/stocks": "#watchlist",
+  "/projections": "#projections",
+  "/calendar": "#calendar",
+};
+
+const MOBILE_USER_AGENT = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile/i;
+
+export function isMobileUserAgent(userAgent: string | null | undefined): boolean {
+  return MOBILE_USER_AGENT.test(userAgent ?? "");
+}
+
+export function getMobileHubClientRedirectUrl({
+  currentSearch,
+  fallbackSearch = "",
+  hash,
+}: {
+  currentSearch: string;
+  fallbackSearch?: string;
+  hash: `#${string}`;
+}): string {
+  return `/goals${currentSearch || fallbackSearch}${hash}`;
+}
+
+export function getMobileHubRedirectUrl({
+  pathname,
+  search,
+  userAgent,
+}: {
+  pathname: string;
+  search: string;
+  userAgent: string | null | undefined;
+}): string | null {
+  if (!isMobileUserAgent(userAgent)) return null;
+
+  const hash = MOBILE_HUB_HASHES[pathname];
+  return hash ? `/goals${search}${hash}` : null;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/demo/demo-policy";
 import { AUTH_SECRET, isPublicDemoEnabled } from "@/lib/env";
 import { getClientIp } from "@/lib/client-ip";
+import { getMobileHubRedirectUrl } from "@/lib/mobile-hub-route";
 import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 
@@ -204,6 +205,15 @@ const authMiddleware = auth((req) => {
   ) {
     const newUrl = new URL("/", req.nextUrl.origin);
     return Response.redirect(newUrl);
+  }
+
+  const mobileHubUrl = getMobileHubRedirectUrl({
+    pathname: req.nextUrl.pathname,
+    search: req.nextUrl.search,
+    userAgent: req.headers.get("user-agent"),
+  });
+  if (isLoggedIn && mobileHubUrl) {
+    return Response.redirect(new URL(mobileHubUrl, req.nextUrl.origin));
   }
 
   return nextResponse(req);

--- a/tests/e2e/mobile-plan.spec.ts
+++ b/tests/e2e/mobile-plan.spec.ts
@@ -61,6 +61,28 @@ test.describe("mobile Plan hub", () => {
     );
   });
 
+  test("inactive mobile panels stay unmounted until their tab is selected", async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== "Mobile Chrome", "Mobile-only panel mounting check");
+
+    await page.goto("/goals");
+
+    const panelContent = (tab: string) => page.locator(`#mobile-plan-panel-${tab} > *`);
+
+    await expect(panelContent("goals")).toHaveCount(0);
+    await expect(panelContent("projections")).toHaveCount(0);
+    await expect(panelContent("calendar")).toHaveCount(0);
+
+    await page.getByRole("tab", { name: "Goals" }).click();
+    await expect(panelContent("goals")).toHaveCount(1);
+
+    await page.getByRole("tab", { name: "Projections" }).click();
+    await expect(panelContent("goals")).toHaveCount(0);
+    await expect(panelContent("projections")).toHaveCount(1);
+    await expect(panelContent("calendar")).toHaveCount(0);
+  });
+
   test("Calendar is the fourth Plan tab and calendar deep links preserve state", async ({
     page,
   }, testInfo) => {

--- a/tests/unit/mobile-calendar-routing.test.ts
+++ b/tests/unit/mobile-calendar-routing.test.ts
@@ -10,7 +10,8 @@ describe("mobile calendar routing", () => {
       "utf8",
     );
     expect(source).toContain('search = ""');
-    expect(source).toContain("`/goals${search}${hash}`");
+    expect(source).toContain("currentSearch: window.location.search");
+    expect(source).toContain("fallbackSearch: search");
   });
 
   it("registers Calendar as the fourth Plan tab", () => {

--- a/tests/unit/mobile-hub-redirect.test.ts
+++ b/tests/unit/mobile-hub-redirect.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+import { getMobileHubClientRedirectUrl, getMobileHubRedirectUrl } from "@/lib/mobile-hub-route";
+
 describe("mobile hub redirects", () => {
   it("hides standalone stocks, projections, and calendar content on mobile before redirect", () => {
     const stocksPage = readFileSync("src/app/(main)/stocks/page.tsx", "utf8");
@@ -22,4 +24,47 @@ describe("mobile hub redirects", () => {
       '<MobileHubRedirect hash="#calendar" search={`?month=${month}&date=${date}`} />',
     );
   });
+
+  it.each([
+    ["/stocks", "", "/goals#watchlist"],
+    ["/projections", "", "/goals#projections"],
+    [
+      "/calendar",
+      "?month=2026-08&date=2026-08-12",
+      "/goals?month=2026-08&date=2026-08-12#calendar",
+    ],
+  ] as const)("builds the mobile hub redirect for %s", (pathname, search, expected) => {
+    expect(
+      getMobileHubRedirectUrl({
+        pathname,
+        search,
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Mobile",
+      }),
+    ).toBe(expected);
+  });
+
+  it("leaves desktop user agents on standalone routes", () => {
+    expect(
+      getMobileHubRedirectUrl({
+        pathname: "/stocks",
+        search: "",
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["?symbol=AAPL&view=compact", "", "#watchlist", "/goals?symbol=AAPL&view=compact#watchlist"],
+    [
+      "",
+      "?month=2026-08&date=2026-08-12",
+      "#calendar",
+      "/goals?month=2026-08&date=2026-08-12#calendar",
+    ],
+  ] as const)(
+    "preserves the complete client query string when redirecting",
+    (currentSearch, fallbackSearch, hash, expected) => {
+      expect(getMobileHubClientRedirectUrl({ currentSearch, fallbackSearch, hash })).toBe(expected);
+    },
+  );
 });

--- a/tests/unit/mobile-plan-tabs.test.ts
+++ b/tests/unit/mobile-plan-tabs.test.ts
@@ -6,6 +6,9 @@ import {
   getMobilePlanPanelId,
   getMobilePlanTabId,
   handleMobilePlanTabKey,
+  renderActiveMobilePlanPanel,
+  shouldRenderMobilePlanContent,
+  shouldRenderGoalsPanel,
   type MobilePlanTab,
 } from "@/components/goals/mobile-plan-tabs";
 
@@ -80,6 +83,98 @@ describe("mobile Plan tabs", () => {
       },
     ]);
   });
+
+  it.each(["watchlist", "projections", "calendar"] as const)(
+    "renders only the active mobile panel: %s",
+    (activeTab) => {
+      const rendered: MobilePlanTab[] = [];
+      const result = renderActiveMobilePlanPanel(true, activeTab, {
+        watchlist: () => {
+          rendered.push("watchlist");
+          return "watchlist";
+        },
+        projections: () => {
+          rendered.push("projections");
+          return "projections";
+        },
+        calendar: () => {
+          rendered.push("calendar");
+          return "calendar";
+        },
+      });
+
+      expect(rendered).toEqual([activeTab]);
+      expect(result).toBe(activeTab);
+    },
+  );
+
+  it("does not render a mobile-only panel while the desktop Goals tab is active", () => {
+    const rendered: MobilePlanTab[] = [];
+    const result = renderActiveMobilePlanPanel(true, "goals", {
+      watchlist: () => {
+        rendered.push("watchlist");
+        return "watchlist";
+      },
+      projections: () => {
+        rendered.push("projections");
+        return "projections";
+      },
+      calendar: () => {
+        rendered.push("calendar");
+        return "calendar";
+      },
+    });
+
+    expect(rendered).toEqual([]);
+    expect(result).toBeNull();
+  });
+
+  it("does not render mobile-only panels on desktop", () => {
+    const rendered: MobilePlanTab[] = [];
+    const result = renderActiveMobilePlanPanel(false, "watchlist", {
+      watchlist: () => {
+        rendered.push("watchlist");
+        return "watchlist";
+      },
+      projections: () => {
+        rendered.push("projections");
+        return "projections";
+      },
+      calendar: () => {
+        rendered.push("calendar");
+        return "calendar";
+      },
+    });
+
+    expect(rendered).toEqual([]);
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    [false, false, false],
+    [false, true, false],
+    [true, false, false],
+    [true, true, true],
+  ] as const)(
+    "mounts mobile-only content only after the viewport is ready",
+    (isViewportReady, isMobile, expected) => {
+      expect(shouldRenderMobilePlanContent(isViewportReady, isMobile)).toBe(expected);
+    },
+  );
+
+  it.each([
+    [false, false, "watchlist", false],
+    [false, false, "goals", false],
+    [true, false, "watchlist", true],
+    [true, false, "goals", true],
+    [true, true, "watchlist", false],
+    [true, true, "goals", true],
+  ] as const)(
+    "mounts the Goals panel only on desktop or when active",
+    (isViewportReady, isMobile, activeTab, expected) => {
+      expect(shouldRenderGoalsPanel(isViewportReady, isMobile, activeTab)).toBe(expected);
+    },
+  );
 
   it("connects every rendered tab and panel to the keyboard model", () => {
     const source = readFileSync("src/components/goals/goals-view.tsx", "utf8");

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -43,9 +43,16 @@ function executeAnonymousRequest(pathname: string): Response {
   return response;
 }
 
-function executeAuthenticatedRequest(pathname: string, isDemo: boolean): Response {
+function executeAuthenticatedRequest(
+  pathname: string,
+  isDemo: boolean,
+  userAgent?: string,
+): Response {
   const request = new NextRequest(`https://astt.app${pathname}`, {
-    headers: { cookie: "authjs.session-token=signed-session" },
+    headers: {
+      cookie: "authjs.session-token=signed-session",
+      ...(userAgent ? { "user-agent": userAgent } : {}),
+    },
   });
   Object.defineProperty(request, "auth", {
     value: {
@@ -87,6 +94,35 @@ describe("Sentry tunnel proxy bypass", () => {
 
     expect(response.headers.get("x-middleware-next")).toBeNull();
     expect(response.headers.get("location")).toBe("https://astt.app/login");
+  });
+});
+
+describe("mobile desktop-only route redirects", () => {
+  const iphoneUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Mobile";
+
+  it.each([
+    ["/stocks", "https://astt.app/goals#watchlist"],
+    ["/projections", "https://astt.app/goals#projections"],
+    [
+      "/calendar?month=2026-08&date=2026-08-12",
+      "https://astt.app/goals?month=2026-08&date=2026-08-12#calendar",
+    ],
+  ])("redirects authenticated mobile %s into the Plan hub", (pathname, expectedLocation) => {
+    const response = executeAuthenticatedRequest(pathname, false, iphoneUserAgent);
+
+    expect(response.headers.get("location")).toBe(expectedLocation);
+  });
+
+  it("keeps authenticated desktop requests on standalone routes", () => {
+    const response = executeAuthenticatedRequest(
+      "/stocks",
+      false,
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("location")).toBeNull();
   });
 });
 

--- a/tests/unit/stock-tracker-source.test.ts
+++ b/tests/unit/stock-tracker-source.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("StockTrackerView responsive row mounting", () => {
+  it("mounts only the viewport-specific StockRow layout", () => {
+    const source = readFileSync("src/components/stocks/stock-tracker-view.tsx", "utf8");
+    const rowStart = source.indexOf("function StockRow(");
+    const rowEnd = source.indexOf("function ReorderStockItem", rowStart);
+    const rowSource = source.slice(rowStart, rowEnd);
+
+    expect(rowSource).toContain("const isMobile = useIsMobile();");
+    expect(rowSource).toContain("isMobile ? (");
+    expect(rowSource).toContain("isMobile ? null : (");
+  });
+});


### PR DESCRIPTION
## Summary

- Prevent inactive mobile Plan panels from mounting until the viewport is ready and only mount the active mobile panel.
- Redirect authenticated mobile visits to standalone `/stocks`, `/projections`, and `/calendar` routes into the Plan hub before server-page data loading, while preserving query state.
- Mount only the viewport-specific `StockRow` layout and keep desktop behavior unchanged.
- Leave the lower-priority Accounts responsive markup unchanged.

Closes #698

## Validation

- `pnpm test:unit` — 102 files, 911 tests passed
- PostgreSQL integration — 2 files, 27 tests passed
- `pnpm check` — format, lint, typecheck, and build passed
- Mobile Plan E2E — 5 passed, 5 skipped
- Stocks E2E — 2 passed, 2 skipped
