### PR TITLE
fix: version client storage and stabilize timers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,20 @@ The current application stack is Next.js 16, React 19, Prisma 7, PostgreSQL, Tai
 - `prisma/schema.prisma` — persistent data model
 - `prisma/migrations/` — ordered production schema history
 
+## Client persistence
+
+App-owned `localStorage` and `sessionStorage` keys use
+`asset-tracker:v<version>:<name>`. The current version is `v1`, and
+`src/lib/client-storage.ts` is the registry for every key and its legacy alias.
+
+Readers accept only values recognized by the current consumer. When no current key exists, a
+recognized legacy value is copied to the `v1` key and the legacy key is removed. Invalid current or
+legacy values and keys from unknown versions are ignored so the consumer's normal default applies.
+Storage access and migration failures are non-fatal; a failed copy leaves the legacy value intact.
+
+The sidebar cookie remains `asset-tracker:sidebar-collapsed` because it seeds server rendering and is
+not Web Storage. The `theme` key is owned by `next-themes` and is outside the app-owned convention.
+
 Authentication uses NextAuth.js with JWT sessions. Non-Vercel deployments may use a built-in single-owner password, Google OAuth, or both; Vercel production remains Google-only. `src/auth.config.ts` stays runtime-safe while `src/auth.ts` contains server-only adapter and credentials-provider configuration.
 
 ## Public Demo boundary

--- a/src/components/layout/color-schema-context.tsx
+++ b/src/components/layout/color-schema-context.tsx
@@ -15,6 +15,7 @@ import {
   APP_ICON_FAVICON_RADIUS,
   createAppIconSvg,
 } from "./app-icon";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
 export type ColorSchema = "emerald" | "anthropic" | "ocean" | "violet" | "amber" | "rose";
 
@@ -32,7 +33,7 @@ const ColorSchemaContext = createContext<ColorSchemaContextType>({
   setColorSchema: () => {},
 });
 
-const STORAGE_KEY = "asset-tracker:color-schema";
+const STORAGE_KEY = CLIENT_STORAGE_KEYS.colorSchema;
 
 function getAppIconPalette() {
   const styles = getComputedStyle(document.documentElement);
@@ -85,8 +86,7 @@ export function ColorSchemaProvider({ children }: { children: React.ReactNode })
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as ColorSchema | null;
-    const schema = stored && VALID_SCHEMAS.includes(stored) ? stored : "emerald";
+    const schema = readClientStorage(localStorage, STORAGE_KEY, VALID_SCHEMAS) ?? "emerald";
     applySchema(schema);
     startTransition(() => {
       setMounted(true);
@@ -95,7 +95,7 @@ export function ColorSchemaProvider({ children }: { children: React.ReactNode })
   }, []);
 
   const setColorSchema = useCallback((next: ColorSchema) => {
-    localStorage.setItem(STORAGE_KEY, next);
+    writeClientStorage(localStorage, STORAGE_KEY, next);
     applySchema(next);
     startTransition(() => setColorSchemaState(next));
   }, []);

--- a/src/components/layout/density-context.tsx
+++ b/src/components/layout/density-context.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   startTransition,
 } from "react";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
 export type Density = "comfortable" | "compact";
 
@@ -24,14 +25,15 @@ const DensityContext = createContext<DensityContextType>({
   setDensity: () => {},
 });
 
