### PR TITLE
test(ci): close the gaps left by the preview and ignore-command reviews

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -264,7 +264,11 @@ jobs:
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
-        if: steps.freshness.outputs.fresh == 'true' && always()
+        # always() first: it reads as the override it is, and a status function
+        # anywhere in the expression already suppresses the implicit success().
+        # Gate on the final check rather than the first one, so a run that
+        # stopped between them does not look for a report that was never made.
+        if: always() && steps.final-freshness.outputs.fresh == 'true'
         with:
           name: vercel-preview-playwright-report
           path: playwright-report/

--- a/scripts/vercel-ignore.mjs
+++ b/scripts/vercel-ignore.mjs
@@ -2,6 +2,8 @@ import { spawnSync } from "node:child_process";
 
 const BUILD = 1;
 const SKIP = 0;
+const DEFAULT_BRANCH = "master";
+const DEFAULT_BRANCH_REMOTE_REF = `refs/remotes/origin/${DEFAULT_BRANCH}`;
 const FETCH_DEPTH = 50;
 const GIT_TIMEOUT_MS = 5_000;
 // The fetch talks to GitHub; local plumbing does not. A cold shallow fetch of
@@ -51,7 +53,7 @@ function hasCompleteRange(base) {
 
 function firstPreviewDocsOnly() {
   const branch = process.env.VERCEL_GIT_COMMIT_REF;
-  if (process.env.VERCEL_ENV !== "preview" || !branch || branch === "master") return false;
+  if (process.env.VERCEL_ENV !== "preview" || !branch || branch === DEFAULT_BRANCH) return false;
   if (git(["check-ref-format", `refs/heads/${branch}`]) !== 0) return false;
   if (git(["remote", "get-url", "origin"]) !== 0) return false;
 
@@ -68,13 +70,13 @@ function firstPreviewDocsOnly() {
       "--no-tags",
       ...(shallow.stdout === "true" ? [`--depth=${FETCH_DEPTH}`] : []),
       "origin",
-      "+refs/heads/master:refs/remotes/origin/master",
+      `+refs/heads/${DEFAULT_BRANCH}:${DEFAULT_BRANCH_REMOTE_REF}`,
       `+refs/heads/${branch}:${remoteBranch}`,
     ],
     false,
     FETCH_TIMEOUT_MS,
   );
-  if (fetched !== 0) return bail(`master fetch failed (${fetched ?? "timed out"})`);
+  if (fetched !== 0) return bail(`${DEFAULT_BRANCH} fetch failed (${fetched ?? "timed out"})`);
 
   // Confirm that the fetched branch really contains this deployed commit. This
   // also prevents a shallow or rewritten ref from becoming a guessed baseline.
@@ -82,12 +84,12 @@ function firstPreviewDocsOnly() {
     return bail("deployed commit is not on the fetched branch");
   }
 
-  const mergeBase = git(["merge-base", "HEAD", "refs/remotes/origin/master"], true);
+  const mergeBase = git(["merge-base", "HEAD", DEFAULT_BRANCH_REMOTE_REF], true);
   if (!mergeBase || mergeBase.status !== 0 || !/^[0-9a-f]{40}$/i.test(mergeBase.stdout)) {
-    return bail("no master merge base reachable in this shallow clone");
+    return bail(`no ${DEFAULT_BRANCH} merge base reachable in this shallow clone`);
   }
   if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "HEAD"]) !== 0) return false;
-  if (git(["merge-base", "--is-ancestor", mergeBase.stdout, "refs/remotes/origin/master"]) !== 0) {
+  if (git(["merge-base", "--is-ancestor", mergeBase.stdout, DEFAULT_BRANCH_REMOTE_REF]) !== 0) {
     return false;
   }
   if (!hasCompleteRange(mergeBase.stdout)) return bail("merge base range is incomplete");

--- a/tests/unit/e2e-workflow.test.ts
+++ b/tests/unit/e2e-workflow.test.ts
@@ -9,22 +9,25 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as
   ...args: string[]
 ) => (...values: unknown[]) => Promise<void>;
 
