### PR TITLE
fix(login): prevent Demo re-login rate limit

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -217,7 +217,11 @@ async function LoginContent() {
 
         <div className="text-center text-xs text-muted-foreground pt-2 mb-[-1rem]">
           {t("footerBefore")}{" "}
-          <Link href="/privacy" className="underline hover:text-foreground transition-colors">
+          <Link
+            href="/privacy"
+            prefetch={false}
+            className="underline hover:text-foreground transition-colors"
+          >
             {t("footerLink")}
           </Link>
           .

--- a/tests/unit/public-demo-auth.test.ts
+++ b/tests/unit/public-demo-auth.test.ts
@@ -96,6 +96,8 @@ async function loadStartAction() {
 type ElementWithProps = ReactElement<{
   action?: () => Promise<unknown>;
   children?: ReactNode;
+  href?: string;
+  prefetch?: boolean;
 }>;
 
 function findElement(
@@ -475,6 +477,24 @@ describe("safe formal sign-in handoff from Demo", () => {
 
   it("accepts only the scalar from=demo handoff for an active Demo", async () => {
     await expect(renderLoginGate({ from: "demo" })).resolves.toBeDefined();
+  });
+});
+
+describe("public Demo login prefetch", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    h.getAuthContext.mockReset().mockResolvedValue({ status: "anonymous" });
+  });
+
+  it("does not prefetch Privacy from the login screen", async () => {
+    const loginContent = await renderLoginGate({});
+    const content = await (loginContent.type as (props: unknown) => Promise<ElementWithProps>)(
+      loginContent.props,
+    );
+
+    const privacyLink = findElement(content, (element) => element.props.href === "/privacy");
+
+    expect(privacyLink?.props.prefetch).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Description

Disable automatic prefetching for the Privacy link on the login screen. This prevents unnecessary Privacy RSC requests from exhausting the Vercel request budget before a user re-enters the public Demo after logging out.

Add a focused regression test for the link's prefetch boundary.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests
- [x] All tests pass

Commands run:

- `pnpm test:unit`
- `pnpm exec prettier --check src/app/login/page.tsx tests/unit/public-demo-auth.test.ts`
- `pnpm exec eslint src/app/login/page.tsx tests/unit/public-demo-auth.test.ts`
- `pnpm typecheck`

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No complex code was added
- [x] Documentation is not needed for this targeted bug fix
- [x] No new warnings generated

## Related Issues

None.
