### PR TITLE
ci(vercel): skip first docs-only previews

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -33,14 +33,17 @@ Pushes to `master` run the production build path and the self-contained Playwrig
 
 Use `[skip ci]` only for changes that cannot affect application behavior, configuration, deployment, migrations, or generated output. GitHub and Vercel may apply their own path filters independently.
 
-Vercel skips its own build for commits that touch only `*.md`, via `ignoreCommand` in `vercel.json`. Four details in that command are load-bearing:
+Vercel skips its own build for commits that touch only `*.md`, via `scripts/vercel-ignore.mjs`, which is called by `ignoreCommand` in `vercel.json`. The script returns Vercel's exit codes directly: 0 skips and 1 builds. Its existing-deployment path has four load-bearing details:
 
 - The base is `$VERCEL_GIT_PREVIOUS_SHA`, the last successfully deployed commit, not `HEAD^`. A push of several commits produces one deployment for the head commit only, so an `HEAD^` comparison would skip the build whenever the last commit of the push happened to be documentation — losing the deployment and its preview check for code that was never deployed.
-- `$VERCEL_GIT_PREVIOUS_SHA` stays double-quoted. It is empty on a branch's first deployment; unquoted, the command would degrade there to `git diff --quiet HEAD`, compare against a clean working tree, exit 0, and skip that build with nothing to explain why.
-- `|| exit 1` normalizes git's error codes. Vercel defines only 0 (skip) and 1 (build), and every failure mode above — empty base, a SHA missing from the shallow clone — must fall through to building.
+- An invalid or unavailable previous SHA builds. Every Git failure returns 1, so corrupt history cannot turn into a skip.
 - An empty diff builds. An empty commit and a redeploy of the same SHA are the two habitual ways to force a deployment after an environment-variable change or a flaky build; without the leading guard both would produce no diff, exit 0, and silently do nothing.
 
-A skipped build produces no deployment, so a documentation-only pull request has no preview and no `vercel-preview-e2e.yml` run. The required `Playwright smoke tests` check from `e2e.yml` runs on `pull_request` and is unaffected.
+When a Preview branch has no previous successful deployment, the script also checks the complete change from a bounded, fetched `master` merge base. It skips only if that diff is nonempty and Markdown-only. This fallback is limited to Preview branches with valid non-`master` metadata; unavailable references, fetch failures, a shallow boundary in the compared branch range, rewritten branch history, and all other uncertainty build. Production is unchanged. A skipped update leaves any existing Preview deployment in place; it does not delete it.
+
+To force a documentation-only Preview build, use Vercel's **Redeploy** control and uncheck **Use project's Ignore Build Step**. This is especially useful before a branch has a successful deployment, where Git metadata alone cannot distinguish a manual trigger from the initial deploy.
+
+A skipped build produces no new deployment, so a documentation-only pull request has no new preview and no `vercel-preview-e2e.yml` run. The required `Playwright smoke tests` check from `e2e.yml` runs on `pull_request` and is unaffected.
 
 The rule assumes no `*.md` file is ever served or read by the application. Nothing under `public/` may be markdown, and no build step may read one.
 

--- a/scripts/vercel-ignore.mjs
+++ b/scripts/vercel-ignore.mjs
@@ -4,16 +4,27 @@ const BUILD = 1;
 const SKIP = 0;
 const FETCH_DEPTH = 50;
 const GIT_TIMEOUT_MS = 5_000;
+// The fetch talks to GitHub; local plumbing does not. A cold shallow fetch of
+// this repository can take far longer than the 5s the other commands need.
+const FETCH_TIMEOUT_MS = 30_000;
 
