### PR TITLE
fix(pwa): apply navigation timeout to preload

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -184,15 +184,18 @@ async function handleNavigation(event) {
   try {
     // The preload promise rejects on network error; without the catch it would
     // escape this try and take the whole offline fallback with it.
-    const preload = await event.preloadResponse.catch(() => undefined);
-    if (preload) {
-      if (!isLogin) cacheNavigation(event, cache, preload);
-      return preload;
-    }
-    const network = fetch(event.request).then((response) => {
-      if (!isLogin) cacheNavigation(event, cache, response);
-      return response;
-    });
+    const network = event.preloadResponse
+      .catch(() => undefined)
+      .then((preload) => {
+        if (preload) {
+          if (!isLogin) cacheNavigation(event, cache, preload);
+          return preload;
+        }
+        return fetch(event.request).then((response) => {
+          if (!isLogin) cacheNavigation(event, cache, response);
+          return response;
+        });
+      });
     const cached = isLogin ? undefined : await cache.match(event.request);
     // No usable fallback, so the timeout has nothing to offer — waiting beats
     // telling an online user on a slow link that they are offline.

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -162,7 +162,7 @@ function hoursAgo(hours: number): string {
 function dispatchFetch(
   fetchListener: FetchListener,
   request: RequestStub,
-  preload?: ResponseStub,
+  preload?: ResponseStub | Promise<ResponseStub | undefined>,
   opts?: { preloadError?: unknown },
 ) {
   let responsePromise: Promise<unknown> | undefined;
@@ -372,6 +372,36 @@ describe("service worker fetch boundary", () => {
     await expect(ev.body()).resolves.toBe("<html>preload</html>");
     await flushMicrotasks();
     expect(cache.get(nav)?.body).toBe("<html>preload</html>");
+  });
+
+  it("returns cached response at timeout for a slow navigation preload with a fresh cache and warms cache after late preload", async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetchListener, cache } = loadFetchListener();
+      const nav = { method: "GET", url: "https://astt.app/", mode: "navigate" } as RequestStub;
+      await cache.put(nav, makeResponse("<html>cached</html>"));
+      let settlePreload: (response: ResponseStub) => void = () => {};
+      const preload = new Promise<ResponseStub>((resolve) => {
+        settlePreload = resolve;
+      });
+
+      const ev = dispatchFetch(fetchListener, nav, preload);
+      await vi.advanceTimersByTimeAsync(0);
+      const responseAtTimeout = new Promise<ResponseStub | undefined>((resolve) => {
+        setTimeout(() => resolve(undefined), 3001);
+      });
+      const response = Promise.race([ev.response(), responseAtTimeout]);
+      await vi.advanceTimersByTimeAsync(3001);
+      await expect(response).resolves.toMatchObject({
+        body: "<html>cached</html>",
+      });
+
+      settlePreload(makeResponse("<html>preload</html>"));
+      await ev.waitUntilAll();
+      expect(cache.get(nav)?.body).toBe("<html>preload</html>");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not cache opaque navigation responses", async () => {


### PR DESCRIPTION
## Description

Routes navigation preload through the existing network timeout path. When a fresh navigation cache entry exists, a slow preload now returns the cached page after three seconds while the late successful preload continues warming the cache.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests
- [x] All tests pass

`pnpm test:unit` — 1,027 tests passed.

Pre-push hooks also passed Prettier, ESLint, and TypeScript checks.

## Screenshots (if applicable)

N/A — service worker behavior only.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review
- [x] I have commented complex code
- [ ] I have updated documentation
- [x] No new warnings generated

## Related Issues

N/A