### PR TITLE
perf: finish mobile PWA audit improvements (#705)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -38,8 +38,10 @@ function isCacheableRequest(request) {
 async function refreshStaticAsset(request) {
   const response = await fetch(request);
   if (response.ok) {
-    const cache = await caches.open(STATIC_CACHE);
-    await cache.put(request, response.clone());
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.put(request, response.clone()))
+      .catch(() => {});
   }
   return response;
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -38,9 +38,10 @@ function isCacheableRequest(request) {
 async function refreshStaticAsset(request) {
   const response = await fetch(request);
   if (response.ok) {
+    const cacheResponse = response.clone();
     caches
       .open(STATIC_CACHE)
-      .then((cache) => cache.put(request, response.clone()))
+      .then((cache) => cache.put(request, cacheResponse))
       .catch(() => {});
   }
   return response;

--- a/public/sw.js
+++ b/public/sw.js
@@ -30,6 +30,7 @@ function isStaticAsset(pathname) {
 
 function isCacheableRequest(request) {
   if (request.method !== "GET") return false;
+  if (request.destination === "document" || request.mode === "navigate") return false;
   const url = new URL(request.url);
   return url.origin === self.location.origin && isStaticAsset(url.pathname);
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,60 @@
-// Minimal network-only service worker.
-// Satisfies Chrome's PWA installability requirement (needs a fetch listener)
-// without adding caching — same-origin GET requests pass through to the network.
+const STATIC_CACHE = "astt-static-v1";
+const STATIC_CACHE_PREFIX = "astt-static-";
+
 self.addEventListener("install", () => self.skipWaiting());
-self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
-self.addEventListener("fetch", (e) => {
-  if (e.request.method === "GET" && new URL(e.request.url).origin === self.location.origin) {
-    e.respondWith(fetch(e.request));
+self.addEventListener("activate", (event) =>
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames
+          .filter((name) => name.startsWith(STATIC_CACHE_PREFIX) && name !== STATIC_CACHE)
+          .map((name) => caches.delete(name)),
+      );
+      await self.clients.claim();
+    })(),
+  ),
+);
+
+function isStaticAsset(pathname) {
+  return (
+    pathname.startsWith("/_next/static/") ||
+    pathname.startsWith("/icons/") ||
+    pathname === "/manifest.webmanifest" ||
+    pathname === "/favicon.ico" ||
+    pathname === "/icon" ||
+    pathname === "/icon.svg" ||
+    pathname === "/apple-icon"
+  );
+}
+
+function isCacheableRequest(request) {
+  if (request.method !== "GET") return false;
+  const url = new URL(request.url);
+  return url.origin === self.location.origin && isStaticAsset(url.pathname);
+}
+
+async function refreshStaticAsset(request) {
+  const response = await fetch(request);
+  if (response.ok) {
+    const cache = await caches.open(STATIC_CACHE);
+    await cache.put(request, response.clone());
   }
+  return response;
+}
+
+self.addEventListener("fetch", (event) => {
+  if (!isCacheableRequest(event.request)) return;
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      const cached = await cache.match(event.request);
+      if (cached) {
+        refreshStaticAsset(event.request).catch(() => {});
+        return cached;
+      }
+      return refreshStaticAsset(event.request);
+    })(),
+  );
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -113,8 +113,12 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://va.vercel-scripts.com" />
+        {enableVercelInsights ? (
+          <>
+            <link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />
+            <link rel="dns-prefetch" href="https://va.vercel-scripts.com" />
+          </>
+        ) : null}
         <link rel="dns-prefetch" href="https://api.frankfurter.app" />
         <link rel="dns-prefetch" href="https://open.er-api.com" />
       </head>

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -44,7 +44,7 @@ export function MobileHeader({ disableAutoHide = false }: { disableAutoHide?: bo
   return (
     <header
       className={cn(
-        "md:hidden sticky top-0 left-0 right-0 z-50 backdrop-blur-md",
+        "md:hidden sticky top-0 left-0 right-0 z-50 backdrop-blur-sm",
         "bg-background/80 dark:bg-card/80",
         "shadow-sm dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5)]",
         "px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))]",

--- a/src/components/layout/pull-to-refresh-context.tsx
+++ b/src/components/layout/pull-to-refresh-context.tsx
@@ -13,6 +13,10 @@ import {
 
 // Space opened above the header for the refresh indicator (8px margin + h-9 indicator + 8px margin)
 export const HANG_OFFSET = 52;
+export const INDICATOR_HIDDEN_Y = -44;
+export const INDICATOR_REST_Y = (HANG_OFFSET - 36) / 2;
+
+export const indicatorTranslate = (y: number) => `translate(-50%, ${y}px)`;
 
 interface PullToRefreshContextValue {
   refreshing: boolean;

--- a/src/components/layout/pull-to-refresh-indicator.tsx
+++ b/src/components/layout/pull-to-refresh-indicator.tsx
@@ -2,7 +2,12 @@
 
 import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { usePullToRefreshContext } from "./pull-to-refresh-context";
+import {
+  indicatorTranslate,
+  INDICATOR_HIDDEN_Y,
+  INDICATOR_REST_Y,
+  usePullToRefreshContext,
+} from "./pull-to-refresh-context";
 
 export function PullToRefreshIndicator() {
   const { refreshing, registerIndicatorRef } = usePullToRefreshContext();
@@ -14,7 +19,13 @@ export function PullToRefreshIndicator() {
         "h-9 w-9 rounded-full bg-background/90 border border-border/50 shadow-md backdrop-blur-md",
         "opacity-0",
       )}
-      style={{ top: "env(safe-area-inset-top)" }}
+      style={{
+        top: "env(safe-area-inset-top)",
+        transform: refreshing
+          ? indicatorTranslate(INDICATOR_REST_Y)
+          : indicatorTranslate(INDICATOR_HIDDEN_Y),
+        opacity: refreshing ? 1 : 0,
+      }}
       ref={registerIndicatorRef}
       aria-hidden
     >

--- a/src/components/layout/pull-to-refresh.tsx
+++ b/src/components/layout/pull-to-refresh.tsx
@@ -43,6 +43,11 @@ export function applyPullTransform(
 export function PullToRefresh({ onRefresh, children }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { refreshing, setRefreshing, getMain, getIndicator } = usePullToRefreshContext();
+  const refreshingRef = useRef(false);
+
+  useEffect(() => {
+    refreshingRef.current = refreshing;
+  }, [refreshing]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -68,7 +73,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
     };
 
     const onTouchStart = (event: TouchEvent) => {
-      if (refreshing) return;
+      if (refreshingRef.current) return;
       const scrollTop = getMain()?.scrollTop ?? window.scrollY;
       if (scrollTop > 0) {
         active = false;
@@ -79,7 +84,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
     };
 
     const onTouchMove = (event: TouchEvent) => {
-      if (!active || refreshing || reduceMotion) return;
+      if (!active || refreshingRef.current || reduceMotion) return;
       currentPull = dampedPull(event.touches[0].clientY - startY);
       if (!rafId) {
         rafId = requestAnimationFrame(() => {
@@ -87,7 +92,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
           const mainElement = getMain();
           const indicatorElement = getIndicator();
           if (mainElement && indicatorElement) {
-            applyPullTransform(mainElement, indicatorElement, currentPull, refreshing);
+            applyPullTransform(mainElement, indicatorElement, currentPull, refreshingRef.current);
           }
         });
       }
@@ -98,7 +103,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
         cancelAnimationFrame(rafId);
         rafId = null;
       }
-      if (!active || refreshing) {
+      if (!active || refreshingRef.current) {
         active = false;
         return;
       }
@@ -128,7 +133,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
       wrapper.removeEventListener("touchcancel", onTouchEnd);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [getIndicator, getMain, onRefresh, refreshing, setRefreshing]);
+  }, [getIndicator, getMain, onRefresh, setRefreshing]);
 
   return <div ref={wrapperRef}>{children}</div>;
 }

--- a/src/components/layout/pull-to-refresh.tsx
+++ b/src/components/layout/pull-to-refresh.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { HANG_OFFSET, usePullToRefreshContext } from "./pull-to-refresh-context";
+import {
+  HANG_OFFSET,
+  indicatorTranslate,
+  INDICATOR_HIDDEN_Y,
+  usePullToRefreshContext,
+} from "./pull-to-refresh-context";
 import { hapticTick } from "@/lib/haptics";
 
 const THRESHOLD = 70;
@@ -64,12 +69,13 @@ export function PullToRefresh({ onRefresh, children }: Props) {
     let currentPull = 0;
     let rafId: number | null = null;
 
-    const resetPullTransform = () => {
-      const mainElement = getMain();
-      const indicatorElement = getIndicator();
-      if (mainElement && indicatorElement) {
-        applyPullTransform(mainElement, indicatorElement, 0, false);
-      }
+    const resetPullStyles = () => {
+      const main = getMain();
+      const indicator = getIndicator();
+
+      main?.style.removeProperty("transform");
+      indicator?.style.setProperty("transform", indicatorTranslate(INDICATOR_HIDDEN_Y));
+      indicator?.style.setProperty("opacity", "0");
     };
 
     const onTouchStart = (event: TouchEvent) => {
@@ -117,7 +123,7 @@ export function PullToRefresh({ onRefresh, children }: Props) {
           setRefreshing(false);
         }
       }
-      resetPullTransform();
+      resetPullStyles();
       currentPull = 0;
     };
 

--- a/tests/unit/issue-592-components.test.ts
+++ b/tests/unit/issue-592-components.test.ts
@@ -41,7 +41,10 @@ describe("history issue #592 regressions", () => {
     const source = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
     expect(source).toContain("const resetPullStyles = () =>");
     expect(source).toContain('main?.style.removeProperty("transform")');
-    expect(source).toContain('indicator?.style.removeProperty("transform")');
+    expect(source).toContain(
+      'indicator?.style.setProperty("transform", indicatorTranslate(INDICATOR_HIDDEN_Y))',
+    );
+    expect(source).toContain('indicator?.style.setProperty("opacity", "0")');
     expect(source).toMatch(
       /else \{\s+setTransitionMode\(false\);\s+resetPullStyles\(\);\s+setPull\(0\);/,
     );

--- a/tests/unit/issue-592-components.test.ts
+++ b/tests/unit/issue-592-components.test.ts
@@ -31,4 +31,9 @@ describe("history issue #592 regressions", () => {
     expect(source).toContain("startTransition(() =>");
     expect(source).toContain("router.refresh()");
   });
+
+  it("cancels any scheduled pull-to-refresh animation frame during cleanup", () => {
+    const source = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
+    expect(source).toContain("cancelAnimationFrame");
+  });
 });

--- a/tests/unit/issue-592-components.test.ts
+++ b/tests/unit/issue-592-components.test.ts
@@ -36,4 +36,14 @@ describe("history issue #592 regressions", () => {
     const source = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
     expect(source).toContain("cancelAnimationFrame");
   });
+
+  it("resets inline pull-to-refresh styles when a release stays below threshold", () => {
+    const source = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
+    expect(source).toContain("const resetPullStyles = () =>");
+    expect(source).toContain('main?.style.removeProperty("transform")');
+    expect(source).toContain('indicator?.style.removeProperty("transform")');
+    expect(source).toMatch(
+      /else \{\s+setTransitionMode\(false\);\s+resetPullStyles\(\);\s+setPull\(0\);/,
+    );
+  });
 });

--- a/tests/unit/issue-592-components.test.ts
+++ b/tests/unit/issue-592-components.test.ts
@@ -45,8 +45,6 @@ describe("history issue #592 regressions", () => {
       'indicator?.style.setProperty("transform", indicatorTranslate(INDICATOR_HIDDEN_Y))',
     );
     expect(source).toContain('indicator?.style.setProperty("opacity", "0")');
-    expect(source).toMatch(
-      /else \{\s+setTransitionMode\(false\);\s+resetPullStyles\(\);\s+setPull\(0\);/,
-    );
+    expect(source).toContain("resetPullStyles();");
   });
 });

--- a/tests/unit/mobile-layout-performance.test.ts
+++ b/tests/unit/mobile-layout-performance.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("mobile PWA audit source contracts", () => {
+  it("moves pull progress onto requestAnimationFrame and shared refs", () => {
+    const context = readFileSync("src/components/layout/pull-to-refresh-context.tsx", "utf8");
+    const pullToRefresh = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
+    const mainShell = readFileSync("src/components/layout/mobile-main-shell.tsx", "utf8");
+    const indicator = readFileSync("src/components/layout/pull-to-refresh-indicator.tsx", "utf8");
+
+    expect(context).toContain("mainRef");
+    expect(context).toContain("indicatorRef");
+    expect(pullToRefresh).toContain("requestAnimationFrame");
+    expect(pullToRefresh).toContain("mainRef");
+    expect(pullToRefresh).not.toContain('document.querySelector("main")');
+    expect(mainShell).toContain("ref={mainRef}");
+    expect(indicator).toContain("ref={indicatorRef}");
+  });
+
+  it("keeps the lighter mobile header blur", () => {
+    const source = readFileSync("src/components/layout/mobile-header.tsx", "utf8");
+
+    expect(source).toContain("backdrop-blur-sm");
+    expect(source).not.toContain("backdrop-blur-md");
+  });
+
+  it("gates Vercel networking hints behind the existing env flag", () => {
+    const layout = readFileSync("src/app/layout.tsx", "utf8");
+    const conditionalBlock =
+      layout.match(/enableVercelInsights \? \(([\s\S]*?)\) : null/)?.[1] ?? "";
+
+    expect(layout).toContain("enableVercelInsights ?");
+    expect(conditionalBlock).toContain('rel="preconnect"');
+    expect(conditionalBlock).toContain('rel="dns-prefetch" href="https://va.vercel-scripts.com"');
+  });
+});

--- a/tests/unit/mobile-layout-performance.test.ts
+++ b/tests/unit/mobile-layout-performance.test.ts
@@ -2,19 +2,21 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("mobile PWA audit source contracts", () => {
-  it("moves pull progress onto requestAnimationFrame and shared refs", () => {
+  it("moves pull progress onto requestAnimationFrame and shared element getters", () => {
     const context = readFileSync("src/components/layout/pull-to-refresh-context.tsx", "utf8");
     const pullToRefresh = readFileSync("src/components/layout/pull-to-refresh.tsx", "utf8");
     const mainShell = readFileSync("src/components/layout/mobile-main-shell.tsx", "utf8");
     const indicator = readFileSync("src/components/layout/pull-to-refresh-indicator.tsx", "utf8");
 
-    expect(context).toContain("mainRef");
-    expect(context).toContain("indicatorRef");
+    expect(context).toContain("registerMainRef");
+    expect(context).toContain("registerIndicatorRef");
+    expect(context).toContain("getMain");
+    expect(context).toContain("getIndicator");
     expect(pullToRefresh).toContain("requestAnimationFrame");
-    expect(pullToRefresh).toContain("mainRef");
+    expect(pullToRefresh).toContain("getMain");
     expect(pullToRefresh).not.toContain('document.querySelector("main")');
-    expect(mainShell).toContain("ref={mainRef}");
-    expect(indicator).toContain("ref={indicatorRef}");
+    expect(mainShell).toContain("ref={registerMainRef}");
+    expect(indicator).toContain("ref={registerIndicatorRef}");
   });
 
   it("keeps the lighter mobile header blur", () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -133,7 +133,7 @@ describe("service worker fetch boundary", () => {
     const { fetchListener, networkFetch } = loadFetchListener();
     const event = dispatchFetch(fetchListener, {
       method: "GET",
-      url: "https://astt.app/dashboard",
+      url: "https://astt.app/icon",
       destination: "document",
       mode: "navigate",
     });

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -35,19 +35,31 @@ function makeResponse(body: string): ResponseStub {
   };
 }
 
-function createCache(): CacheStub & { get: (request: RequestStub) => ResponseStub | undefined } {
+function createCache(): CacheStub & {
+  get: (request: RequestStub) => ResponseStub | undefined;
+  failNextPut: (error?: Error) => void;
+} {
   const entries = new Map<string, ResponseStub>();
   const keyFor = (request: RequestStub) => request.url;
+  let putError: Error | undefined;
 
   return {
     async match(request) {
       return entries.get(keyFor(request));
     },
     async put(request, response) {
+      if (putError) {
+        const error = putError;
+        putError = undefined;
+        throw error;
+      }
       entries.set(keyFor(request), response);
     },
     get(request) {
       return entries.get(keyFor(request));
+    },
+    failNextPut(error = new Error("cache put failed")) {
+      putError = error;
     },
   };
 }
@@ -127,6 +139,22 @@ describe("service worker fetch boundary", () => {
     expect(event.respondWith).toHaveBeenCalledOnce();
     expect(await event.body()).toBe("icon");
     expect(cache.get(request)?.body).toBe("icon");
+  });
+
+  it("serves a network response even when cache storage write fails on a miss", async () => {
+    const { fetchListener, networkFetch, cache } = loadFetchListener();
+    const request = { method: "GET", url: "https://astt.app/icon.svg" };
+    cache.failNextPut();
+    networkFetch.mockResolvedValueOnce(makeResponse("fresh"));
+
+    const event = dispatchFetch(fetchListener, request);
+
+    expect(event.respondWith).toHaveBeenCalledOnce();
+    await expect(event.body()).resolves.toBe("fresh");
+
+    await flushMicrotasks();
+
+    expect(cache.get(request)).toBeUndefined();
   });
 
   it("does not intercept document requests", () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -27,11 +27,14 @@ interface CacheStub {
 
 type FetchListener = (event: FetchEventStub) => void;
 
-function makeResponse(body: string): ResponseStub {
+function makeResponse(body: string, onClone?: () => void): ResponseStub {
   return {
     body,
     ok: true,
-    clone: () => makeResponse(body),
+    clone: () => {
+      onClone?.();
+      return makeResponse(body, onClone);
+    },
   };
 }
 
@@ -67,6 +70,8 @@ function createCache(): CacheStub & {
 function loadFetchListener() {
   let fetchListener: FetchListener | undefined;
   const cache = createCache();
+  const cacheEvents: string[] = [];
+  let cacheOpenCount = 0;
   const networkFetch = vi.fn<(request: RequestStub) => Promise<ResponseStub>>();
   const serviceWorker = {
     location: { origin: "https://astt.app" },
@@ -77,7 +82,10 @@ function loadFetchListener() {
     },
   };
   const caches = {
-    open: vi.fn(async () => cache),
+    open: vi.fn(async () => {
+      cacheEvents.push(`open-${++cacheOpenCount}`);
+      return cache;
+    }),
     keys: vi.fn(async () => []),
     delete: vi.fn(async () => true),
   };
@@ -86,7 +94,7 @@ function loadFetchListener() {
   runInNewContext(source, { self: serviceWorker, fetch: networkFetch, caches, URL });
 
   if (!fetchListener) throw new Error("public/sw.js did not register a fetch listener");
-  return { fetchListener, networkFetch, cache };
+  return { fetchListener, networkFetch, cache, cacheEvents };
 }
 
 function dispatchFetch(fetchListener: FetchListener, request: RequestStub) {
@@ -139,6 +147,17 @@ describe("service worker fetch boundary", () => {
     expect(event.respondWith).toHaveBeenCalledOnce();
     expect(await event.body()).toBe("icon");
     expect(cache.get(request)?.body).toBe("icon");
+  });
+
+  it("clones a network response before opening the cache for its write", async () => {
+    const { fetchListener, networkFetch, cacheEvents } = loadFetchListener();
+    const request = { method: "GET", url: "https://astt.app/icon.svg" };
+    networkFetch.mockResolvedValueOnce(makeResponse("fresh", () => cacheEvents.push("clone")));
+
+    const event = dispatchFetch(fetchListener, request);
+
+    await expect(event.body()).resolves.toBe("fresh");
+    expect(cacheEvents.slice(0, 3)).toEqual(["open-1", "clone", "open-2"]);
   });
 
   it("serves a network response even when cache storage write fails on a miss", async () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -2,17 +2,60 @@ import { readFileSync } from "node:fs";
 import { runInNewContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 
+interface RequestStub {
+  method: string;
+  url: string;
+  destination?: string;
+  mode?: string;
+}
+
+interface ResponseStub {
+  body: string;
+  ok: boolean;
+  clone: () => ResponseStub;
+}
+
 interface FetchEventStub {
-  request: { method: string; url: string };
+  request: RequestStub;
   respondWith: (response: unknown) => void;
+}
+
+interface CacheStub {
+  match: (request: RequestStub) => Promise<ResponseStub | undefined>;
+  put: (request: RequestStub, response: ResponseStub) => Promise<void>;
 }
 
 type FetchListener = (event: FetchEventStub) => void;
 
+function makeResponse(body: string): ResponseStub {
+  return {
+    body,
+    ok: true,
+    clone: () => makeResponse(body),
+  };
+}
+
+function createCache(): CacheStub & { get: (request: RequestStub) => ResponseStub | undefined } {
+  const entries = new Map<string, ResponseStub>();
+  const keyFor = (request: RequestStub) => request.url;
+
+  return {
+    async match(request) {
+      return entries.get(keyFor(request));
+    },
+    async put(request, response) {
+      entries.set(keyFor(request), response);
+    },
+    get(request) {
+      return entries.get(keyFor(request));
+    },
+  };
+}
+
 function loadFetchListener() {
   let fetchListener: FetchListener | undefined;
-  const networkResponse = Promise.resolve({ ok: true });
-  const networkFetch = vi.fn(() => networkResponse);
+  const cache = createCache();
+  const networkFetch = vi.fn<(request: RequestStub) => Promise<ResponseStub>>();
   const serviceWorker = {
     location: { origin: "https://astt.app" },
     skipWaiting: vi.fn(),
@@ -21,49 +64,114 @@ function loadFetchListener() {
       if (type === "fetch") fetchListener = listener as FetchListener;
     },
   };
+  const caches = {
+    open: vi.fn(async () => cache),
+    keys: vi.fn(async () => []),
+    delete: vi.fn(async () => true),
+  };
 
   const source = readFileSync(new URL("../../public/sw.js", import.meta.url), "utf8");
-  runInNewContext(source, { self: serviceWorker, fetch: networkFetch, URL });
+  runInNewContext(source, { self: serviceWorker, fetch: networkFetch, caches, URL });
 
   if (!fetchListener) throw new Error("public/sw.js did not register a fetch listener");
-  return { fetchListener, networkFetch, networkResponse };
+  return { fetchListener, networkFetch, cache };
+}
+
+function dispatchFetch(fetchListener: FetchListener, request: RequestStub) {
+  let responsePromise: Promise<unknown> | undefined;
+  const respondWith = vi.fn((response: unknown) => {
+    responsePromise = Promise.resolve(response);
+  });
+
+  fetchListener({ request, respondWith });
+
+  return {
+    respondWith,
+    async body() {
+      const response = (await responsePromise) as ResponseStub;
+      return response.body;
+    },
+  };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("service worker fetch boundary", () => {
-  it("passes same-origin GET requests through the network", () => {
-    const { fetchListener, networkFetch, networkResponse } = loadFetchListener();
-    const respondWith = vi.fn();
-    const request = { method: "GET", url: "https://astt.app/dashboard" };
+  it("returns a cached static asset immediately and refreshes it in the background", async () => {
+    const { fetchListener, networkFetch, cache } = loadFetchListener();
+    const request = { method: "GET", url: "https://astt.app/_next/static/chunk.js" };
+    await cache.put(request, makeResponse("cached"));
+    networkFetch.mockResolvedValueOnce(makeResponse("fresh"));
 
-    fetchListener({ request, respondWith });
+    const event = dispatchFetch(fetchListener, request);
 
+    expect(event.respondWith).toHaveBeenCalledOnce();
+    expect(await event.body()).toBe("cached");
     expect(networkFetch).toHaveBeenCalledWith(request);
-    expect(respondWith).toHaveBeenCalledWith(networkResponse);
+
+    await flushMicrotasks();
+
+    expect(cache.get(request)?.body).toBe("fresh");
+  });
+
+  it("waits for the network when a cacheable static asset is missing", async () => {
+    const { fetchListener, networkFetch, cache } = loadFetchListener();
+    const request = { method: "GET", url: "https://astt.app/icons/icon-192.png" };
+    networkFetch.mockResolvedValueOnce(makeResponse("icon"));
+
+    const event = dispatchFetch(fetchListener, request);
+
+    expect(event.respondWith).toHaveBeenCalledOnce();
+    expect(await event.body()).toBe("icon");
+    expect(cache.get(request)?.body).toBe("icon");
+  });
+
+  it("does not intercept document requests", () => {
+    const { fetchListener, networkFetch } = loadFetchListener();
+    const event = dispatchFetch(fetchListener, {
+      method: "GET",
+      url: "https://astt.app/dashboard",
+      destination: "document",
+      mode: "navigate",
+    });
+
+    expect(networkFetch).not.toHaveBeenCalled();
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept API requests", () => {
+    const { fetchListener, networkFetch } = loadFetchListener();
+    const event = dispatchFetch(fetchListener, {
+      method: "GET",
+      url: "https://astt.app/api/accounts",
+    });
+
+    expect(networkFetch).not.toHaveBeenCalled();
+    expect(event.respondWith).not.toHaveBeenCalled();
   });
 
   it("does not intercept cross-origin GET requests", () => {
     const { fetchListener, networkFetch } = loadFetchListener();
-    const respondWith = vi.fn();
-
-    fetchListener({
-      request: { method: "GET", url: "https://lh3.googleusercontent.com/avatar.png" },
-      respondWith,
+    const event = dispatchFetch(fetchListener, {
+      method: "GET",
+      url: "https://lh3.googleusercontent.com/avatar.png",
     });
 
     expect(networkFetch).not.toHaveBeenCalled();
-    expect(respondWith).not.toHaveBeenCalled();
+    expect(event.respondWith).not.toHaveBeenCalled();
   });
 
   it("does not intercept non-GET requests", () => {
     const { fetchListener, networkFetch } = loadFetchListener();
-    const respondWith = vi.fn();
-
-    fetchListener({
-      request: { method: "POST", url: "https://astt.app/api/accounts" },
-      respondWith,
+    const event = dispatchFetch(fetchListener, {
+      method: "POST",
+      url: "https://astt.app/icons/icon-192.png",
     });
 
     expect(networkFetch).not.toHaveBeenCalled();
-    expect(respondWith).not.toHaveBeenCalled();
+    expect(event.respondWith).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Cache only same-origin static GET assets in the service worker with SWR; documents, RSC, API, and private data remain network-only.
- Move pull-to-refresh drag updates to rAF/ref DOM writes with explicit cleanup and preserved gesture behavior.
- Reduce mobile header blur and gate Vercel preconnect hints.
- Make cache writes best-effort and protect navigation/document boundaries.

Closes #705

## Verification

- Focused unit suite: 4 files, 41 tests passed.
- Mobile Chrome E2E: 5 passed, 5 skipped.
- Typecheck and production build: passed.
- Final task/fix/scoped reviews: clean.