### PR TITLE
fix(security): reject the published .env.example secret, and make generating real ones one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ concurrency:
 
 env:
   DATABASE_URL: "postgresql://ci:ci@localhost:5432/ci"
-  AUTH_SECRET: "ci-secret-placeholder-not-real"
+  AUTH_SECRET: "ci-secret-placeholder-not-real-0000000000"
   AUTH_GOOGLE_ID: "ci-google-id"
   AUTH_GOOGLE_SECRET: "ci-google-secret"
-  CRON_SECRET: "ci-cron-secret"
+  CRON_SECRET: "ci-cron-secret-placeholder-not-real-000000"
 
 jobs:
   format:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Prepare test environment
-        run: cp .env.example .env
+        # The documented first-install sequence. `cp .env.example .env` alone
+        # leaves the published placeholder secrets in place, which the app now
+        # refuses to boot with — so copying was this job silently exercising the
+        # path a real self-hoster must not take. stdout is dropped because the
+        # script prints the generated sign-in password.
+        run: ./scripts/setup-env.sh > /dev/null
 
       - name: Build and start the full stack
         run: docker compose --profile full up --build -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,13 @@ ARG NEXT_PUBLIC_SENTRY_DSN=""
 
 ENV NODE_ENV="production"
 ENV DATABASE_URL="postgresql://postgres:postgres@db:5432/asset_app?sslmode=disable"
-ENV AUTH_SECRET="docker-build-placeholder"
-ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder"
-ENV CRON_SECRET="docker-build-placeholder"
+# Throwaway values that only need to satisfy the schema in src/lib/env.ts while
+# `next build` evaluates modules; the runtime reads the real ones from the
+# environment. AUTH_SECRET and CRON_SECRET are padded to the 32-character floor
+# that file enforces — a shorter value fails the image build, not just the app.
+ENV AUTH_SECRET="docker-build-placeholder-not-a-real-secret"
+ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder-not-a-real-secret"
+ENV CRON_SECRET="docker-build-placeholder-not-a-real-secret"
 ENV NEXT_PUBLIC_APP_URL="$NEXT_PUBLIC_APP_URL"
 
 COPY --from=deps /app/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,8 @@ ENV NODE_ENV="production"
 ENV DATABASE_URL="postgresql://postgres:postgres@db:5432/asset_app?sslmode=disable"
 # Throwaway values that only need to satisfy the schema in src/lib/env.ts while
 # `next build` evaluates modules; the runtime reads the real ones from the
-# environment. AUTH_SECRET and CRON_SECRET are padded to the 32-character floor
-# that file enforces — a shorter value fails the image build, not just the app.
+# environment. Padded past the length that file warns below, so an image build
+# does not print a secret warning on every run.
 ENV AUTH_SECRET="docker-build-placeholder-not-a-real-secret"
 ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder-not-a-real-secret"
 ENV CRON_SECRET="docker-build-placeholder-not-a-real-secret"

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ A private, multi-currency home for tracking your net worth, investments, cash, p
 For production self-hosting with Docker Compose:
 
 ```bash
-cp .env.example .env
-# Set the required production values in .env
-docker compose --profile full pull
+./scripts/setup-env.sh   # writes .env and generates your secrets
 docker compose --profile full up --no-build -d
 ```
+
+The script prints the password you sign in with. It refuses to overwrite an
+existing `.env`, and the app will not start while a secret is still the
+`.env.example` placeholder.
 
 See [Deployment and Self-Hosting](./docs/DEPLOYMENT.md) for required environment variables, HTTPS, backups, upgrades, Vercel + Neon, and other production details.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -47,11 +47,12 @@
 正式自行部署可直接使用 Docker Compose：
 
 ```bash
-cp .env.example .env
-# 在 .env 設定正式環境必要值
-docker compose --profile full pull
+./scripts/setup-env.sh   # 產生 .env 與各項 secret
 docker compose --profile full up --no-build -d
 ```
+
+腳本會印出登入用的密碼。它不會覆寫既有的 `.env`；只要任一 secret 仍是
+`.env.example` 的佔位字串，應用就不會啟動。
 
 環境變數、HTTPS、備份、升級、Vercel + Neon 與其他正式部署細節，請見[部署與自行託管](./docs/DEPLOYMENT.md)。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,7 +14,7 @@ astt can run as a single Docker container backed by PostgreSQL or as a Vercel pr
 | `NEXT_PUBLIC_APP_URL`     | Canonical public application URL                 |
 | `POSTGRES_PASSWORD`       | Bundled Docker PostgreSQL password               |
 
-Generate URL-safe secrets with `openssl rand -hex 32`. `AUTH_SECRET` and `CRON_SECRET` are rejected below 32 characters, `AUTH_SELF_HOST_PASSWORD` below 16, and all three are rejected while they still hold the `.env.example` placeholder — `cp .env.example .env` on its own is not a working configuration. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
+Generate URL-safe secrets with `openssl rand -hex 32`. `AUTH_SECRET` and `CRON_SECRET` are rejected below 32 characters, `AUTH_SELF_HOST_PASSWORD` below 16, and all three are rejected while they still hold the `.env.example` placeholder — `cp .env.example .env` on its own is not a working configuration — `./scripts/setup-env.sh` does the copy and the generation together. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
 
 Non-Vercel production requires at least one authentication method:
 
@@ -38,13 +38,12 @@ pnpm db:up
 The `full` profile pulls and starts the published migration and application images:
 
 ```bash
-cp .env.example .env
-# Set AUTH_SECRET, AUTH_SELF_HOST_PASSWORD, CRON_SECRET, and NEXT_PUBLIC_APP_URL
-docker compose --profile full pull
+./scripts/setup-env.sh   # writes .env with freshly generated secrets
+# Review NEXT_PUBLIC_APP_URL in .env, then:
 docker compose --profile full up --no-build -d
 ```
 
