### PR TITLE
fix(db): widen money columns to Decimal(28,8) and bound imports

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -9,6 +9,12 @@ astt uses PostgreSQL through Prisma. Standard PostgreSQL connections use `@prism
 
 For local development, `.env.example` contains URLs for the PostgreSQL service in `docker-compose.yml`.
 
+## Numeric precision
+
+Balances, amounts, quantities and prices are `DECIMAL(28, 8)`; net-worth snapshot aggregates are `DECIMAL(28, 2)`. Option strikes stay `DECIMAL(18, 4)` and exchange rates `DECIMAL(18, 8)`.
+
+The API accepts a smaller range than the columns hold: every amount crosses the wire as a JSON `number`, and an IEEE double keeps roughly 15.95 significant digits, so the validators in `src/lib/validators.ts` reject any magnitude at or above `1e15` (`1e14` for option strikes) with a 400. That headroom means an accumulating `cashBalance` cannot overflow its column.
+
 ## Creating migrations
 
 Create schema changes against a disposable development database:

--- a/prisma/migrations/20260901215445_widen_money_columns/migration.sql
+++ b/prisma/migrations/20260901215445_widen_money_columns/migration.sql
@@ -1,0 +1,32 @@
+-- AlterTable
+ALTER TABLE "Account" ALTER COLUMN "cashBalance" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "CashTransaction" ALTER COLUMN "amount" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "Goal" ALTER COLUMN "targetAmount" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "Holding" ALTER COLUMN "quantity" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "HoldingTransaction" ALTER COLUMN "quantity" SET DATA TYPE DECIMAL(28,8),
+ALTER COLUMN "unitPrice" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "NetWorthSnapshot" ALTER COLUMN "totalAssets" SET DATA TYPE DECIMAL(28,2),
+ALTER COLUMN "totalLiabilities" SET DATA TYPE DECIMAL(28,2),
+ALTER COLUMN "netWorth" SET DATA TYPE DECIMAL(28,2);
+
+-- AlterTable
+ALTER TABLE "PriceCache" ALTER COLUMN "price" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "RecurringCashTransaction" ALTER COLUMN "amount" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "RecurringInvestment" ALTER COLUMN "amount" SET DATA TYPE DECIMAL(28,8);
+
+-- AlterTable
+ALTER TABLE "StockWatchItem" ALTER COLUMN "recordPrice" SET DATA TYPE DECIMAL(28,8);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Account {
   type             AccountType
   category         AccountCategory
   currency         String            @default("USD")
-  cashBalance      Decimal           @default(0) @db.Decimal(18, 8)
+  cashBalance      Decimal           @default(0) @db.Decimal(28, 8)
   isActive         Boolean           @default(true)
   isPinned         Boolean           @default(false)
   sortOrder        Int               @default(0)
@@ -77,7 +77,7 @@ model Holding {
   account            Account              @relation(fields: [accountId], references: [id], onDelete: Cascade)
   symbol             String
   name               String
-  quantity           Decimal              @db.Decimal(18, 8)
+  quantity           Decimal              @db.Decimal(28, 8)
   currency           String               @default("USD")
   assetType          HoldingAssetType
   underlyingSymbol   String?
@@ -104,8 +104,8 @@ model HoldingTransaction {
   holdingId String
   holding   Holding         @relation(fields: [holdingId], references: [id], onDelete: Cascade)
   type      TransactionType
-  quantity  Decimal         @db.Decimal(18, 8)
-  unitPrice Decimal?        @db.Decimal(18, 8)
+  quantity  Decimal         @db.Decimal(28, 8)
+  unitPrice Decimal?        @db.Decimal(28, 8)
   note      String?
   createdAt DateTime        @default(now())
 
@@ -131,7 +131,7 @@ model CashTransaction {
   accountId String
   account   Account             @relation(fields: [accountId], references: [id], onDelete: Cascade)
   type      CashTransactionType
-  amount    Decimal             @db.Decimal(18, 8)
+  amount    Decimal             @db.Decimal(28, 8)
   note      String?
   createdAt DateTime            @default(now())
 
@@ -172,7 +172,7 @@ model RecurringCashTransaction {
   // Only DEPOSIT / WITHDRAWAL are meaningful for a recurring rule; EDIT (an
   // explicit balance adjustment) is rejected by the validator.
   type        CashTransactionType
-  amount      Decimal             @db.Decimal(18, 8)
+  amount      Decimal             @db.Decimal(28, 8)
   frequency   RecurringFrequency
   note        String?
   // Date-only (no time-of-day): occurrences land at the cron's run time.
@@ -206,7 +206,7 @@ model RecurringInvestment {
   holdingCurrency String           @default("USD")
   // Per-period cash invested, in the ACCOUNT's currency (this is what gets
   // debited from cashBalance); shares = amount→holdingCurrency ÷ price.
-  amount          Decimal          @db.Decimal(18, 8)
+  amount          Decimal          @db.Decimal(28, 8)
   frequency       RecurringFrequency
   note            String?
   startDate       DateTime         @db.Date
@@ -223,7 +223,7 @@ model RecurringInvestment {
 
 model PriceCache {
   symbol       String    @id
-  price        Decimal   @db.Decimal(18, 8)
+  price        Decimal   @db.Decimal(28, 8)
   currency     String    @default("USD")
   updatedAt    DateTime  @updatedAt
   refreshingAt DateTime?
@@ -239,7 +239,7 @@ model StockWatchItem {
   name        String
   exchange    String   @default("")
   currency    String   @default("USD")
-  recordPrice Decimal  @db.Decimal(18, 8)
+  recordPrice Decimal  @db.Decimal(28, 8)
   recordDate  DateTime @db.Date
   note        String?  @db.Text
   sortOrder   Int      @default(0)
@@ -264,9 +264,9 @@ model NetWorthSnapshot {
   userId           String
   user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   date             DateTime @db.Date
-  totalAssets      Decimal  @db.Decimal(18, 2)
-  totalLiabilities Decimal  @db.Decimal(18, 2)
-  netWorth         Decimal  @db.Decimal(18, 2)
+  totalAssets      Decimal  @db.Decimal(28, 2)
+  totalLiabilities Decimal  @db.Decimal(28, 2)
+  netWorth         Decimal  @db.Decimal(28, 2)
   baseCurrency     String
   breakdown        Json?
   label            String?  @db.VarChar(80)
@@ -290,7 +290,7 @@ model Goal {
   userId         String
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   name           String
-  targetAmount   Decimal   @db.Decimal(18, 8)
+  targetAmount   Decimal   @db.Decimal(28, 8)
   targetCurrency String    @default("USD")
   targetDate     DateTime? @db.Date
   scope          GoalScope

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -15,11 +15,22 @@ import { CALENDAR_ENTRY_CATEGORIES } from "@/lib/types";
 
 const OCC_SHAPE = /^[A-Z][A-Z0-9.\-]{0,5}\d{6}[CP]\d{8}$/;
 const supportedLocaleSchema = z.enum(SUPPORTED_LOCALES);
-const CRUD_DECIMAL_ABS_MAX = 10_000_000_000;
+// Money and quantity columns are Decimal(28, 8) — 20 integer digits — so the
+// database is no longer what binds. Every amount crosses the wire as a JSON
+// `number`, and an IEEE double keeps ~15.95 significant digits: 1e15 is the
+// largest magnitude at which the fractional part is still meaningful.
+const CRUD_DECIMAL_ABS_MAX = 1_000_000_000_000_000;
 const crudDecimalNumber = z
   .number()
   .gt(-CRUD_DECIMAL_ABS_MAX, "Value exceeds supported precision")
   .lt(CRUD_DECIMAL_ABS_MAX, "Value exceeds supported precision");
+// Holding.strike stays Decimal(18, 4) — 14 integer digits — so it keeps the
+// tighter ceiling its column can actually store.
+const STRIKE_DECIMAL_ABS_MAX = 100_000_000_000_000;
+const strikeDecimalNumber = z
+  .number()
+  .gt(-STRIKE_DECIMAL_ABS_MAX, "Value exceeds supported precision")
+  .lt(STRIKE_DECIMAL_ABS_MAX, "Value exceeds supported precision");
 
 export const createAccountSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
@@ -76,7 +87,7 @@ const createOptionHoldingSchema = z
     assetType: z.literal("OPTION"),
     underlyingSymbol: z.string().min(1).max(8).optional(),
     optionType: z.enum(OPTION_TYPES).optional(),
-    strike: crudDecimalNumber.positive().optional(),
+    strike: strikeDecimalNumber.positive().optional(),
     expiration: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}/)
@@ -426,7 +437,16 @@ export const createCalendarEarningsWatchSchema = z.object({
 });
 
 const decimalStringSchema = z.string().regex(/^-?\d+(\.\d+)?$/, "Must be a decimal number");
-const decimalSchema = z.union([decimalStringSchema, z.number().finite()]);
+// Imported amounts carry the same magnitude ceiling as the CRUD schemas, on
+// both the string and the number branch. Without it an oversized backup value
+// only fails at write time, as a Prisma `numeric field overflow` 500 with no
+// field path (#735).
+const boundedDecimalSchema = (absMax: number) =>
+  z
+    .union([decimalStringSchema, z.number().finite()])
+    .refine((value) => Math.abs(Number(value)) < absMax, "Value exceeds supported precision");
+const decimalSchema = boundedDecimalSchema(CRUD_DECIMAL_ABS_MAX);
+const strikeDecimalSchema = boundedDecimalSchema(STRIKE_DECIMAL_ABS_MAX);
 
 const MAX_IMPORT_ACCOUNTS = 200;
 const MAX_IMPORT_HOLDINGS_PER_ACCOUNT = 2_000;
@@ -491,7 +511,7 @@ export const dataImportSchema = z.object({
               updatedAt: importTimestamp,
               underlyingSymbol: z.string().optional().nullable(),
               optionType: z.enum(OPTION_TYPES).optional().nullable(),
-              strike: decimalSchema.optional().nullable(),
+              strike: strikeDecimalSchema.optional().nullable(),
               expiration: z.iso.datetime().optional().nullable(),
               contractMultiplier: z.number().int().optional().nullable(),
               transactions: z

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -50,96 +50,120 @@ describe("updateAccountSchema", () => {
 });
 
 describe("Decimal-backed CRUD number schemas", () => {
-  it.each([
+  // The money columns hold Decimal(28, 8); the ceiling that binds is the JSON
+  // wire format, where an IEEE double keeps ~15.95 significant digits.
+  const MAX = 1e15;
+  const UNDER_MAX = 999_999_999_999_999;
+
+  const cases: [string, (value: number) => { success: boolean }][] = [
     [
       "account cashBalance",
-      () =>
+      (value) =>
         createAccountSchema.safeParse({
           name: "Cash",
           type: "ASSET",
           category: "BANK",
           currency: "USD",
-          cashBalance: 1e10,
+          cashBalance: value,
         }),
     ],
     [
+      "account cashBalance (update)",
+      (value) => updateAccountSchema.safeParse({ cashBalance: value }),
+    ],
+    [
       "holding quantity",
-      () =>
+      (value) =>
         createHoldingSchema.safeParse({
           symbol: "AAPL",
           name: "Apple",
           assetType: "STOCK",
-          quantity: 1e10,
+          quantity: value,
         }),
     ],
     [
       "holding unitPrice",
-      () =>
+      (value) =>
         createHoldingSchema.safeParse({
           symbol: "AAPL",
           name: "Apple",
           assetType: "STOCK",
           quantity: 1,
-          unitPrice: 1e10,
-        }),
-    ],
-    [
-      "option strike",
-      () =>
-        createHoldingSchema.safeParse({
-          symbol: "AAPL240119C00150000",
-          name: "AAPL Call",
-          assetType: "OPTION",
-          quantity: 1,
-          strike: 1e10,
+          unitPrice: value,
         }),
     ],
     [
       "holding transaction quantity",
-      () => updateTransactionSchema.safeParse({ id: "t1", type: "BUY", quantity: 1e10 }),
+      (value) => updateTransactionSchema.safeParse({ id: "t1", type: "BUY", quantity: value }),
     ],
     [
       "cash transaction amount",
-      () => createCashTransactionSchema.safeParse({ type: "DEPOSIT", amount: 1e10 }),
+      (value) => createCashTransactionSchema.safeParse({ type: "DEPOSIT", amount: value }),
     ],
     [
       "recurring cash amount",
-      () =>
+      (value) =>
         createRecurringCashTransactionSchema.safeParse({
           type: "DEPOSIT",
-          amount: 1e10,
+          amount: value,
           frequency: "MONTHLY",
           startDate: "2026-01-01",
         }),
     ],
     [
       "recurring investment amount",
-      () =>
+      (value) =>
         createRecurringInvestmentSchema.safeParse({
           symbol: "VT",
           name: "Vanguard Total World",
           assetType: "ETF",
-          amount: 1e10,
+          amount: value,
           frequency: "MONTHLY",
           startDate: "2026-01-01",
         }),
     ],
     [
       "goal targetAmount",
-      () => createGoalSchema.safeParse({ name: "House", targetAmount: 1e10, scope: "NET_WORTH" }),
+      (value) =>
+        createGoalSchema.safeParse({ name: "House", targetAmount: value, scope: "NET_WORTH" }),
     ],
     [
       "stock watch recordPrice",
-      () =>
+      (value) =>
         createStockWatchItemSchema.safeParse({
           symbol: "TSLA",
           name: "Tesla",
-          recordPrice: 1e10,
+          recordPrice: value,
           recordDate: "2026-06-14",
         }),
     ],
-  ])("rejects 1e10 for %s", (_label, parse) => {
-    expect(parse().success).toBe(false);
+  ];
+
+  it.each(cases)("rejects 1e15 for %s", (_label, parse) => {
+    expect(parse(MAX).success).toBe(false);
+  });
+
+  it.each(cases)("accepts just under 1e15 for %s", (_label, parse) => {
+    expect(parse(UNDER_MAX).success).toBe(true);
+  });
+
+  // Holding.strike stays Decimal(18, 4), so it keeps a tighter ceiling than
+  // the widened money columns.
+  const parseStrike = (strike: number) =>
+    createHoldingSchema.safeParse({
+      symbol: "AAPL240119C00150000",
+      name: "AAPL Call",
+      assetType: "OPTION",
+      quantity: 1,
+      strike,
+    });
+
+  it("rejects 1e14 for option strike", () => {
+    expect(parseStrike(1e14).success).toBe(false);
+  });
+
+  it("accepts just under 1e14 for option strike", () => {
+    expect(parseStrike(99_999_999_999_999).success).toBe(true);
   });
 });
 
@@ -441,6 +465,40 @@ describe("snapshotsQuerySchema", () => {
 });
 
 describe("dataImportSchema", () => {
+  const importWithCashBalance = (cashBalance: number | string) =>
+    dataImportSchema.safeParse({
+      version: "1.2",
+      accounts: [
+        {
+          name: "Checking",
+          type: "ASSET",
+          category: "BANK",
+          currency: "IDR",
+          cashBalance,
+        },
+      ],
+    });
+
+  it.each([
+    ["a numeric cashBalance", 999_999_999_999_999],
+    ["a decimal-string cashBalance", "999999999999999.12345678"],
+  ])("accepts %s just under the supported maximum", (_label, cashBalance) => {
+    expect(importWithCashBalance(cashBalance).success).toBe(true);
+  });
+
+  it.each([
+    ["a numeric cashBalance", 1e15],
+    ["a decimal-string cashBalance", "1000000000000000"],
+  ])("rejects %s at or above the supported maximum", (_label, cashBalance) => {
+    const result = importWithCashBalance(cashBalance);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues[0];
+    expect(issue.message).toBe("Value exceeds supported precision");
+    expect(issue.path).toEqual(["accounts", 0, "cashBalance"]);
+  });
+
   it("rejects an imported settings locale outside supported locales", () => {
     const result = dataImportSchema.safeParse({
       version: "1.2",


### PR DESCRIPTION
## Problem

`numeric(18,8)` stores at most `9,999,999,999.99999999`, and every money/quantity column used that width.

- `CRUD_DECIMAL_ABS_MAX = 10_000_000_000` rejected a *single* input ≥ 1e10, but `cashBalance` is updated with `increment` / `decrement`. A sequence of individually valid deposits could push the stored balance past the ceiling → Postgres `numeric field overflow` → 500 from the route, mid-transaction.
- The import path validated amounts with an unbounded `decimalSchema` (`z.number().finite()` / decimal string), so a backup containing such a balance failed the whole import with a generic 500 and no field path.

1e10 IDR ≈ US$600k, 1e10 VND ≈ US$400k — reachable in normal use for those currencies.

## Fix

- **Schema** — widened every money/quantity column from `Decimal(18, 8)` to `Decimal(28, 8)` (`Account.cashBalance`, `Holding.quantity`, `HoldingTransaction.quantity` / `unitPrice`, `CashTransaction.amount`, `RecurringCashTransaction.amount`, `RecurringInvestment.amount`, `PriceCache.price`, `StockWatchItem.recordPrice`, `Goal.targetAmount`) and the three `NetWorthSnapshot` aggregates from `Decimal(18, 2)` to `Decimal(28, 2)`.
- **Validators** — `CRUD_DECIMAL_ABS_MAX` raised to `1e15`. The DB now holds 20 integer digits, so it is no longer what binds: every amount crosses the wire as a JSON `number` and an IEEE double keeps ~15.95 significant digits, so 1e15 is the largest magnitude at which the fractional part is still meaningful. The same bound now applies to the import `decimalSchema` on **both** its string and number branch, so an oversized backup value is a 400 with a field path (`accounts.0.cashBalance`) instead of a Prisma 500.
- **Docs** — `docs/DATABASE.md` gains a short "Numeric precision" section recording the column widths and the wire-format ceiling.

## Migration notes

`prisma/migrations/20260901215445_widen_money_columns/migration.sql` — 12 `ALTER COLUMN … SET DATA TYPE` statements. Widening a `numeric` is a metadata-only change in PostgreSQL: no table rewrite, no data conversion, no downtime.

**Self-hosters must run `pnpm exec prisma migrate deploy`** (the Docker Compose `migrate` service and `build:vercel` already do this) before running a build that accepts the new range.

## Tests

`pnpm test:unit` (1090 passed) · `pnpm format:check` · `pnpm lint` · `pnpm typecheck` — all clean. `pnpm test:integration` ran locally against `asset_app_asset_tracker_test` after `migrate deploy`: 27 passed.

`tests/unit/validators.test.ts`:
- The old `rejects 1e10 for %s` table was **updated, not deleted** — it is now parametrized by value and asserts both boundaries (`1e15` rejected, `999_999_999_999_999` accepted) for `createAccountSchema.cashBalance`, `updateAccountSchema.cashBalance`, holding quantity/unitPrice, holding-transaction quantity, cash-transaction amount, both recurring amounts, goal targetAmount and stock-watch recordPrice.
- New `dataImportSchema` cases: a numeric and a decimal-string `cashBalance` just under the maximum are accepted; `1e15` and `"1000000000000000"` are rejected with message `Value exceeds supported precision` at path `["accounts", 0, "cashBalance"]`.
- New option-strike cases at its own boundary.

## Decisions

- **`ExchangeRate.rate` untouched** — a separate change widens its scale, as noted in the issue.
- **`Holding.strike` stays `Decimal(18, 4)`** (14 integer digits, max ~1e14). Raising the shared validator cap to 1e15 while leaving that column narrow would have reopened exactly this bug at a higher magnitude, so strike now carries its own `STRIKE_DECIMAL_ABS_MAX = 1e14` bound in both the CRUD and the import schema. Three lines, and it restores the invariant that everything the validator accepts fits its column.
- **1e15, not the column width (1e20)** — the API contract is JSON, and a double cannot represent 1e16 + 0.5. Accepting values the wire format silently rounds would trade a loud 500 for quiet corruption.
- The migration was generated with `prisma migrate dev` against a **scratch database**, because the shared local dev DB reported drift on an unrelated earlier migration; `prisma migrate diff --from-config-datasource --to-schema` against that fully migrated scratch DB reports "No difference detected".

Fixes #735

https://claude.ai/code/session_017pSzCj5y5uAnuYhj1uhwVf