-function git(args, captureOutput = false) {
+function git(args, captureOutput = false, timeoutMs = GIT_TIMEOUT_MS) {
   const result = spawnSync("git", args, {
     encoding: "utf8",
     stdio: captureOutput ? ["ignore", "pipe", "ignore"] : "ignore",
-    timeout: GIT_TIMEOUT_MS,
+    timeout: timeoutMs,
   });
 
   if (result.error || result.status === null) return undefined;
   return captureOutput ? { status: result.status, stdout: result.stdout.trim() } : result.status;
+}
+
+// Every uncertain-history path builds, which is safe but silent: in the build
+// log "the fetch never worked" and "this branch changed more than Markdown"
+// look identical. Say which one happened.
+function bail(reason) {
+  console.error(`vercel-ignore: ${reason}; building.`);
+  return false;
 }
 
 function changedOnlyMarkdown(base) {
@@ -44,29 +55,42 @@ function firstPreviewDocsOnly() {
   if (git(["check-ref-format", `refs/heads/${branch}`]) !== 0) return false;
   if (git(["remote", "get-url", "origin"]) !== 0) return false;
 
+  // --depth bounds a shallow clone; against a complete one it would *truncate*
+  // history that the build itself may later need, so only pass it when the
+  // repository is already shallow.
+  const shallow = git(["rev-parse", "--is-shallow-repository"], true);
+  if (shallow?.status !== 0) return false;
+
   const remoteBranch = `refs/remotes/origin/${branch}`;
-  const fetched = git([
-    "fetch",
-    "--no-tags",
-    `--depth=${FETCH_DEPTH}`,
-    "origin",
-    "+refs/heads/master:refs/remotes/origin/master",
-    `+refs/heads/${branch}:${remoteBranch}`,
-  ]);
-  if (fetched !== 0) return false;
+  const fetched = git(
+    [
+      "fetch",
+      "--no-tags",
+      ...(shallow.stdout === "true" ? [`--depth=${FETCH_DEPTH}`] : []),
+      "origin",
+      "+refs/heads/master:refs/remotes/origin/master",
+      `+refs/heads/${branch}:${remoteBranch}`,
+    ],
+    false,
+    FETCH_TIMEOUT_MS,
+  );
+  if (fetched !== 0) return bail(`master fetch failed (${fetched ?? "timed out"})`);
 
   // Confirm that the fetched branch really contains this deployed commit. This
   // also prevents a shallow or rewritten ref from becoming a guessed baseline.
-  if (git(["merge-base", "--is-ancestor", "HEAD", remoteBranch]) !== 0) return false;
+  if (git(["merge-base", "--is-ancestor", "HEAD", remoteBranch]) !== 0) {
+    return bail("deployed commit is not on the fetched branch");
+  }
 
   const mergeBase = git(["merge-base", "HEAD", "refs/remotes/origin/master"], true);
-  if (!mergeBase || mergeBase.status !== 0 || !/^[0-9a-f]{40}$/i.test(mergeBase.stdout))
-    return false;
+  if (!mergeBase || mergeBase.status !== 0 || !/^[0-9a-f]{40}$/i.test(mergeBase.stdout)) {
+    return bail("no master merge base reachable in this shallow clone");
+  }
   if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "HEAD"]) !== 0) return false;
   if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "refs/remotes/origin/master"]) !== 0) {
     return false;
   }
-  if (!hasCompleteRange(mergeBase.stdout)) return false;
+  if (!hasCompleteRange(mergeBase.stdout)) return bail("merge base range is incomplete");
 
   return changedOnlyMarkdown(mergeBase.stdout);
 }

