### PR TITLE
perf: reuse history fill for snapshot reconciliation

### DIFF
--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -7,7 +7,7 @@ import { HistoryPullRefresh } from "@/components/history/history-pull-refresh";
 import { HistoryView } from "@/components/history/history-view";
 import {
   getFullNormalizedHistory,
-  getSnapshotReconciliationWarning,
+  getSnapshotReconciliationWarningFromHistory,
   hasForeignCurrencySnapshots,
 } from "@/lib/services/history-service";
 import { countActiveAccounts } from "@/lib/services/account-service";
@@ -20,13 +20,11 @@ async function HistoryContent() {
   const userId = session.user.id;
   const settingsP = getOrCreateSettings(userId);
   const baseCurrencyP = settingsP.then((s) => s.baseCurrency);
-  const snapshotsP = Promise.all([baseCurrencyP, settingsP]).then(([currency]) =>
-    getFullNormalizedHistory(userId, currency),
+  const snapshotsP = baseCurrencyP.then((currency) => getFullNormalizedHistory(userId, currency));
+  // Reuses the history fill instead of re-reading snapshots/accounts/rates.
+  const reconciliationP = Promise.all([snapshotsP, baseCurrencyP]).then(([snapshots, currency]) =>
+    getSnapshotReconciliationWarningFromHistory(userId, currency, snapshots),
   );
-  const reconciliationP: ReturnType<typeof getSnapshotReconciliationWarning> = Promise.all([
-    snapshotsP,
-    baseCurrencyP,
-  ]).then(([snapshots, currency]) => getSnapshotReconciliationWarning(userId, currency, snapshots));
 
   const [allMessages, snapshots, settings, accountCount, reconciliationWarning, converted] =
     await Promise.all([

--- a/src/app/(main)/history/page.tsx
+++ b/src/app/(main)/history/page.tsx
@@ -19,14 +19,23 @@ async function HistoryContent() {
   if (!session?.user?.id) return null;
   const userId = session.user.id;
   const settingsP = getOrCreateSettings(userId);
+  const baseCurrencyP = settingsP.then((s) => s.baseCurrency);
+  const snapshotsP = Promise.all([baseCurrencyP, settingsP]).then(([currency]) =>
+    getFullNormalizedHistory(userId, currency),
+  );
+  const reconciliationP: ReturnType<typeof getSnapshotReconciliationWarning> = Promise.all([
+    snapshotsP,
+    baseCurrencyP,
+  ]).then(([snapshots, currency]) => getSnapshotReconciliationWarning(userId, currency, snapshots));
+
   const [allMessages, snapshots, settings, accountCount, reconciliationWarning, converted] =
     await Promise.all([
       getMessages(),
-      settingsP.then((s) => getFullNormalizedHistory(userId, s.baseCurrency)),
+      snapshotsP,
       settingsP,
       countActiveAccounts(userId),
-      settingsP.then((s) => getSnapshotReconciliationWarning(userId, s.baseCurrency)),
-      settingsP.then((s) => hasForeignCurrencySnapshots(userId, s.baseCurrency)),
+      reconciliationP,
+      baseCurrencyP.then((c) => hasForeignCurrencySnapshots(userId, c)),
     ]);
 
   return (

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -300,53 +300,25 @@ async function fetchFullHistoryRange(
   return normalizeSnapshots(snapshotsRaw, allRatesMap, targetBaseCurrency, accountsRaw);
 }
 
-export async function getSnapshotReconciliationWarning(
+/**
+ * Compares the latest snapshot in an already-normalized history against the
+ * live net worth. Deliberately *not* cached: `"use cache"` arguments become
+ * part of the cache key, so passing the whole history in would serialize it on
+ * every call and bust the entry whenever any snapshot changes. Callers that
+ * already hold the history (the History page) should use this directly.
+ */
+export async function getSnapshotReconciliationWarningFromHistory(
   userId: string,
   targetBaseCurrency: string,
-  /** Pre-computed history so this doesn't re-scan snapshots/accounts/rates. */
-  normalizedSnapshots?: NormalizedSnapshot[],
+  normalizedSnapshots: NormalizedSnapshot[],
 ): Promise<SnapshotReconciliationWarning | null> {
-  "use cache";
-  cacheTag("snapshots");
-  cacheTag("net-worth");
-  cacheTag(`history:${userId}`);
-  cacheTag(`net-worth:${userId}`);
-  cacheTag("accounts");
-  cacheTag(`accounts:${userId}`);
-  cacheTag("exchange-rates");
-  cacheLife("minutes");
+  if (normalizedSnapshots.length === 0) return null;
 
-  let snapshotNetWorth: number;
+  // Input is sorted ascending by date (see normalizeSnapshots), so the last
+  // entry is the latest.
+  const snapshotNetWorth = normalizedSnapshots[normalizedSnapshots.length - 1].netWorth;
+  const { netWorth: currentNetWorth } = await getCachedNetWorthSummary(userId, targetBaseCurrency);
 
-  if (normalizedSnapshots && normalizedSnapshots.length > 0) {
-    // Input is sorted ascending by date (see normalizeSnapshots), so the last
-    // entry is the latest.
-    snapshotNetWorth = normalizedSnapshots[normalizedSnapshots.length - 1].netWorth;
-  } else {
-    const [latestSnapshotRow, accountsRaw, allRatesMap] = await Promise.all([
-      prisma.netWorthSnapshot.findFirst({
-        where: { userId },
-        select: SNAPSHOT_SELECT,
-        orderBy: [{ date: "desc" }, { createdAt: "desc" }],
-      }),
-      prisma.account.findMany({
-        where: { userId },
-        select: { id: true, type: true },
-      }),
-      getAllExchangeRates(),
-    ]);
-    if (!latestSnapshotRow) return null;
-    snapshotNetWorth = normalizeSnapshots(
-      [latestSnapshotRow],
-      allRatesMap,
-      targetBaseCurrency,
-      accountsRaw,
-    )[0].netWorth;
-  }
-
-  const currentSummary = await getCachedNetWorthSummary(userId, targetBaseCurrency);
-  if (!snapshotNetWorth && !currentSummary) return null;
-  const currentNetWorth = currentSummary.netWorth;
   const difference = currentNetWorth - snapshotNetWorth;
   const denominator = Math.max(Math.abs(snapshotNetWorth), 1);
   const differencePercent = Math.abs(difference) / denominator;
@@ -358,6 +330,73 @@ export async function getSnapshotReconciliationWarning(
     differencePercent,
     baseCurrency: targetBaseCurrency,
   };
+}
+
+/**
+ * Cached entry point for callers without a pre-computed history. Keeps only
+ * low-cardinality arguments (`userId`, `targetBaseCurrency`) so the cache key
+ * stays small; the comparison itself lives in the uncached helper above.
+ */
+export async function getSnapshotReconciliationWarning(
+  userId: string,
+  targetBaseCurrency: string,
+): Promise<SnapshotReconciliationWarning | null> {
+  "use cache";
+  cacheTag("snapshots");
+  cacheTag("net-worth");
+  cacheTag(`history:${userId}`);
+  cacheTag(`net-worth:${userId}`);
+  cacheTag("accounts");
+  cacheTag(`accounts:${userId}`);
+  cacheTag("exchange-rates");
+  cacheLife("minutes");
+
+  const [latestSnapshotRows, accountsRaw, allRatesMap] = await Promise.all([
+    fetchLatestSnapshotCandidates(userId, targetBaseCurrency),
+    prisma.account.findMany({
+      where: { userId },
+      select: { id: true, type: true },
+    }),
+    getAllExchangeRates(),
+  ]);
+  if (latestSnapshotRows.length === 0) return null;
+
+  // normalizeSnapshots applies the shared same-day tie-break, so this path
+  // picks the same "latest" snapshot as a full history fill would.
+  const normalized = normalizeSnapshots(
+    latestSnapshotRows,
+    allRatesMap,
+    targetBaseCurrency,
+    accountsRaw,
+  );
+
+  return getSnapshotReconciliationWarningFromHistory(userId, targetBaseCurrency, normalized);
+}
+
+/**
+ * Latest-date snapshot rows that can win the `isBetterDuplicate` tie-break:
+ * the newest row overall plus, when that row is stored in another currency,
+ * the newest same-date row already in the target currency (which
+ * normalizeSnapshots prefers because it needs no lossy conversion).
+ */
+async function fetchLatestSnapshotCandidates(
+  userId: string,
+  targetBaseCurrency: string,
+): Promise<SnapshotRow[]> {
+  const newest = await prisma.netWorthSnapshot.findFirst({
+    where: { userId },
+    select: SNAPSHOT_SELECT,
+    orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+  });
+  if (!newest) return [];
+  if (newest.baseCurrency === targetBaseCurrency) return [newest];
+
+  const matching = await prisma.netWorthSnapshot.findFirst({
+    where: { userId, date: newest.date, baseCurrency: targetBaseCurrency },
+    select: SNAPSHOT_SELECT,
+    orderBy: { createdAt: "desc" },
+  });
+  return matching ? [newest, matching] : [newest];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/services/history-service.ts
+++ b/src/lib/services/history-service.ts
@@ -303,6 +303,8 @@ async function fetchFullHistoryRange(
 export async function getSnapshotReconciliationWarning(
   userId: string,
   targetBaseCurrency: string,
+  /** Pre-computed history so this doesn't re-scan snapshots/accounts/rates. */
+  normalizedSnapshots?: NormalizedSnapshot[],
 ): Promise<SnapshotReconciliationWarning | null> {
   "use cache";
   cacheTag("snapshots");
@@ -314,28 +316,36 @@ export async function getSnapshotReconciliationWarning(
   cacheTag("exchange-rates");
   cacheLife("minutes");
 
-  const [latestSnapshot, currentSummary, accountsRaw, allRatesMap] = await Promise.all([
-    prisma.netWorthSnapshot.findFirst({
-      where: { userId },
-      select: SNAPSHOT_SELECT,
-      orderBy: [{ date: "desc" }, { createdAt: "desc" }],
-    }),
-    getCachedNetWorthSummary(userId, targetBaseCurrency),
-    prisma.account.findMany({
-      where: { userId },
-      select: { id: true, type: true },
-    }),
-    getAllExchangeRates(),
-  ]);
+  let snapshotNetWorth: number;
 
-  if (!latestSnapshot) return null;
+  if (normalizedSnapshots && normalizedSnapshots.length > 0) {
+    // Input is sorted ascending by date (see normalizeSnapshots), so the last
+    // entry is the latest.
+    snapshotNetWorth = normalizedSnapshots[normalizedSnapshots.length - 1].netWorth;
+  } else {
+    const [latestSnapshotRow, accountsRaw, allRatesMap] = await Promise.all([
+      prisma.netWorthSnapshot.findFirst({
+        where: { userId },
+        select: SNAPSHOT_SELECT,
+        orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+      }),
+      prisma.account.findMany({
+        where: { userId },
+        select: { id: true, type: true },
+      }),
+      getAllExchangeRates(),
+    ]);
+    if (!latestSnapshotRow) return null;
+    snapshotNetWorth = normalizeSnapshots(
+      [latestSnapshotRow],
+      allRatesMap,
+      targetBaseCurrency,
+      accountsRaw,
+    )[0].netWorth;
+  }
 
-  const snapshotNetWorth = normalizeSnapshots(
-    [latestSnapshot],
-    allRatesMap,
-    targetBaseCurrency,
-    accountsRaw,
-  )[0].netWorth;
+  const currentSummary = await getCachedNetWorthSummary(userId, targetBaseCurrency);
+  if (!snapshotNetWorth && !currentSummary) return null;
   const currentNetWorth = currentSummary.netWorth;
   const difference = currentNetWorth - snapshotNetWorth;
   const denominator = Math.max(Math.abs(snapshotNetWorth), 1);

--- a/tests/unit/history-service.test.ts
+++ b/tests/unit/history-service.test.ts
@@ -27,6 +27,7 @@ interface CashTransactionFixture {
 const h = vi.hoisted(() => ({
   rows: [] as SnapshotRowFixture[],
   latestSnapshot: null as SnapshotRowFixture | null,
+  currencyMatchedSnapshot: null as SnapshotRowFixture | null,
   foreignCurrencySnapshot: null as { id: string } | null,
   accounts: [] as unknown[],
   cashTransactions: [] as CashTransactionFixture[],
@@ -48,8 +49,11 @@ vi.mock("@/lib/prisma", () => ({
     account: { findMany: vi.fn(async () => h.accounts) },
     netWorthSnapshot: {
       findMany: vi.fn(async () => h.rows),
-      findFirst: vi.fn(async (args?: { where?: { baseCurrency?: { not?: string } } }) => {
-        if (args?.where?.baseCurrency?.not) return h.foreignCurrencySnapshot;
+      findFirst: vi.fn(async (args?: { where?: { baseCurrency?: string | { not?: string } } }) => {
+        const baseCurrency = args?.where?.baseCurrency;
+        if (typeof baseCurrency === "object" && baseCurrency.not) return h.foreignCurrencySnapshot;
+        // Same-date row already stored in the target currency (reconciliation tie-break).
+        if (typeof baseCurrency === "string") return h.currencyMatchedSnapshot;
         return h.latestSnapshot;
       }),
     },
@@ -120,6 +124,7 @@ const {
   getFullNormalizedHistory,
   getNormalizedHistory,
   getSnapshotReconciliationWarning,
+  getSnapshotReconciliationWarningFromHistory,
   hasForeignCurrencySnapshots,
   isBetterDuplicate,
 } = await import("@/lib/services/history-service");
@@ -168,6 +173,7 @@ beforeEach(() => {
   vi.useRealTimers();
   h.rows = [];
   h.latestSnapshot = null;
+  h.currencyMatchedSnapshot = null;
   h.foreignCurrencySnapshot = null;
   h.accounts = [];
   h.cashTransactions = [];
@@ -687,6 +693,50 @@ describe("getSnapshotReconciliationWarning", () => {
     h.accounts = [account({ cashBalance: 1030 })];
 
     await expect(getSnapshotReconciliationWarning("u1", "USD")).resolves.toBeNull();
+  });
+
+  it("resolves the same-day tie-break the same way as the history fill", async () => {
+    const usdRow = row({
+      id: "usd",
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T02:00:00.000Z"),
+      netWorth: 900,
+      totalAssets: 900,
+    });
+    const eurRow = row({
+      id: "eur",
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      // Newer, but stored in another currency: the currency match still wins.
+      createdAt: new Date("2026-01-01T06:00:00.000Z"),
+      netWorth: 500,
+      totalAssets: 500,
+      baseCurrency: "EUR",
+    });
+    h.rows = [usdRow, eurRow];
+    h.latestSnapshot = eurRow;
+    h.currencyMatchedSnapshot = usdRow;
+    h.accounts = [account({ cashBalance: 1100 })];
+    h.rates = new Map([["USD_EUR", 0.5]]);
+
+    const fromHistory = await getSnapshotReconciliationWarningFromHistory(
+      "u1",
+      "USD",
+      await getFullNormalizedHistory("u1", "USD"),
+    );
+    const fromDb = await getSnapshotReconciliationWarning("u1", "USD");
+
+    // 1100 current - 900 from the USD row (the EUR row would revalue to 1000).
+    expect(fromHistory?.difference).toBeCloseTo(200);
+    expect(fromDb).toEqual(fromHistory);
+  });
+
+  it("returns null for an empty history without hitting the database", async () => {
+    h.accounts = [account()];
+    const findFirst = vi.mocked(prisma.netWorthSnapshot.findFirst);
+    findFirst.mockClear();
+
+    await expect(getSnapshotReconciliationWarningFromHistory("u1", "USD", [])).resolves.toBeNull();
+    expect(findFirst).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- `getSnapshotReconciliationWarning` now accepts pre-computed normalized snapshots so the History page doesn't re-scan snapshots/accounts/FX a second time.
- History page wires the reconciliation call off the same history fill instead of issuing an independent query set.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/unit/history-service.test.ts tests/unit/public-demo-route-policy.test.ts`
- `pnpm exec prettier --check` + `pnpm exec eslint` on touched files