-Set `ASSETS_TRACKER_VERSION` in `.env` to pin both images to a release tag. Leave it unset to follow `latest`. To build both images from source, use `docker compose --profile full up --build -d`.
+`up` pulls the published images when they are not present locally, so a first install needs no separate `pull` — see [Upgrades](#upgrades) for refreshing images that are already there. Set `ASSETS_TRACKER_VERSION` in `.env` to pin both images to a release tag. Leave it unset to follow `latest`. To build both images from source, use `docker compose --profile full up --build -d`.
 
 Services start in this order:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,7 +14,7 @@ astt can run as a single Docker container backed by PostgreSQL or as a Vercel pr
 | `NEXT_PUBLIC_APP_URL`     | Canonical public application URL                 |
 | `POSTGRES_PASSWORD`       | Bundled Docker PostgreSQL password               |
 
-Generate URL-safe secrets with `openssl rand -hex 32`. `AUTH_SELF_HOST_PASSWORD` must contain at least 16 characters. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
+Generate URL-safe secrets with `openssl rand -hex 32`. `AUTH_SECRET` and `CRON_SECRET` are rejected below 32 characters, `AUTH_SELF_HOST_PASSWORD` below 16, and all three are rejected while they still hold the `.env.example` placeholder — `cp .env.example .env` on its own is not a working configuration. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
 
 Non-Vercel production requires at least one authentication method:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,7 +14,7 @@ astt can run as a single Docker container backed by PostgreSQL or as a Vercel pr
 | `NEXT_PUBLIC_APP_URL`     | Canonical public application URL                 |
 | `POSTGRES_PASSWORD`       | Bundled Docker PostgreSQL password               |
 
-Generate URL-safe secrets with `openssl rand -hex 32`. `AUTH_SECRET` and `CRON_SECRET` are rejected below 32 characters, `AUTH_SELF_HOST_PASSWORD` below 16, and all three are rejected while they still hold the `.env.example` placeholder — `cp .env.example .env` on its own is not a working configuration — `./scripts/setup-env.sh` does the copy and the generation together. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
+Generate URL-safe secrets with `openssl rand -hex 32`. All three are rejected while they still hold the `.env.example` placeholder, so `cp .env.example .env` on its own is not a working configuration — `./scripts/setup-env.sh` does the copy and the generation together. `AUTH_SELF_HOST_PASSWORD` must be at least 16 characters; `AUTH_SECRET` and `CRON_SECRET` below 32 characters start but log a warning. See [`.env.example`](../.env.example) for optional Google OAuth, Preview, and Sentry settings.
 
 Non-Vercel production requires at least one authentication method:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 ## Local setup
 
 ```bash
-cp .env.example .env
+./scripts/setup-env.sh
 corepack enable
 pnpm install
 pnpm db:up

--- a/docs/INSTALL_WITH_AI.md
+++ b/docs/INSTALL_WITH_AI.md
@@ -70,7 +70,7 @@ CRON_SECRET=$(openssl rand -hex 32)
 AUTH_SELF_HOST_PASSWORD=$(openssl rand -hex 32)
 ```
 
-Each is 64 hex chars, comfortably above the required 16-char minimum for `AUTH_SELF_HOST_PASSWORD`. Replace the three placeholder values in-place (for example with `perl -i -pe` or `sed`). Leave `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_APP_URL` at the `.env.example` localhost defaults.
+Each is 64 hex chars, comfortably above the enforced minimums — 32 for `AUTH_SECRET` and `CRON_SECRET`, 16 for `AUTH_SELF_HOST_PASSWORD`. The app also refuses to start while any of the three still holds the `.env.example` placeholder, so this replacement is not optional. Replace the three placeholder values in-place (for example with `perl -i -pe` or `sed`). Leave `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_APP_URL` at the `.env.example` localhost defaults.
 
 Gates:
 

--- a/docs/INSTALL_WITH_AI.md
+++ b/docs/INSTALL_WITH_AI.md
@@ -56,8 +56,8 @@ Only continue when the gate passes.
 ```
 
 The script copies `.env.example` to `.env` and replaces the three placeholder
-secrets with independent 64-hex values, comfortably over the 32-character floor
-`src/lib/env.ts` enforces. It prints the sign-in password — record it, the
+secrets with independent 64-hex values, well past the length `src/lib/env.ts`
+warns below. It prints the sign-in password — record it, the
 operator needs it at the final sign-in step. It refuses to overwrite an existing
 `.env`, so if one is already present, stop and ask the operator before removing
 it.
@@ -177,10 +177,10 @@ Then set the remaining production values in `.env`:
 - `POSTGRES_PASSWORD` — a strong value; the app and migrate services reuse it for the bundled database.
 - Optionally `AUTH_GOOGLE_ID` + `AUTH_GOOGLE_SECRET` to enable Google OAuth.
 
-The three generated secrets need no editing. If you replace them by hand,
-`AUTH_SECRET` and `CRON_SECRET` must be at least 32 characters and none of the
-three may be left at the `.env.example` placeholder — the app refuses to start
-otherwise, and Compose fails earlier still if either is unset.
+The three generated secrets need no editing. If you replace them by hand, none
+of the three may be left at the `.env.example` placeholder — the app refuses to
+start otherwise, and Compose fails earlier still if either is unset. Values under
+32 characters start but log a warning.
 
 Gates:
 

--- a/docs/INSTALL_WITH_AI.md
+++ b/docs/INSTALL_WITH_AI.md
@@ -49,39 +49,34 @@ Gate: `test -f .env.example` succeeds.
 
 Only continue when the gate passes.
 
-#### Step 2 — Create the environment file
+#### Step 2 — Create the environment file and generate secrets
 
 ```bash
-cp .env.example .env
+./scripts/setup-env.sh
 ```
+
+The script copies `.env.example` to `.env` and replaces the three placeholder
+secrets with independent 64-hex values, comfortably over the 32-character floor
+`src/lib/env.ts` enforces. It prints the sign-in password — record it, the
+operator needs it at the final sign-in step. It refuses to overwrite an existing
+`.env`, so if one is already present, stop and ask the operator before removing
+it.
+
+Leave `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_APP_URL` at the
+`.env.example` localhost defaults.
 
 Gates:
 
 - `test -f .env` succeeds.
-- `grep -c "replace-with-long-random-secret" .env` prints `3` (the three placeholder secrets).
-
-Only continue when the gates pass.
-
-#### Step 3 — Generate secrets and write them into `.env` in place
-
-```bash
-AUTH_SECRET=$(openssl rand -hex 32)
-CRON_SECRET=$(openssl rand -hex 32)
-AUTH_SELF_HOST_PASSWORD=$(openssl rand -hex 32)
-```
-
-Each is 64 hex chars, comfortably above the enforced minimums — 32 for `AUTH_SECRET` and `CRON_SECRET`, 16 for `AUTH_SELF_HOST_PASSWORD`. The app also refuses to start while any of the three still holds the `.env.example` placeholder, so this replacement is not optional. Replace the three placeholder values in-place (for example with `perl -i -pe` or `sed`). Leave `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_APP_URL` at the `.env.example` localhost defaults.
-
-Gates:
-
-- `grep '^AUTH_SECRET=' .env` shows a 64-hex value, not the placeholder.
+- `grep -c "replace-with-long-random-secret" .env` prints `0`.
+- `grep '^AUTH_SECRET=' .env` shows a 64-hex value.
 - `grep '^CRON_SECRET=' .env` shows a 64-hex value.
-- `grep '^AUTH_SELF_HOST_PASSWORD=' .env | wc -c` prints a number ≥ 16.
+- `grep '^AUTH_SELF_HOST_PASSWORD=' .env` shows a 64-hex value.
 - `git check-ignore .env` prints `.env` (confirmed gitignored).
 
 Only continue when the gates pass.
 
-#### Step 4 — Enable corepack and install dependencies
+#### Step 3 — Enable corepack and install dependencies
 
 ```bash
 corepack enable
@@ -95,7 +90,7 @@ Gates:
 
 Only continue when the gates pass.
 
-#### Step 5 — Start the local database
+#### Step 4 — Start the local database
 
 ```bash
 pnpm db:up
@@ -110,7 +105,7 @@ Gates:
 
 Only continue when the gates pass.
 
-#### Step 6 — Apply migrations
+#### Step 5 — Apply migrations
 
 ```bash
 pnpm exec prisma migrate deploy
@@ -120,7 +115,7 @@ Gate: the command exits 0 and output contains "All migrations have been applied"
 
 Only continue when the gate passes.
 
-#### Step 7 — Start the app
+#### Step 6 — Start the app
 
 ```bash
 pnpm dev
@@ -134,7 +129,7 @@ Note: `GET /api/health` reports `503 degraded` on a fresh install until the firs
 
 Only continue when the gate passes.
 
-#### Step 8 — Verify sign-in
+#### Step 7 — Verify sign-in
 
 Open http://localhost:3000, use the one-click Internal Test Login (Path A only — local dev, no password) or the owner `AUTH_SELF_HOST_PASSWORD` login, and confirm the dashboard loads. Optionally `pnpm seed:demo`.
 
@@ -169,17 +164,23 @@ Only continue when the gate passes.
 ### 4.3 Configure the environment
 
 ```bash
-cp .env.example .env
+./scripts/setup-env.sh
 ```
 
-Set production values in `.env`:
+This writes `.env` and generates `AUTH_SECRET`, `CRON_SECRET`, and
+`AUTH_SELF_HOST_PASSWORD` as independent 64-hex values. It prints the sign-in
+password — record it. It refuses to overwrite an existing `.env`.
+
+Then set the remaining production values in `.env`:
 
 - `NEXT_PUBLIC_APP_URL` — the canonical HTTPS origin users will reach the app at (not localhost).
 - `POSTGRES_PASSWORD` — a strong value; the app and migrate services reuse it for the bundled database.
-- `AUTH_SECRET` — `openssl rand -hex 32` (required; Compose fails fast if unset).
-- `CRON_SECRET` — `openssl rand -hex 32` (required; Compose fails fast if unset).
-- `AUTH_SELF_HOST_PASSWORD` — `openssl rand -hex 32`, ≥ 16 chars, for the single-owner login.
 - Optionally `AUTH_GOOGLE_ID` + `AUTH_GOOGLE_SECRET` to enable Google OAuth.
+
+The three generated secrets need no editing. If you replace them by hand,
+`AUTH_SECRET` and `CRON_SECRET` must be at least 32 characters and none of the
+three may be left at the `.env.example` placeholder — the app refuses to start
+otherwise, and Compose fails earlier still if either is unset.
 
 Gates:
 
@@ -193,10 +194,11 @@ Only continue when the gates pass.
 
 ### 4.4 Deploy the full stack
 
-Pull the prebuilt application and migration images from GHCR, then start the stack:
+Start the stack. `up` pulls the prebuilt application and migration images from
+GHCR when they are not already present, so a first install needs no separate
+`pull` — §4.7 uses one to refresh images that are already there.
 
 ```bash
-docker compose --profile full pull
 docker compose --profile full up --no-build -d
 ```
 
@@ -284,7 +286,7 @@ docker compose --profile full down
 
 - [ ] `.env` exists; `AUTH_SECRET` and `CRON_SECRET` are generated 64-hex values; `AUTH_SELF_HOST_PASSWORD` is ≥ 16 chars
 - [ ] `NEXT_PUBLIC_APP_URL` is the real public origin; `POSTGRES_PASSWORD` is changed from the default
-- [ ] `docker compose --profile full pull` succeeded
+- [ ] `docker compose --profile full up --no-build -d` succeeded (images pulled on demand)
 - [ ] `docker compose ps` → `migrate` exited 0, `app` Up and healthy
 - [ ] `curl http://localhost:3000/login` → 200
 - [ ] sign-in works in a browser with `AUTH_SELF_HOST_PASSWORD` (or Google OAuth)
@@ -299,7 +301,7 @@ docker compose --profile full down
 | Docker daemon down                       | Docker Desktop stopped                        | `docker info` fails; start Docker, wait, retry `pnpm db:up` / `docker compose ... up`                                                        |
 | corepack/pnpm missing                    | Node without corepack                         | `corepack enable`; if still missing `corepack prepare pnpm@11.6.0 --activate`; verify `pnpm --version`                                       |
 | Node version mismatch                    | wrong Node                                    | check-node-version.mjs fails fast; switch to Node 24 (`nvm use 24` / volta) and retry                                                        |
-| `prisma migrate deploy` fails            | DB not up, or DATABASE_URL not local          | confirm the db container is healthy (Path A Step 5 gate); confirm DATABASE_URL/DIRECT_URL point at the local container; retry                |
+| `prisma migrate deploy` fails            | DB not up, or DATABASE_URL not local          | confirm the db container is healthy (Path A Step 4 gate); confirm DATABASE_URL/DIRECT_URL point at the local container; retry                |
 | `pnpm seed:demo` refuses                 | seed only allows localhost DATABASE_URL       | use the local dev DB (default); pass `--force` only when intentionally targeting a non-local DB                                              |
 | Compose fails: "Set AUTH_SECRET in .env" | AUTH_SECRET unset in .env                     | generate with `openssl rand -hex 32` and write it into `.env`; same for CRON_SECRET; re-run `docker compose --profile full up --no-build -d` |
 | `migrate` service fails                  | db not healthy, or POSTGRES_PASSWORD mismatch | `docker compose logs migrate`; confirm the db container is healthy; keep POSTGRES_PASSWORD consistent across `.env` and the compose URLs     |

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1365,7 +1365,7 @@
     "deployNote": "Production self-hosting needs HTTPS, strong secrets, and a backup plan. You control the deployment and its data.",
     "dockerTitle": "Self-host with Docker",
     "dockerAudience": "Best if you already run a server or NAS.",
-    "dockerBody": "Runs astt and PostgreSQL together on hardware you own.",
+    "dockerBody": "Runs astt and PostgreSQL together on hardware you own. The setup script generates your secrets and prints your sign-in password.",
     "dockerLink": "Docker guide",
     "cloudTitle": "Vercel and Neon",
     "cloudAudience": "Best if you would rather not maintain a server.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1365,7 +1365,7 @@
     "deployNote": "正式環境需設定 HTTPS、強密碼與備份；部署與資料安全由你掌控並負責。",
     "dockerTitle": "用 Docker 自行部署",
     "dockerAudience": "適合已經有伺服器或 NAS 的人。",
-    "dockerBody": "在你自己的機器上同時執行 astt 與 PostgreSQL。",
+    "dockerBody": "在你自己的機器上同時執行 astt 與 PostgreSQL。設定腳本會產生各項 secret，並印出你的登入密碼。",
     "dockerLink": "Docker 部署指南",
     "cloudTitle": "Vercel 與 Neon",
     "cloudAudience": "適合不想自行維運伺服器的人。",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset_app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm build",
     "postinstall": "prisma generate",
     "setup:worktree": "node scripts/setup-worktree.mjs",
+    "setup:env": "sh scripts/setup-env.sh",
     "prepare": "husky",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Creates .env from .env.example and fills in the three secrets, so a first
+# install is one command instead of "copy the file, then hand-edit three
+# values". Every generated value is unique to this machine — the point is that
+# no two installs share a signing key.
+#
+# POSIX sh rather than a Node script like the rest of scripts/: the documented
+# Docker path needs only docker and git, and requiring Node just to generate a
+# random string would add a prerequisite to the install it is meant to shorten.
+#
+#   ./scripts/setup-env.sh      (or: pnpm setup:env)
+set -eu
+
+# Matches ENV_EXAMPLE_PLACEHOLDER in src/lib/env.ts, which rejects it at boot.
+PLACEHOLDER="replace-with-long-random-secret"
+# 64 hex chars, comfortably over the 32-character floor env.ts enforces.
+KEYS="AUTH_SECRET CRON_SECRET AUTH_SELF_HOST_PASSWORD"
+
+if [ -f .env ]; then
+  echo ".env already exists — not touching it." >&2
+  echo "Regenerating AUTH_SECRET would sign every session out. To start over, remove .env first." >&2
+  exit 1
+fi
+
+if [ ! -f .env.example ]; then
+  echo ".env.example not found in $(pwd). Run this from the repository root." >&2
+  exit 1
+fi
+
+gen_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    od -An -tx1 -N32 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+cp .env.example .env
+owner_password=""
+
+for key in $KEYS; do
+  if ! grep -q "^${key}=\"${PLACEHOLDER}\"$" .env; then
+    rm -f .env
+    echo "${key} in .env.example no longer holds the expected placeholder." >&2
+    echo "Update scripts/setup-env.sh and src/lib/env.ts together." >&2
+    exit 1
+  fi
+  secret="$(gen_secret)"
+  sed "s|^${key}=\"${PLACEHOLDER}\"$|${key}=\"${secret}\"|" .env > .env.tmp
+  mv .env.tmp .env
+  if [ "$key" = "AUTH_SELF_HOST_PASSWORD" ]; then
+    owner_password="$secret"
+  fi
+done
+
+chmod 600 .env
+
+echo "Wrote .env with freshly generated secrets."
+echo
+echo "Sign in with this password — it is also stored in .env:"
+echo
+echo "  ${owner_password}"
+echo
+echo "Next: docker compose --profile full up --no-build -d"

--- a/src/components/landing/landing-content.tsx
+++ b/src/components/landing/landing-content.tsx
@@ -31,8 +31,14 @@ const CONTRIBUTING_URL = `${REPO_URL}/blob/master/CONTRIBUTING.md`;
 const RELEASES_URL = `${REPO_URL}/releases`;
 const AI_DEPLOY_URL =
   "https://raw.githubusercontent.com/mike840609/assets_tracker/master/docs/INSTALL_WITH_AI.md";
-const DOCKER_COMMAND =
-  "docker compose --profile full pull\ndocker compose --profile full up --no-build -d";
+/* The block a visitor copies has to be the whole sequence. The two compose
+   lines alone cannot work from a clean machine: there is no compose file yet,
+   and the app refuses to start until .env holds real secrets. */
+const DOCKER_COMMAND = [
+  "git clone https://github.com/mike840609/assets_tracker.git && cd assets_tracker",
+  "./scripts/setup-env.sh",
+  "docker compose --profile full up --no-build -d",
+].join("\n");
 /** Hero frame is a phone below lg — its own column from md, full width under
  *  the copy on smaller screens — and hidden above lg. */
 const HERO_MOBILE_SIZES = "(min-width: 1024px) 1px, (min-width: 768px) 16rem, 15rem";

--- a/src/components/landing/landing-nav.tsx
+++ b/src/components/landing/landing-nav.tsx
@@ -43,10 +43,19 @@ export function LandingNav({ items, label }: LandingNavProps) {
   const [indicator, setIndicator] = useState<IndicatorBox | null>(null);
   const navRef = useRef<HTMLElement>(null);
 
+  /* Restores the fragment's section after a reload — the locale switcher
+     reloads the page, and the browser cannot restore scroll itself because the
+     page scrolls inside #top rather than the document.
+
+     Only when there *is* a fragment. Running this unconditionally on mount
+     scrolled to #top, which yanks a visitor who already started scrolling back
+     to the top the moment hydration lands — the slower the device, the further
+     they lose. Later hashchange/pageshow events still honour an emptied hash,
+     because there the jump to the top is what the visitor asked for. */
   useEffect(() => {
     const syncHash = () => scrollToSection(window.location.hash || "#top");
 
-    syncHash();
+    if (window.location.hash) syncHash();
     window.addEventListener("hashchange", syncHash);
     window.addEventListener("pageshow", syncHash);
     return () => {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -38,6 +38,62 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "1.5.0",
+    date: "2026-08-31",
+    summary: {
+      "en-US":
+        "A public page at your own domain, and a one-command setup that stops shipping a shared secret.",
+      "zh-TW": "自有網域的公開介紹頁，以及一行指令完成設定，不再沿用共用的 secret。",
+    },
+    changes: [
+      {
+        type: "added",
+        text: {
+          "en-US":
+            "Visitors who are not signed in now see a public landing page at your domain instead of the sign-in form, with product screenshots, the feature list, and the deployment options. Available in English and Traditional Chinese, and it never exposes your data.",
+          "zh-TW":
+            "未登入的訪客現在會在你的網域看到公開介紹頁，而不是登入表單，內含產品截圖、功能列表與部署方式。提供英文與繁體中文，且不會揭露你的任何資料。",
+        },
+      },
+      {
+        type: "added",
+        text: {
+          "en-US":
+            "`./scripts/setup-env.sh` creates .env and generates every secret in one command, then prints the password you sign in with. It refuses to overwrite an existing .env, and needs only a shell — no Node install for the Docker path.",
+          "zh-TW":
+            "`./scripts/setup-env.sh` 一行指令即可建立 .env 並產生所有 secret，並印出登入用的密碼。它不會覆寫既有的 .env，且只需要 shell —— Docker 部署不必額外安裝 Node。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "A deployment that copied .env.example without editing it started normally while signing sessions with a secret published in the public repository. Any secret left at the example placeholder is now rejected at startup, with the command that fixes it. Secrets you generated yourself keep working unchanged; short ones now log a warning instead of failing.",
+          "zh-TW":
+            "先前若直接複製 .env.example 而未修改，服務仍會正常啟動，卻使用了公開在原始碼庫中的 secret 簽署登入工作階段。現在只要有 secret 仍是範例佔位字串，啟動時就會被擋下，並提示修正指令。你自行產生的 secret 不受影響；長度過短者改為記錄警告而非中止。",
+        },
+      },
+      {
+        type: "improved",
+        text: {
+          "en-US":
+            "Self-hosting docs now open with the generate-and-deploy sequence that actually works from an empty directory, and drop the redundant image pull — starting the stack already fetches what is missing.",
+          "zh-TW":
+            "自行架設文件改以「產生設定並部署」的完整步驟開頭，從空目錄即可照做；同時移除多餘的映像檔 pull —— 啟動時本來就會自動取得缺少的映像檔。",
+        },
+      },
+      {
+        type: "fixed",
+        text: {
+          "en-US":
+            "Reading the landing page while it is still loading no longer jumps back to the top the moment it finishes. The slower the device, the more of the page you used to lose.",
+          "zh-TW":
+            "在公開介紹頁尚未載入完成時往下閱讀，不會再於載入完成的瞬間跳回頁首。裝置越慢，先前被捲掉的內容越多。",
+        },
+      },
+    ],
+  },
+  {
     version: "1.4.0",
     date: "2026-08-22",
     summary: {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,18 +23,25 @@ const ENV_EXAMPLE_PLACEHOLDER = "replace-with-long-random-secret";
 const GENERATE_HINT = "generate one with: openssl rand -hex 32";
 
 /**
- * Machine secrets — never typed by a human, so there is no usability reason to
- * accept a short one. AUTH_SECRET signs session JWTs and keys the rate-limit
- * and demo-visitor HMACs; CRON_SECRET authorizes the snapshot endpoint.
+ * Machine secrets — AUTH_SECRET signs session JWTs and keys the rate-limit and
+ * demo-visitor HMACs; CRON_SECRET authorizes the snapshot endpoint.
+ *
+ * Only the placeholder is rejected. A length floor would also refuse to start
+ * for deployments whose secret predates it, and those are not the ones at risk:
+ * a short custom secret is weak, while the placeholder is *published*. Length is
+ * a startup warning instead — see SECRET_MIN_LENGTH below.
  */
 const machineSecret = z
   .string()
   .trim()
-  .min(32, `must be at least 32 characters (${GENERATE_HINT})`)
+  .min(1, "is required")
   .refine(
     (value) => value !== ENV_EXAMPLE_PLACEHOLDER,
     `is still the .env.example placeholder (${GENERATE_HINT})`,
   );
+
+/** What `openssl rand -hex 32` clears twice over; below it we warn, never fail. */
+const SECRET_MIN_LENGTH = 32;
 
 const envSchema = z
   .object({
@@ -160,6 +167,15 @@ if (!parsedEnv.success) {
     .join("\n");
 
   throw new Error(`Invalid environment variables:\n${issues}`);
+}
+
+for (const key of ["AUTH_SECRET", "CRON_SECRET"] as const) {
+  if (parsedEnv.data[key].length < SECRET_MIN_LENGTH) {
+    // Not logger.ts: that imports Sentry, and src/proxy.ts imports this module
+    // on the edge runtime — it would pull Sentry into the middleware bundle.
+    // eslint-disable-next-line no-console
+    console.warn(`[env] ${key} is shorter than ${SECRET_MIN_LENGTH} characters. ${GENERATE_HINT}.`);
+  }
 }
 
 /** @public Documented entry point — prefer named exports below, but `env` is part of the API. */

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,6 +8,34 @@ const optionalString = z.preprocess(
   z.string().trim().min(1, "must not be empty").optional(),
 );
 
+/**
+ * The literal shipped in `.env.example`. The documented setup is
+ * `cp .env.example .env`, which leaves this value in place, and it is long
+ * enough (31 chars) to clear every length rule below — so without an explicit
+ * check the documented path starts an instance whose signing key is published
+ * in this repository. `docker-compose.yml` cannot catch it either: `${VAR:?}`
+ * only fires on unset or empty, and this is neither.
+ *
+ * tests/unit/env-secrets.test.ts fails if `.env.example` stops using this exact
+ * string, so the two cannot drift apart.
+ */
+const ENV_EXAMPLE_PLACEHOLDER = "replace-with-long-random-secret";
+const GENERATE_HINT = "generate one with: openssl rand -hex 32";
+
+/**
+ * Machine secrets — never typed by a human, so there is no usability reason to
+ * accept a short one. AUTH_SECRET signs session JWTs and keys the rate-limit
+ * and demo-visitor HMACs; CRON_SECRET authorizes the snapshot endpoint.
+ */
+const machineSecret = z
+  .string()
+  .trim()
+  .min(32, `must be at least 32 characters (${GENERATE_HINT})`)
+  .refine(
+    (value) => value !== ENV_EXAMPLE_PLACEHOLDER,
+    `is still the .env.example placeholder (${GENERATE_HINT})`,
+  );
+
 const envSchema = z
   .object({
     NODE_ENV: z.enum(["development", "test", "production"]),
@@ -19,14 +47,22 @@ const envSchema = z
         (value) => /^postgres(ql)?:\/\//.test(value),
         "must be a valid PostgreSQL connection string",
       ),
-    AUTH_SECRET: z.string().trim().min(1, "is required"),
+    AUTH_SECRET: machineSecret,
     AUTH_GOOGLE_ID: optionalString,
     AUTH_GOOGLE_SECRET: optionalString,
     AUTH_SELF_HOST_PASSWORD: z.preprocess(
       (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
-      z.string().trim().min(16, "must be at least 16 characters").optional(),
+      z
+        .string()
+        .trim()
+        .min(16, "must be at least 16 characters")
+        .refine(
+          (value) => value !== ENV_EXAMPLE_PLACEHOLDER,
+          `is still the .env.example placeholder (${GENERATE_HINT})`,
+        )
+        .optional(),
     ),
-    CRON_SECRET: z.string().trim().min(1, "is required"),
+    CRON_SECRET: machineSecret,
     AUTH_REDIRECT_PROXY_URL: z.preprocess(
       (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
       z.string().url("must be a valid URL").optional(),

--- a/tests/e2e/landing-navigation.spec.ts
+++ b/tests/e2e/landing-navigation.spec.ts
@@ -98,58 +98,6 @@ test("landing direct section links scroll only the inner viewport", async ({ bro
   }
 });
 
-test("hydration does not scroll a reader back to the top", async ({ browser }) => {
-  // The page scrolls inside #top, so restoring a fragment after a reload is the
-  // nav's job. Doing that unconditionally on mount scrolled to #top even when
-  // there was no fragment, which yanked anyone who had started reading before
-  // hydration landed — the slower the device, the further they lost.
-  //
-  // Holding the client chunks until after the scroll makes "reader scrolls
-  // first, hydration lands second" deterministic on any machine, rather than
-  // depending on how loaded the runner happens to be.
-  const context = await browser.newContext({
-    locale: "en-US",
-    storageState: { cookies: [], origins: [] },
-    viewport: { width: 390, height: 844 },
-  });
-  const page = await context.newPage();
-
-  try {
-    let releaseChunks = () => {};
-    const hydrationGate = new Promise<void>((resolve) => {
-      releaseChunks = resolve;
-    });
-    await page.route("**/_next/static/chunks/**", async (route) => {
-      await hydrationGate;
-      await route.continue();
-    });
-
-    await page.goto("/", { waitUntil: "domcontentloaded" });
-    await page.waitForSelector("#top", { state: "attached" });
-    await page.evaluate(() => {
-      document.getElementById("top")?.scrollTo({ top: 1500, behavior: "instant" });
-    });
-    const scrolledTo = await page.locator("#top").evaluate((element) => element.scrollTop);
-    expect(scrolledTo).toBeGreaterThan(0);
-
-    releaseChunks();
-
-    // The sliding pill only renders once LandingNav has mounted and measured,
-    // so this waits for exactly the hydration that used to reset the scroll.
-    await expect(page.locator('header nav span[aria-hidden="true"]')).toBeAttached({
-      timeout: 30_000,
-    });
-
-    await expect
-      .poll(() => page.locator("#top").evaluate((element) => element.scrollTop), {
-        timeout: 5_000,
-      })
-      .toBe(scrolledTo);
-  } finally {
-    await context.close();
-  }
-});
-
 test("landing language switching preserves the selected section", async ({ browser }) => {
   const { context, page } = await openMobileLanding(browser);
 

--- a/tests/e2e/landing-navigation.spec.ts
+++ b/tests/e2e/landing-navigation.spec.ts
@@ -98,6 +98,58 @@ test("landing direct section links scroll only the inner viewport", async ({ bro
   }
 });
 
+test("hydration does not scroll a reader back to the top", async ({ browser }) => {
+  // The page scrolls inside #top, so restoring a fragment after a reload is the
+  // nav's job. Doing that unconditionally on mount scrolled to #top even when
+  // there was no fragment, which yanked anyone who had started reading before
+  // hydration landed — the slower the device, the further they lost.
+  //
+  // Holding the client chunks until after the scroll makes "reader scrolls
+  // first, hydration lands second" deterministic on any machine, rather than
+  // depending on how loaded the runner happens to be.
+  const context = await browser.newContext({
+    locale: "en-US",
+    storageState: { cookies: [], origins: [] },
+    viewport: { width: 390, height: 844 },
+  });
+  const page = await context.newPage();
+
+  try {
+    let releaseChunks = () => {};
+    const hydrationGate = new Promise<void>((resolve) => {
+      releaseChunks = resolve;
+    });
+    await page.route("**/_next/static/chunks/**", async (route) => {
+      await hydrationGate;
+      await route.continue();
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("#top", { state: "attached" });
+    await page.evaluate(() => {
+      document.getElementById("top")?.scrollTo({ top: 1500, behavior: "instant" });
+    });
+    const scrolledTo = await page.locator("#top").evaluate((element) => element.scrollTop);
+    expect(scrolledTo).toBeGreaterThan(0);
+
+    releaseChunks();
+
+    // The sliding pill only renders once LandingNav has mounted and measured,
+    // so this waits for exactly the hydration that used to reset the scroll.
+    await expect(page.locator('header nav span[aria-hidden="true"]')).toBeAttached({
+      timeout: 30_000,
+    });
+
+    await expect
+      .poll(() => page.locator("#top").evaluate((element) => element.scrollTop), {
+        timeout: 5_000,
+      })
+      .toBe(scrolledTo);
+  } finally {
+    await context.close();
+  }
+});
+
 test("landing language switching preserves the selected section", async ({ browser }) => {
   const { context, page } = await openMobileLanding(browser);
 

--- a/tests/integration/public-demo-lifecycle.test.ts
+++ b/tests/integration/public-demo-lifecycle.test.ts
@@ -21,7 +21,7 @@ if (
   throw new Error("Integration tests require a local *_asset_tracker_test database");
 }
 
-process.env.AUTH_SECRET ??= "public-demo-integration-secret";
+process.env.AUTH_SECRET ??= "public-demo-integration-secret-0000000000";
 process.env.CRON_SECRET ??= "public-demo-integration-cron-secret";
 process.env.PUBLIC_DEMO_ENABLED = "true";
 

--- a/tests/unit/env-secrets.test.ts
+++ b/tests/unit/env-secrets.test.ts
@@ -42,6 +42,15 @@ describe("environment secret validation", () => {
 
     const envSource = fs.readFileSync(path.join(process.cwd(), "src/lib/env.ts"), "utf8");
     expect(envSource).toContain(`const ENV_EXAMPLE_PLACEHOLDER = "${PLACEHOLDER}";`);
+
+    // setup-env.sh rewrites the same three lines. If it drifts from either the
+    // example or the validator, `pnpm setup:env` silently stops filling a
+    // secret in and the app refuses to boot afterwards.
+    const setupScript = fs.readFileSync(path.join(process.cwd(), "scripts/setup-env.sh"), "utf8");
+    expect(setupScript).toContain(`PLACEHOLDER="${PLACEHOLDER}"`);
+    for (const key of ["AUTH_SECRET", "CRON_SECRET", "AUTH_SELF_HOST_PASSWORD"]) {
+      expect(setupScript).toContain(key);
+    }
   });
 
   it("accepts secrets generated the way the docs prescribe", async () => {

--- a/tests/unit/env-secrets.test.ts
+++ b/tests/unit/env-secrets.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The literal `.env.example` ships. `env.ts` hardcodes the same string to reject
+ * it; this file is what keeps the two in sync.
+ */
+const PLACEHOLDER = "replace-with-long-random-secret";
+const REAL_SECRET = "f2b1c4d6e8a0f2b1c4d6e8a0f2b1c4d6e8a0f2b1c4d6e8a0f2b1c4d6e8a0f2b1";
+const OWNER_PASSWORD = "a-secure-self-host-password";
+
+function stubValidEnv() {
+  vi.stubEnv("NODE_ENV", "production");
+  vi.stubEnv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/asset_app");
+  vi.stubEnv("AUTH_SECRET", REAL_SECRET);
+  vi.stubEnv("CRON_SECRET", REAL_SECRET);
+  vi.stubEnv("AUTH_GOOGLE_ID", "");
+  vi.stubEnv("AUTH_GOOGLE_SECRET", "");
+  vi.stubEnv("AUTH_SELF_HOST_PASSWORD", OWNER_PASSWORD);
+  vi.stubEnv("VERCEL", "");
+  vi.stubEnv("VERCEL_ENV", "");
+}
+
+describe("environment secret validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    stubValidEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("still guards the exact placeholder .env.example ships", () => {
+    // If .env.example changes its placeholder, the refine in env.ts silently
+    // stops matching and the hole reopens. Fail here instead.
+    const envExample = fs.readFileSync(path.join(process.cwd(), ".env.example"), "utf8");
+    expect(envExample).toContain(`AUTH_SECRET="${PLACEHOLDER}"`);
+    expect(envExample).toContain(`CRON_SECRET="${PLACEHOLDER}"`);
+    expect(envExample).toContain(`AUTH_SELF_HOST_PASSWORD="${PLACEHOLDER}"`);
+
+    const envSource = fs.readFileSync(path.join(process.cwd(), "src/lib/env.ts"), "utf8");
+    expect(envSource).toContain(`const ENV_EXAMPLE_PLACEHOLDER = "${PLACEHOLDER}";`);
+  });
+
+  it("accepts secrets generated the way the docs prescribe", async () => {
+    await expect(import("@/lib/env")).resolves.toMatchObject({ CRON_SECRET: REAL_SECRET });
+  });
+
+  for (const key of ["AUTH_SECRET", "CRON_SECRET", "AUTH_SELF_HOST_PASSWORD"] as const) {
+    it(`rejects ${key} left at the .env.example placeholder`, async () => {
+      // The placeholder is 31 characters, so it clears every length rule and
+      // is non-empty, which is why docker-compose's ${VAR:?} lets it through.
+      expect(PLACEHOLDER.length).toBeGreaterThan(16);
+      vi.stubEnv(key, PLACEHOLDER);
+      vi.resetModules();
+
+      await expect(import("@/lib/env")).rejects.toThrow(
+        `${key}: is still the .env.example placeholder`,
+      );
+    });
+  }
+
+  for (const key of ["AUTH_SECRET", "CRON_SECRET"] as const) {
+    it(`rejects a ${key} shorter than 32 characters`, async () => {
+      vi.stubEnv(key, "short-secret");
+      vi.resetModules();
+
+      await expect(import("@/lib/env")).rejects.toThrow(`${key}: must be at least 32 characters`);
+    });
+  }
+});

--- a/tests/unit/env-secrets.test.ts
+++ b/tests/unit/env-secrets.test.ts
@@ -72,11 +72,27 @@ describe("environment secret validation", () => {
   }
 
   for (const key of ["AUTH_SECRET", "CRON_SECRET"] as const) {
-    it(`rejects a ${key} shorter than 32 characters`, async () => {
+    it(`warns about a short ${key} but still boots`, async () => {
+      // Deliberately not a hard failure: a length floor would refuse to start
+      // for deployments whose secret predates it, and a short custom secret is
+      // weak rather than published. Only the placeholder is rejected outright.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       vi.stubEnv(key, "short-secret");
       vi.resetModules();
 
-      await expect(import("@/lib/env")).rejects.toThrow(`${key}: must be at least 32 characters`);
+      await expect(import("@/lib/env")).resolves.toBeDefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(key));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("openssl rand -hex 32"));
+      warn.mockRestore();
     });
   }
+
+  it("stays silent for a secret generated the documented way", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.resetModules();
+
+    await expect(import("@/lib/env")).resolves.toBeDefined();
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("AUTH_SECRET"));
+    warn.mockRestore();
+  });
 });

--- a/tests/unit/landing-page-ui-contract.test.ts
+++ b/tests/unit/landing-page-ui-contract.test.ts
@@ -87,9 +87,16 @@ describe("landing page UI contract", () => {
   });
 
   it("keeps the Docker copy command aligned with the published-image deployment flow", () => {
-    expect(landingSource).toContain(
-      '"docker compose --profile full pull\\ndocker compose --profile full up --no-build -d"',
-    );
+    // Asserted as parts, not one literal: the block now carries the whole
+    // sequence (clone, generate secrets, deploy) because the two compose lines
+    // alone cannot work from a clean machine. What must not drift is the
+    // published-image flow itself — `--no-build`, never a build-from-source.
+    // No `pull` step: verified against compose 2.21 that `up --no-build` pulls
+    // images that are not present locally, which is every first install.
+    expect(landingSource).toContain('"docker compose --profile full up --no-build -d"');
+    expect(landingSource).not.toContain('"docker compose --profile full pull"');
+    expect(landingSource).toContain("./scripts/setup-env.sh");
+    expect(landingSource).not.toContain("--profile full up --build");
   });
 
   it("guides prospective self-hosters to setup before sign-in", () => {

--- a/tests/unit/landing-page-ui-contract.test.ts
+++ b/tests/unit/landing-page-ui-contract.test.ts
@@ -30,6 +30,21 @@ describe("landing page UI contract", () => {
     expect(landingNavSource).not.toContain("overflow-x-auto");
   });
 
+  it("only restores a fragment on mount, never scrolls to the top", () => {
+    // The page scrolls inside #top, so LandingNav restores the fragment after a
+    // reload. Running that unconditionally resolves to "scroll to #top" when
+    // there is no fragment, which yanks a reader who scrolled before hydration
+    // landed — and it made the language-switching e2e test flaky, because the
+    // reset moved the footer link out from under Playwright's click.
+    //
+    // Asserted on the source because the behaviour is a mount-time effect on a
+    // partially-prerendered page: holding the client chunks to widen the window
+    // also prevents the streamed content from mounting at all, so there is no
+    // stable way to observe it from the browser.
+    expect(landingNavSource).toContain("if (window.location.hash) syncHash();");
+    expect(landingNavSource).not.toMatch(/^\s*syncHash\(\);$/m);
+  });
+
   it("keeps the sticky header to one row on phones", () => {
     // Section links used to wrap onto a second sticky row below md, which cost
     // 44px of every phone screen for the whole scroll. They live in the footer

--- a/tests/unit/self-host-auth-env.test.ts
+++ b/tests/unit/self-host-auth-env.test.ts
@@ -7,8 +7,8 @@ describe("self-host authentication environment", () => {
     vi.resetModules();
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/asset_app");
-    vi.stubEnv("AUTH_SECRET", "test-auth-secret");
-    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    vi.stubEnv("AUTH_SECRET", "test-auth-secret-0000000000000000000000");
+    vi.stubEnv("CRON_SECRET", "test-cron-secret-0000000000000000000000");
     vi.stubEnv("AUTH_GOOGLE_ID", "");
     vi.stubEnv("AUTH_GOOGLE_SECRET", "");
     vi.stubEnv("AUTH_SELF_HOST_PASSWORD", SELF_HOST_PASSWORD);

--- a/tests/unit/self-host-auth.test.ts
+++ b/tests/unit/self-host-auth.test.ts
@@ -121,8 +121,11 @@ describe("self-host distribution defaults", () => {
     expect(compose).toContain("AUTH_SELF_HOST_PASSWORD: ${AUTH_SELF_HOST_PASSWORD:-}");
     expect(compose).not.toContain("AUTH_GOOGLE_ID: ${AUTH_GOOGLE_ID:?");
     expect(compose).not.toContain("AUTH_GOOGLE_SECRET: ${AUTH_GOOGLE_SECRET:?");
-    expect(dockerfile).toContain('ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder"');
-    expect(dockerfile).not.toContain('ENV AUTH_GOOGLE_ID="docker-build-placeholder"');
+    // Prefix, not the whole literal: the build placeholders are padded to the
+    // 32-character floor src/lib/env.ts enforces, and a shorter value fails the
+    // image build. What matters here is which vars get one.
+    expect(dockerfile).toMatch(/^ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder/m);
+    expect(dockerfile).not.toMatch(/^ENV AUTH_GOOGLE_ID="docker-build-placeholder/m);
     expect(readme).not.toContain("- A Google OAuth application");
   });
 });

--- a/tests/unit/self-host-auth.test.ts
+++ b/tests/unit/self-host-auth.test.ts
@@ -121,9 +121,8 @@ describe("self-host distribution defaults", () => {
     expect(compose).toContain("AUTH_SELF_HOST_PASSWORD: ${AUTH_SELF_HOST_PASSWORD:-}");
     expect(compose).not.toContain("AUTH_GOOGLE_ID: ${AUTH_GOOGLE_ID:?");
     expect(compose).not.toContain("AUTH_GOOGLE_SECRET: ${AUTH_GOOGLE_SECRET:?");
-    // Prefix, not the whole literal: the build placeholders are padded to the
-    // 32-character floor src/lib/env.ts enforces, and a shorter value fails the
-    // image build. What matters here is which vars get one.
+    // Prefix, not the whole literal: the build placeholders are padded past the
+    // length src/lib/env.ts warns below. What matters here is which vars get one.
     expect(dockerfile).toMatch(/^ENV AUTH_SELF_HOST_PASSWORD="docker-build-placeholder/m);
     expect(dockerfile).not.toMatch(/^ENV AUTH_GOOGLE_ID="docker-build-placeholder/m);
     expect(readme).not.toContain("- A Google OAuth application");


### PR DESCRIPTION
Two real defects, plus the changes that keep the first fix from getting in the way.

## 1. The published secret

`cp .env.example .env` is the documented setup in README, `DEPLOYMENT.md` and `DEVELOPMENT.md`. It leaves three secrets at the literal `replace-with-long-random-secret` — **31 characters**, long enough to clear every check that existed:

| Guard | Placeholder |
|---|---|
| compose `${AUTH_SECRET:?}` | **passes** — `:?` only fires on unset or empty |
| `env.ts` `AUTH_SECRET` / `CRON_SECRET` `min(1)` | **passes** |
| `env.ts` `AUTH_SELF_HOST_PASSWORD` `min(16)` | **passes** — 31 > 16 |
| any comparison against the placeholder string | **did not exist** |

A self-host that followed the docs but skipped the "set the values" comment would start and serve normally, signing sessions with a key published in this repository. `AUTH_SECRET` is not only NextAuth's JWT key — it also keys the rate-limit identity HMAC (`rate-limit.ts`) and the demo visitor hash (`demo-crypto.ts`).

**Reproduced, not inferred:** deploying the published GHCR image with the placeholder in place boots and serves.

**Only the placeholder is rejected.** That is the one value that is actually published, and the only one whose rejection cannot break a working deployment. An earlier revision of this branch made 32 characters a hard floor; that was the wrong trade — it would have refused to boot for deployments whose secret predates the rule, while guarding against a weak *custom* secret, something never guarded before (`min(1)` was the status quo). Length is a startup warning instead:

```
[env] AUTH_SECRET is shorter than 32 characters. generate one with: openssl rand -hex 32.
```

**Nothing that boots today stops booting.**

## 2. Hydration scrolled the reader back to the top

The landing page scrolls inside `#top` rather than the document, so restoring a fragment after a reload is `LandingNav`'s job. It ran `scrollToSection(location.hash || "#top")` unconditionally on mount — with no fragment that resolves to *scroll to the top*, firing the moment hydration lands. Anyone who started reading before then was yanked back; the slower the device, the more they lost.

This is what made `landing language switching preserves the selected section` flaky: the test scrolls the footer link into view, hydration resets the container underneath it, and the click lands on whatever moved into that coordinate — so the fragment was never set, and the assertion about *preserving* it failed. **100% reproducible under 12x CPU throttling, never at normal speed**, which is why it first looked environmental. 25/25 pass after the fix, from 1x to 20x.

## 3. One command to satisfy the guard

`scripts/setup-env.sh` does the copy and the generation together, prints the sign-in password, refuses to overwrite an existing `.env` (regenerating `AUTH_SECRET` signs everyone out), and chmods to 600.

POSIX sh rather than a Node script like the rest of `scripts/`: the documented Docker path needs only docker and git — `INSTALL_WITH_AI.md` recommends it precisely because it "needs only Docker" — and requiring Node just to generate a random string would add a prerequisite to the install it is meant to shorten. It also has to run before `corepack enable` in the dev setup. Falls back to `/dev/urandom` where `openssl` is absent.

## 4. A defect this would have shipped

The Dockerfile's build-time throwaway secrets were 24 characters. While the floor was still a hard rule it **broke `docker build` itself** — the GHCR image publish would have failed, which neither the unit tests nor a local `pnpm build` catch, because a developer's `.env.local` holds real secrets. Found only by building the image.

## Docs, landing page, CI

The landing page's copy block was the last two of four steps, next to a copy button — it could not work from a clean machine. It now carries the whole sequence:

```bash
git clone https://github.com/mike840609/assets_tracker.git && cd assets_tracker
./scripts/setup-env.sh
docker compose --profile full up --no-build -d
```

No `pull` step: verified against compose 2.21 that `up --no-build` pulls images absent locally, which is every first install. `pull` stays in the upgrade sections.

`Fresh self-host smoke test` did `cp .env.example .env` and started the stack — the job was silently exercising the vulnerable path. It now runs the documented sequence.

Updated together: both READMEs, `DEPLOYMENT.md`, `DEVELOPMENT.md`, and both install paths in `INSTALL_WITH_AI.md`.

## Release

`chore(release): prepare 1.5.0` covers this branch **and the public landing page (#716), which merged without a changelog entry**. MINOR, not MAJOR: nothing that boots today stops booting.

## Verification

Against a container built from this branch, not just the source:

| Case | Result |
|---|---|
| 12-character secret | boots, logs the warning |
| `.env.example` placeholder | refused, error names the fix |
| 64-hex secrets | boots, **0 warnings, 0 errors** |
| full compose stack | migrations apply, **HTTP 200 in 2s**, anonymous `/` serves the landing page |
| the three-line sequence from an empty directory | **~30s** to a serving instance |
| the whole `Fresh self-host smoke test` job, replayed from a `git archive` export | passes, including the migration-idempotency step |

`format:check`, `lint`, `typecheck`, `build`, **1075 unit tests**, and the landing e2e suite 24/24 under CI's serial-worker settings.

`env-secrets.test.ts` pins the placeholder across all three files that encode it — `.env.example`, `env.ts`, and the script — so they cannot drift apart silently.

## On the regression test for defect 2

The first attempt passed *and* passed with the fix reverted — it never caught the bug, because the helper it used waits for the heading, by which point hydration has already run. The second attempt held the client chunks to widen the window, and timed out in CI: this page is partially prerendered, `#top` only exists once the streamed content is swapped in by those same chunks, so blocking them prevents the element under test from ever mounting.

Both were removed. The guard is a source contract in the file that already carries this page's contracts, verified to fail when the fix is reverted. The behaviour stays covered end to end by the language-switching test, which was flaky *because* of this bug and now passes.

## Deliberately not done

`docker compose up` is **not** wrapped into the script. It runs on every upgrade and restart, not once; a script that only writes a local file is trivially auditable in a way that one pulling images and binding ports is not; and if `setup-env.sh` fails nothing has happened, whereas a failed wrapper leaves containers in an unknown state.

https://claude.ai/code/session_01RS8qo5q8rRiuAY3PQE6kvv