--- a/scripts/vercel-ignore.mjs
+++ b/scripts/vercel-ignore.mjs
@@ -1,0 +1,81 @@
+import { spawnSync } from "node:child_process";
+
+const BUILD = 1;
+const SKIP = 0;
+const FETCH_DEPTH = 50;
+const GIT_TIMEOUT_MS = 5_000;
+
+function git(args, captureOutput = false) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    stdio: captureOutput ? ["ignore", "pipe", "ignore"] : "ignore",
+    timeout: GIT_TIMEOUT_MS,
+  });
+
+  if (result.error || result.status === null) return undefined;
+  return captureOutput ? { status: result.status, stdout: result.stdout.trim() } : result.status;
+}
+
+function changedOnlyMarkdown(base) {
+  const hasChanges = git(["diff", "--quiet", base, "HEAD"]);
+  if (hasChanges !== 1) return false;
+
+  return git(["diff", "--quiet", base, "HEAD", "--", ".", ":(exclude)*.md"]) === 0;
+}
+
+function resolveCommit(value) {
+  if (!/^[0-9a-f]{40}$/i.test(value)) return undefined;
+
+  const result = git(["rev-parse", "--verify", `${value}^{commit}`], true);
+  return result?.status === 0 && /^[0-9a-f]{40}$/i.test(result.stdout) ? result.stdout : undefined;
+}
+
+function hasCompleteRange(base) {
+  const commits = git(["rev-list", "--parents", `${base}..HEAD`], true);
+  return (
+    commits?.status === 0 &&
+    commits.stdout.split("\n").every((commit) => commit.split(" ").filter(Boolean).length > 1)
+  );
+}
+
+function firstPreviewDocsOnly() {
+  const branch = process.env.VERCEL_GIT_COMMIT_REF;
+  if (process.env.VERCEL_ENV !== "preview" || !branch || branch === "master") return false;
+  if (git(["check-ref-format", `refs/heads/${branch}`]) !== 0) return false;
+  if (git(["remote", "get-url", "origin"]) !== 0) return false;
+
+  const remoteBranch = `refs/remotes/origin/${branch}`;
+  const fetched = git([
+    "fetch",
+    "--no-tags",
+    `--depth=${FETCH_DEPTH}`,
+    "origin",
+    "+refs/heads/master:refs/remotes/origin/master",
+    `+refs/heads/${branch}:${remoteBranch}`,
+  ]);
+  if (fetched !== 0) return false;
+
+  // Confirm that the fetched branch really contains this deployed commit. This
+  // also prevents a shallow or rewritten ref from becoming a guessed baseline.
+  if (git(["merge-base", "--is-ancestor", "HEAD", remoteBranch]) !== 0) return false;
+
+  const mergeBase = git(["merge-base", "HEAD", "refs/remotes/origin/master"], true);
+  if (!mergeBase || mergeBase.status !== 0 || !/^[0-9a-f]{40}$/i.test(mergeBase.stdout))
+    return false;
+  if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "HEAD"]) !== 0) return false;
+  if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "refs/remotes/origin/master"]) !== 0) {
+    return false;
+  }
+  if (!hasCompleteRange(mergeBase.stdout)) return false;
+
+  return changedOnlyMarkdown(mergeBase.stdout);
+}
+
+const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA;
+
+if (previousSha) {
+  const previousCommit = resolveCommit(previousSha);
+  process.exitCode = previousCommit && changedOnlyMarkdown(previousCommit) ? SKIP : BUILD;
+} else {
+  process.exitCode = firstPreviewDocsOnly() ? SKIP : BUILD;
+}

