### PR TITLE
perf: memoize exchange-rate lookups in net worth

### DIFF
--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -225,6 +225,8 @@ export async function computeNetWorthSummary(
   // not once per holding.
   const rateMemo = new Map<string, number>();
   function getRate(from: string, to: string): number {
+    // Deliberate fast path: resolveRate opens with the same identity check, so
+    // this only saves the call — keep the two in step if either changes.
     if (from === to) return 1;
     const memoKey = `${from}_${to}`;
     const memoized = rateMemo.get(memoKey);
@@ -238,6 +240,12 @@ export async function computeNetWorthSummary(
       warnedPairs.add(memoKey);
       log.warn("rates.unresolved", { from, to, userId, baseCurrency });
     }
+    // Memoize the fallback too: a miss is the most expensive path (resolveRate
+    // exhausted direct, inverse and the USD cross before giving up), and
+    // allRatesMap is fixed for this call, so the answer cannot change. The
+    // warning is already deduped by warnedPairs and fires on the first miss,
+    // above, so short-circuiting here suppresses nothing.
+    rateMemo.set(memoKey, 1);
     return 1;
   }
 

--- a/src/lib/services/net-worth-service.ts
+++ b/src/lib/services/net-worth-service.ts
@@ -220,12 +220,22 @@ export async function computeNetWorthSummary(
   // Render-time helper: read-only against ExchangeRate. Missing pairs fall
   // back to 1 (rates are warmed by the daily cron and on-write hooks).
   const warnedPairs = new Set<string>();
+  // Memoize repeated pair lookups: the second pass resolves the same
+  // (holding→base) and (holding→account) pairs once per currency combination,
+  // not once per holding.
+  const rateMemo = new Map<string, number>();
   function getRate(from: string, to: string): number {
+    if (from === to) return 1;
+    const memoKey = `${from}_${to}`;
+    const memoized = rateMemo.get(memoKey);
+    if (memoized !== undefined) return memoized;
     const resolved = resolveRate(allRatesMap, from, to);
-    if (resolved !== undefined) return resolved;
-    const key = `${from}_${to}`;
-    if (!warnedPairs.has(key)) {
-      warnedPairs.add(key);
+    if (resolved !== undefined) {
+      rateMemo.set(memoKey, resolved);
+      return resolved;
+    }
+    if (!warnedPairs.has(memoKey)) {
+      warnedPairs.add(memoKey);
       log.warn("rates.unresolved", { from, to, userId, baseCurrency });
     }
     return 1;

--- a/tests/unit/net-worth-service.test.ts
+++ b/tests/unit/net-worth-service.test.ts
@@ -201,6 +201,44 @@ describe("getCachedNetWorthSummary (two-pass valuation)", () => {
     expect(h.warnings.some((w) => w.msg === "rates.unresolved")).toBe(true);
   });
 
+  it("resolves an unresolvable pair once per call, not once per holding", async () => {
+    // A miss is the most expensive lookup: resolveRate walks direct, inverse
+    // and the USD cross before giving up. Memoizing only hits would make every
+    // holding in an unpriced currency repeat that whole walk.
+    async function run(holdingCount: number) {
+      h.warnings = [];
+      h.rates = new Map([["USD_TWD", 30]]); // no XXX path
+      const reads = vi.spyOn(h.rates, "get");
+      const symbols = Array.from({ length: holdingCount }, (_, i) => `XXX${i}`);
+      h.prices = symbols.map((symbol) => ({ symbol, price: 10, currency: "XXX" }));
+      h.accounts = [
+        account({
+          id: "A",
+          type: "ASSET",
+          currency: "USD",
+          holdings: symbols.map((symbol, i) =>
+            holding({ id: `h${i}`, symbol, quantity: 1, currency: "XXX" }),
+          ),
+        }),
+      ];
+
+      await getCachedNetWorthSummary("u1", "USD");
+
+      return {
+        reads: reads.mock.calls.length,
+        unresolved: h.warnings.filter((w) => w.msg === "rates.unresolved").length,
+      };
+    }
+
+    const one = await run(1);
+    const many = await run(5);
+
+    // Five holdings cost the same rate lookups as one: XXX→USD resolves once.
+    expect(one.reads).toBeGreaterThan(0);
+    expect(many.reads).toBe(one.reads);
+    expect(many.unresolved).toBe(1);
+  });
+
   it("leaves holdings unpriced (null market value) when no cached price exists", async () => {
     h.warnings = [];
     h.rates = new Map();


### PR DESCRIPTION
## Summary
- `computeNetWorthSummary` now memoizes resolved (from→to) pairs so repeated holding conversions hit a map lookup instead of the full direct/inverse/USD-cross chain every time.
- No behavior change; same unresolved-pair warning path.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/unit/net-worth-service.test.ts`
- `pnpm exec prettier --check` + `pnpm exec eslint` on touched file