### PR TITLE
fix(accounts): make account type immutable via PATCH

### DIFF
--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -41,6 +41,10 @@ export const PATCH = withAuth<IdCtx>(
     // `currency` is immutable via PATCH — updateAccountSchema rejects it
     // (z.never()): cash transactions store no currency of their own, so a
     // currency change would silently re-denominate all history (#557, #563).
+    // `type` is immutable for the same reason: snapshot breakdowns store only
+    // value+currency per account, and the sign is derived from the account's
+    // live type at read time, so flipping ASSET/LIABILITY would re-sign the
+    // entire stored history (#733).
     const { note, occurrenceDate, ...accountData } = parsed.data;
 
     // A manual balance edit logs the difference as an EDIT cash transaction. The

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -32,6 +32,7 @@ export const createAccountSchema = z.object({
 export const updateAccountSchema = createAccountSchema
   .extend({
     currency: z.never("Currency cannot be changed after account creation"),
+    type: z.never("Account type cannot be changed after account creation"),
     isActive: z.boolean(),
     isPinned: z.boolean(),
     note: z.string().max(500).optional().nullable(),

--- a/tests/unit/account-ledger-routes.test.ts
+++ b/tests/unit/account-ledger-routes.test.ts
@@ -254,6 +254,17 @@ describe("account ledger routes", () => {
     expect(h.calls).toEqual([]);
   });
 
+  it("rejects account type changes without writing", async () => {
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { type: "LIABILITY" }), {
+      params: Promise.resolve({ id: "acc1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(h.calls).toEqual([]);
+  });
+
   it("records manual account balance edits atomically and strips note from account data", async () => {
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
 

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -47,6 +47,24 @@ describe("updateAccountSchema", () => {
   it("rejects currency changes", () => {
     expect(updateAccountSchema.safeParse({ currency: "JPY" }).success).toBe(false);
   });
+
+  it("rejects account type changes", () => {
+    expect(updateAccountSchema.safeParse({ type: "LIABILITY" }).success).toBe(false);
+  });
+
+  it("accepts category, name, and cashBalance edits", () => {
+    const result = updateAccountSchema.safeParse({
+      category: "BROKERAGE",
+      name: "Renamed account",
+      cashBalance: 250,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.category).toBe("BROKERAGE");
+      expect(result.data.name).toBe("Renamed account");
+      expect(result.data.cashBalance).toBe(250);
+    }
+  });
 });
 
 describe("Decimal-backed CRUD number schemas", () => {


### PR DESCRIPTION
## Problem

`NetWorthSnapshot.breakdown` stores only `{ value, currency }` per account. `history-service.ts` derives each stored breakdown entry's sign from the account's **current** `type` (`normalizeBreakdown`, ~line 163-170) and again for the cash-flow sign in `getAccountMonthlyCashFlow` (~line 641). `updateAccountSchema` locked `currency` with `z.never()` but inherited `type` unchanged from `createAccountSchema`, so flipping an account between ASSET and LIABILITY through `PATCH /api/accounts/[id]` silently rewrote the sign of every historical snapshot and past cash-flow contribution — contradicting the stored `netWorth` aggregate. The UI never exposed this (AccountForm only POSTs on create), so it was API-only, but it broke the "lossless net-worth history" invariant at the API layer.

## Fix

- `src/lib/validators.ts`: lock `type` in `updateAccountSchema` the same way `currency` is locked — `z.never("Account type cannot be changed after account creation")`. `category` stays mutable; re-bucketing the category chart after fixing a mis-categorised account is desired behavior.
- `src/app/api/accounts/[id]/route.ts`: extended the existing comment explaining `currency`'s immutability with one sentence on why `type` is immutable too (refs #733).

## Tests

- `tests/unit/validators.test.ts`: `updateAccountSchema` rejects a body containing `type` (mirrors the existing currency test) and still accepts `category` / `name` / `cashBalance` edits.
- `tests/unit/account-ledger-routes.test.ts`: `PATCH /api/accounts/[id]` with `type` in the body returns 400 and writes nothing (mirrors the existing currency-rejection route test).

All pass: `pnpm test:unit` (1079/1079), `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all clean.

## Decisions

- Chose the "lock type via z.never()" option from the issue rather than persisting `type` per-breakdown-entry at snapshot time — smaller diff, matches the existing `currency` precedent exactly, and the issue's own severity note treats this as sufficient (the alternative is a larger schema/migration change out of scope for this fix).
- Verified no client code sends `type` in a PATCH to the per-account route: `src/components/accounts/accounts-list.tsx`'s `queue.type` (~line 396) targets `/api/accounts/reorder` (validated by `reorderAccountsSchema`, which legitimately requires `type`), not the per-account `PATCH /api/accounts/[id]`. Grepped `src/components`, `src/app`, `tests/e2e`, `src/lib/demo`, and `scripts` for other PATCH bodies containing `type` — none target this route.

Fixes #733

https://claude.ai/code/session_017pSzCj5y5uAnuYhj1uhwVf