### PR TITLE
perf: lazy-load mobile Plan tab data (#703)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -125,6 +125,7 @@
     "delete": "Delete",
     "cancel": "Cancel",
     "save": "Save",
+    "loading": "Loading...",
     "saving": "Saving...",
     "deleting": "Deleting...",
     "asset": "Asset",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -125,6 +125,7 @@
     "delete": "刪除",
     "cancel": "取消",
     "save": "儲存",
+    "loading": "載入中...",
     "saving": "儲存中...",
     "deleting": "刪除中...",
     "asset": "資產",

--- a/src/app/(main)/goals/page.tsx
+++ b/src/app/(main)/goals/page.tsx
@@ -7,6 +7,7 @@ import { getProjectionData } from "@/lib/services/projection-service";
 import { getCachedTrackedStocks } from "@/lib/services/stock-watch-service";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
+import { headers } from "next/headers";
 import { pickMessages } from "@/lib/i18n-utils";
 import { LargeTitleHeading } from "@/components/layout/large-title-heading";
 import { GoalsView } from "@/components/goals/goals-view";
@@ -24,9 +25,13 @@ import {
   type CalendarEarningsItem,
 } from "@/lib/services/calendar-earnings-data";
 import { rateLimitSubjectCheckWithPrune } from "@/lib/rate-limit";
+import { isMobileUserAgent } from "@/lib/mobile-hub-route";
+import { parseMobilePlanTab, type MobilePlanTab } from "@/components/goals/mobile-plan-tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { GoalWithProgress, SerializedAccount } from "@/lib/types";
+import type { GoalWithProgress, SerializedAccount, SerializedCalendarEntry } from "@/lib/types";
+import type { ProjectionData } from "@/lib/services/projection-service";
+import type { SerializedTrackedStock } from "@/lib/services/stock-watch-service";
 
 const CLIENT_NAMESPACES = [
   "goals",
@@ -42,7 +47,7 @@ const CLIENT_NAMESPACES = [
 ];
 
 type GoalsPageProps = {
-  searchParams: Promise<{ month?: string; date?: string }>;
+  searchParams: Promise<{ month?: string; date?: string; tab?: string }>;
 };
 
 function PanelSkeleton() {
@@ -61,40 +66,94 @@ function PanelSkeleton() {
 }
 
 type GoalsViewEagerProps = {
-  goalsWithProgress: GoalWithProgress[];
+  goalsWithProgress?: GoalWithProgress[];
   baseCurrency: string;
-  accounts: SerializedAccount[];
+  accounts?: SerializedAccount[];
   calendarMonth: string;
   calendarSelectedDate: string;
   calendarToday: string;
   locale: string;
 };
 
-async function GoalsDeferredData({
+type GoalsPanelData = {
+  projectionData?: ProjectionData;
+  stocks?: SerializedTrackedStock[];
+  calendarEntries?: SerializedCalendarEntry[];
+  calendarEarnings?: CalendarEarningsItem[];
+};
+
+function getGoalsPanelData({
   userId,
-  eagerProps,
+  isMobile,
+  activeTab,
+  baseCurrency,
+  calendarMonth,
 }: {
   userId: string;
-  eagerProps: GoalsViewEagerProps;
-}) {
-  const { baseCurrency, calendarMonth } = eagerProps;
+  isMobile: boolean;
+  activeTab: MobilePlanTab;
+  baseCurrency: string;
+  calendarMonth: string;
+}): Promise<GoalsPanelData> {
+  if (isMobile && activeTab === "goals") return Promise.resolve({});
+  if (isMobile && activeTab === "watchlist") {
+    return getCachedTrackedStocks(userId).then((stocks) => ({ stocks }));
+  }
+  if (isMobile && activeTab === "projections") {
+    return getProjectionData(userId, baseCurrency).then((projectionData) => ({ projectionData }));
+  }
+
   const { from, to } = getVisibleCalendarRange(calendarMonth);
+  const fromDate = parseDateOnly(from);
+  const toDate = parseDateOnly(to);
+  if (!fromDate || !toDate) {
+    throw new Error(`Invalid visible calendar range: ${from}..${to}`);
+  }
+
   const earningsLimited = rateLimitSubjectCheckWithPrune(
     userId,
     "yahoo",
     CALENDAR_EARNINGS_RATE_LIMIT,
   );
-  const [projectionData, stocks, calendarEntries, calendarEarnings] = await Promise.all([
+  if (isMobile) {
+    return Promise.all([
+      getCalendarEntriesInRange(userId, fromDate, toDate),
+      earningsLimited
+        ? Promise.resolve<CalendarEarningsItem[]>([])
+        : getCalendarEarnings(userId, from, to),
+    ]).then(([calendarEntries, calendarEarnings]) => ({ calendarEntries, calendarEarnings }));
+  }
+
+  return Promise.all([
     getProjectionData(userId, baseCurrency),
     getCachedTrackedStocks(userId),
-    getCalendarEntriesInRange(userId, parseDateOnly(from)!, parseDateOnly(to)!),
+    getCalendarEntriesInRange(userId, fromDate, toDate),
     earningsLimited
       ? Promise.resolve<CalendarEarningsItem[]>([])
       : getCalendarEarnings(userId, from, to),
-  ]);
+  ]).then(([projectionData, stocks, calendarEntries, calendarEarnings]) => ({
+    projectionData,
+    stocks,
+    calendarEntries,
+    calendarEarnings,
+  }));
+}
+
+async function GoalsDeferredData({
+  activeTab,
+  requestedTab,
+  eagerProps,
+  panelDataP,
+}: {
+  activeTab: MobilePlanTab;
+  requestedTab?: MobilePlanTab;
+  eagerProps: GoalsViewEagerProps;
+  panelDataP: Promise<GoalsPanelData>;
+}) {
+  const panelData = await panelDataP;
 
   const earningsByDate = new Map<string, CalendarEarningsItem[]>();
-  for (const item of calendarEarnings) {
+  for (const item of panelData.calendarEarnings ?? []) {
     const day = earningsByDate.get(item.date) ?? [];
     day.push(item);
     earningsByDate.set(item.date, day);
@@ -103,32 +162,59 @@ async function GoalsDeferredData({
   return (
     <GoalsView
       {...eagerProps}
-      projectionData={projectionData}
-      stocks={stocks}
-      calendarEntries={calendarEntries}
+      loadedTab={activeTab}
+      requestedTab={requestedTab}
+      projectionData={panelData.projectionData}
+      stocks={panelData.stocks}
+      calendarEntries={panelData.calendarEntries}
       earningsByDate={earningsByDate}
     />
   );
 }
 
-async function GoalsContent({ searchParams }: GoalsPageProps) {
+export async function GoalsContent({ searchParams }: GoalsPageProps) {
   const session = await getSession();
   if (!session?.user?.id) return null;
   const userId = session.user.id;
-  const { month, date } = normalizeCalendarUrlState(await searchParams);
+  const [{ tab, ...calendarSearchParams }, requestHeaders] = await Promise.all([
+    searchParams,
+    headers(),
+  ]);
+  const { month, date } = normalizeCalendarUrlState(calendarSearchParams);
+  const isMobile = isMobileUserAgent(requestHeaders.get("user-agent"));
+  const requestedTab = isMobile && tab !== undefined ? parseMobilePlanTab(tab) : undefined;
+  const activeTab = requestedTab ?? (isMobile ? "watchlist" : "goals");
 
   const settingsP = getOrCreateSettings(userId);
-  const [t, navT, messages, locale, goalsWithProgress, rawAccounts, settings] = await Promise.all([
+  const goalsDataP =
+    !isMobile || activeTab === "goals"
+      ? settingsP.then(async (settings) => {
+          const [goalsWithProgress, rawAccounts] = await Promise.all([
+            computeGoalsWithProgress(userId, settings.baseCurrency),
+            fetchUserAccountsWithHoldings(userId),
+          ]);
+          return { goalsWithProgress, rawAccounts };
+        })
+      : Promise.resolve(undefined);
+  const panelDataP = settingsP.then((settings) =>
+    getGoalsPanelData({
+      userId,
+      isMobile,
+      activeTab,
+      baseCurrency: settings.baseCurrency,
+      calendarMonth: month,
+    }),
+  );
+  const [t, navT, messages, locale, settings, goalsData] = await Promise.all([
     getTranslations("goals"),
     getTranslations("nav"),
     getMessages(),
     getLocale(),
-    settingsP.then((s) => computeGoalsWithProgress(userId, s.baseCurrency)),
-    fetchUserAccountsWithHoldings(userId),
     settingsP,
+    goalsDataP,
   ]);
 
-  const accounts: SerializedAccount[] = rawAccounts.map(({ holdings: _h, ...rest }) => rest);
+  const accounts = goalsData?.rawAccounts.map(({ holdings: _h, ...rest }) => rest);
   const calendarToday = formatDateOnly(taiwanCalendarDay(new Date()));
 
   return (
@@ -140,9 +226,10 @@ async function GoalsContent({ searchParams }: GoalsPageProps) {
         </LargeTitleHeading>
         <Suspense fallback={<PanelSkeleton />}>
           <GoalsDeferredData
-            userId={userId}
+            activeTab={activeTab}
+            requestedTab={requestedTab}
             eagerProps={{
-              goalsWithProgress,
+              goalsWithProgress: goalsData?.goalsWithProgress,
               baseCurrency: settings.baseCurrency,
               accounts,
               calendarMonth: month,
@@ -150,6 +237,7 @@ async function GoalsContent({ searchParams }: GoalsPageProps) {
               calendarToday,
               locale,
             }}
+            panelDataP={panelDataP}
           />
         </Suspense>
       </div>

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -49,13 +49,14 @@ const CalendarView = dynamic(
 );
 
 interface GoalsViewProps {
-  goalsWithProgress: GoalWithProgress[];
+  loadedTab: MobilePlanTab;
+  goalsWithProgress?: GoalWithProgress[];
   baseCurrency: string;
-  accounts: SerializedAccount[];
-  projectionData: ProjectionData;
-  stocks: SerializedTrackedStock[];
-  calendarEntries: SerializedCalendarEntry[];
-  earningsByDate: ReadonlyMap<string, CalendarEarningsItem[]>;
+  accounts?: SerializedAccount[];
+  projectionData?: ProjectionData;
+  stocks?: SerializedTrackedStock[];
+  calendarEntries?: SerializedCalendarEntry[];
+  earningsByDate?: ReadonlyMap<string, CalendarEarningsItem[]>;
   calendarMonth: string;
   calendarSelectedDate: string;
   calendarToday: string;
@@ -131,6 +132,7 @@ function ManageGoalsList({
 }
 
 export function GoalsView({
+  loadedTab,
   goalsWithProgress,
   baseCurrency,
   accounts,
@@ -154,9 +156,13 @@ export function GoalsView({
   const [savingOrder, setSavingOrder] = useState(false);
   const [draft, setDraft] = useState<GoalWithProgress[]>([]);
   const tabRefs = useRef<Partial<Record<MobilePlanTab, HTMLButtonElement | null>>>({});
+  const migratedLegacyHash = useRef<string | null>(null);
+  const pendingLegacyHash = useRef<string | null>(null);
+  const loadedGoals = goalsWithProgress ?? [];
+  const loadedAccounts = accounts ?? [];
 
   function enterManageMode() {
-    setDraft([...goalsWithProgress]);
+    setDraft([...loadedGoals]);
     setManageMode(true);
   }
 
@@ -208,6 +214,7 @@ export function GoalsView({
           ? "calendar"
           : "watchlist";
   const activeTab: MobilePlanTab = override ?? hashTab;
+  const hasLoadedActivePanel = activeTab === loadedTab;
 
   // Keep the structural tabpanels in the DOM so every tab retains its
   // aria-controls target, but only create the heavy mobile child for the active
@@ -215,21 +222,28 @@ export function GoalsView({
   // child out of the desktop render.
   const mobileContentEnabled = shouldRenderMobilePlanContent(isViewportReady, isMobile);
   const activeMobilePanelContent = renderActiveMobilePlanPanel(mobileContentEnabled, activeTab, {
-    watchlist: () => <StockTrackerView stocks={stocks} />,
-    projections: () => (
-      <ProjectionView projectionData={projectionData} baseCurrency={baseCurrency} />
-    ),
-    calendar: () => (
-      <CalendarView
-        initialEntries={calendarEntries}
-        month={calendarMonth}
-        selectedDate={calendarSelectedDate}
-        today={calendarToday}
-        locale={locale}
-        showHeader={false}
-        earningsByDate={earningsByDate}
-      />
-    ),
+    watchlist: () =>
+      hasLoadedActivePanel && stocks ? <StockTrackerView stocks={stocks} /> : <MobilePlanLoading />,
+    projections: () =>
+      hasLoadedActivePanel && projectionData ? (
+        <ProjectionView projectionData={projectionData} baseCurrency={baseCurrency} />
+      ) : (
+        <MobilePlanLoading />
+      ),
+    calendar: () =>
+      hasLoadedActivePanel && calendarEntries && earningsByDate ? (
+        <CalendarView
+          initialEntries={calendarEntries}
+          month={calendarMonth}
+          selectedDate={calendarSelectedDate}
+          today={calendarToday}
+          locale={locale}
+          showHeader={false}
+          earningsByDate={earningsByDate}
+        />
+      ) : (
+        <MobilePlanLoading />
+      ),
   });
   const renderGoalsContent = shouldRenderGoalsPanel(isViewportReady, isMobile, activeTab);
 
@@ -243,10 +257,42 @@ export function GoalsView({
     });
   }, [activeTab, isMobile]);
 
+  useEffect(() => {
+    if (
+      !isMobile ||
+      !hash ||
+      migratedLegacyHash.current === hash ||
+      new URLSearchParams(window.location.search).has("tab")
+    ) {
+      return;
+    }
+
+    migratedLegacyHash.current = hash;
+    pendingLegacyHash.current = hash;
+    setOverride(activeTab);
+    const params = new URLSearchParams(window.location.search);
+    params.set("tab", activeTab);
+    const href = `${window.location.pathname}?${params.toString()}`;
+    router.replace(href);
+  }, [activeTab, hash, isMobile, router]);
+
+  useEffect(() => {
+    const legacyHash = pendingLegacyHash.current;
+    if (!legacyHash || loadedTab !== activeTab) return;
+
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}${legacyHash}`,
+    );
+    pendingLegacyHash.current = null;
+  }, [activeTab, loadedTab]);
+
   const handleTabChange = (tab: MobilePlanTab) => {
     setOverride(tab);
-    const base = window.location.pathname + window.location.search;
-    window.history.replaceState(null, "", tab === "watchlist" ? base : `${base}#${tab}`);
+    const params = new URLSearchParams(window.location.search);
+    params.set("tab", tab);
+    router.replace(`${window.location.pathname}?${params.toString()}#${tab}`);
   };
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, tab: MobilePlanTab) => {
@@ -311,7 +357,7 @@ export function GoalsView({
         aria-labelledby={getMobilePlanTabId("goals")}
         className={activeTab === "goals" ? "block" : "hidden md:block"}
       >
-        {renderGoalsContent ? (
+        {renderGoalsContent && hasLoadedActivePanel && goalsWithProgress && accounts ? (
           <div className="space-y-6">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
@@ -333,7 +379,7 @@ export function GoalsView({
                 </div>
               ) : (
                 <div className="flex flex-wrap gap-2 sm:flex-nowrap">
-                  {goalsWithProgress.length > 1 && (
+                  {loadedGoals.length > 1 && (
                     <Button
                       variant="outline"
                       onClick={enterManageMode}
@@ -354,18 +400,18 @@ export function GoalsView({
               )}
             </div>
 
-            {goalsWithProgress.length === 0 ? (
+            {loadedGoals.length === 0 ? (
               <GoalsOnboarding onAdd={() => setCreateOpen(true)} />
             ) : manageMode ? (
               <ManageGoalsList draft={draft} onReorder={setDraft} />
             ) : (
               <div className="grid gap-4">
-                {goalsWithProgress.map((data) => (
+                {loadedGoals.map((data) => (
                   <GoalCard
                     key={data.goal.id}
                     data={data}
                     baseCurrency={baseCurrency}
-                    accounts={accounts}
+                    accounts={loadedAccounts}
                     defaultCurrency={baseCurrency}
                   />
                 ))}
@@ -375,10 +421,12 @@ export function GoalsView({
             <GoalFormDialog
               open={createOpen}
               onOpenChange={setCreateOpen}
-              accounts={accounts}
+              accounts={loadedAccounts}
               defaultCurrency={baseCurrency}
             />
           </div>
+        ) : renderGoalsContent ? (
+          <MobilePlanLoading />
         ) : null}
       </div>
 
@@ -405,4 +453,8 @@ export function GoalsView({
       </div>
     </div>
   );
+}
+
+function MobilePlanLoading() {
+  return <div aria-label="Loading" className="h-48 animate-pulse rounded-lg bg-muted" />;
 }

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -160,8 +160,6 @@ export function GoalsView({
   const [draft, setDraft] = useState<GoalWithProgress[]>([]);
   const tabRefs = useRef<Partial<Record<MobilePlanTab, HTMLButtonElement | null>>>({});
   const [pendingTab, setPendingTab] = useState<MobilePlanTab | null>(null);
-  const reconciledTab = useRef<MobilePlanTab | null>(null);
-  const pendingHash = useRef<string | null>(null);
   const loadedGoals = goalsWithProgress ?? [];
   const loadedAccounts = accounts ?? [];
 
@@ -196,10 +194,8 @@ export function GoalsView({
     }
   }
   // Deep links for goals, projections, and Calendar open their matching sub-view.
-  // The bare "Plan" tab (no hash) lands on Watchlist, the leftmost sub-tab.
-  // useSyncExternalStore reads the hash with a server snapshot of "" so SSR and
-  // hydration agree; a pending switch wins until the server returns the selected
-  // branch and rewrites the query/hash for shareable, Back-friendly URLs.
+  // The query is the canonical server selector; hashes remain supported for
+  // existing links and are removed after the first client render.
   const hash = useSyncExternalStore(
     (onChange) => {
       window.addEventListener("hashchange", onChange);
@@ -209,10 +205,7 @@ export function GoalsView({
     () => "",
   );
   const desiredTab = getMobilePlanTabFromUrl(isMobile, requestedTab, hash);
-  const activeTab: MobilePlanTab =
-    pendingTab && (requestedTab !== pendingTab || loadedTab !== pendingTab)
-      ? pendingTab
-      : desiredTab;
+  const activeTab: MobilePlanTab = pendingTab && pendingTab !== loadedTab ? pendingTab : desiredTab;
   const hasLoadedActivePanel = activeTab === loadedTab;
 
   // Keep the structural tabpanels in the DOM so every tab retains its
@@ -257,40 +250,32 @@ export function GoalsView({
   }, [activeTab, isMobile]);
 
   useEffect(() => {
-    if (!isViewportReady || loadedTab === desiredTab || reconciledTab.current === desiredTab) {
-      if (loadedTab === desiredTab && reconciledTab.current === desiredTab) {
-        reconciledTab.current = null;
-      }
+    if (!isViewportReady || !isMobile) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const canonicalTab = desiredTab === "watchlist" ? null : desiredTab;
+    const needsTabUpdate = canonicalTab ? params.get("tab") !== canonicalTab : params.has("tab");
+    if (loadedTab === desiredTab && !needsTabUpdate && !hash) return;
+
+    if (canonicalTab) params.set("tab", canonicalTab);
+    else params.delete("tab");
+    const query = params.toString();
+    const href = `${window.location.pathname}${query ? `?${query}` : ""}`;
+    if (loadedTab === desiredTab) {
+      window.history.replaceState(null, "", href);
       return;
     }
 
-    reconciledTab.current = desiredTab;
-    setPendingTab(desiredTab);
-    pendingHash.current = window.location.hash || null;
-    const params = new URLSearchParams(window.location.search);
-    params.set("tab", desiredTab);
-    const href = `${window.location.pathname}?${params.toString()}`;
     router.replace(href);
-  }, [desiredTab, isViewportReady, loadedTab, router]);
-
-  useEffect(() => {
-    const hashToRestore = pendingHash.current;
-    if (!hashToRestore || loadedTab !== desiredTab) return;
-
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}${window.location.search}${hashToRestore}`,
-    );
-    pendingHash.current = null;
-  }, [desiredTab, loadedTab]);
+  }, [desiredTab, hash, isMobile, isViewportReady, loadedTab, router]);
 
   const handleTabChange = (tab: MobilePlanTab) => {
     setPendingTab(tab);
-    pendingHash.current = `#${tab}`;
     const params = new URLSearchParams(window.location.search);
-    params.set("tab", tab);
-    router.replace(`${window.location.pathname}?${params.toString()}`);
+    if (tab === "watchlist") params.delete("tab");
+    else params.set("tab", tab);
+    const query = params.toString();
+    router.replace(`${window.location.pathname}${query ? `?${query}` : ""}`);
   };
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, tab: MobilePlanTab) => {

--- a/src/components/goals/goals-view.tsx
+++ b/src/components/goals/goals-view.tsx
@@ -28,6 +28,7 @@ import {
   MOBILE_PLAN_TABS,
   getMobilePlanPanelId,
   getMobilePlanTabId,
+  getMobilePlanTabFromUrl,
   handleMobilePlanTabKey,
   renderActiveMobilePlanPanel,
   shouldRenderMobilePlanContent,
@@ -50,6 +51,7 @@ const CalendarView = dynamic(
 
 interface GoalsViewProps {
   loadedTab: MobilePlanTab;
+  requestedTab?: MobilePlanTab;
   goalsWithProgress?: GoalWithProgress[];
   baseCurrency: string;
   accounts?: SerializedAccount[];
@@ -133,6 +135,7 @@ function ManageGoalsList({
 
 export function GoalsView({
   loadedTab,
+  requestedTab,
   goalsWithProgress,
   baseCurrency,
   accounts,
@@ -156,8 +159,9 @@ export function GoalsView({
   const [savingOrder, setSavingOrder] = useState(false);
   const [draft, setDraft] = useState<GoalWithProgress[]>([]);
   const tabRefs = useRef<Partial<Record<MobilePlanTab, HTMLButtonElement | null>>>({});
-  const migratedLegacyHash = useRef<string | null>(null);
-  const pendingLegacyHash = useRef<string | null>(null);
+  const [pendingTab, setPendingTab] = useState<MobilePlanTab | null>(null);
+  const reconciledTab = useRef<MobilePlanTab | null>(null);
+  const pendingHash = useRef<string | null>(null);
   const loadedGoals = goalsWithProgress ?? [];
   const loadedAccounts = accounts ?? [];
 
@@ -194,8 +198,8 @@ export function GoalsView({
   // Deep links for goals, projections, and Calendar open their matching sub-view.
   // The bare "Plan" tab (no hash) lands on Watchlist, the leftmost sub-tab.
   // useSyncExternalStore reads the hash with a server snapshot of "" so SSR and
-  // hydration agree; a manual switch sets `override`, which wins and rewrites the
-  // hash for shareable, Back-friendly URLs.
+  // hydration agree; a pending switch wins until the server returns the selected
+  // branch and rewrites the query/hash for shareable, Back-friendly URLs.
   const hash = useSyncExternalStore(
     (onChange) => {
       window.addEventListener("hashchange", onChange);
@@ -204,16 +208,11 @@ export function GoalsView({
     () => window.location.hash,
     () => "",
   );
-  const [override, setOverride] = useState<MobilePlanTab | null>(null);
-  const hashTab: MobilePlanTab =
-    hash === "#goals"
-      ? "goals"
-      : hash === "#projections"
-        ? "projections"
-        : hash === "#calendar"
-          ? "calendar"
-          : "watchlist";
-  const activeTab: MobilePlanTab = override ?? hashTab;
+  const desiredTab = getMobilePlanTabFromUrl(isMobile, requestedTab, hash);
+  const activeTab: MobilePlanTab =
+    pendingTab && (requestedTab !== pendingTab || loadedTab !== pendingTab)
+      ? pendingTab
+      : desiredTab;
   const hasLoadedActivePanel = activeTab === loadedTab;
 
   // Keep the structural tabpanels in the DOM so every tab retains its
@@ -258,41 +257,40 @@ export function GoalsView({
   }, [activeTab, isMobile]);
 
   useEffect(() => {
-    if (
-      !isMobile ||
-      !hash ||
-      migratedLegacyHash.current === hash ||
-      new URLSearchParams(window.location.search).has("tab")
-    ) {
+    if (!isViewportReady || loadedTab === desiredTab || reconciledTab.current === desiredTab) {
+      if (loadedTab === desiredTab && reconciledTab.current === desiredTab) {
+        reconciledTab.current = null;
+      }
       return;
     }
 
-    migratedLegacyHash.current = hash;
-    pendingLegacyHash.current = hash;
-    setOverride(activeTab);
+    reconciledTab.current = desiredTab;
+    setPendingTab(desiredTab);
+    pendingHash.current = window.location.hash || null;
     const params = new URLSearchParams(window.location.search);
-    params.set("tab", activeTab);
+    params.set("tab", desiredTab);
     const href = `${window.location.pathname}?${params.toString()}`;
     router.replace(href);
-  }, [activeTab, hash, isMobile, router]);
+  }, [desiredTab, isViewportReady, loadedTab, router]);
 
   useEffect(() => {
-    const legacyHash = pendingLegacyHash.current;
-    if (!legacyHash || loadedTab !== activeTab) return;
+    const hashToRestore = pendingHash.current;
+    if (!hashToRestore || loadedTab !== desiredTab) return;
 
     window.history.replaceState(
       null,
       "",
-      `${window.location.pathname}${window.location.search}${legacyHash}`,
+      `${window.location.pathname}${window.location.search}${hashToRestore}`,
     );
-    pendingLegacyHash.current = null;
-  }, [activeTab, loadedTab]);
+    pendingHash.current = null;
+  }, [desiredTab, loadedTab]);
 
   const handleTabChange = (tab: MobilePlanTab) => {
-    setOverride(tab);
+    setPendingTab(tab);
+    pendingHash.current = `#${tab}`;
     const params = new URLSearchParams(window.location.search);
     params.set("tab", tab);
-    router.replace(`${window.location.pathname}?${params.toString()}#${tab}`);
+    router.replace(`${window.location.pathname}?${params.toString()}`);
   };
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, tab: MobilePlanTab) => {
@@ -357,7 +355,10 @@ export function GoalsView({
         aria-labelledby={getMobilePlanTabId("goals")}
         className={activeTab === "goals" ? "block" : "hidden md:block"}
       >
-        {renderGoalsContent && hasLoadedActivePanel && goalsWithProgress && accounts ? (
+        {renderGoalsContent &&
+        (!isMobile || hasLoadedActivePanel) &&
+        goalsWithProgress &&
+        accounts ? (
           <div className="space-y-6">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
@@ -456,5 +457,12 @@ export function GoalsView({
 }
 
 function MobilePlanLoading() {
-  return <div aria-label="Loading" className="h-48 animate-pulse rounded-lg bg-muted" />;
+  const common = useTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-label={common("loading")}
+      className="h-48 animate-pulse rounded-lg bg-muted"
+    />
+  );
 }

--- a/src/components/goals/mobile-plan-tabs.ts
+++ b/src/components/goals/mobile-plan-tabs.ts
@@ -6,6 +6,10 @@ export type MobilePlanTab = (typeof MOBILE_PLAN_TABS)[number];
 export type MobileOnlyPlanTab = Exclude<MobilePlanTab, "goals">;
 export type MobilePlanPanelRenderers = Record<MobileOnlyPlanTab, () => ReactNode>;
 
+export function parseMobilePlanTab(value: string | undefined): MobilePlanTab {
+  return MOBILE_PLAN_TABS.find((tab) => tab === value) ?? "watchlist";
+}
+
 export function getMobilePlanTabId(tab: MobilePlanTab): string {
   return `mobile-plan-tab-${tab}`;
 }

--- a/src/components/goals/mobile-plan-tabs.ts
+++ b/src/components/goals/mobile-plan-tabs.ts
@@ -10,6 +10,16 @@ export function parseMobilePlanTab(value: string | undefined): MobilePlanTab {
   return MOBILE_PLAN_TABS.find((tab) => tab === value) ?? "watchlist";
 }
 
+export function getMobilePlanTabFromUrl(
+  isMobile: boolean,
+  queryTab: string | undefined,
+  hash: string,
+): MobilePlanTab {
+  if (!isMobile) return "goals";
+  if (queryTab !== undefined) return parseMobilePlanTab(queryTab);
+  return parseMobilePlanTab(hash.startsWith("#") ? hash.slice(1) : undefined);
+}
+
 export function getMobilePlanTabId(tab: MobilePlanTab): string {
   return `mobile-plan-tab-${tab}`;
 }

--- a/src/lib/mobile-hub-route.ts
+++ b/src/lib/mobile-hub-route.ts
@@ -39,7 +39,9 @@ export function getMobileHubRedirectUrl({
 
 function getMobileHubUrl(search: string, hash: `#${string}`): string {
   const params = new URLSearchParams(search);
-  params.set("tab", hash.slice(1));
+  const tab = hash.slice(1);
+  if (tab === "watchlist") params.delete("tab");
+  else params.set("tab", tab);
   const query = params.toString();
-  return `/goals${query ? `?${query}` : ""}${hash}`;
+  return `/goals${query ? `?${query}` : ""}`;
 }

--- a/src/lib/mobile-hub-route.ts
+++ b/src/lib/mobile-hub-route.ts
@@ -19,7 +19,7 @@ export function getMobileHubClientRedirectUrl({
   fallbackSearch?: string;
   hash: `#${string}`;
 }): string {
-  return `/goals${currentSearch || fallbackSearch}${hash}`;
+  return getMobileHubUrl(currentSearch || fallbackSearch, hash);
 }
 
 export function getMobileHubRedirectUrl({
@@ -34,5 +34,12 @@ export function getMobileHubRedirectUrl({
   if (!isMobileUserAgent(userAgent)) return null;
 
   const hash = MOBILE_HUB_HASHES[pathname];
-  return hash ? `/goals${search}${hash}` : null;
+  return hash ? getMobileHubUrl(search, hash) : null;
+}
+
+function getMobileHubUrl(search: string, hash: `#${string}`): string {
+  const params = new URLSearchParams(search);
+  params.set("tab", hash.slice(1));
+  const query = params.toString();
+  return `/goals${query ? `?${query}` : ""}${hash}`;
 }

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -298,7 +298,7 @@ test.describe("calendar entry workflows", () => {
         .getByRole("gridcell")
         .getByRole("button", { name: /November 1, 2033/ })
         .tap();
-      await expect(page).toHaveURL(/\/goals\?month=2033-11&date=2033-11-01&tab=calendar#calendar$/);
+      await expect(page).toHaveURL(/\/goals\?month=2033-11&date=2033-11-01&tab=calendar$/);
       const adjacentAgenda = page.getByRole("region", {
         name: /on Tuesday, November 1, 2033/,
       });

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -298,7 +298,7 @@ test.describe("calendar entry workflows", () => {
         .getByRole("gridcell")
         .getByRole("button", { name: /November 1, 2033/ })
         .tap();
-      await expect(page).toHaveURL(/\/goals\?month=2033-11&date=2033-11-01#calendar$/);
+      await expect(page).toHaveURL(/\/goals\?month=2033-11&date=2033-11-01&tab=calendar#calendar$/);
       const adjacentAgenda = page.getByRole("region", {
         name: /on Tuesday, November 1, 2033/,
       });

--- a/tests/e2e/mobile-plan.spec.ts
+++ b/tests/e2e/mobile-plan.spec.ts
@@ -44,7 +44,7 @@ test.describe("mobile Plan hub", () => {
       "aria-selected",
       "true",
     );
-    await expect(page).toHaveURL(/\/goals#goals$/);
+    await expect(page).toHaveURL(/\/goals\?tab=goals#goals$/);
     await expect(page.getByRole("button", { name: "New Goal" }).first()).toBeVisible();
 
     await tablist.getByRole("tab", { name: "Projections" }).click();
@@ -52,9 +52,10 @@ test.describe("mobile Plan hub", () => {
       "aria-selected",
       "true",
     );
-    await expect(page).toHaveURL(/\/goals#projections$/);
+    await expect(page).toHaveURL(/\/goals\?tab=projections#projections$/);
 
     await page.goto("/goals#projections");
+    await expect(page).toHaveURL(/\/goals\?tab=projections#projections$/);
     await expect(tablist.getByRole("tab", { name: "Projections" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -92,14 +93,14 @@ test.describe("mobile Plan hub", () => {
     const tablist = page.getByRole("tablist");
     const calendarTab = tablist.getByRole("tab", { name: "Calendar" });
     await expect(calendarTab).toHaveAttribute("aria-selected", "true");
-    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar#calendar$/);
     await expect(page.getByRole("grid")).toBeVisible();
 
     await page.getByRole("button", { name: "Next month" }).click();
-    await expect(page).toHaveURL(/\/goals\?month=2026-09&date=2026-09-12#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-09&date=2026-09-12&tab=calendar#calendar$/);
 
     await page.goto("/calendar?month=2026-08&date=2026-08-12");
-    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar#calendar$/);
     await expect(calendarTab).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/tests/e2e/mobile-plan.spec.ts
+++ b/tests/e2e/mobile-plan.spec.ts
@@ -44,7 +44,7 @@ test.describe("mobile Plan hub", () => {
       "aria-selected",
       "true",
     );
-    await expect(page).toHaveURL(/\/goals\?tab=goals#goals$/);
+    await expect(page).toHaveURL(/\/goals\?tab=goals$/);
     await expect(page.getByRole("button", { name: "New Goal" }).first()).toBeVisible();
 
     await tablist.getByRole("tab", { name: "Projections" }).click();
@@ -52,10 +52,10 @@ test.describe("mobile Plan hub", () => {
       "aria-selected",
       "true",
     );
-    await expect(page).toHaveURL(/\/goals\?tab=projections#projections$/);
+    await expect(page).toHaveURL(/\/goals\?tab=projections$/);
 
     await page.goto("/goals#projections");
-    await expect(page).toHaveURL(/\/goals\?tab=projections#projections$/);
+    await expect(page).toHaveURL(/\/goals\?tab=projections$/);
     await expect(tablist.getByRole("tab", { name: "Projections" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -99,14 +99,14 @@ test.describe("mobile Plan hub", () => {
     const tablist = page.getByRole("tablist");
     const calendarTab = tablist.getByRole("tab", { name: "Calendar" });
     await expect(calendarTab).toHaveAttribute("aria-selected", "true");
-    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar$/);
     await expect(page.getByRole("grid")).toBeVisible();
 
     await page.getByRole("button", { name: "Next month" }).click();
-    await expect(page).toHaveURL(/\/goals\?month=2026-09&date=2026-09-12&tab=calendar#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-09&date=2026-09-12&tab=calendar$/);
 
     await page.goto("/calendar?month=2026-08&date=2026-08-12");
-    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar#calendar$/);
+    await expect(page).toHaveURL(/\/goals\?month=2026-08&date=2026-08-12&tab=calendar$/);
     await expect(calendarTab).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/tests/e2e/mobile-plan.spec.ts
+++ b/tests/e2e/mobile-plan.spec.ts
@@ -81,6 +81,12 @@ test.describe("mobile Plan hub", () => {
     await page.getByRole("tab", { name: "Projections" }).click();
     await expect(panelContent("goals")).toHaveCount(0);
     await expect(panelContent("projections")).toHaveCount(1);
+    await expect(panelContent("projections").getByRole("status")).toHaveCount(0);
+    await expect(
+      panelContent("projections").getByText(
+        /Projection Assumptions|Projections are waiting on history|Give the projection engine a portfolio/,
+      ),
+    ).toBeVisible();
     await expect(panelContent("calendar")).toHaveCount(0);
   });
 

--- a/tests/unit/goals-page-data-selection.test.ts
+++ b/tests/unit/goals-page-data-selection.test.ts
@@ -76,9 +76,11 @@ function setDefaultMocks() {
   h.headers.mockResolvedValue(new Headers({ "user-agent": mobileUserAgent }));
 }
 
-async function load(tab: string, userAgent = mobileUserAgent) {
+async function load(tab?: string, userAgent = mobileUserAgent) {
   h.headers.mockResolvedValue(new Headers({ "user-agent": userAgent }));
-  await GoalsContent({ searchParams: Promise.resolve({ tab }) });
+  await GoalsContent({
+    searchParams: Promise.resolve(tab === undefined ? {} : { tab }),
+  });
 }
 
 describe("Goals mobile panel data selection", () => {
@@ -113,8 +115,19 @@ describe("Goals mobile panel data selection", () => {
     }
   });
 
-  it("ignores the mobile tab query for a desktop user agent", async () => {
+  it("uses an explicit tab query while also loading desktop Goals data", async () => {
     await load("projections", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+    expect(h.computeGoalsWithProgress).toHaveBeenCalledOnce();
+    expect(h.fetchUserAccountsWithHoldings).toHaveBeenCalledOnce();
+    expect(h.getProjectionData).toHaveBeenCalledOnce();
+    expect(h.getCachedTrackedStocks).not.toHaveBeenCalled();
+    expect(h.getCalendarEntriesInRange).not.toHaveBeenCalled();
+    expect(h.getCalendarEarnings).not.toHaveBeenCalled();
+  });
+
+  it("loads only Goals for a desktop request without a tab query", async () => {
+    await load(undefined, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
 
     expect(h.computeGoalsWithProgress).toHaveBeenCalledOnce();
     expect(h.fetchUserAccountsWithHoldings).toHaveBeenCalledOnce();

--- a/tests/unit/goals-page-data-selection.test.ts
+++ b/tests/unit/goals-page-data-selection.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOrCreateSettings: vi.fn(),
+  computeGoalsWithProgress: vi.fn(),
+  fetchUserAccountsWithHoldings: vi.fn(),
+  getProjectionData: vi.fn(),
+  getCachedTrackedStocks: vi.fn(),
+  getCalendarEntriesInRange: vi.fn(),
+  getCalendarEarnings: vi.fn(),
+  getTranslations: vi.fn(),
+  getMessages: vi.fn(),
+  getLocale: vi.fn(),
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-session", () => ({ getSession: h.getSession }));
+vi.mock("@/lib/services/settings-service", () => ({
+  getOrCreateSettings: h.getOrCreateSettings,
+}));
+vi.mock("@/lib/services/goal-service", () => ({
+  computeGoalsWithProgress: h.computeGoalsWithProgress,
+}));
+vi.mock("@/lib/services/net-worth-service", () => ({
+  fetchUserAccountsWithHoldings: h.fetchUserAccountsWithHoldings,
+}));
+vi.mock("@/lib/services/projection-service", () => ({ getProjectionData: h.getProjectionData }));
+vi.mock("@/lib/services/stock-watch-service", () => ({
+  getCachedTrackedStocks: h.getCachedTrackedStocks,
+}));
+vi.mock("@/lib/services/calendar-entry-service", () => ({
+  getCalendarEntriesInRange: h.getCalendarEntriesInRange,
+}));
+vi.mock("@/lib/services/calendar-earnings-data", () => ({
+  CALENDAR_EARNINGS_RATE_LIMIT: 1,
+  getCalendarEarnings: h.getCalendarEarnings,
+}));
+vi.mock("@/lib/rate-limit", () => ({ rateLimitSubjectCheckWithPrune: () => false }));
+vi.mock("next/headers", () => ({ headers: h.headers }));
+vi.mock("next-intl/server", () => ({
+  getTranslations: h.getTranslations,
+  getMessages: h.getMessages,
+  getLocale: h.getLocale,
+}));
+vi.mock("next-intl", () => ({
+  NextIntlClientProvider: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("@/lib/i18n-utils", () => ({ pickMessages: (messages: unknown) => messages }));
+vi.mock("@/components/layout/large-title-heading", () => ({
+  LargeTitleHeading: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("@/components/goals/goals-view", () => ({ GoalsView: () => null }));
+
+import { GoalsContent } from "@/app/(main)/goals/page";
+
+const mobileUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Mobile";
+
+function setDefaultMocks() {
+  h.getSession.mockResolvedValue({ user: { id: "user-1" } });
+  h.getOrCreateSettings.mockResolvedValue({ baseCurrency: "USD" });
+  h.computeGoalsWithProgress.mockResolvedValue([]);
+  h.fetchUserAccountsWithHoldings.mockResolvedValue([]);
+  h.getProjectionData.mockResolvedValue({
+    latestNetWorth: 0,
+    trailing12mSavings: 0,
+    annualSnapshots: [],
+    hasData: false,
+  });
+  h.getCachedTrackedStocks.mockResolvedValue([]);
+  h.getCalendarEntriesInRange.mockResolvedValue([]);
+  h.getCalendarEarnings.mockResolvedValue([]);
+  h.getTranslations.mockResolvedValue(() => "translated");
+  h.getMessages.mockResolvedValue({});
+  h.getLocale.mockResolvedValue("en-US");
+  h.headers.mockResolvedValue(new Headers({ "user-agent": mobileUserAgent }));
+}
+
+async function load(tab: string) {
+  await GoalsContent({ searchParams: Promise.resolve({ tab }) });
+}
+
+describe("Goals mobile panel data selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultMocks();
+  });
+
+  it.each([
+    ["watchlist", "getCachedTrackedStocks"],
+    ["goals", "computeGoalsWithProgress"],
+    ["projections", "getProjectionData"],
+    ["calendar", "getCalendarEntriesInRange"],
+  ] as const)("reads only the %s panel services", async (tab, activeReader) => {
+    await load(tab);
+
+    for (const reader of [
+      "getCachedTrackedStocks",
+      "computeGoalsWithProgress",
+      "fetchUserAccountsWithHoldings",
+      "getProjectionData",
+      "getCalendarEntriesInRange",
+      "getCalendarEarnings",
+    ] as const) {
+      const expectedCalls =
+        reader === activeReader ||
+        (tab === "goals" && reader === "fetchUserAccountsWithHoldings") ||
+        (tab === "calendar" && reader === "getCalendarEarnings")
+          ? 1
+          : 0;
+      expect(h[reader]).toHaveBeenCalledTimes(expectedCalls);
+    }
+  });
+
+  it("starts the selected reader while translations are still pending", async () => {
+    const resolvers: Array<(value: () => string) => void> = [];
+    h.getTranslations.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
+
+    const page = load("watchlist");
+    await vi.waitFor(() => expect(h.getCachedTrackedStocks).toHaveBeenCalledOnce());
+    expect(h.getMessages).toHaveBeenCalledOnce();
+
+    for (const resolve of resolvers) resolve(() => "translated");
+    await page;
+  });
+});

--- a/tests/unit/goals-page-data-selection.test.ts
+++ b/tests/unit/goals-page-data-selection.test.ts
@@ -78,7 +78,7 @@ function setDefaultMocks() {
 
 async function load(tab?: string, userAgent = mobileUserAgent) {
   h.headers.mockResolvedValue(new Headers({ "user-agent": userAgent }));
-  await GoalsContent({
+  return GoalsContent({
     searchParams: Promise.resolve(tab === undefined ? {} : { tab }),
   });
 }
@@ -94,8 +94,10 @@ describe("Goals mobile panel data selection", () => {
     ["goals", "computeGoalsWithProgress"],
     ["projections", "getProjectionData"],
     ["calendar", "getCalendarEntriesInRange"],
-  ] as const)("reads only the %s panel services", async (tab, activeReader) => {
+  ] as const)("reads only the %s panel services on mobile", async (tab, activeReader) => {
     await load(tab);
+
+    await vi.waitFor(() => expect(h[activeReader]).toHaveBeenCalledOnce());
 
     for (const reader of [
       "getCachedTrackedStocks",
@@ -115,26 +117,30 @@ describe("Goals mobile panel data selection", () => {
     }
   });
 
-  it("uses an explicit tab query while also loading desktop Goals data", async () => {
+  it("keeps #706's deferred non-default readers on desktop", async () => {
     await load("projections", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+    await vi.waitFor(() => expect(h.getCalendarEarnings).toHaveBeenCalledOnce());
 
     expect(h.computeGoalsWithProgress).toHaveBeenCalledOnce();
     expect(h.fetchUserAccountsWithHoldings).toHaveBeenCalledOnce();
     expect(h.getProjectionData).toHaveBeenCalledOnce();
-    expect(h.getCachedTrackedStocks).not.toHaveBeenCalled();
-    expect(h.getCalendarEntriesInRange).not.toHaveBeenCalled();
-    expect(h.getCalendarEarnings).not.toHaveBeenCalled();
+    expect(h.getCachedTrackedStocks).toHaveBeenCalledOnce();
+    expect(h.getCalendarEntriesInRange).toHaveBeenCalledOnce();
+    expect(h.getCalendarEarnings).toHaveBeenCalledOnce();
   });
 
-  it("loads only Goals for a desktop request without a tab query", async () => {
-    await load(undefined, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+  it("ignores an invalid tab query when selecting desktop Goals data", async () => {
+    await load("not-a-tab", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+    await vi.waitFor(() => expect(h.getCalendarEarnings).toHaveBeenCalledOnce());
 
     expect(h.computeGoalsWithProgress).toHaveBeenCalledOnce();
     expect(h.fetchUserAccountsWithHoldings).toHaveBeenCalledOnce();
-    expect(h.getProjectionData).not.toHaveBeenCalled();
-    expect(h.getCachedTrackedStocks).not.toHaveBeenCalled();
-    expect(h.getCalendarEntriesInRange).not.toHaveBeenCalled();
-    expect(h.getCalendarEarnings).not.toHaveBeenCalled();
+    expect(h.getProjectionData).toHaveBeenCalledOnce();
+    expect(h.getCachedTrackedStocks).toHaveBeenCalledOnce();
+    expect(h.getCalendarEntriesInRange).toHaveBeenCalledOnce();
+    expect(h.getCalendarEarnings).toHaveBeenCalledOnce();
   });
 
   it("starts the selected reader while translations are still pending", async () => {

--- a/tests/unit/goals-page-data-selection.test.ts
+++ b/tests/unit/goals-page-data-selection.test.ts
@@ -76,7 +76,8 @@ function setDefaultMocks() {
   h.headers.mockResolvedValue(new Headers({ "user-agent": mobileUserAgent }));
 }
 
-async function load(tab: string) {
+async function load(tab: string, userAgent = mobileUserAgent) {
+  h.headers.mockResolvedValue(new Headers({ "user-agent": userAgent }));
   await GoalsContent({ searchParams: Promise.resolve({ tab }) });
 }
 
@@ -110,6 +111,17 @@ describe("Goals mobile panel data selection", () => {
           : 0;
       expect(h[reader]).toHaveBeenCalledTimes(expectedCalls);
     }
+  });
+
+  it("ignores the mobile tab query for a desktop user agent", async () => {
+    await load("projections", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+    expect(h.computeGoalsWithProgress).toHaveBeenCalledOnce();
+    expect(h.fetchUserAccountsWithHoldings).toHaveBeenCalledOnce();
+    expect(h.getProjectionData).not.toHaveBeenCalled();
+    expect(h.getCachedTrackedStocks).not.toHaveBeenCalled();
+    expect(h.getCalendarEntriesInRange).not.toHaveBeenCalled();
+    expect(h.getCalendarEarnings).not.toHaveBeenCalled();
   });
 
   it("starts the selected reader while translations are still pending", async () => {

--- a/tests/unit/goals-page-source.test.ts
+++ b/tests/unit/goals-page-source.test.ts
@@ -11,8 +11,20 @@ describe("Goals calendar earnings integration", () => {
 
     expect(page).toContain("getCalendarEarnings");
     expect(page).toContain("earningsByDate");
-    expect(page).toContain("earningsByDate={earningsByDate}");
-    expect(view).toContain("earningsByDate: ReadonlyMap<string, CalendarEarningsItem[]>");
+    expect(page).toContain('"calendarEarnings" in panelData ? earningsByDate : undefined');
+    expect(view).toContain("earningsByDate?: ReadonlyMap<string, CalendarEarningsItem[]>");
     expect(view).toContain("earningsByDate={earningsByDate}");
+  });
+
+  it("selects one authenticated mobile panel data branch from the tab query", () => {
+    const page = fs.readFileSync(path.join(root, "src/app/(main)/goals/page.tsx"), "utf8");
+
+    expect(page).toContain("tab?: string");
+    expect(page).toContain("headers()");
+    expect(page).toContain("isMobileUserAgent");
+    expect(page).toContain("parseMobilePlanTab(tab)");
+    expect(page).toContain('activeTab === "watchlist"');
+    expect(page).toContain('activeTab === "projections"');
+    expect(page).toContain('activeTab === "calendar"');
   });
 });

--- a/tests/unit/goals-page-source.test.ts
+++ b/tests/unit/goals-page-source.test.ts
@@ -11,20 +11,24 @@ describe("Goals calendar earnings integration", () => {
 
     expect(page).toContain("getCalendarEarnings");
     expect(page).toContain("earningsByDate");
-    expect(page).toContain('"calendarEarnings" in panelData ? earningsByDate : undefined');
+    expect(page).toContain("panelData.calendarEarnings");
     expect(view).toContain("earningsByDate?: ReadonlyMap<string, CalendarEarningsItem[]>");
     expect(view).toContain("earningsByDate={earningsByDate}");
   });
 
-  it("selects one authenticated mobile panel data branch from the tab query", () => {
+  it("keeps mobile selection inside the Goals Suspense architecture", () => {
     const page = fs.readFileSync(path.join(root, "src/app/(main)/goals/page.tsx"), "utf8");
 
     expect(page).toContain("tab?: string");
     expect(page).toContain("headers()");
     expect(page).toContain("isMobileUserAgent");
     expect(page).toContain("parseMobilePlanTab(tab)");
+    expect(page).toContain("<Suspense fallback={<PanelSkeleton />}");
+    expect(page).toContain("GoalsDeferredData");
+    expect(page).toContain("getGoalsPanelData");
     expect(page).toContain('activeTab === "watchlist"');
     expect(page).toContain('activeTab === "projections"');
-    expect(page).toContain('activeTab === "calendar"');
+    expect(page).toContain("isMobile && tab !== undefined");
+    expect(page).not.toContain("goalsDataP!");
   });
 });

--- a/tests/unit/mobile-hub-redirect.test.ts
+++ b/tests/unit/mobile-hub-redirect.test.ts
@@ -26,12 +26,12 @@ describe("mobile hub redirects", () => {
   });
 
   it.each([
-    ["/stocks", "", "/goals#watchlist"],
-    ["/projections", "", "/goals#projections"],
+    ["/stocks", "", "/goals?tab=watchlist#watchlist"],
+    ["/projections", "", "/goals?tab=projections#projections"],
     [
       "/calendar",
       "?month=2026-08&date=2026-08-12",
-      "/goals?month=2026-08&date=2026-08-12#calendar",
+      "/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
     ],
   ] as const)("builds the mobile hub redirect for %s", (pathname, search, expected) => {
     expect(
@@ -54,12 +54,17 @@ describe("mobile hub redirects", () => {
   });
 
   it.each([
-    ["?symbol=AAPL&view=compact", "", "#watchlist", "/goals?symbol=AAPL&view=compact#watchlist"],
+    [
+      "?symbol=AAPL&view=compact",
+      "",
+      "#watchlist",
+      "/goals?symbol=AAPL&view=compact&tab=watchlist#watchlist",
+    ],
     [
       "",
       "?month=2026-08&date=2026-08-12",
       "#calendar",
-      "/goals?month=2026-08&date=2026-08-12#calendar",
+      "/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
     ],
   ] as const)(
     "preserves the complete client query string when redirecting",

--- a/tests/unit/mobile-hub-redirect.test.ts
+++ b/tests/unit/mobile-hub-redirect.test.ts
@@ -26,12 +26,12 @@ describe("mobile hub redirects", () => {
   });
 
   it.each([
-    ["/stocks", "", "/goals?tab=watchlist#watchlist"],
-    ["/projections", "", "/goals?tab=projections#projections"],
+    ["/stocks", "", "/goals"],
+    ["/projections", "", "/goals?tab=projections"],
     [
       "/calendar",
       "?month=2026-08&date=2026-08-12",
-      "/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
+      "/goals?month=2026-08&date=2026-08-12&tab=calendar",
     ],
   ] as const)("builds the mobile hub redirect for %s", (pathname, search, expected) => {
     expect(
@@ -54,17 +54,12 @@ describe("mobile hub redirects", () => {
   });
 
   it.each([
-    [
-      "?symbol=AAPL&view=compact",
-      "",
-      "#watchlist",
-      "/goals?symbol=AAPL&view=compact&tab=watchlist#watchlist",
-    ],
+    ["?symbol=AAPL&view=compact", "", "#watchlist", "/goals?symbol=AAPL&view=compact"],
     [
       "",
       "?month=2026-08&date=2026-08-12",
       "#calendar",
-      "/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
+      "/goals?month=2026-08&date=2026-08-12&tab=calendar",
     ],
   ] as const)(
     "preserves the complete client query string when redirecting",

--- a/tests/unit/mobile-plan-tabs.test.ts
+++ b/tests/unit/mobile-plan-tabs.test.ts
@@ -6,6 +6,7 @@ import {
   getMobilePlanPanelId,
   getMobilePlanTabId,
   handleMobilePlanTabKey,
+  parseMobilePlanTab,
   renderActiveMobilePlanPanel,
   shouldRenderMobilePlanContent,
   shouldRenderGoalsPanel,
@@ -30,6 +31,17 @@ function pressNavigationKey(currentTab: MobilePlanTab, key: string) {
 }
 
 describe("mobile Plan tabs", () => {
+  it.each([
+    ["watchlist", "watchlist"],
+    ["goals", "goals"],
+    ["projections", "projections"],
+    ["calendar", "calendar"],
+    [undefined, "watchlist"],
+    ["not-a-tab", "watchlist"],
+  ] as const)("parses %s as %s", (value, expected) => {
+    expect(parseMobilePlanTab(value)).toBe(expected);
+  });
+
   it.each([
     ["watchlist", "ArrowRight", "goals"],
     ["calendar", "ArrowRight", "watchlist"],

--- a/tests/unit/mobile-plan-tabs.test.ts
+++ b/tests/unit/mobile-plan-tabs.test.ts
@@ -5,6 +5,7 @@ import {
   MOBILE_PLAN_TABS,
   getMobilePlanPanelId,
   getMobilePlanTabId,
+  getMobilePlanTabFromUrl,
   handleMobilePlanTabKey,
   parseMobilePlanTab,
   renderActiveMobilePlanPanel,
@@ -41,6 +42,20 @@ describe("mobile Plan tabs", () => {
   ] as const)("parses %s as %s", (value, expected) => {
     expect(parseMobilePlanTab(value)).toBe(expected);
   });
+
+  it.each([
+    [true, "calendar", "", "calendar"],
+    [true, "goals", "#projections", "goals"],
+    [true, "not-a-tab", "#calendar", "watchlist"],
+    [true, undefined, "#projections", "projections"],
+    [true, undefined, "", "watchlist"],
+    [false, "calendar", "#projections", "goals"],
+  ] as const)(
+    "resolves the client tab from mobile=%s query=%s hash=%s as %s",
+    (isMobile, queryTab, hash, expected) => {
+      expect(getMobilePlanTabFromUrl(isMobile, queryTab, hash)).toBe(expected);
+    },
+  );
 
   it.each([
     ["watchlist", "ArrowRight", "goals"],

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -102,11 +102,11 @@ describe("mobile desktop-only route redirects", () => {
     "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Mobile";
 
   it.each([
-    ["/stocks", "https://astt.app/goals#watchlist"],
-    ["/projections", "https://astt.app/goals#projections"],
+    ["/stocks", "https://astt.app/goals?tab=watchlist#watchlist"],
+    ["/projections", "https://astt.app/goals?tab=projections#projections"],
     [
       "/calendar?month=2026-08&date=2026-08-12",
-      "https://astt.app/goals?month=2026-08&date=2026-08-12#calendar",
+      "https://astt.app/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
     ],
   ])("redirects authenticated mobile %s into the Plan hub", (pathname, expectedLocation) => {
     const response = executeAuthenticatedRequest(pathname, false, iphoneUserAgent);

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -102,11 +102,11 @@ describe("mobile desktop-only route redirects", () => {
     "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Mobile";
 
   it.each([
-    ["/stocks", "https://astt.app/goals?tab=watchlist#watchlist"],
-    ["/projections", "https://astt.app/goals?tab=projections#projections"],
+    ["/stocks", "https://astt.app/goals"],
+    ["/projections", "https://astt.app/goals?tab=projections"],
     [
       "/calendar?month=2026-08&date=2026-08-12",
-      "https://astt.app/goals?month=2026-08&date=2026-08-12&tab=calendar#calendar",
+      "https://astt.app/goals?month=2026-08&date=2026-08-12&tab=calendar",
     ],
   ])("redirects authenticated mobile %s into the Plan hub", (pathname, expectedLocation) => {
     const response = executeAuthenticatedRequest(pathname, false, iphoneUserAgent);


### PR DESCRIPTION
## Summary

- Select only the active mobile Plan panel's authenticated server readers.
- Preserve desktop Goals behavior, tab query/hash deep links, and Calendar month/date state.
- Reconcile UA/viewport differences without permanent loading skeletons and keep i18n/service work parallel.
- Add route/data-selection regressions and keep loading state accessible.

Closes #703

## Verification

- Full unit suite: 103 files, 931 tests passed.
- Focused Goals tests and Mobile Chrome Plan/Calendar E2E: passed.
- Typecheck, formatting, and diff checks: passed.
- Final task/fix/scoped reviews: clean.