-const STORAGE_KEY = "asset-tracker:density";
+const STORAGE_KEY = CLIENT_STORAGE_KEYS.density;
+const DENSITIES: Density[] = ["comfortable", "compact"];
 
 export function DensityProvider({ children }: { children: React.ReactNode }) {
   const [density, setDensityState] = useState<Density>("comfortable");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = readClientStorage(localStorage, STORAGE_KEY, DENSITIES);
     startTransition(() => {
       setMounted(true);
       if (stored === "compact") setDensityState("compact");
@@ -39,7 +41,7 @@ export function DensityProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setDensity = useCallback((next: Density) => {
-    localStorage.setItem(STORAGE_KEY, next);
+    writeClientStorage(localStorage, STORAGE_KEY, next);
     startTransition(() => setDensityState(next));
   }, []);
 

--- a/src/components/layout/privacy-mode-context.tsx
+++ b/src/components/layout/privacy-mode-context.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, startTransition, useSyncExternalStore } from "react";
 import { hapticTick } from "@/lib/haptics";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
-const PRIVACY_KEY = "privacy-mode";
+const PRIVACY_KEY = CLIENT_STORAGE_KEYS.privacyMode;
+const PRIVACY_VALUES = ["true", "false"] as const;
 
 type PrivacyListener = () => void;
 
@@ -14,7 +16,7 @@ function notifyPrivacyListeners() {
 }
 
 function handlePrivacyStorage(event: StorageEvent) {
-  if (event.key === PRIVACY_KEY) notifyPrivacyListeners();
+  if (event.key === PRIVACY_KEY.current) notifyPrivacyListeners();
 }
 
 function handlePrivacyModeChange() {
@@ -44,7 +46,7 @@ export function subscribeToPrivacyMode(callback: PrivacyListener) {
 
 export function getPrivacyModeSnapshot() {
   if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(PRIVACY_KEY) === "true";
+  return readClientStorage(window.localStorage, PRIVACY_KEY, PRIVACY_VALUES) === "true";
 }
 
 export function getPrivacyModeServerSnapshot() {
@@ -65,8 +67,8 @@ export function usePrivacyMode() {
 
   const togglePrivacyMode = useCallback(() => {
     hapticTick();
-    const next = window.localStorage.getItem(PRIVACY_KEY) !== "true";
-    window.localStorage.setItem(PRIVACY_KEY, String(next));
+    const next = readClientStorage(window.localStorage, PRIVACY_KEY, PRIVACY_VALUES) !== "true";
+    writeClientStorage(window.localStorage, PRIVACY_KEY, String(next));
 
     // Flip the visible state in a transition so the dozens of currency cells
     // across the tree re-render without blocking the click -> paint cycle.

--- a/src/components/layout/pwa-install-hint.tsx
+++ b/src/components/layout/pwa-install-hint.tsx
@@ -4,8 +4,9 @@ import { useEffect } from "react";
 import { useLocale } from "next-intl";
 import { toast } from "sonner";
 import { copyPageUrl, publishUntilRendered, shouldShowSafariPwaHint } from "@/lib/pwa-install-hint";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
-const STORAGE_KEY = "assets-tracker:pwa-safari-hint-shown";
+const STORAGE_KEY = CLIENT_STORAGE_KEYS.pwaSafariHintShown;
 const TOAST_ID = "pwa-safari-install-hint";
 // Also the CSS hook for the full-height Copy link button in globals.css.
 const TOAST_CLASS = "pwa-install-hint";
@@ -35,13 +36,7 @@ export function PwaInstallHint() {
   const locale = useLocale();
 
   useEffect(() => {
-    let hasBeenShown: boolean;
-
-    try {
-      hasBeenShown = window.localStorage.getItem(STORAGE_KEY) === "1";
-    } catch {
-      return;
-    }
+    const hasBeenShown = readClientStorage(window.localStorage, STORAGE_KEY, ["1"]) === "1";
 
     const navigatorWithStandalone = navigator as NavigatorWithStandalone;
     const isStandalone =
@@ -69,11 +64,7 @@ export function PwaInstallHint() {
     };
 
     const markShown = () => {
-      try {
-        window.localStorage.setItem(STORAGE_KEY, "1");
-      } catch {
-        // The hint is optional; storage failures must not affect app rendering.
-      }
+      writeClientStorage(window.localStorage, STORAGE_KEY, "1");
     };
 
     const showToast = (actionLabel: string) => {

--- a/src/components/layout/pwa-install-prompt.tsx
+++ b/src/components/layout/pwa-install-prompt.tsx
@@ -5,8 +5,9 @@ import { useLocale } from "next-intl";
 import { toast } from "sonner";
 import { publishUntilRendered } from "@/lib/pwa-install-hint";
 import { isStandalonePwa, shouldOfferPwaInstall } from "@/lib/pwa-install-status";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
-const STORAGE_KEY = "assets-tracker:pwa-install-prompt-dismissed";
+const STORAGE_KEY = CLIENT_STORAGE_KEYS.pwaInstallPromptDismissed;
 const TOAST_ID = "pwa-install-prompt";
 // DOM hook so publishUntilRendered can confirm the toast really mounted.
 const TOAST_CLASS = "pwa-install-prompt";
@@ -39,19 +40,11 @@ type BeforeInstallPromptEvent = Event & {
 };
 
 function readDismissedFlag(): boolean {
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === "1";
-  } catch {
-    return false;
-  }
+  return readClientStorage(window.localStorage, STORAGE_KEY, ["1"]) === "1";
 }
 
 function persistDismissedFlag(): void {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, "1");
-  } catch {
-    // Install onboarding is optional; storage failures must not affect rendering.
-  }
+  writeClientStorage(window.localStorage, STORAGE_KEY, "1");
 }
 
 function getStandaloneStatus(): boolean {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -36,8 +36,11 @@ import {
 import { AppIcon } from "./app-icon";
 import { GitHubMark } from "./github-mark";
 import { REPO_URL } from "@/lib/repo";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
-const SIDEBAR_STORAGE_KEY = "asset-tracker:sidebar-collapsed";
+const SIDEBAR_STORAGE_KEY = CLIENT_STORAGE_KEYS.sidebarCollapsed;
+const SIDEBAR_COOKIE_KEY = "asset-tracker:sidebar-collapsed";
+const SIDEBAR_VALUES = ["1", "0"] as const;
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 const SIDEBAR_SHORTCUT_HINT = "Ctrl+\\ (⌘\\ on Mac)";
 
@@ -47,8 +50,8 @@ const SIDEBAR_SHORTCUT_HINT = "Ctrl+\\ (⌘\\ on Mac)";
 // in-session reads and cross-tab `storage` events.
 function persistCollapsed(value: boolean) {
   const raw = value ? "1" : "0";
-  window.localStorage.setItem(SIDEBAR_STORAGE_KEY, raw);
-  document.cookie = `${SIDEBAR_STORAGE_KEY}=${raw}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
+  writeClientStorage(window.localStorage, SIDEBAR_STORAGE_KEY, raw);
+  document.cookie = `${SIDEBAR_COOKIE_KEY}=${raw}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
 }
 
 export function Sidebar({
@@ -83,7 +86,7 @@ export function Sidebar({
         window.removeEventListener("sidebar-collapsed-change", handleChange);
       };
     },
-    () => window.localStorage.getItem(SIDEBAR_STORAGE_KEY) === "1",
+    () => readClientStorage(window.localStorage, SIDEBAR_STORAGE_KEY, SIDEBAR_VALUES) === "1",
     // Server + hydration snapshot: the cookie value the server already rendered
     // with. Matching it here means no post-hydration width swap (no flash).
     () => defaultCollapsed,
@@ -93,10 +96,9 @@ export function Sidebar({
   // the preference before the cookie existed (otherwise their first reload after
   // this change would still flash once).
   useEffect(() => {
-    const stored = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
-    if (stored === "1" || stored === "0") {
-      document.cookie = `${SIDEBAR_STORAGE_KEY}=${stored}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
-    }
+    const stored = readClientStorage(window.localStorage, SIDEBAR_STORAGE_KEY, SIDEBAR_VALUES);
+    if (stored)
+      document.cookie = `${SIDEBAR_COOKIE_KEY}=${stored}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
   }, []);
 
   const toggleCollapsed = useCallback(() => {

--- a/src/components/projections/projection-view.tsx
+++ b/src/components/projections/projection-view.tsx
@@ -10,6 +10,7 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { formatCurrency, formatNumber, getCurrencySymbol } from "@/lib/currencies";
 import { maskAmountInput, parseAmountInput, formatAmountInput } from "@/lib/amount-input";
 import { usePrivacyMode } from "@/components/layout/privacy-mode-context";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 import { useDensity } from "@/components/layout/density-context";
 import { useCountUp } from "@/hooks/use-count-up";
 import type { ProjectionData } from "@/lib/services/projection-service";
@@ -17,7 +18,8 @@ import type { ChartPoint } from "./projection-chart";
 import { LazyProjectionChart } from "./lazy-projection-chart";
 import { ProjectionOnboarding } from "./projection-onboarding";
 
-const GUIDE_STORAGE_KEY = "asset-tracker:projections-guide-open";
+const GUIDE_STORAGE_KEY = CLIENT_STORAGE_KEYS.projectionsGuideOpen;
+const GUIDE_VALUES = ["1", "0"] as const;
 const MAX_YEARS = 60;
 const DEFAULT_HORIZON = 30;
 
@@ -327,14 +329,18 @@ export function ProjectionView({ projectionData, baseCurrency, hasAccounts }: Pr
 
   useEffect(
     () =>
-      startTransition(() => setGuideOpen(window.localStorage.getItem(GUIDE_STORAGE_KEY) === "1")),
+      startTransition(() =>
+        setGuideOpen(
+          readClientStorage(window.localStorage, GUIDE_STORAGE_KEY, GUIDE_VALUES) === "1",
+        ),
+      ),
     [],
   );
 
   const toggleGuide = () => {
     const next = !guideOpen;
     setGuideOpen(next);
-    window.localStorage.setItem(GUIDE_STORAGE_KEY, next ? "1" : "0");
+    writeClientStorage(window.localStorage, GUIDE_STORAGE_KEY, next ? "1" : "0");
   };
 
   const projection = useMemo(

--- a/src/components/stocks/stock-tracker-view.tsx
+++ b/src/components/stocks/stock-tracker-view.tsx
@@ -57,6 +57,7 @@ import { CLIENT_REFRESH_COOLDOWN_MS } from "@/lib/refresh-policy";
 import { stockManualRefreshFeedback, type PriceRefreshPayload } from "@/lib/price-refresh-contract";
 import { cn, daysBetweenDates, localToday } from "@/lib/utils";
 import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
+import { startCooldownTicker } from "@/lib/timer-lifecycles";
 
 type QuoteResponse = {
   symbol: string;
@@ -741,10 +742,8 @@ export function StockTrackerView({ stocks }: { stocks: SerializedTrackedStock[] 
 
   // 1s tick while a cooldown is active so the button re-enables on time.
   useEffect(() => {
-    if (cooldownUntil <= now) return;
-    const interval = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(interval);
-  }, [cooldownUntil, now]);
+    return startCooldownTicker(cooldownUntil, setNow);
+  }, [cooldownUntil]);
 
   const coolingDown = cooldownUntil > now;
 

--- a/src/components/ui/freshness-badge.tsx
+++ b/src/components/ui/freshness-badge.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Camera, Clock, RefreshCw, TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FX_RATES_STALE_MS, SNAPSHOT_STALE_MS } from "@/lib/refresh-policy";
 import { formatRelativeTime, formatRelativeTimeShort } from "@/lib/format-relative-time";
+import {
+  getFreshnessClockServerSnapshot,
+  getFreshnessClockSnapshot,
+  refreshFreshnessClock,
+  subscribeToFreshnessClock,
+} from "@/lib/timer-lifecycles";
 
 type FreshnessKind = "price" | "rates" | "snapshot";
 
@@ -31,21 +37,19 @@ export function FreshnessBadge({
 }: FreshnessBadgeProps) {
   const t = useTranslations("freshness");
   const locale = useLocale();
-  const [now, setNow] = useState<number | null>(null);
+  const hasTimestamp = Boolean(timestamp);
+  const subscribe = useCallback(
+    (listener: () => void) => (hasTimestamp ? subscribeToFreshnessClock(listener) : () => {}),
+    [hasTimestamp],
+  );
+  const now = useSyncExternalStore(
+    subscribe,
+    getFreshnessClockSnapshot,
+    getFreshnessClockServerSnapshot,
+  );
 
   useEffect(() => {
-    const updateNow = () => setNow(Date.now());
-    const initialTimer = window.setTimeout(updateNow, 0);
-    const intervalTimer = window.setInterval(updateNow, 30_000);
-    return () => {
-      window.clearTimeout(initialTimer);
-      window.clearInterval(intervalTimer);
-    };
-  }, []);
-
-  useEffect(() => {
-    const id = window.setTimeout(() => setNow(Date.now()), 0);
-    return () => window.clearTimeout(id);
+    refreshFreshnessClock();
   }, [timestamp]);
 
   if (!timestamp) return null;

--- a/src/hooks/use-persisted-range.ts
+++ b/src/hooks/use-persisted-range.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, startTransition } from "react";
+import { CLIENT_STORAGE_KEYS, readClientStorage, writeClientStorage } from "@/lib/client-storage";
 
 /**
  * sessionStorage survives a deploy, so a stored value can name an option that
@@ -27,7 +28,7 @@ export function usePersistedRange<T extends string>(
   useEffect(() => {
     startTransition(() => {
       setMounted(true);
-      const stored = sessionStorage.getItem(`asset-tracker:range:${key}`);
+      const stored = readClientStorage(sessionStorage, CLIENT_STORAGE_KEYS.range(key), allowed);
       setRange(resolvePersistedRange(stored, allowed, initialValue));
     });
     // `allowed`/`initialValue` are read once on mount; re-running on a new
@@ -37,11 +38,7 @@ export function usePersistedRange<T extends string>(
 
   const setPersistedRange = (newRange: T) => {
     setRange(newRange);
-    try {
-      sessionStorage.setItem(`asset-tracker:range:${key}`, newRange);
-    } catch (_e) {
-      // Ignore sessionStorage errors (e.g. quota exceeded, private mode)
-    }
+    writeClientStorage(sessionStorage, CLIENT_STORAGE_KEYS.range(key), newRange);
   };
 
   return [mounted ? range : initialValue, setPersistedRange] as const;

--- a/src/lib/client-storage.ts
+++ b/src/lib/client-storage.ts
@@ -1,0 +1,68 @@
+const CLIENT_STORAGE_VERSION = 1;
+const CLIENT_STORAGE_PREFIX = `asset-tracker:v${CLIENT_STORAGE_VERSION}`;
+
+export type ClientStorageKey = Readonly<{
+  current: string;
+  legacy: string;
+}>;
+
+type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): unknown;
+  removeItem(key: string): unknown;
+};
+
+function key(name: string, legacy: string): ClientStorageKey {
+  return { current: `${CLIENT_STORAGE_PREFIX}:${name}`, legacy };
+}
+
+/** App-owned Web Storage keys. Cookies and dependency-owned keys are separate. */
+export const CLIENT_STORAGE_KEYS = {
+  privacyMode: key("privacy-mode", "privacy-mode"),
+  colorSchema: key("color-schema", "asset-tracker:color-schema"),
+  sidebarCollapsed: key("sidebar-collapsed", "asset-tracker:sidebar-collapsed"),
+  density: key("density", "asset-tracker:density"),
+  projectionsGuideOpen: key("projections-guide-open", "asset-tracker:projections-guide-open"),
+  pwaInstallPromptDismissed: key(
+    "pwa-install-prompt-dismissed",
+    "assets-tracker:pwa-install-prompt-dismissed",
+  ),
+  pwaSafariHintShown: key("pwa-safari-hint-shown", "assets-tracker:pwa-safari-hint-shown"),
+  range: (name: string) => key(`range:${name}`, `asset-tracker:range:${name}`),
+} as const;
+
+export function readClientStorage<T extends string>(
+  storage: StorageLike,
+  storageKey: ClientStorageKey,
+  allowed: readonly T[],
+): T | null {
+  try {
+    const current = storage.getItem(storageKey.current);
+    if (current !== null) return allowed.includes(current as T) ? (current as T) : null;
+
+    const legacy = storage.getItem(storageKey.legacy);
+    if (legacy === null || !allowed.includes(legacy as T)) return null;
+
+    try {
+      storage.setItem(storageKey.current, legacy);
+      storage.removeItem(storageKey.legacy);
+    } catch {
+      // Keep the valid legacy value when migration cannot be persisted.
+    }
+    return legacy as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeClientStorage(
+  storage: StorageLike,
+  storageKey: ClientStorageKey,
+  value: string,
+): void {
+  try {
+    storage.setItem(storageKey.current, value);
+  } catch {
+    // Client preferences are optional; storage failures must not break rendering.
+  }
+}

--- a/src/lib/timer-lifecycles.ts
+++ b/src/lib/timer-lifecycles.ts
@@ -1,0 +1,72 @@
+"use client";
+
+type ClockListener = () => void;
+
+let freshnessNow: number | null = null;
+let freshnessInterval: number | null = null;
+let freshnessInitialTimer: number | null = null;
+const freshnessListeners = new Set<ClockListener>();
+
+function notifyFreshnessListeners() {
+  freshnessNow = Date.now();
+  for (const listener of freshnessListeners) listener();
+}
+
+export function subscribeToFreshnessClock(listener: ClockListener) {
+  if (typeof window === "undefined") return () => {};
+
+  freshnessListeners.add(listener);
+  if (freshnessListeners.size === 1) {
+    freshnessInitialTimer = window.setTimeout(() => {
+      freshnessInitialTimer = null;
+      notifyFreshnessListeners();
+    }, 0);
+    freshnessInterval = window.setInterval(notifyFreshnessListeners, 30_000);
+  }
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    freshnessListeners.delete(listener);
+    if (freshnessListeners.size === 0) {
+      if (freshnessInitialTimer !== null) window.clearTimeout(freshnessInitialTimer);
+      if (freshnessInterval !== null) window.clearInterval(freshnessInterval);
+      freshnessInitialTimer = null;
+      freshnessInterval = null;
+      freshnessNow = null;
+    }
+  };
+}
+
+export function getFreshnessClockSnapshot() {
+  return freshnessNow;
+}
+
+export function getFreshnessClockServerSnapshot() {
+  return null;
+}
+
+export function refreshFreshnessClock() {
+  if (freshnessListeners.size > 0) notifyFreshnessListeners();
+}
+
+export function startCooldownTicker(cooldownUntil: number, onTick: (now: number) => void) {
+  if (typeof window === "undefined" || cooldownUntil <= Date.now()) return () => {};
+
+  let active = true;
+  const interval = window.setInterval(() => {
+    const now = Date.now();
+    onTick(now);
+    if (now >= cooldownUntil) {
+      active = false;
+      window.clearInterval(interval);
+    }
+  }, 1_000);
+
+  return () => {
+    if (!active) return;
+    active = false;
+    window.clearInterval(interval);
+  };
+}

--- a/tests/unit/client-storage.test.ts
+++ b/tests/unit/client-storage.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_STORAGE_KEYS,
+  readClientStorage,
+  writeClientStorage,
+  type ClientStorageKey,
+} from "@/lib/client-storage";
+
+function createStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+
+  return {
+    values,
+    storage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    },
+  };
+}
+
+describe("client storage versioning", () => {
+  it("uses the v1 namespace for every app-owned Web Storage key", () => {
+    expect(CLIENT_STORAGE_KEYS.privacyMode.current).toBe("asset-tracker:v1:privacy-mode");
+    expect(CLIENT_STORAGE_KEYS.colorSchema.current).toBe("asset-tracker:v1:color-schema");
+    expect(CLIENT_STORAGE_KEYS.sidebarCollapsed.current).toBe("asset-tracker:v1:sidebar-collapsed");
+    expect(CLIENT_STORAGE_KEYS.density.current).toBe("asset-tracker:v1:density");
+    expect(CLIENT_STORAGE_KEYS.projectionsGuideOpen.current).toBe(
+      "asset-tracker:v1:projections-guide-open",
+    );
+    expect(CLIENT_STORAGE_KEYS.pwaInstallPromptDismissed.current).toBe(
+      "asset-tracker:v1:pwa-install-prompt-dismissed",
+    );
+    expect(CLIENT_STORAGE_KEYS.pwaSafariHintShown.current).toBe(
+      "asset-tracker:v1:pwa-safari-hint-shown",
+    );
+    expect(CLIENT_STORAGE_KEYS.range("analysis-view").current).toBe(
+      "asset-tracker:v1:range:analysis-view",
+    );
+  });
+
+  it("reads and writes recognized current-version values", () => {
+    const { storage, values } = createStorage();
+
+    writeClientStorage(storage, CLIENT_STORAGE_KEYS.density, "compact");
+
+    expect(
+      readClientStorage(storage, CLIENT_STORAGE_KEYS.density, ["comfortable", "compact"]),
+    ).toBe("compact");
+    expect(values.get("asset-tracker:v1:density")).toBe("compact");
+  });
+
+  it("migrates every recognized legacy value and removes its legacy key", () => {
+    const migrations: Array<{
+      key: ClientStorageKey;
+      legacy: string;
+      value: string;
+      allowed: readonly string[];
+    }> = [
+      {
+        key: CLIENT_STORAGE_KEYS.privacyMode,
+        legacy: "privacy-mode",
+        value: "true",
+        allowed: ["true", "false"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.colorSchema,
+        legacy: "asset-tracker:color-schema",
+        value: "ocean",
+        allowed: ["emerald", "ocean"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.sidebarCollapsed,
+        legacy: "asset-tracker:sidebar-collapsed",
+        value: "1",
+        allowed: ["1", "0"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.density,
+        legacy: "asset-tracker:density",
+        value: "compact",
+        allowed: ["comfortable", "compact"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.projectionsGuideOpen,
+        legacy: "asset-tracker:projections-guide-open",
+        value: "1",
+        allowed: ["1", "0"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.pwaInstallPromptDismissed,
+        legacy: "assets-tracker:pwa-install-prompt-dismissed",
+        value: "1",
+        allowed: ["1"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.pwaSafariHintShown,
+        legacy: "assets-tracker:pwa-safari-hint-shown",
+        value: "1",
+        allowed: ["1"],
+      },
+      {
+        key: CLIENT_STORAGE_KEYS.range("analysis-view"),
+        legacy: "asset-tracker:range:analysis-view",
+        value: "All",
+        allowed: ["YTD", "All"],
+      },
+    ];
+
+    for (const migration of migrations) {
+      const { storage, values } = createStorage({ [migration.legacy]: migration.value });
+
+      expect(readClientStorage(storage, migration.key, migration.allowed)).toBe(migration.value);
+      expect(values.get(migration.key.current)).toBe(migration.value);
+      expect(values.has(migration.legacy)).toBe(false);
+    }
+  });
+
+  it("ignores invalid current values without reviving legacy state", () => {
+    const { storage, values } = createStorage({
+      "asset-tracker:v1:density": "dense",
+      "asset-tracker:density": "compact",
+    });
+
+    expect(
+      readClientStorage(storage, CLIENT_STORAGE_KEYS.density, ["comfortable", "compact"]),
+    ).toBeNull();
+    expect(values.get("asset-tracker:density")).toBe("compact");
+  });
+
+  it("ignores invalid legacy values and unknown versions", () => {
+    const { storage, values } = createStorage({
+      "asset-tracker:density": "dense",
+      "asset-tracker:v99:density": "compact",
+    });
+
+    expect(
+      readClientStorage(storage, CLIENT_STORAGE_KEYS.density, ["comfortable", "compact"]),
+    ).toBeNull();
+    expect(values.has("asset-tracker:v1:density")).toBe(false);
+    expect(values.get("asset-tracker:density")).toBe("dense");
+  });
+
+  it("falls back safely when storage reads or writes throw", () => {
+    const inaccessible = {
+      getItem: () => {
+        throw new Error("storage disabled");
+      },
+      setItem: () => {
+        throw new Error("storage disabled");
+      },
+      removeItem: () => {
+        throw new Error("storage disabled");
+      },
+    };
+
+    expect(
+      readClientStorage(inaccessible, CLIENT_STORAGE_KEYS.privacyMode, ["true", "false"]),
+    ).toBeNull();
+    expect(() =>
+      writeClientStorage(inaccessible, CLIENT_STORAGE_KEYS.privacyMode, "true"),
+    ).not.toThrow();
+  });
+
+  it("keeps a valid legacy value when copying it fails", () => {
+    const legacy = new Map([["privacy-mode", "true"]]);
+    const storage = {
+      getItem: (key: string) => legacy.get(key) ?? null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+      removeItem: (key: string) => legacy.delete(key),
+    };
+
+    expect(readClientStorage(storage, CLIENT_STORAGE_KEYS.privacyMode, ["true", "false"])).toBe(
+      "true",
+    );
+    expect(legacy.get("privacy-mode")).toBe("true");
+  });
+});

--- a/tests/unit/dashboard-history-parity.test.ts
+++ b/tests/unit/dashboard-history-parity.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
  * feed it from different fetchers — the dashboard from `getNormalizedHistory`
  * (hard-capped at DEFAULT_HISTORY_DAYS = 90) and History from
  * `getFullNormalizedHistory` (everything). Because both charts share one
- * sessionStorage range key (`asset-tracker:range:trend-chart`, see
+ * sessionStorage range key (`asset-tracker:v1:range:trend-chart`, see
  * use-persisted-range.ts), picking 6M/YTD/1Y/All showed the full series on
  * History and a silently truncated one on the dashboard, along with a
  * mismatched period-change badge and Y-axis domain.

--- a/tests/unit/external-store-subscriptions.test.ts
+++ b/tests/unit/external-store-subscriptions.test.ts
@@ -50,6 +50,7 @@ function createWindowStub() {
       localStorage: {
         getItem: (key: string) => values.get(key) ?? null,
         setItem: (key: string, value: string) => values.set(key, value),
+        removeItem: (key: string) => values.delete(key),
       },
       matchMedia,
     },
@@ -57,6 +58,7 @@ function createWindowStub() {
     removeEventListener,
     matchMedia,
     mediaQueries,
+    values,
   };
 }
 
@@ -93,7 +95,7 @@ describe("privacy mode external store", () => {
     expect(first).not.toHaveBeenCalled();
     expect(second).not.toHaveBeenCalled();
 
-    harness.window.dispatchEvent(storageEvent("privacy-mode"));
+    harness.window.dispatchEvent(storageEvent("asset-tracker:v1:privacy-mode"));
     harness.window.dispatchEvent(new Event("privacy-mode-change"));
     expect(first).toHaveBeenCalledTimes(2);
     expect(second).toHaveBeenCalledTimes(2);
@@ -120,6 +122,17 @@ describe("privacy mode external store", () => {
 
     const stop = subscribeToPrivacyMode(vi.fn());
     stop();
+  });
+
+  it("migrates recognized legacy state and defaults invalid current state", () => {
+    harness.values.set("privacy-mode", "true");
+
+    expect(getPrivacyModeSnapshot()).toBe(true);
+    expect(harness.values.get("asset-tracker:v1:privacy-mode")).toBe("true");
+    expect(harness.values.has("privacy-mode")).toBe(false);
+
+    harness.values.set("asset-tracker:v1:privacy-mode", "invalid");
+    expect(getPrivacyModeSnapshot()).toBe(false);
   });
 });
 

--- a/tests/unit/timer-lifecycles.test.ts
+++ b/tests/unit/timer-lifecycles.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getFreshnessClockSnapshot,
+  refreshFreshnessClock,
+  startCooldownTicker,
+  subscribeToFreshnessClock,
+} from "@/lib/timer-lifecycles";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("startCooldownTicker", () => {
+  it("ticks once per second and stops when the cooldown expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T00:00:00Z"));
+    vi.stubGlobal("window", globalThis);
+    const onTick = vi.fn();
+    const stop = startCooldownTicker(Date.now() + 2_000, onTick);
+
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(1_000);
+    expect(onTick).toHaveBeenLastCalledWith(Date.parse("2026-08-23T00:00:01Z"));
+    vi.advanceTimersByTime(1_000);
+    expect(onTick).toHaveBeenLastCalledWith(Date.parse("2026-08-23T00:00:02Z"));
+    expect(vi.getTimerCount()).toBe(0);
+
+    stop();
+  });
+});
+
+describe("freshness clock", () => {
+  it("shares one clock and updates all subscribers promptly", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T00:00:00Z"));
+    vi.stubGlobal("window", globalThis);
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const stopFirst = subscribeToFreshnessClock(first);
+    const stopSecond = subscribeToFreshnessClock(second);
+    expect(vi.getTimerCount()).toBe(2);
+
+    vi.advanceTimersByTime(0);
+    expect(getFreshnessClockSnapshot()).toBe(Date.parse("2026-08-23T00:00:00Z"));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+
+    refreshFreshnessClock();
+    expect(first).toHaveBeenCalledTimes(3);
+    expect(second).toHaveBeenCalledTimes(3);
+
+    stopFirst();
+    stopSecond();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #696 by centralizing app-owned Web Storage keys under asset-tracker:v1, validating values, and lazily migrating recognized legacy keys with safe defaults.
- Fixes #697 by keeping cooldown timers stable and sharing one freshness clock across badges with cleanup and prompt timestamp refresh.

## Verification

- pnpm test:unit — 111 files, 963 tests passed
- pnpm typecheck
- pnpm lint
- pnpm format:check
- git diff --check

Closes #696
Closes #697