### PR TITLE
perf: scope FX banner invalidation to the user

### DIFF
--- a/src/lib/services/exchange-rate-service.ts
+++ b/src/lib/services/exchange-rate-service.ts
@@ -461,9 +461,7 @@ export async function getUnresolvedRatePairs(
   "use cache";
   cacheTag("exchange-rates");
   cacheTag(`accounts:${userId}`);
-  cacheTag("goals");
   cacheTag(`goals:${userId}`);
-  cacheTag("snapshots");
   cacheTag(`history:${userId}`);
   cacheLife("minutes");
 


### PR DESCRIPTION
## Summary
- `getUnresolvedRatePairs` now only carries user-scoped tags (`accounts:{userId}`, `goals:{userId}`, `history:{userId}`) plus the shared `exchange-rates` tag.
- Removes global `goals` / `snapshots` tags so one user's goal edit or any cron snapshot no longer rebuilds every user's FX warning banner.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/unit/exchange-rate-service.test.ts tests/unit/public-demo-route-policy.test.ts`
- `pnpm exec prettier --check` + `pnpm exec eslint` on touched file