### PR TITLE
fix(recurring): skip or refetch stale DCA prices

### DIFF
--- a/src/lib/refresh-policy.ts
+++ b/src/lib/refresh-policy.ts
@@ -29,5 +29,14 @@ export const FX_RATES_STALE_MS = 48 * 60 * 60 * 1000;
  */
 export const SNAPSHOT_STALE_MS = 48 * 60 * 60 * 1000;
 
+/**
+ * Refuse to price a recurring-investment (DCA) buy from a cached price older
+ * than this. The daily cron refreshes held symbols immediately before
+ * materializing, so ~24h is the normal age; 48h means that symbol's refresh
+ * failed at least once (rate limit, delisting) and the cached price can no
+ * longer stand in for today's.
+ */
+export const DCA_PRICE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
 /** Minimum client-side cooldown after any manual refresh attempt. */
 export const CLIENT_REFRESH_COOLDOWN_MS = 15_000;

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -6,6 +6,7 @@ import { computeDueOccurrences, utcDateOnly } from "./recurring-cash-service";
 import { taiwanCalendarDay } from "@/lib/app-day";
 import { getFreshExchangeRates, resolveRate } from "./exchange-rate-service";
 import { fetchStockPrices, fetchCryptoPrices } from "./price-service";
+import { DCA_PRICE_MAX_AGE_MS } from "@/lib/refresh-policy";
 
 class HoldingCurrencyMismatchError extends Error {
   constructor(readonly holdingCurrency: string) {
@@ -42,18 +43,26 @@ class HoldingCurrencyMismatchError extends Error {
 async function resolvePrice(
   symbol: string,
   assetType: string,
+  now: Date,
 ): Promise<{ price: number; currency: string } | null> {
   // Direct read (see file header) so a freshly-refreshed price isn't masked by
   // the still-stale `prices` cache during the cron run.
   const cached = await prisma.priceCache.findUnique({
     where: { symbol },
-    select: { price: true, currency: true },
+    select: { price: true, currency: true, updatedAt: true },
   });
   if (cached && Number(cached.price) > 0) {
-    return { price: Number(cached.price), currency: cached.currency };
+    // The cron continues past a `partial_success` refresh, so a rate-limited or
+    // delisted symbol keeps its previous price. Buying at it would mint a
+    // permanently wrong share count — re-fetch instead of trusting the row.
+    const ageMs = now.getTime() - cached.updatedAt.getTime();
+    if (ageMs <= DCA_PRICE_MAX_AGE_MS) {
+      return { price: Number(cached.price), currency: cached.currency };
+    }
+    log.warn("cron.investment.stale_price", { symbol, ageMs });
   }
   // Brand-new symbol with no holding yet won't be in PriceCache (the cron only
-  // refreshes held symbols), so fetch + cache it here.
+  // refreshes held symbols), and a stale row can't price a buy, so fetch here.
   try {
     const fetched =
       assetType === "CRYPTO" ? await fetchCryptoPrices([symbol]) : await fetchStockPrices([symbol]);
@@ -116,9 +125,9 @@ export async function materializeDueInvestments(
       continue;
     }
 
-    const priced = await resolvePrice(rule.symbol, rule.assetType);
+    const priced = await resolvePrice(rule.symbol, rule.assetType, now);
     if (!priced) {
-      // No price available — leave nextRunDate untouched so it retries next run
+      // No usable price — leave nextRunDate untouched so it retries next run
       // rather than silently posting nothing and advancing past the occurrence.
       log.warn("cron.investment.skip_no_price", { ruleId: rule.id, symbol: rule.symbol });
       continue;

--- a/tests/unit/recurring-investment-service.test.ts
+++ b/tests/unit/recurring-investment-service.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const h = vi.hoisted(() => ({
   dueRules: [] as Array<Record<string, unknown>>,
   rates: new Map<string, number>(),
-  prices: [] as Array<{ symbol: string; price: number; currency: string }>,
+  prices: [] as Array<{ symbol: string; price: number; currency: string; updatedAt: Date }>,
+  warns: [] as Array<{ event: string; data?: Record<string, unknown> }>,
   existingHoldingCurrency: null as string | null,
   transactionalHoldingCurrency: "USD",
   upserts: [] as Array<Record<string, unknown>>,
@@ -16,7 +17,14 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/logger", () => ({
-  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  log: {
+    info: () => {},
+    warn: (event: string, data?: Record<string, unknown>) => {
+      h.warns.push({ event, data });
+    },
+    error: () => {},
+    debug: () => {},
+  },
 }));
 
 // Keep resolveRate real (pure); the service now reads rates straight from the
@@ -56,7 +64,7 @@ vi.mock("@/lib/prisma", () => ({
     priceCache: {
       findUnique: vi.fn(async (args: { where: { symbol: string } }) => {
         const p = h.prices.find((x) => x.symbol === args.where.symbol);
-        return p ? { price: p.price, currency: p.currency } : null;
+        return p ? { price: p.price, currency: p.currency, updatedAt: p.updatedAt } : null;
       }),
       upsert: vi.fn(async () => ({})),
     },
@@ -113,8 +121,27 @@ vi.mock("@/lib/prisma", () => ({
 }));
 
 import { materializeDueInvestments } from "@/lib/services/recurring-investment-service";
+import { DCA_PRICE_MAX_AGE_MS } from "@/lib/refresh-policy";
 
 const d = (s: string) => new Date(`${s}T00:00:00.000Z`);
+
+/** The clock every rule below is materialized against. */
+const NOW = d("2026-06-14");
+const HOUR_MS = 60 * 60 * 1000;
+
+/** A PriceCache row this morning's cron refreshed — inside the DCA window. */
+const freshPrice = () => ({
+  symbol: "NVDA",
+  price: 200,
+  currency: "USD",
+  updatedAt: new Date(NOW.getTime() - 6 * HOUR_MS),
+});
+
+/** A PriceCache row the cron failed to refresh for more than two days. */
+const stalePrice = () => ({
+  ...freshPrice(),
+  updatedAt: new Date(NOW.getTime() - DCA_PRICE_MAX_AGE_MS - HOUR_MS),
+});
 
 function rule(over: Record<string, unknown> = {}) {
   return {
@@ -139,7 +166,8 @@ describe("materializeDueInvestments", () => {
   beforeEach(() => {
     h.dueRules = [];
     h.rates = new Map();
-    h.prices = [{ symbol: "NVDA", price: 200, currency: "USD" }];
+    h.prices = [freshPrice()];
+    h.warns = [];
     h.existingHoldingCurrency = null;
     h.transactionalHoldingCurrency = "USD";
     h.upserts = [];
@@ -178,7 +206,7 @@ describe("materializeDueInvestments", () => {
   it("converts the amount when account and price currencies differ", async () => {
     // Account in TWD, NVDA priced in USD. 30000 TWD * (USD per TWD) ÷ price.
     h.rates = new Map([["USD_TWD", 30]]); // resolveRate(TWD→USD) = 1/30
-    h.prices = [{ symbol: "NVDA", price: 200, currency: "USD" }];
+    h.prices = [freshPrice()];
     h.dueRules = [rule({ amount: 30000, account: { currency: "TWD" } })];
 
     await materializeDueInvestments(d("2026-06-14"));
@@ -213,10 +241,64 @@ describe("materializeDueInvestments", () => {
     expect(h.ruleUpdates).toHaveLength(0); // nextRunDate untouched → retries next run
   });
 
+  it("refetches and buys at the live price when the cached price is stale", async () => {
+    // A partial price-refresh failure leaves yesterday's (or older) price in
+    // PriceCache; pricing the buy with it mints a permanently wrong share count.
+    const { fetchStockPrices } = await import("@/lib/services/price-service");
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(prisma.priceCache.upsert).mockClear();
+    vi.mocked(fetchStockPrices).mockResolvedValueOnce(
+      new Map([["NVDA", { price: 250, currency: "USD" }]]),
+    );
+    h.prices = [stalePrice()];
+    h.dueRules = [rule()];
+
+    const result = await materializeDueInvestments(NOW);
+
+    expect(result).toEqual({ created: 1, rulesProcessed: 1 });
+    expect(Number(h.createManyCalls[0].data[0].unitPrice)).toBe(250);
+    expect(Number(h.createManyCalls[0].data[0].quantity)).toBe(4); // 1000 / 250
+    expect(vi.mocked(prisma.priceCache.upsert)).toHaveBeenCalledTimes(1);
+    expect(h.warns.map((w) => w.event)).toContain("cron.investment.stale_price");
+  });
+
+  it("skips (no writes, no advance) when a stale price cannot be refetched", async () => {
+    h.prices = [stalePrice()]; // fetchStockPrices resolves to an empty map
+    h.dueRules = [rule()];
+
+    const result = await materializeDueInvestments(NOW);
+
+    expect(result).toEqual({ created: 0, rulesProcessed: 1 });
+    expect(h.createManyCalls).toHaveLength(0);
+    expect(h.holdingUpdates).toHaveLength(0);
+    expect(h.accountUpdates).toHaveLength(0);
+    expect(h.ruleUpdates).toHaveLength(0); // nextRunDate untouched → retries next run
+    expect(h.warns.map((w) => w.event)).toEqual([
+      "cron.investment.stale_price",
+      "cron.investment.skip_no_price",
+    ]);
+  });
+
+  it("uses the cached price without refetching while it is inside the window", async () => {
+    const { fetchStockPrices } = await import("@/lib/services/price-service");
+    vi.mocked(fetchStockPrices).mockClear();
+    h.prices = [
+      { ...freshPrice(), updatedAt: new Date(NOW.getTime() - DCA_PRICE_MAX_AGE_MS + 1000) },
+    ];
+    h.dueRules = [rule()];
+
+    const result = await materializeDueInvestments(NOW);
+
+    expect(result).toEqual({ created: 1, rulesProcessed: 1 });
+    expect(Number(h.createManyCalls[0].data[0].unitPrice)).toBe(200);
+    expect(vi.mocked(fetchStockPrices)).not.toHaveBeenCalled();
+    expect(h.warns).toHaveLength(0);
+  });
+
   it("skips (no writes, no advance) when the cross-currency rate is unresolvable", async () => {
     // TWD account buying a USD-priced stock, but the rate map is empty.
     h.rates = new Map();
-    h.prices = [{ symbol: "NVDA", price: 200, currency: "USD" }];
+    h.prices = [freshPrice()];
     h.dueRules = [rule({ amount: 30000, account: { currency: "TWD" } })];
     const result = await materializeDueInvestments(d("2026-06-14"));
 


### PR DESCRIPTION
## Problem

`resolvePrice` in `src/lib/services/recurring-investment-service.ts` accepted any `PriceCache` row with `price > 0` and never looked at `updatedAt`.

The daily cron refreshes prices immediately before calling `materializeDueInvestments`, but it only aborts on a `total_failure`. A `partial_success` (one symbol rate-limited or delisted) continues, so a due DCA rule for that symbol was converted to shares at whatever price was left in the cache — possibly days old. The BUY row, the holding quantity increment and the cash debit were all persisted with that wrong share count: silent, permanent, and only visible on days a provider drops a symbol.

## Fix

- `src/lib/refresh-policy.ts`: new `DCA_PRICE_MAX_AGE_MS = 48h`. The cron refreshes held symbols right before materializing, so ~24h is the normal age; 48h means that symbol's refresh failed at least once.
- `src/lib/services/recurring-investment-service.ts`: `resolvePrice` also selects `updatedAt` and takes the run clock (`now`, threaded from the `now` the service already receives, so tests can pin it). A cached row older than the threshold is logged as `log.warn("cron.investment.stale_price", { symbol, ageMs })` and treated like a missing row — it falls through to the existing live-fetch branch (`fetchStockPrices` / `fetchCryptoPrices`), which re-caches on success. If that fetch fails or returns nothing, `resolvePrice` returns `null` and the caller's existing `cron.investment.skip_no_price` branch skips the rule with `nextRunDate` untouched, so it retries on the next run.
- The cron route is unchanged.

## Tests

`tests/unit/recurring-investment-service.test.ts` — the mocked `priceCache.findUnique` now returns `updatedAt`, and `log.warn` is captured. Three new cases:

1. stale cached row + successful live refetch → the BUY uses the refetched price (250, so 4 shares instead of 5), the cache is upserted, and `cron.investment.stale_price` is logged.
2. stale cached row + empty refetch → rule skipped, no transaction/holding/account writes, `nextRunDate` not advanced, both `stale_price` and `skip_no_price` logged.
3. cached row 1s inside the window → unchanged behaviour, no refetch, no warning (regression guard).

`pnpm test:unit` (1079 tests), `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all clean.

## Decisions

- **48h, matching `FX_RATES_STALE_MS` / `SNAPSHOT_STALE_MS`.** A tighter bound (e.g. 25h) would refetch on every ordinary cron jitter; 48h only trips after a genuine missed refresh, which is exactly the partial-failure case in the issue.
- **Refetch first, skip second** (the issue offered either). Refetching keeps the rule on schedule whenever the symbol is merely transiently unavailable, and only falls back to the skip-and-retry path — which is already the behaviour for "no price" and "no rate" — when it truly can't be priced. No new failure mode: the fetch is the same call the brand-new-symbol path already made.
- **`ageMs` is computed against the passed `now`, not wall-clock.** That keeps the check consistent with the Taiwan-business-day cutoff the same call already uses and makes it deterministic under test. A negative age (clock skew, or an integration test running a past `RUN_DATE` against a just-written cache row) counts as fresh.
- The two `/api/accounts/[id]/recurring-investments` routes that materialize on create/resume call this with `new Date()`, so a rule created against a >48h-old cache row now triggers one live fetch instead of pricing off the stale row — the correct trade for a user-initiated action.

Fixes #731

https://claude.ai/code/session_017pSzCj5y5uAnuYhj1uhwVf
