### PR TITLE
fix(release): publish GitHub releases for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Publish GitHub Releases
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semver tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-releases
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+
+jobs:
+  publish-tag:
+    name: Publish tagged release
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ -n "$DISPATCH_TAG" ]]; then
+            tag="$DISPATCH_TAG"
+          else
+            tag="$REF_NAME"
+          fi
+
+          if [[ ! "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unsupported release tag: $tag" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release if missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists; nothing to do."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --verify-tag \
+            --title "astt $VERSION" \
+            --generate-notes
+
+  reconcile-missing:
+    name: Reconcile missing releases
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish releases for semver tags that are missing one
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t tags < <(
+            gh api --paginate "repos/$GH_REPO/tags?per_page=100" \
+              --jq '.[].name' \
+              | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V
+          )
+
+          for tag in "${tags[@]}"; do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              continue
+            fi
+
+            version="${tag#v}"
+            echo "Publishing missing GitHub Release $tag"
+            gh release create "$tag" \
+              --verify-tag \
+              --title "astt $version" \
+              --generate-notes
+          done


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Release workflow for bare semver and `v*` semver tags
- keep GitHub Releases independent from the existing GHCR container publishing workflow
- add an idempotent reconciliation job on `master` pushes so existing tags without Releases are backfilled automatically
- add `workflow_dispatch` for manual recovery/backfill of a specific existing tag

## Why
`1.5.0` and `1.6.0` tags exist and container publishing succeeded, but no workflow creates GitHub Releases. As a result, the Releases page is still stuck at `1.4.0`.

## Validation
- parsed `.github/workflows/release.yml` successfully as YAML
- verified both embedded shell scripts with `bash -n`

After merge, the `master` reconciliation run should create missing Releases in ascending semver order, including `1.5.0` and `1.6.0`.