--- a/tests/unit/vercel-ignore-command.test.ts
+++ b/tests/unit/vercel-ignore-command.test.ts
@@ -2,13 +2,14 @@ import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { pathToFileURL } from "node:url";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
 /**
  * `vercel.json`'s ignoreCommand decides whether Vercel builds at all. Vercel
  * defines exit code 0 as "skip the build" and 1 as "build", so a wrong exit
  * code here silently stops deploying. This file runs the real command string
- * from `vercel.json` against throwaway repositories.
+ * from `vercel.json` against throwaway repositories and file:// remotes.
  */
 const ignoreCommand = (
   JSON.parse(fs.readFileSync(path.join(process.cwd(), "vercel.json"), "utf8")) as {
@@ -19,19 +20,32 @@ const ignoreCommand = (
 const SKIP_BUILD = 0;
 const RUN_BUILD = 1;
 
-let repo: string;
+type Fixture = {
+  root: string;
+  repo: string;
+  origin: string;
+  branch: string;
+  masterSha: string;
+};
 
-function git(...args: string[]) {
-  return execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+const fixtures = new Set<string>();
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 
-function commit(files: Record<string, string>, message: string) {
+function commit(cwd: string, files: Record<string, string>, message: string) {
   for (const [name, contents] of Object.entries(files)) {
-    fs.mkdirSync(path.join(repo, path.dirname(name)), { recursive: true });
-    fs.writeFileSync(path.join(repo, name), contents);
+    fs.mkdirSync(path.join(cwd, path.dirname(name)), { recursive: true });
+    fs.writeFileSync(path.join(cwd, name), contents);
   }
-  git("add", "-A");
+  git(cwd, "add", "-A");
   git(
+    cwd,
     "-c",
     "user.email=t@t",
     "-c",
@@ -39,64 +53,284 @@ function commit(files: Record<string, string>, message: string) {
     "-c",
     "commit.gpgsign=false",
     "commit",
+    "--allow-empty",
     "-m",
     message,
   );
-  return git("rev-parse", "HEAD");
+  return git(cwd, "rev-parse", "HEAD");
 }
 
-/** Runs the ignoreCommand the way Vercel does: a shell, with the SHA injected. */
-function runIgnoreCommand(previousSha: string) {
-  return spawnSync("sh", ["-c", ignoreCommand], {
-    cwd: repo,
-    env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previousSha },
-  }).status;
+function copyIgnoreScript(repo: string) {
+  // The initial RED run still uses the existing inline command. Once the
+  // implementation script exists, fixtures include it exactly as Vercel does.
+  const source = path.join(process.cwd(), "scripts/vercel-ignore.mjs");
+  if (!fs.existsSync(source)) return;
+  const destination = path.join(repo, "scripts/vercel-ignore.mjs");
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
 }
 
-beforeAll(() => {
-  repo = fs.mkdtempSync(path.join(os.tmpdir(), "ignore-command-"));
-  git("init", "-q");
-  // Every test resolves HEAD, so none of them may depend on an earlier one
-  // having committed first — `vitest run -t "<name>"` has to work too.
-  commit({ "src/seed.ts": "export const seed = 0;\n" }, "seed");
+function makeFixture(branch: string, setupBranch: (repo: string) => void): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vercel-ignore-command-"));
+  fixtures.add(root);
+  const origin = path.join(root, "origin.git");
+  const source = path.join(root, "source");
+  const repo = path.join(root, "checkout");
+
+  fs.mkdirSync(source, { recursive: true });
+  git(source, "-c", "init.defaultBranch=master", "init", "-q");
+  git(source, "config", "user.email", "t@t");
+  git(source, "config", "user.name", "t");
+  commit(source, { "src/base.ts": "export const base = true;\n" }, "base");
+
+  git(root, "init", "--bare", "-q", origin);
+  git(source, "remote", "add", "origin", pathToFileURL(origin).href);
+  git(source, "push", "-q", "origin", "master");
+  const masterSha = git(source, "rev-parse", "master");
+
+  git(source, "switch", "-c", branch);
+  setupBranch(source);
+  git(source, "push", "-q", "origin", branch);
+
+  git(
+    root,
+    "clone",
+    "-q",
+    "--depth=10",
+    "--single-branch",
+    "--branch",
+    branch,
+    pathToFileURL(origin).href,
+    repo,
+  );
+  copyIgnoreScript(repo);
+  return { root, repo, origin, branch, masterSha };
+}
+
+function runIgnore(
+  fixture: Fixture,
+  options: {
+    previousSha?: string;
+    environment?: string;
+    branch?: string;
+  } = {},
+) {
+  const env = { ...process.env };
+  for (const name of Object.keys(env)) {
+    if (name.startsWith("VERCEL_")) delete env[name];
+  }
+  if (options.previousSha !== undefined) env.VERCEL_GIT_PREVIOUS_SHA = options.previousSha;
+  if (options.environment !== undefined) env.VERCEL_ENV = options.environment;
+  if (options.branch !== undefined) env.VERCEL_GIT_COMMIT_REF = options.branch;
+  return (
+    spawnSync("sh", ["-c", ignoreCommand], {
+      cwd: fixture.repo,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).status ?? RUN_BUILD
+  );
+}
+
+afterEach(() => {
+  for (const root of fixtures) fs.rmSync(root, { recursive: true, force: true });
+  fixtures.clear();
 });
 
 afterAll(() => {
-  fs.rmSync(repo, { recursive: true, force: true });
+  for (const root of fixtures) fs.rmSync(root, { recursive: true, force: true });
 });
 
 describe("vercel.json ignoreCommand", () => {
-  it("skips the build when only markdown changed since the last deployment", () => {
-    const deployed = commit({ "src/app.ts": "export const a = 1;\n" }, "code");
-    commit({ "README.md": "# hi\n", "docs/nested/note.md": "nested\n" }, "docs");
+  it("skips a first preview deployment when the whole branch is markdown-only", () => {
+    const fixture = makeFixture("feature/docs-only", (repo) => {
+      commit(repo, { "README.md": "# hi\n", "docs/nested/note.md": "nested\n" }, "docs");
+    });
 
-    expect(runIgnoreCommand(deployed)).toBe(SKIP_BUILD);
+    expect(
+      runIgnore(fixture, {
+        previousSha: "",
+        environment: "preview",
+        branch: fixture.branch,
+      }),
+    ).toBe(SKIP_BUILD);
   });
 
-  it("builds when a non-markdown file changed", () => {
-    const deployed = git("rev-parse", "HEAD");
-    commit({ "src/app.ts": "export const a = 2;\n" }, "code again");
+  it("fetches the missing production baseline for a first docs-only preview", () => {
+    const fixture = makeFixture("feature/docs-baseline", (repo) => {
+      commit(repo, { "docs/one.md": "one\n" }, "docs");
+    });
 
-    expect(runIgnoreCommand(deployed)).toBe(RUN_BUILD);
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(SKIP_BUILD);
+    expect(git(fixture.repo, "rev-parse", "--verify", "refs/remotes/origin/master")).toBe(
+      fixture.masterSha,
+    );
   });
 
-  it("builds when code landed earlier in the same push and the head commit is docs-only", () => {
-    // Vercel deploys the head commit of a push, so an HEAD^ comparison would
-    // miss the code commit behind it and skip a build that was never deployed.
-    const deployed = git("rev-parse", "HEAD");
-    commit({ "src/app.ts": "export const a = 3;\n" }, "code");
-    commit({ "docs/CI.md": "docs\n" }, "docs on top of code");
+  it("builds a first preview when code and markdown both changed", () => {
+    const fixture = makeFixture("feature/mixed", (repo) => {
+      commit(repo, { "src/app.ts": "export const app = 1;\n" }, "code");
+      commit(repo, { "docs/app.md": "app\n" }, "docs");
+    });
 
-    expect(runIgnoreCommand(deployed)).toBe(RUN_BUILD);
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
   });
 
-  it("builds when the previous SHA is empty, as on a branch's first deployment", () => {
-    expect(runIgnoreCommand("")).toBe(RUN_BUILD);
+  it("builds when code landed before the last ten shallow commits", () => {
+    const fixture = makeFixture("feature/shallow-code", (repo) => {
+      commit(
+        repo,
+        { "src/early.ts": "export const early = true;\n" },
+        "code before shallow boundary",
+      );
+      for (let index = 0; index < 10; index += 1) {
+        commit(repo, { [`docs/note-${index}.md`]: `${index}\n` }, `docs ${index}`);
+      }
+    });
+
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
   });
 
-  it("builds when nothing changed, as on an empty commit or a redeploy of the same SHA", () => {
-    // Both are the habitual ways to force a deployment after an environment
-    // change. An empty diff must not read as "nothing to do".
-    expect(runIgnoreCommand(git("rev-parse", "HEAD"))).toBe(RUN_BUILD);
+  it("builds when a docs-only branch remains beyond the bounded shallow history", () => {
+    const fixture = makeFixture("feature/deep-docs", (repo) => {
+      for (let index = 0; index < 51; index += 1) {
+        commit(repo, { [`docs/note-${index}.md`]: `${index}\n` }, `docs ${index}`);
+      }
+    });
+
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
+  });
+
+  it("builds when the production baseline is unavailable", () => {
+    const fixture = makeFixture("feature/no-origin", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+    git(fixture.repo, "remote", "remove", "origin");
+
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
+  });
+
+  it("builds when fetching the production baseline fails", () => {
+    const fixture = makeFixture("feature/fetch-failure", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+    git(
+      fixture.repo,
+      "remote",
+      "set-url",
+      "origin",
+      pathToFileURL(path.join(fixture.root, "missing.git")).href,
+    );
+
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
+  });
+
+  it.each([
+    ["production", "production"],
+    ["missing environment", undefined],
+    ["unknown environment", "development"],
+  ])("builds for the %s environment guard", (_name, environment) => {
+    const fixture = makeFixture("feature/guard", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    const options: { previousSha: string; branch: string; environment?: string } = {
+      previousSha: "",
+      branch: fixture.branch,
+    };
+    if (environment !== undefined) options.environment = environment;
+    expect(runIgnore(fixture, options)).toBe(RUN_BUILD);
+  });
+
+  it("builds when the first deployment metadata names master", () => {
+    const fixture = makeFixture("feature/master-guard", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { previousSha: "", environment: "preview", branch: "master" })).toBe(
+      RUN_BUILD,
+    );
+  });
+
+  it("builds when the first deployment branch metadata is invalid", () => {
+    const fixture = makeFixture("feature/invalid-metadata", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    expect(
+      runIgnore(fixture, {
+        previousSha: "",
+        environment: "preview",
+        branch: "feature/../../run-away",
+      }),
+    ).toBe(RUN_BUILD);
+  });
+
+  it("builds when the first deployment branch metadata is missing", () => {
+    const fixture = makeFixture("feature/missing-metadata", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { previousSha: "", environment: "preview" })).toBe(RUN_BUILD);
+  });
+
+  it("builds for an invalid nonempty previous SHA", () => {
+    const fixture = makeFixture("feature/invalid-previous", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { previousSha: "not-a-commit" })).toBe(RUN_BUILD);
+  });
+
+  it("builds when the previous SHA equals HEAD", () => {
+    const fixture = makeFixture("feature/same-sha", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { previousSha: git(fixture.repo, "rev-parse", "HEAD") })).toBe(
+      RUN_BUILD,
+    );
+  });
+
+  it("skips markdown-only changes from an existing deployment without fetching", () => {
+    const fixture = makeFixture("feature/existing-previous", (repo) => {
+      commit(repo, { "docs/note.md": "docs\n" }, "docs");
+    });
+    git(
+      fixture.repo,
+      "remote",
+      "set-url",
+      "origin",
+      pathToFileURL(path.join(fixture.root, "missing.git")).href,
+    );
+
+    expect(runIgnore(fixture, { previousSha: fixture.masterSha })).toBe(SKIP_BUILD);
+  });
+
+  it("builds when docs follow code across multiple commits", () => {
+    const fixture = makeFixture("feature/docs-after-code", (repo) => {
+      commit(repo, { "src/app.ts": "export const app = 2;\n" }, "code");
+      commit(repo, { "docs/app.md": "app\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { previousSha: fixture.masterSha })).toBe(RUN_BUILD);
+  });
+
+  it("builds when no files changed since the previous deployment", () => {
+    const fixture = makeFixture("feature/no-diff", () => undefined);
+
+    expect(runIgnore(fixture, { previousSha: fixture.masterSha })).toBe(RUN_BUILD);
   });
 });

--- a/tests/unit/vercel-ignore-command.test.ts
+++ b/tests/unit/vercel-ignore-command.test.ts
@@ -70,7 +70,11 @@ function copyIgnoreScript(repo: string) {
   fs.copyFileSync(source, destination);
 }
 
-function makeFixture(branch: string, setupBranch: (repo: string) => void): Fixture {
+function makeFixture(
+  branch: string,
+  setupBranch: (repo: string) => void,
+  options: { fullClone?: boolean } = {},
+): Fixture {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "vercel-ignore-command-"));
   fixtures.add(root);
   const origin = path.join(root, "origin.git");
@@ -96,8 +100,7 @@ function makeFixture(branch: string, setupBranch: (repo: string) => void): Fixtu
     root,
     "clone",
     "-q",
-    "--depth=10",
-    "--single-branch",
+    ...(options.fullClone ? [] : ["--depth=10", "--single-branch"]),
     "--branch",
     branch,
     pathToFileURL(origin).href,
@@ -167,6 +170,26 @@ describe("vercel.json ignoreCommand", () => {
     expect(git(fixture.repo, "rev-parse", "--verify", "refs/remotes/origin/master")).toBe(
       fixture.masterSha,
     );
+  });
+
+  it("does not truncate a complete clone while resolving the merge base", () => {
+    // --depth bounds a shallow fetch but re-shallows a complete one, which would
+    // silently take history away from the build that runs next. The branch has
+    // to be deeper than the script's fetch depth for that truncation to show.
+    const fixture = makeFixture(
+      "feature/docs-full-clone",
+      (repo) => {
+        for (let i = 0; i < 52; i += 1) commit(repo, {}, `filler ${i}`);
+        commit(repo, { "docs/one.md": "one\n" }, "docs");
+      },
+      { fullClone: true },
+    );
+
+    expect(git(fixture.repo, "rev-parse", "--is-shallow-repository")).toBe("false");
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(SKIP_BUILD);
+    expect(git(fixture.repo, "rev-parse", "--is-shallow-repository")).toBe("false");
   });
 
   it("builds a first preview when code and markdown both changed", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm run build:vercel",
-  "ignoreCommand": "git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD && exit 1; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ':(exclude)*.md' || exit 1",
+  "ignoreCommand": "node scripts/vercel-ignore.mjs",
   "regions": ["sin1"],
   "crons": [
     {


### PR DESCRIPTION
Follow-up to #752 for first Preview deployments. When Vercel has no previous successful SHA, scripts/vercel-ignore.mjs resolves a bounded master merge base and skips only nonempty Markdown-only diffs; missing or uncertain history builds. Existing previous-SHA behavior remains unchanged. Verified with 18 focused tests, Prettier, ESLint, TypeScript, and node --check.