+const indentOf = (line: string) => /^ */.exec(line)![0].length;
+
 function githubScript(stepName: string) {
   const workflow = read(".github/workflows/vercel-preview-e2e.yml");
-  const marker = `      - name: ${stepName}`;
-  const stepStart = workflow.indexOf(marker);
+  const stepStart = workflow.indexOf(`- name: ${stepName}\n`);
   if (stepStart === -1) throw new Error(`Missing workflow step: ${stepName}`);
-  const scriptMarker = "          script: |\n";
-  const scriptStart = workflow.indexOf(scriptMarker, stepStart);
+  const scriptStart = workflow.indexOf("script: |\n", stepStart);
   if (scriptStart === -1) throw new Error(`Missing script in workflow step: ${stepName}`);
-  const nextStep = workflow.indexOf("\n      - ", scriptStart + scriptMarker.length);
-  const nextJob = workflow.indexOf("\n  e2e:\n", scriptStart + scriptMarker.length);
-  const blockEnd = [nextStep, nextJob].filter((index) => index !== -1).sort((a, b) => a - b)[0];
-  const block = workflow.slice(scriptStart + scriptMarker.length, blockEnd ?? workflow.length);
-  return block
-    .split("\n")
-    .map((line) => line.replace(/^ {12}/, ""))
-    .join("\n");
+  // A block scalar runs until the first non-empty line indented less than its
+  // own body, so derive both from the text rather than pinning the step's depth
+  // and the name of whatever job happens to come next.
+  const lines = workflow.slice(workflow.indexOf("\n", scriptStart) + 1).split("\n");
+  const indent = indentOf(lines[0]);
+  const body: string[] = [];
+  for (const line of lines) {
+    if (line.trim() !== "" && indentOf(line) < indent) break;
+    body.push(line.slice(indent));
+  }
+  return body.join("\n");
 }
 
 type PullRequest = {
@@ -406,6 +409,30 @@ describe("E2E CI contract", () => {
       expect(result.outputs.get("fresh")).toBe("false");
     },
   );
+
+  test("keeps the two freshness gates in lockstep", () => {
+    // The same predicate lives in two steps because YAML has no sharing
+    // primitive short of a composite action, which two copies do not justify.
+    // This is the guard instead: a fix applied to one cannot silently miss the
+    // other. Comments and the notice wording are allowed to differ.
+    const logic = (stepName: string) =>
+      githubScript(stepName)
+        .split("\n")
+        .filter((line) => line.trim() !== "" && !line.trim().startsWith("//"))
+        .join("\n")
+        .replace(/"Preview commit is still current[^"]*"/, '"<notice>"');
+
+    expect(logic("Check preview freshness before setup")).toBe(logic("Revalidate preview commit"));
+  });
+
+  test("uploads a Playwright report only for a run that reached Playwright", () => {
+    const workflow = read(".github/workflows/vercel-preview-e2e.yml");
+    const uploadStep = workflow.slice(workflow.indexOf("- name: Upload Playwright report"));
+
+    // Gating on the first check would ask upload-artifact for a report that a
+    // run stopping at the final check never produced.
+    expect(uploadStep).toContain("if: always() && steps.final-freshness.outputs.fresh == 'true'");
+  });
 
   test("serializes every pending run per pull request without cancellation", () => {
     const workflow = read(".github/workflows/vercel-preview-e2e.yml");

--- a/tests/unit/vercel-ignore-command.test.ts
+++ b/tests/unit/vercel-ignore-command.test.ts
@@ -61,10 +61,10 @@ function commit(cwd: string, files: Record<string, string>, message: string) {
 }
 
 function copyIgnoreScript(repo: string) {
-  // The initial RED run still uses the existing inline command. Once the
-  // implementation script exists, fixtures include it exactly as Vercel does.
+  // Fixtures include the real script exactly as Vercel does. Never guard this
+  // on the file existing: a missing script would turn every "builds" assertion
+  // below into a pass, because the absent command also exits nonzero.
   const source = path.join(process.cwd(), "scripts/vercel-ignore.mjs");
-  if (!fs.existsSync(source)) return;
   const destination = path.join(repo, "scripts/vercel-ignore.mjs");
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(source, destination);
@@ -190,6 +190,28 @@ describe("vercel.json ignoreCommand", () => {
       runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
     ).toBe(SKIP_BUILD);
     expect(git(fixture.repo, "rev-parse", "--is-shallow-repository")).toBe("false");
+  });
+
+  it("skips a first docs-only preview when the previous SHA is unset, not merely empty", () => {
+    // Vercel is likelier to omit the variable than to set it empty, and that is
+    // the trigger condition for the whole merge-base path.
+    const fixture = makeFixture("feature/docs-unset-previous", (repo) => {
+      commit(repo, { "docs/one.md": "one\n" }, "docs");
+    });
+
+    expect(runIgnore(fixture, { environment: "preview", branch: fixture.branch })).toBe(SKIP_BUILD);
+  });
+
+  it("builds a first preview whose branch changed nothing at all", () => {
+    // An empty diff must build here too. Today hasCompleteRange happens to
+    // reject the empty range first, so without this the guard is incidental.
+    const fixture = makeFixture("feature/empty-first", (repo) => {
+      commit(repo, {}, "empty");
+    });
+
+    expect(
+      runIgnore(fixture, { previousSha: "", environment: "preview", branch: fixture.branch }),
+    ).toBe(RUN_BUILD);
   });
 
   it("builds a first preview when code and markdown both changed", () => {


### PR DESCRIPTION
## Description

Follow-up to #753 and #754, clearing the Minor findings from both reviews. No behaviour change to what gets built or tested; the substance is that the existing tests now fail when they should.

The ignore-command fixtures skipped copying the script when it did not exist — scaffolding from the first RED run. Because an absent command also exits nonzero, and every "builds" assertion expects nonzero, deleting `scripts/vercel-ignore.mjs` left 15 of 19 tests passing. With the guard gone the suite fails all 22.

Two conditions on the first-preview path had no test: a previous SHA that is **unset** rather than empty (the likelier shape from Vercel, and the trigger for the whole merge-base branch), and a branch that changed nothing at all — where the empty-diff guard is currently incidental, since `hasCompleteRange` rejects the empty range before the explicit check is reached.

The two freshness gates are one predicate written twice. YAML has no sharing primitive short of a composite action, which two copies do not earn, so a test holds them in lockstep instead — comments and notice wording may differ, logic may not. `githubScript` also stops pinning the step's indentation and the name of whatever job follows, and derives the block scalar's extent the way YAML defines it.

The report upload gated on the *first* freshness check, so a run that stopped at the second asked upload-artifact for a report that was never written. It now gates on the final check, with `always()` leading where it reads as the override it is.

Also folds in a `DEFAULT_BRANCH` constant: `"master"` appeared four times in three spellings.

### Type of Change

- [x] Test coverage
- [x] Refactor

## Testing

Each change was mutation-checked rather than assumed:

| Mutation | Before | After |
|---|---|---|
| `scripts/vercel-ignore.mjs` deleted | 15 of 19 pass | all 22 fail |
| Freshness gates drift apart | silent | 1 fails |
| Upload gated on the first check again | silent | 1 fails |

Full unit suite 1,219 passing. Prettier, ESLint, `tsc --noEmit`, `node --check` clean.

https://claude.ai/code/session_014jFyyNTHs2G51NGvBBC6L9