### PR TITLE
fix(landing): avoid metadata resume mismatch

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -5,48 +5,61 @@
 // force-static is incompatible with nextConfig.cacheComponents (PPR mode);
 // PPR prerendering the Suspense fallback shell is the correct tier here, and
 // the locale cookie read by next-intl is what makes the visible content dynamic.
-// Keep metadata request-independent: Next.js 16.2 can otherwise resume a
-// different metadata subtree under Cache Components and fall back to client
-// rendering with a __next_metadata_boundary__ mismatch.
+//
+// Do not put request-bound locale reads in generateMetadata(): Next.js 16.2 can
+// resume a different metadata subtree under Cache Components and fall back to
+// client rendering with a __next_metadata_boundary__ mismatch. React 19 can
+// hoist <title>, <meta>, and <link> tags rendered by a Server Component into
+// <head>, so localized metadata stays in the same dynamic Suspense subtree as
+// the localized landing content instead of using Next's dynamic Metadata API.
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
 import { LandingContent } from "@/components/landing/landing-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isPublicDemoEnabled } from "@/lib/env";
 import { getAppAssetUrl } from "@/lib/app-url";
 
-const landingTitle = "astt — Self-hosted Net Worth & Portfolio Tracker";
-const landingDescription =
-  "Open-source, self-hosted net worth and portfolio tracker for accounts, investments, property, liabilities, and long-term goals in multiple currencies.";
-const socialPreviewUrl = getAppAssetUrl("/landing/social-preview.png").toString();
-
+// Clear route-level fields inherited from the root Metadata API. The localized
+// equivalents below are rendered as React 19 document metadata, avoiding
+// duplicate title/description/social tags while keeping the Next metadata tree
+// request-independent for PPR resume.
 export const metadata: Metadata = {
-  title: landingTitle,
-  description: landingDescription,
-  alternates: { canonical: "/" },
-  openGraph: {
-    title: landingTitle,
-    description: landingDescription,
-    url: "/",
-    siteName: "astt",
-    images: [
-      {
-        url: socialPreviewUrl,
-        width: 1200,
-        height: 630,
-        alt: "astt landing page",
-      },
-    ],
-    type: "website",
-    locale: "en_US",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: landingTitle,
-    description: landingDescription,
-    images: [socialPreviewUrl],
-  },
+  title: null,
+  description: null,
+  openGraph: null,
+  twitter: null,
 };
