### PR TITLE
fix(transactions): reverse a DCA buy's recorded cash debit exactly

### DIFF
--- a/prisma/migrations/20260902000000_add_holding_materialization_provenance/migration.sql
+++ b/prisma/migrations/20260902000000_add_holding_materialization_provenance/migration.sql
@@ -1,0 +1,26 @@
+-- Keep DCA-generated buy provenance after its source rule is deleted, and
+-- record the exact cash each materialized buy removed from the account.
+--
+-- HoldingTransaction.recurringId is ON DELETE SET NULL, so deleting a recurring
+-- investment made its generated buys indistinguishable from manual ones and
+-- their cash debit was never reversed. "materializedAt" survives that deletion.
+-- "cashDebit" is stored in the ACCOUNT's currency (the one the cash balance is
+-- denominated in), so a reversal replays the original amount instead of
+-- recomputing quantity x unitPrice at today's exchange rate.
+ALTER TABLE "HoldingTransaction"
+  ADD COLUMN "materializedAt" TIMESTAMPTZ(3),
+  ADD COLUMN "cashDebit" DECIMAL(28,8);
+
+-- Same compatibility move the CashTransaction provenance migration made: rows
+-- still linked to a rule are known-generated, and the legacy materializer wrote
+-- createdAt = the occurrence day, the best recoverable bound. Rows whose rule
+-- was already deleted have recurringId = NULL and are indistinguishable from
+-- manual rows, so they stay unclassified rather than guessed at.
+--
+-- "cashDebit" is deliberately left NULL for every legacy row: the amount spent
+-- per occurrence is not recoverable, because the rule's "amount" may have been
+-- edited since the row was posted. Those rows keep the approximate
+-- quantity x unitPrice reversal.
+UPDATE "HoldingTransaction"
+SET "materializedAt" = "createdAt"
+WHERE "recurringId" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,17 @@ model HoldingTransaction {
   recurringId    String?
   recurring      RecurringInvestment? @relation(fields: [recurringId], references: [id], onDelete: SetNull)
   occurrenceDate DateTime?            @db.Date
+  // Durable DCA-generation provenance, mirroring CashTransaction. Unlike
+  // recurringId (SetNull) this survives rule deletion, so a generated BUY stays
+  // recognizable — and its cash reversible — after the rule is gone.
+  // `cashDebit` is the exact cash the materialization removed from the account,
+  // in the ACCOUNT's currency, so a reversal never re-derives it from price and
+  // today's FX. NULL on manual rows and on rows generated before these columns
+  // existed (their per-occurrence amount is unrecoverable: the rule's `amount`
+  // may have been edited since). No `materializedAtEstimated` twin here: this
+  // timestamp is provenance only — nothing reads or displays it as an instant.
+  materializedAt DateTime?            @db.Timestamptz(3)
+  cashDebit      Decimal?             @db.Decimal(28, 8)
 
   @@unique([recurringId, occurrenceDate])
   @@index([holdingId, createdAt(sort: Desc)])

--- a/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
+++ b/src/app/api/accounts/[id]/transactions/[transactionId]/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from "next/cache";
+import type { TransactionType } from "@/generated/prisma/client";
 import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { prisma } from "@/lib/prisma";
 import { updateTransactionSchema, updateCashTransactionSchema } from "@/lib/validators";
@@ -10,6 +11,7 @@ import {
   normalizeHoldingTransactionQuantity,
   toDbMoneyDelta,
 } from "@/lib/services/balance";
+import { getFreshExchangeRates, resolveRate } from "@/lib/services/exchange-rate-service";
 import { ok, failure, validationError } from "@/lib/api-responses";
 import { withAuth } from "@/lib/api-handler";
 
@@ -24,6 +26,124 @@ function invalidateAccountCaches(userId: string) {
 class NegativeHoldingQuantityError extends Error {}
 class StaleHoldingTransactionError extends Error {}
 class StaleCashTransactionError extends Error {}
+class GeneratedBuyCashError extends Error {}
+
+const GENERATED_BUY_CASH_ERROR =
+  "Cannot reverse the cash of a generated buy; adjust the balance manually";
+
+/**
+ * A holding transaction is "generated" when the DCA materializer
+ * (recurring-investment-service.ts) posted it — the only writer that posts a BUY
+ * *and* debits the account's cash for it. Manual holding rows never move cash,
+ * so only generated buys owe a reversal when they are deleted or resized.
+ *
+ * `materializedAt` is the durable half of the provenance: `recurringId` is
+ * `onDelete: SetNull` and disappears with its rule, while `materializedAt`
+ * survives. Rows posted before that column existed carry only `recurringId`, so
+ * either mark suffices.
+ */
+function isGeneratedBuy(tx: {
+  type: TransactionType;
+  recurringId: string | null;
+  materializedAt: Date | null;
+}): boolean {
+  return tx.type === "BUY" && (tx.materializedAt != null || tx.recurringId != null);
+}
+
+/** The stored fields a generated buy's cash reversal is derived from. */
+type GeneratedBuyRow = {
+  quantity: Decimal;
+  unitPrice: Decimal | null;
+  cashDebit: Decimal | null;
+  holding: { currency: string };
+};
+
+/**
+ * LEGACY fallback: cash per share for a generated buy that predates `cashDebit`.
+ *
+ * `unitPrice` is stored in the holding's currency, so a cross-currency pair is
+ * converted at *today's* rate — the rate that applied on the occurrence date is
+ * not recoverable, and neither is the rule's `amount` (it may have been edited
+ * since). This can therefore return a different amount than was originally
+ * spent; rows written by the current materializer carry `cashDebit` and never
+ * reach here. The common case (holding currency == account currency) resolves to
+ * 1 and is exact.
+ *
+ * DCA rules only ever target plain symbols, never OPTION holdings, so no
+ * `contractMultiplier` enters the arithmetic: cash = quantity x unitPrice.
+ *
+ * Throws `GeneratedBuyCashError` when the cash cannot be derived (no unitPrice,
+ * or an unresolvable rate) so callers fail closed instead of writing a balance
+ * that only half matches the ledger.
+ */
+async function legacyCashPerShare(
+  unitPrice: Decimal | null,
+  holdingCurrency: string,
+  accountCurrency: string,
+): Promise<Decimal> {
+  if (unitPrice === null) throw new GeneratedBuyCashError();
+  const price = new Decimal(unitPrice);
+  if (holdingCurrency === accountCurrency) return price;
+  const rate = resolveRate(await getFreshExchangeRates(), holdingCurrency, accountCurrency);
+  if (rate === undefined) throw new GeneratedBuyCashError();
+  return price.times(rate);
+}
+
+/**
+ * Cash to credit back when a generated buy is deleted, in the account's
+ * currency. `cashDebit` is what materialization actually removed from the
+ * balance, so replaying it is exact — no FX read, no re-derivation from price.
+ */
+async function generatedBuyReversal(
+  tx: GeneratedBuyRow,
+  accountCurrency: string,
+): Promise<Decimal> {
+  if (tx.cashDebit != null) return toDbMoney(new Decimal(tx.cashDebit));
+  const perShare = await legacyCashPerShare(tx.unitPrice, tx.holding.currency, accountCurrency);
+  return toDbMoney(perShare.times(new Decimal(tx.quantity)));
+}
+
+/**
+ * Resizing a generated buy to `nextQuantity`: the cash balance delta (growing
+ * it spends more — negative; shrinking it gives the difference back — positive)
+ * and the `cashDebit` the row must carry afterwards.
+ *
+ * With `cashDebit` stored, the original amount is scaled by the quantity ratio
+ * rather than re-priced, so the row's own cost stays the only input. The scaled
+ * debit is written back in the same transaction: it is what a later delete
+ * reverses, so leaving it at the pre-resize amount would strand the difference.
+ * Deriving the delta from the two stored amounts (equivalent to
+ * `cashDebit x (next - old) / old`) keeps balance and row exact to the same
+ * 8-dp rounding.
+ *
+ * `nextCashDebit` is null on the legacy path — there is nothing stored to keep
+ * in step, and that path re-derives the amount from quantity every time.
+ */
+async function generatedBuyResize(
+  tx: GeneratedBuyRow,
+  accountCurrency: string,
+  nextQuantity: number,
+): Promise<{ delta: Decimal; nextCashDebit: Decimal | null }> {
+  const oldQuantity = new Decimal(tx.quantity);
+
+  if (tx.cashDebit != null) {
+    // A zero-quantity BUY carries no per-share cost to scale by (only an
+    // imported row can be one), so fail closed rather than divide by zero.
+    if (oldQuantity.isZero()) throw new GeneratedBuyCashError();
+    const oldCashDebit = toDbMoney(new Decimal(tx.cashDebit));
+    const nextCashDebit = toDbMoney(oldCashDebit.times(nextQuantity).div(oldQuantity));
+    return { delta: oldCashDebit.minus(nextCashDebit), nextCashDebit };
+  }
+
+  const quantityChange = new Decimal(nextQuantity).minus(oldQuantity);
+  const perShare = await legacyCashPerShare(tx.unitPrice, tx.holding.currency, accountCurrency);
+  return { delta: toDbMoney(perShare.times(quantityChange).negated()), nextCashDebit: null };
+}
+
+/** Snap a Decimal money amount to the column's Decimal(28, 8) scale. */
+function toDbMoney(amount: Decimal): Decimal {
+  return new Decimal(amount.toFixed(8));
+}
 
 // Same convention as the recurring-cash routes: occurrence dates are calendar
 // days (YYYY-MM-DD) persisted as UTC midnight into the `@db.Date` column.
@@ -68,9 +188,12 @@ export const PATCH = withAuth<TxCtx>(
   async (request, { params }, userId) => {
     const { id: accountId, transactionId } = await params;
 
+    // `currency` is only needed by the legacy reversal path, which converts a
+    // pre-`cashDebit` generated buy's unitPrice into the currency the cash
+    // balance is denominated in.
     const account = await prisma.account.findUnique({
       where: { id: accountId, userId },
-      select: { id: true },
+      select: { id: true, currency: true },
     });
     if (!account) return failure("Not found", 404);
 
@@ -92,6 +215,13 @@ export const PATCH = withAuth<TxCtx>(
 
       const { id: _txId, ...data } = parsed.data;
 
+      const generated = isGeneratedBuy(holdingTx);
+      // A generated buy's cash debit is tied to it being a BUY; turning it into
+      // a SELL or EDIT has no meaningful cash reversal, so refuse it outright.
+      if (generated && data.type !== undefined && data.type !== holdingTx.type) {
+        return failure("Generated buys cannot change type; delete the row instead", 400);
+      }
+
       const nextType = data.type ?? holdingTx.type;
       const nextQuantity = normalizeHoldingTransactionQuantity({
         type: nextType,
@@ -109,6 +239,26 @@ export const PATCH = withAuth<TxCtx>(
         { type: nextType, quantity: nextQuantity },
       );
 
+      // Resizing a generated buy resizes the cash it consumed: growing it debits
+      // more, shrinking it credits the difference back. Resolved before the
+      // write so an underivable amount leaves the ledger untouched.
+      let cashDelta: Decimal | null = null;
+      let nextCashDebit: Decimal | null = null;
+      if (generated && data.quantity !== undefined) {
+        try {
+          ({ delta: cashDelta, nextCashDebit } = await generatedBuyResize(
+            holdingTx,
+            account.currency,
+            nextQuantity,
+          ));
+        } catch (error) {
+          if (error instanceof GeneratedBuyCashError) {
+            return failure(GENERATED_BUY_CASH_ERROR, 409);
+          }
+          throw error;
+        }
+      }
+
       let updatedTx;
       try {
         updatedTx = await prisma.$transaction(async (tx) => {
@@ -123,6 +273,9 @@ export const PATCH = withAuth<TxCtx>(
               ...(data.type !== undefined && { type: data.type }),
               ...(data.note !== undefined && { note: data.note }),
               ...(data.createdAt !== undefined && { createdAt: new Date(data.createdAt) }),
+              // Keep the recorded debit in step with the cash this resize
+              // moves, so a later delete reverses the resized amount.
+              ...(nextCashDebit !== null && { cashDebit: nextCashDebit }),
             },
           });
           if (result.count !== 1) {
@@ -130,6 +283,13 @@ export const PATCH = withAuth<TxCtx>(
           }
 
           await applyHoldingQuantityDelta(tx, holdingTx.holding.id, holdingDelta);
+
+          if (cashDelta !== null && !cashDelta.isZero()) {
+            await tx.account.update({
+              where: { id: accountId },
+              data: { cashBalance: { increment: cashDelta } },
+            });
+          }
 
           return tx.holdingTransaction.findUniqueOrThrow({
             where: { id: transactionId },
@@ -242,9 +402,12 @@ export const DELETE = withAuth<TxCtx>(
   async (_request, { params }, userId) => {
     const { id: accountId, transactionId } = await params;
 
+    // `currency` is only needed by the legacy reversal path, which converts a
+    // pre-`cashDebit` generated buy's unitPrice into the currency the cash
+    // balance is denominated in.
     const account = await prisma.account.findUnique({
       where: { id: accountId, userId },
-      select: { id: true },
+      select: { id: true, currency: true },
     });
     if (!account) return failure("Not found", 404);
 
@@ -263,6 +426,23 @@ export const DELETE = withAuth<TxCtx>(
         null,
       );
 
+      // Deleting a generated buy must give back the cash its materialization
+      // debited, otherwise the balance stays short and the ledger no longer
+      // explains it. Resolved before the write so an underivable amount leaves
+      // both the shares and the balance untouched. `materializedAt` keeps this
+      // working after the source rule has been deleted.
+      let cashReversal: Decimal | null = null;
+      if (isGeneratedBuy(holdingTx)) {
+        try {
+          cashReversal = await generatedBuyReversal(holdingTx, account.currency);
+        } catch (error) {
+          if (error instanceof GeneratedBuyCashError) {
+            return failure(GENERATED_BUY_CASH_ERROR, 409);
+          }
+          throw error;
+        }
+      }
+
       try {
         await prisma.$transaction(async (tx) => {
           const result = await tx.holdingTransaction.deleteMany({
@@ -277,6 +457,13 @@ export const DELETE = withAuth<TxCtx>(
           }
 
           await applyHoldingQuantityDelta(tx, holdingTx.holding.id, holdingDelta);
+
+          if (cashReversal !== null && !cashReversal.isZero()) {
+            await tx.account.update({
+              where: { id: accountId },
+              data: { cashBalance: { increment: cashReversal } },
+            });
+          }
         });
       } catch (error) {
         if (error instanceof NegativeHoldingQuantityError) {

--- a/src/app/api/settings/data/route.ts
+++ b/src/app/api/settings/data/route.ts
@@ -298,7 +298,9 @@ export const GET = withAuth(
       if (!data) return failure("User not found", 404);
 
       const exportData = {
-        version: "1.4",
+        // 1.5 adds HoldingTransaction.materializedAt / .cashDebit (durable DCA
+        // provenance and the exact cash each generated buy consumed).
+        version: "1.5",
         exportedAt: new Date().toISOString(),
         settings: data.appSettings,
         accounts: data.appAccounts,
@@ -505,6 +507,17 @@ export const POST = withAuth(
                       recurringId: t.recurringId
                         ? (recurringInvestmentIdMap.get(t.recurringId) ?? null)
                         : null,
+                      // v1.5+ backups carry durable DCA provenance. An older
+                      // backup only has recurringId, which the remap above can
+                      // drop to null, so apply the same compatibility move the
+                      // provenance migration made: a row that was generated
+                      // keeps createdAt as its recoverable materialization
+                      // bound. cashDebit stays null there — the per-occurrence
+                      // amount is not recoverable, since the rule's amount may
+                      // have been edited since the row was posted.
+                      materializedAt:
+                        t.materializedAt ?? (t.recurringId ? (t.createdAt ?? null) : null),
+                      cashDebit: t.cashDebit ?? null,
                     })),
                   });
                 }

--- a/src/lib/services/recurring-investment-service.ts
+++ b/src/lib/services/recurring-investment-service.ts
@@ -86,6 +86,10 @@ async function resolvePrice(
  * creating it if needed), and debits the account's cash — all in one atomic
  * `$transaction`. Balance/quantity are scaled by the number of rows actually
  * inserted (`createMany().count`) so an idempotent skip can't double-apply.
+ *
+ * Every posted row carries `materializedAt` (durable generation provenance) and
+ * `cashDebit` (the exact cash it consumed, in the account's currency) so a later
+ * delete or resize can reverse the original amount rather than approximate it.
  */
 export async function materializeDueInvestments(
   now: Date = new Date(),
@@ -213,6 +217,13 @@ export async function materializeDueInvestments(
             recurringId: rule.id,
             occurrenceDate: d,
             createdAt: d,
+            // Durable provenance (recurringId is SetNull, this is not) plus the
+            // exact cash this row removes from the account, in the account's
+            // currency: the debit below is `rule.amount` per inserted row. A
+            // later delete/resize reverses this stored number instead of
+            // recomputing quantity x unitPrice at whatever FX rate applies then.
+            materializedAt: now,
+            cashDebit: new Decimal(rule.amount),
           })),
           skipDuplicates: true,
         });

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -470,6 +470,10 @@ const importNullableTimestamp = z.iso.datetime().optional().nullable();
 // since analysis bucketing falls back to createdAt only when it is null.
 const importOccurrenceDate = z.iso.datetime().optional().nullable();
 const importMaterializedAt = z.iso.datetime().optional().nullable();
+// The exact cash a DCA-materialized buy removed from its account, in the
+// account's currency. Absent in pre-1.5 backups and null on manual rows; those
+// rows fall back to the approximate reversal (see the transactions route).
+const importCashDebit = decimalSchema.optional().nullable();
 const importHoldingTransactionUnitPrice = decimalSchema
   .optional()
   .nullable()
@@ -525,6 +529,8 @@ export const dataImportSchema = z.object({
                     createdAt: importTimestamp,
                     occurrenceDate: importOccurrenceDate,
                     recurringId: z.string().optional().nullable(),
+                    materializedAt: importMaterializedAt,
+                    cashDebit: importCashDebit,
                   }),
                 )
                 .max(MAX_IMPORT_TRANSACTIONS_PER_HOLDING)

--- a/tests/unit/account-ledger-routes.test.ts
+++ b/tests/unit/account-ledger-routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Decimal } from "@/generated/prisma/internal/prismaNamespace";
 import { toDbMoneyDelta } from "@/lib/services/balance";
+import { getFreshExchangeRates } from "@/lib/services/exchange-rate-service";
 
 const h = vi.hoisted(() => ({
   account: null as Record<string, unknown> | null,
@@ -11,12 +13,22 @@ const h = vi.hoisted(() => ({
   holdingTransactionDeleteManyCount: 1,
   holdingUpdateManyCount: 1,
   transactionRows: [] as Record<string, unknown>[],
+  exchangeRates: new Map<string, number>(),
   calls: [] as Array<{ op: string; args?: Record<string, unknown> }>,
 }));
 
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
 }));
+
+// Keep `resolveRate` real (it is pure); only the DB read is stubbed so the
+// cross-currency reversal is exercised through the production resolver.
+vi.mock("@/lib/services/exchange-rate-service", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/services/exchange-rate-service")>();
+  return { ...actual, getFreshExchangeRates: vi.fn(async () => h.exchangeRates) };
+});
 
 vi.mock("@/lib/api-handler", () => ({
   withAuth:
@@ -126,7 +138,9 @@ describe("account ledger routes", () => {
     h.holdingTransactionDeleteManyCount = 1;
     h.holdingUpdateManyCount = 1;
     h.transactionRows = [];
+    h.exchangeRates = new Map();
     h.calls = [];
+    vi.mocked(getFreshExchangeRates).mockClear();
   });
 
   it("serializes holding transaction unitPrice as number or null", async () => {
@@ -307,6 +321,9 @@ describe("account ledger routes", () => {
       id: "tx1",
       type: "BUY",
       quantity: 10,
+      recurringId: null,
+      materializedAt: null,
+      cashDebit: null,
       holding: { id: "holding1", accountId: "acc1", quantity: 10 },
     };
     const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
@@ -333,6 +350,9 @@ describe("account ledger routes", () => {
       id: "tx1",
       type: "BUY",
       quantity: 10,
+      recurringId: null,
+      materializedAt: null,
+      cashDebit: null,
       holding: { id: "holding1", accountId: "acc1", quantity: 10 },
     };
     const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
@@ -349,6 +369,9 @@ describe("account ledger routes", () => {
       id: "tx1",
       type: "BUY",
       quantity: 7,
+      recurringId: null,
+      materializedAt: null,
+      cashDebit: null,
       holding: { id: "holding1", accountId: "acc1", quantity: 7 },
     };
     const { DELETE } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
@@ -370,6 +393,227 @@ describe("account ledger routes", () => {
     expect(deleteWrite.where.id).toBe("holding1");
     expect(Number(deleteWrite.where.quantity.gte)).toBe(7);
     expect(Number(deleteWrite.data.quantity.decrement)).toBe(7);
+  });
+
+  // --- DCA (generated) buys: creation debited cash, so mutations must undo it ---
+
+  /**
+   * A buy as the materializer writes it today: durable provenance
+   * (`materializedAt`) plus `cashDebit`, the exact account-currency cash the
+   * row removed.
+   */
+  const generatedBuy = (overrides: Record<string, unknown> = {}) => ({
+    id: "tx1",
+    type: "BUY",
+    quantity: new Decimal(2),
+    unitPrice: new Decimal("101.25"),
+    recurringId: "rule1",
+    materializedAt: new Date("2026-06-14T21:30:00.000Z"),
+    cashDebit: new Decimal("202.50"),
+    holding: { id: "holding1", accountId: "acc1", currency: "USD", quantity: new Decimal(2) },
+    ...overrides,
+  });
+
+  /** A buy generated before the provenance columns existed: recurringId only. */
+  const legacyGeneratedBuy = (overrides: Record<string, unknown> = {}) =>
+    generatedBuy({ materializedAt: null, cashDebit: null, ...overrides });
+
+  /** A hand-entered buy: no provenance at all, and it never moved cash. */
+  const manualBuy = (overrides: Record<string, unknown> = {}) =>
+    generatedBuy({ recurringId: null, materializedAt: null, cashDebit: null, ...overrides });
+
+  const deleteTx = async () => {
+    const { DELETE } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+    return DELETE(new Request("http://unit.test", { method: "DELETE" }), params());
+  };
+
+  const cashIncrement = () =>
+    Number(
+      (
+        h.calls.find((call) => call.op === "account.update")?.args?.data as {
+          cashBalance: { increment: unknown };
+        }
+      ).cashBalance.increment,
+    );
+
+  it("reverses the exact stored cash debit, without any FX lookup, on delete", async () => {
+    // Cross-currency on purpose: the holding is priced in TWD while the account
+    // is USD, yet nothing is converted — cashDebit already is account currency.
+    h.holdingTx = generatedBuy({
+      holding: { id: "holding1", accountId: "acc1", currency: "TWD", quantity: new Decimal(2) },
+    });
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(200);
+    expect(cashIncrement()).toBe(202.5);
+    // The rate loader must never be consulted: an exact reversal cannot depend
+    // on today's FX rate, and the empty rate map would otherwise fail closed.
+    expect(vi.mocked(getFreshExchangeRates)).not.toHaveBeenCalled();
+  });
+
+  it("reverses the stored debit after the recurring rule was deleted", async () => {
+    // recurringId is onDelete: SetNull, so only materializedAt still says this
+    // row was generated. Without it the debit would silently never come back.
+    h.holdingTx = generatedBuy({ recurringId: null });
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(200);
+    expect(cashIncrement()).toBe(202.5);
+    expect(vi.mocked(getFreshExchangeRates)).not.toHaveBeenCalled();
+  });
+
+  it("scales the stored debit by the quantity ratio when a generated buy is resized", async () => {
+    h.holdingTx = generatedBuy();
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    let response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+    expect(response.status).toBe(200);
+    // Growing 2 -> 3 shares spends another half of the original 202.50.
+    expect(cashIncrement()).toBe(-101.25);
+
+    h.calls = [];
+    response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 1 }), params());
+    expect(response.status).toBe(200);
+    // Shrinking 2 -> 1 share gives that same half back.
+    expect(cashIncrement()).toBe(101.25);
+    expect(vi.mocked(getFreshExchangeRates)).not.toHaveBeenCalled();
+  });
+
+  it("writes the resized debit back so a later delete reverses the resized amount", async () => {
+    h.holdingTx = generatedBuy();
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+    expect(response.status).toBe(200);
+    const write = h.calls.find((call) => call.op === "holdingTransaction.updateMany")?.args
+      ?.data as { cashDebit?: unknown };
+    // 202.50 for 2 shares becomes 303.75 for 3 — the 202.50 already out plus
+    // the 101.25 this resize just spent.
+    expect(Number(write.cashDebit)).toBe(303.75);
+
+    // Deleting the resized row must now give all of it back.
+    h.holdingTx = generatedBuy({ quantity: new Decimal(3), cashDebit: new Decimal("303.75") });
+    h.calls = [];
+    expect((await deleteTx()).status).toBe(200);
+    expect(cashIncrement()).toBe(303.75);
+  });
+
+  it("leaves a legacy row's null debit alone when it is resized", async () => {
+    h.holdingTx = legacyGeneratedBuy({ unitPrice: new Decimal(100) });
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+
+    expect(response.status).toBe(200);
+    const write = h.calls.find((call) => call.op === "holdingTransaction.updateMany")?.args
+      ?.data as Record<string, unknown>;
+    // Nothing stored to keep in step: that path re-derives from quantity.
+    expect(write).not.toHaveProperty("cashDebit");
+  });
+
+  it("fails closed with 409 when a stored debit cannot be scaled by a zero quantity", async () => {
+    h.holdingTx = generatedBuy({ quantity: new Decimal(0) });
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+
+    expect(response.status).toBe(409);
+    expect(h.calls).toEqual([]);
+  });
+
+  it("credits back a legacy generated buy's cash approximated from unitPrice", async () => {
+    h.holdingTx = legacyGeneratedBuy();
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(200);
+    // 2 shares x 101.25, holding currency == account currency so no conversion.
+    expect(cashIncrement()).toBe(202.5);
+  });
+
+  it("converts a legacy cross-currency generated buy at today's rate", async () => {
+    h.exchangeRates = new Map([["TWD_USD", 0.03125]]);
+    h.holdingTx = legacyGeneratedBuy({
+      unitPrice: new Decimal(100),
+      holding: { id: "holding1", accountId: "acc1", currency: "TWD", quantity: new Decimal(2) },
+    });
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(200);
+    // 2 x 100 TWD = 200 TWD -> 6.25 USD at 0.03125. Approximate by
+    // construction: the occurrence-day rate is gone for a pre-cashDebit row.
+    expect(cashIncrement()).toBe(6.25);
+    // Counterpart to the exact path's "never called": this legacy row is the
+    // only kind of reversal that may read a rate at all.
+    expect(vi.mocked(getFreshExchangeRates)).toHaveBeenCalled();
+  });
+
+  it("fails closed with 409 when a legacy generated buy's rate cannot be resolved", async () => {
+    h.holdingTx = legacyGeneratedBuy({
+      holding: { id: "holding1", accountId: "acc1", currency: "TWD", quantity: new Decimal(2) },
+    });
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(409);
+    expect(h.calls).toEqual([]);
+  });
+
+  it("fails closed with 409 when a legacy generated buy has no unitPrice", async () => {
+    h.holdingTx = legacyGeneratedBuy({ unitPrice: null });
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(409);
+    expect(h.calls).toEqual([]);
+  });
+
+  it("applies a proportional cash delta when a legacy generated buy is resized", async () => {
+    h.holdingTx = legacyGeneratedBuy({ unitPrice: new Decimal(100) });
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    let response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+    expect(response.status).toBe(200);
+    // Growing 2 -> 3 shares spends another 100.
+    expect(cashIncrement()).toBe(-100);
+
+    h.calls = [];
+    response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 1 }), params());
+    expect(response.status).toBe(200);
+    // Shrinking 2 -> 1 share gives 100 back.
+    expect(cashIncrement()).toBe(100);
+  });
+
+  it("leaves cash untouched when deleting a manual buy", async () => {
+    h.holdingTx = manualBuy();
+
+    const response = await deleteTx();
+
+    expect(response.status).toBe(200);
+    expect(h.calls.some((call) => call.op === "account.update")).toBe(false);
+  });
+
+  it("leaves cash untouched when resizing a manual buy", async () => {
+    h.holdingTx = manualBuy();
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", quantity: 3 }), params());
+
+    expect(response.status).toBe(200);
+    expect(h.calls.some((call) => call.op === "account.update")).toBe(false);
+  });
+
+  it("rejects changing the type of a generated buy without writing", async () => {
+    h.holdingTx = generatedBuy();
+    const { PATCH } = await import("@/app/api/accounts/[id]/transactions/[transactionId]/route");
+
+    const response = await PATCH(jsonRequest("PATCH", { id: "tx1", type: "SELL" }), params());
+
+    expect(response.status).toBe(400);
+    expect(h.calls).toEqual([]);
   });
 
   it("edits a cash transaction with a guarded balance delta", async () => {

--- a/tests/unit/calendar-backup-route.test.ts
+++ b/tests/unit/calendar-backup-route.test.ts
@@ -5,12 +5,12 @@ const h = vi.hoisted(() => {
   const makeTx = () => ({
     account: { deleteMany: vi.fn(), create: vi.fn(async () => ({ id: "new_account_1" })) },
     cashTransaction: { createMany: vi.fn() },
-    holding: { create: vi.fn() },
+    holding: { create: vi.fn(async () => ({ id: "new_holding_1" })) },
     holdingTransaction: { createMany: vi.fn() },
     netWorthSnapshot: { deleteMany: vi.fn(), createMany: vi.fn() },
     goal: { deleteMany: vi.fn(), createMany: vi.fn() },
     recurringCashTransaction: { create: vi.fn(async () => ({ id: "new_cash_rule_1" })) },
-    recurringInvestment: { create: vi.fn() },
+    recurringInvestment: { create: vi.fn(async () => ({ id: "new_investment_rule_1" })) },
     stockWatchItem: { deleteMany: vi.fn(), createMany: vi.fn() },
     calendarEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
     setting: { upsert: vi.fn() },
@@ -187,11 +187,11 @@ describe("Calendar whole-app backup", () => {
     vi.clearAllMocks();
   });
 
-  it("exports calendar entries in backup v1.4", async () => {
+  it("exports calendar entries in backup v1.5", async () => {
     const response = await GET(new Request("http://unit.test/api/settings/data"), undefined);
     const { json } = await exportedJson(response);
 
-    expect(json.version).toBe("1.4");
+    expect(json.version).toBe("1.5");
     expect(json.calendarEntries).toEqual([exportedCalendarFixture]);
   });
 
@@ -496,6 +496,125 @@ describe("Calendar whole-app backup", () => {
           materializedAtEstimated: true,
           recurringId: null,
         }),
+      ],
+    });
+  });
+
+  it("preserves durable DCA provenance on a v1.5 holding transaction round-trip", async () => {
+    const response = await importBackup({
+      version: "1.5",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          recurringInvestments: [
+            {
+              id: "old_investment_rule_1",
+              symbol: "NVDA",
+              name: "NVIDIA",
+              assetType: "STOCK",
+              holdingCurrency: "USD",
+              amount: 1000,
+              frequency: "MONTHLY",
+              startDate: "2026-01-01T00:00:00.000Z",
+              nextRunDate: "2026-02-01T00:00:00.000Z",
+              isActive: true,
+            },
+          ],
+          holdings: [
+            {
+              symbol: "NVDA",
+              name: "NVIDIA",
+              quantity: 5,
+              currency: "USD",
+              assetType: "STOCK",
+              transactions: [
+                {
+                  type: "BUY",
+                  quantity: 5,
+                  unitPrice: 200,
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  occurrenceDate: "2026-01-01T00:00:00.000Z",
+                  recurringId: "old_investment_rule_1",
+                  materializedAt: "2026-01-01T21:30:00.000Z",
+                  cashDebit: 1000,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.holdingTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          holdingId: "new_holding_1",
+          recurringId: "new_investment_rule_1",
+          materializedAt: "2026-01-01T21:30:00.000Z",
+          cashDebit: 1000,
+        }),
+      ],
+    });
+  });
+
+  it("imports an older backup without holding provenance, recovering only what is knowable", async () => {
+    const response = await importBackup({
+      version: "1.4",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: 100,
+          holdings: [
+            {
+              symbol: "NVDA",
+              name: "NVIDIA",
+              quantity: 8,
+              currency: "USD",
+              assetType: "STOCK",
+              transactions: [
+                {
+                  type: "BUY",
+                  quantity: 5,
+                  unitPrice: 200,
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  occurrenceDate: "2026-01-01T00:00:00.000Z",
+                  // The rule itself is gone from this backup, so the id cannot
+                  // be remapped — only createdAt survives as a materialization
+                  // bound, exactly as the provenance migration backfilled it.
+                  recurringId: "missing_investment_rule",
+                },
+                {
+                  type: "BUY",
+                  quantity: 3,
+                  unitPrice: 210,
+                  createdAt: "2026-02-01T00:00:00.000Z",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(h.tx.holdingTransaction.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          recurringId: null,
+          materializedAt: "2026-01-01T00:00:00.000Z",
+          // Not recoverable: the rule's amount may have changed since.
+          cashDebit: null,
+        }),
+        // A manual row keeps no provenance and never moved cash.
+        expect.objectContaining({ recurringId: null, materializedAt: null, cashDebit: null }),
       ],
     });
   });

--- a/tests/unit/recurring-investment-service.test.ts
+++ b/tests/unit/recurring-investment-service.test.ts
@@ -190,6 +190,10 @@ describe("materializeDueInvestments", () => {
     expect(h.createManyCalls[0].data[0].type).toBe("BUY");
     expect(Number(h.holdingUpdates[0].data.quantity.increment)).toBe(5);
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(1000);
+    // Durable provenance (survives rule deletion) plus the exact cash removed,
+    // so deleting or resizing this buy later reverses the real amount.
+    expect(h.createManyCalls[0].data[0].materializedAt).toEqual(d("2026-06-14"));
+    expect(Number(h.createManyCalls[0].data[0].cashDebit)).toBe(1000);
   });
 
   it("scales shares + cash by occurrence count on catch-up", async () => {
@@ -201,6 +205,10 @@ describe("materializeDueInvestments", () => {
     expect(h.createManyCalls[0].data).toHaveLength(3);
     expect(Number(h.holdingUpdates[0].data.quantity.increment)).toBe(15); // 5 * 3
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(3000); // 1000 * 3
+    // The debit is rule.amount x count, so each row records rule.amount.
+    expect(h.createManyCalls[0].data.map((row) => Number(row.cashDebit))).toEqual([
+      1000, 1000, 1000,
+    ]);
   });
 
   it("converts the amount when account and price currencies differ", async () => {
@@ -217,6 +225,9 @@ describe("materializeDueInvestments", () => {
     expect(Number(h.createManyCalls[0].data[0].quantity)).toBeCloseTo(5, 6);
     // Cash debited in the account's own currency (TWD), not converted.
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(30000);
+    // cashDebit records that same account-currency amount, so reversing it
+    // never has to re-run this conversion at a later day's rate.
+    expect(Number(h.createManyCalls[0].data[0].cashDebit)).toBe(30000);
   });
 
   it("auto-creates the holding with the resolved price currency", async () => {
@@ -346,6 +357,8 @@ describe("materializeDueInvestments", () => {
     expect(result.created).toBe(1);
     expect(Number(h.holdingUpdates[0].data.quantity.increment)).toBe(5); // 5 * 1
     expect(Number(h.accountUpdates[0].data.cashBalance.decrement)).toBe(1000);
+    // Per-row cashDebit is the per-occurrence amount, never the scaled total.
+    expect(h.createManyCalls[0].data.every((row) => Number(row.cashDebit) === 1000)).toBe(true);
   });
 
   it("does not create a holding or reactivate a rule disabled after price resolution", async () => {

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -590,6 +590,56 @@ describe("dataImportSchema", () => {
     ]);
   });
 
+  it("preserves holding transaction DCA provenance and bounds its cash debit", () => {
+    const backup = (cashDebit: unknown) => ({
+      version: "1.5",
+      accounts: [
+        {
+          name: "Brokerage",
+          type: "ASSET",
+          category: "BROKERAGE",
+          currency: "USD",
+          cashBalance: "100",
+          holdings: [
+            {
+              symbol: "NVDA",
+              name: "NVIDIA",
+              quantity: "5",
+              currency: "USD",
+              assetType: "STOCK",
+              transactions: [
+                {
+                  type: "BUY",
+                  quantity: "5",
+                  materializedAt: "2026-01-01T21:30:00.000Z",
+                  cashDebit,
+                },
+                // A pre-1.5 row omits both fields entirely.
+                { type: "BUY", quantity: "3" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = dataImportSchema.safeParse(backup("1000.00000000"));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const transactions = result.data.accounts[0].holdings?.[0].transactions;
+      expect(transactions?.map((t) => t.materializedAt)).toEqual([
+        "2026-01-01T21:30:00.000Z",
+        undefined,
+      ]);
+      expect(transactions?.map((t) => t.cashDebit)).toEqual(["1000.00000000", undefined]);
+    }
+
+    // Same magnitude ceiling as every other imported amount: an oversized value
+    // must fail with a field path, not as a Prisma overflow at write time.
+    expect(dataImportSchema.safeParse(backup(1e15)).success).toBe(false);
+    expect(dataImportSchema.safeParse(backup(null)).success).toBe(true);
+  });
+
   it("preserves imported holding transaction unitPrice through parsing", () => {
     const result = dataImportSchema.safeParse({
       version: "1.2",


### PR DESCRIPTION
## Problem

Manual holding transactions never move cash, so `PATCH`/`DELETE` on
`/api/accounts/[id]/transactions/[transactionId]` only ever applied a quantity
delta. DCA materialization is the one exception: `recurring-investment-service.ts`
posts a BUY `HoldingTransaction` **and** debits the account's `cashBalance` by the
rule's `amount` in the same `$transaction`. Deleting or shrinking that BUY removed
the shares but left the debit in place, so the account stayed permanently short and
the ledger no longer explained the balance.

Fixes #734

## Why this was reworked

The first revision identified generated rows by `recurringId` and recomputed the
cash as `quantity x unitPrice x today's FX rate`. Review held it, correctly:

1. `HoldingTransaction.recurringId` is `onDelete: SetNull`. Once the recurring
   rule is deleted, a generated BUY is indistinguishable from a manual one and its
   debit is never reversed — the ledger-integrity bug was only half fixed.
2. A cross-currency reversal priced at today's rate can return a different amount
   than was actually spent.

Both are consequences of deriving, at reversal time, facts that were only known at
posting time. So the fix now **records those facts when the row is posted**.

## Design

`HoldingTransaction` gains two nullable columns:

- **`materializedAt DateTime? @db.Timestamptz(3)`** — durable generation
  provenance, exactly mirroring `CashTransaction`. Unlike `recurringId` it
  survives rule deletion, so a generated BUY stays recognizable forever.
- **`cashDebit Decimal? @db.Decimal(28, 8)`** — the exact cash the row removed
  from the account, **in the account's currency**. The materializer's debit is
  `rule.amount` per occurrence, so that is what each row stores.

No index: nothing queries either column (unlike `CashTransaction.materializedAt`,
which analysis floors by). No `materializedAtEstimated` twin either — this
timestamp is provenance only; nothing reads or displays it as an instant.

**Materializer** (`recurring-investment-service.ts`) sets `materializedAt` to the
run instant and `cashDebit` to `rule.amount` on every row `createMany` posts,
inside the existing reservation/CAS transaction.

**Reversal** (`transactions/[transactionId]/route.ts`):

- a row is generated when `materializedAt != null || recurringId != null`, so the
  reversal keeps working after the rule is gone — the case the review called out;
- **DELETE** with `cashDebit` present credits back that stored amount directly:
  no FX lookup, no recomputation, exact even when the holding's currency differs
  from the account's;
- **PATCH** resize scales the stored debit by the quantity ratio
  (`cashDebit x (newQty - oldQty) / oldQty`, in `Decimal`, snapped to 8 dp) and
  **writes the scaled debit back on the row** in the same `$transaction` — a
  resize that only moved cash would otherwise leave a later delete refunding the
  pre-resize amount and stranding the difference;
- **PATCH** still returns **400** on a type change (a BUY-shaped debit has no
  meaningful reversal as a SELL or EDIT), and both verbs still fail closed with
  **409** when no amount can be derived, writing nothing.

### The legacy fallback, and why it stays approximate

Rows generated before this migration have no `cashDebit`, so they keep the old
path: `quantity x unitPrice`, converted at today's rate. That is documented as the
legacy fallback in code, and it cannot be made exact retroactively:

- `unitPrice` is stored in the holding's currency and no rate snapshot was ever
  taken, so the occurrence-day rate is gone;
- the rule's `amount` is not a substitute — it may have been edited since, and the
  rule may not exist at all any more.

Same-currency rows (the common case) short-circuit to rate 1 and are exact.

## Migration

`20260902000000_add_holding_materialization_provenance`

```sql
ALTER TABLE "HoldingTransaction"
  ADD COLUMN "materializedAt" TIMESTAMPTZ(3),
  ADD COLUMN "cashDebit" DECIMAL(28,8);

UPDATE "HoldingTransaction"
SET "materializedAt" = "createdAt"
WHERE "recurringId" IS NOT NULL;
```

**Self-hosters:** additive and online — two nullable columns plus one backfill
`UPDATE`, no rewrite of existing values, no downtime step. The backfill is the same
compatibility move the `CashTransaction` provenance migration made: rows still
linked to a rule are known-generated, and the legacy materializer wrote
`createdAt` = the occurrence day, the best recoverable bound. Rows whose rule was
already deleted have `recurringId = NULL` and are indistinguishable from manual
rows, so they stay unclassified rather than guessed at. `cashDebit` is left NULL
for every pre-existing row on purpose (see above), so they keep the approximate
reversal.

Hand-written per repo convention, then verified by replaying the whole migration
directory into a throwaway database and diffing it against the schema
(`prisma migrate diff --from-config-datasource --to-schema` → *No difference
detected*).

## Backup round-trip

The export dumps whole models, so both fields flow out automatically; the export
`version` is bumped **1.4 → 1.5**. `dataImportSchema` accepts `materializedAt`
(nullable ISO datetime) and `cashDebit` (nullable bounded decimal, same 1e15
ceiling as every other imported amount), and the import route maps them.

An older backup still imports unchanged, and recovers what is knowable: a holding
transaction that carries a `recurringId` gets `materializedAt = createdAt` — the
same bound the migration backfills, so a user who exported before upgrading and
imported after ends up in the same state as one who simply migrated. `cashDebit`
stays null there.

## Tests

`tests/unit/account-ledger-routes.test.ts`

- DELETE with `cashDebit` reverses exactly that amount, cross-currency, and
  **asserts the rate loader is never called** (the empty rate map would fail
  closed if it were)
- DELETE still reverses when `recurringId` is null but `materializedAt` is set —
  the review's case
- PATCH resize scales the stored debit proportionally, both signs, no FX
- PATCH resize writes the scaled `cashDebit` back, and the resized row then
  deletes for the full resized amount
- legacy row (`cashDebit` null, `recurringId` set): same-currency, cross-currency
  at today's rate (asserting the loader *is* used), 409 on unresolvable rate, 409
  on missing `unitPrice`, proportional resize, and no `cashDebit` write-back
- 409 when a stored debit cannot be scaled by a zero quantity
- manual row moves no cash on delete or resize
- 400 on a generated buy's type change

`tests/unit/recurring-investment-service.test.ts` — materialization stores
`materializedAt` = the run instant and `cashDebit` = `rule.amount`; per-row (not
scaled) on catch-up and on an idempotent partial insert; in the account's currency
for a cross-currency rule.

`tests/unit/calendar-backup-route.test.ts` — v1.5 round-trip preserves both fields
through the id remap; an older backup recovers `materializedAt` from `createdAt`
for a generated row and leaves a manual row's provenance null; export version
asserted as 1.5.

`tests/unit/validators.test.ts` — both fields survive parsing, absent fields stay
`undefined`, and an oversized `cashDebit` is rejected by the schema rather than at
write time.

`pnpm test:unit` (1118 passed), `format:check`, `lint`, `typecheck` clean;
`pnpm test:integration` (27 passed) against a local `_asset_tracker_test` database
with the migration applied via `prisma migrate deploy`.

## Decisions

- **Two columns, not one.** Provenance alone would keep the reversal firing after
  a rule is deleted but leave it approximate; the amount alone would still be
  invisible once `recurringId` is nulled. The review asked for both, and both are
  needed.
- **`cashDebit` in the account's currency.** That is the currency `cashBalance` is
  denominated in and the currency the debit was applied in, so the reversal never
  needs an exchange rate at any point in the row's life.
- **Resize rewrites `cashDebit`.** Necessary for the invariant "the stored debit is
  what this row currently owes the account"; the delta is derived from the old and
  new stored amounts so balance and row round identically.
- **No `materializedAtEstimated`.** `CashTransaction` needs it because analysis
  surfaces that timestamp; here it is pure provenance, never read as an instant.
- **No contract multiplier.** DCA rules only ever target plain symbols, never
  OPTION holdings.

https://claude.ai/code/session_017pSzCj5y5uAnuYhj1uhwVf