+
+async function LandingDocumentMetadata() {
+  const [t, locale] = await Promise.all([getTranslations("landing"), getLocale()]);
+  const title = t("metaTitle");
+  const description = t("metaDescription");
+  const openGraphLocale = locale === "zh-TW" ? "zh_TW" : "en_US";
+  const socialPreviewUrl = getAppAssetUrl("/landing/social-preview.png").toString();
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href="/" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content="/" />
+      <meta property="og:site_name" content="astt" />
+      <meta property="og:type" content="website" />
+      <meta property="og:locale" content={openGraphLocale} />
+      <meta property="og:image" content={socialPreviewUrl} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image:alt" content="astt landing page" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={socialPreviewUrl} />
+    </>
+  );
+}
 
 function FeatureSkeletonList({ count }: { count: number }) {
   return (
@@ -260,6 +273,7 @@ function LandingSkeleton() {
 export default function LandingPage() {
   return (
     <Suspense fallback={<LandingSkeleton />}>
+      <LandingDocumentMetadata />
       <LandingContent />
     </Suspense>
   );

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -4,50 +4,49 @@
 //
 // force-static is incompatible with nextConfig.cacheComponents (PPR mode);
 // PPR prerendering the Suspense fallback shell is the correct tier here, and
-// the locale cookie read by next-intl is what makes the content dynamic.
+// the locale cookie read by next-intl is what makes the visible content dynamic.
+// Keep metadata request-independent: Next.js 16.2 can otherwise resume a
+// different metadata subtree under Cache Components and fall back to client
+// rendering with a __next_metadata_boundary__ mismatch.
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { getLocale, getTranslations } from "next-intl/server";
 import { LandingContent } from "@/components/landing/landing-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isPublicDemoEnabled } from "@/lib/env";
 import { getAppAssetUrl } from "@/lib/app-url";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const [t, locale] = await Promise.all([getTranslations("landing"), getLocale()]);
-  const title = t("metaTitle");
-  const description = t("metaDescription");
-  const openGraphLocale = locale === "zh-TW" ? "zh_TW" : "en_US";
-  const socialPreviewUrl = getAppAssetUrl("/landing/social-preview.png").toString();
+const landingTitle = "astt — Self-hosted Net Worth & Portfolio Tracker";
+const landingDescription =
+  "Open-source, self-hosted net worth and portfolio tracker for accounts, investments, property, liabilities, and long-term goals in multiple currencies.";
+const socialPreviewUrl = getAppAssetUrl("/landing/social-preview.png").toString();
 
-  return {
-    title,
-    description,
-    alternates: { canonical: "/" },
-    openGraph: {
-      title,
-      description,
-      url: "/",
-      siteName: "astt",
-      images: [
-        {
-          url: socialPreviewUrl,
-          width: 1200,
-          height: 630,
-          alt: "astt landing page",
-        },
-      ],
-      type: "website",
-      locale: openGraphLocale,
-    },
-    twitter: {
-      card: "summary_large_image",
-      title,
-      description,
-      images: [socialPreviewUrl],
-    },
-  };
-}
+export const metadata: Metadata = {
+  title: landingTitle,
+  description: landingDescription,
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: landingTitle,
+    description: landingDescription,
+    url: "/",
+    siteName: "astt",
+    images: [
+      {
+        url: socialPreviewUrl,
+        width: 1200,
+        height: 630,
+        alt: "astt landing page",
+      },
+    ],
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: landingTitle,
+    description: landingDescription,
+    images: [socialPreviewUrl],
+  },
+};
 
 function FeatureSkeletonList({ count }: { count: number }) {
   return (

--- a/tests/unit/landing-metadata-rendering.test.ts
+++ b/tests/unit/landing-metadata-rendering.test.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const landingPageSource = fs.readFileSync(
+  path.join(process.cwd(), "src/app/landing/page.tsx"),
+  "utf8",
+);
+
+describe("landing metadata rendering", () => {
+  it("keeps request-bound locale reads out of the metadata resume path", () => {
+    expect(landingPageSource).toContain("export const metadata: Metadata");
+    expect(landingPageSource).not.toContain("export async function generateMetadata");
+    expect(landingPageSource).not.toContain('getTranslations("landing")');
+    expect(landingPageSource).not.toContain("getLocale()");
+  });
+});

--- a/tests/unit/landing-metadata-rendering.test.ts
+++ b/tests/unit/landing-metadata-rendering.test.ts
@@ -8,10 +8,13 @@ const landingPageSource = fs.readFileSync(
 );
 
 describe("landing metadata rendering", () => {
-  it("keeps request-bound locale reads out of the metadata resume path", () => {
+  it("keeps request-bound locale reads out of the Next metadata resume path", () => {
     expect(landingPageSource).toContain("export const metadata: Metadata");
     expect(landingPageSource).not.toContain("export async function generateMetadata");
-    expect(landingPageSource).not.toContain('getTranslations("landing")');
-    expect(landingPageSource).not.toContain("getLocale()");
+    expect(landingPageSource).toContain("async function LandingDocumentMetadata()");
+    expect(landingPageSource).toContain('getTranslations("landing")');
+    expect(landingPageSource).toContain("getLocale()");
+    expect(landingPageSource).toContain("<title>{title}</title>");
+    expect(landingPageSource).toContain('<meta name="description" content={description} />');
   });
 });


### PR DESCRIPTION
## Why

Production runtime logs show Next.js occasionally falling back to client rendering on `/landing` with:

`Expected the resume to render <div> in this slot but instead it rendered <__next_metadata_boundary__>.`

The landing page previously resolved request-bound locale data inside Next.js `generateMetadata()` while Cache Components / partial prerendering is enabled. Next.js 16.2.x has upstream reports of this metadata/PPR resume-tree mismatch: the request can still return 200, but React discards the mismatched streamed SSR subtree and falls back to client rendering.

## What changed

- remove request-bound Next.js `generateMetadata()` from `/landing`
- keep the route-level Next metadata tree request-independent
- render localized `<title>`, `<meta>`, and `<link>` document metadata from `LandingDocumentMetadata()` inside the same dynamic landing `Suspense` subtree
- preserve English and Traditional Chinese title/description/Open Graph/Twitter metadata behavior
- add a regression contract that prevents request-bound locale reads from moving back into Next's dynamic Metadata API

React 19 hoists document metadata elements rendered by Server Components into `<head>`, so this preserves localized metadata without reintroducing the failing dynamic Next Metadata boundary.

## TDD / validation

- **RED:** test-only commit `52337a8` made the Unit tests job fail against the original request-bound `generateMetadata()` implementation.
- A first narrow workaround made metadata static English. Normal CI passed, but the existing Playwright contract correctly failed because switching to `zh-TW` no longer localized the page title/description. That implementation was rejected.
- **GREEN:** final head `354bc8c` preserves localized metadata while avoiding request-bound `generateMetadata()`.
- GitHub **CI**: success, including unit, typecheck, lint, format, build/bundle and PostgreSQL integration checks.
- GitHub **E2E Smoke Tests**: success, including the existing localized landing metadata assertions.
- Vercel Preview `dpl_C3RMM6TsoAGwCRNhSGHt2hzPa8v2`: READY.
- Preview `/landing`: HTTP 200 with expected canonical, localized-capable title/description, Open Graph and Twitter tags; `x-nextjs-prerender: 1`, `x-vercel-cache: PRERENDER`.
- Preview runtime error query after verification: no error logs found.

## Production verification after merge

1. Watch `/landing` for recurrence of digest `300139828` / `__next_metadata_boundary__`.
2. Compare Fluid Active CPU separately; this PR removes one request-bound metadata boundary but **does not make the entire landing page static**.
3. If Fluid CPU remains elevated, optimize the broader public landing/i18n/proxy path in a separate experiment.

## Non-goals

- no Next.js upgrade
- no root i18n architecture migration
- no Sentry transport changes (#748 is separate)
- no full static landing refactor
- no cron/cache changes
